### PR TITLE
dont add workspace entry for new packages

### DIFF
--- a/scripts/copy_construct_template.ts
+++ b/scripts/copy_construct_template.ts
@@ -25,12 +25,6 @@ const main = async () => {
     libName
   );
   await fs.writeFile(packageJsonPath, newPackageJson);
-
-  // add an entry to the root package.json workspaces
-  const rootPackageJsonPath = path.resolve(__dirname, '..', 'package.json');
-  const rootPackageJson = await fs.readJSON(rootPackageJsonPath);
-  rootPackageJson.workspaces.unshift(`packages/${libName}`);
-  await fs.writeJSON(rootPackageJsonPath, rootPackageJson, { spaces: 2 });
 };
 
 main().catch((err) => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now that we're using tsc to build packages in dependency order, we no longer need workspace entries for each package in the root package json file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
