### PR TITLE
use tsc --build to build monorepo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4540,6 +4540,7 @@
       }
     },
     "packages/auth-construct": {
+      "name": "@aws-amplify/auth-construct",
       "version": "0.1.0",
       "devDependencies": {
         "aws-cdk-lib": "^2.72.0",

--- a/package.json
+++ b/package.json
@@ -3,20 +3,21 @@
   "version": "0.0.1",
   "description": "",
   "scripts": {
-    "api:update": "npm run api:update -ws",
+    "api:update": "npm run api:update --workspaces",
     "api:check": "npm run api:update && tsx scripts/check_api_extract.ts",
-    "build": "npm run build -ws",
-    "clean": "npm run clean -ws && rimraf node_modules coverage .eslintcache",
+    "build": "tsc --build packages/*",
+    "clean": "npm run clean --workspaces --if-present && rimraf node_modules coverage .eslintcache",
     "diff:check": "tsx scripts/check_pr_size.ts",
     "docs": "typedoc",
     "new:construct": "tsx scripts/copy_construct_template.ts",
-    "install:local": "npm run build && npm link --force",
+    "install:local": "npm run build && npm run install:local --workspaces --if-present",
     "lint": "eslint --max-warnings 0 . && prettier --check .",
     "lint:fix": "eslint --cache --fix . && prettier --write .",
     "prepare": "husky install",
     "test": "tsx scripts/run_unit_tests.ts",
     "test:coverage:generate": "NODE_V8_COVERAGE=coverage/ npm run test",
-    "test:coverage:threshold": "c8 npm run test"
+    "test:coverage:threshold": "c8 npm run test",
+    "watch": "npm run build -- --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/auth-construct/package.json
+++ b/packages/auth-construct/package.json
@@ -6,7 +6,6 @@
   "type": "module",
   "scripts": {
     "api:update": "api-extractor run --local",
-    "build": "tsc",
     "clean": "rimraf lib node_modules tsconfig.tsbuildinfo",
     "watch": "tsc -w"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,8 +8,8 @@
   "type": "module",
   "scripts": {
     "api:update": "api-extractor run --local",
-    "build": "tsc && npm link",
-    "clean": "rimraf lib node_modules tsconfig.tsbuildinfo"
+    "clean": "rimraf lib node_modules tsconfig.tsbuildinfo",
+    "install:local": "npm link"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib"
-  }
+  },
+  "references": [{ "path": "../lib-synth" }]
 }

--- a/packages/lib-synth/package.json
+++ b/packages/lib-synth/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "api:update": "api-extractor run --local",
-    "build": "tsc",
     "clean": "rimraf lib node_modules tsconfig.tsbuildinfo"
   },
   "types": "lib/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Switch out npm workspace build with tsc --build packages/*
See https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript

The build scripts in individual packages is no longer needed so those have been removed

Also added a watch script and a bit of other housekeeping in the root package.json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
