### PR TITLE
remove --global from npm registry config

### DIFF
--- a/scripts/start_npm_proxy.ts
+++ b/scripts/start_npm_proxy.ts
@@ -41,7 +41,7 @@ const main = async () => {
 
   console.log(`Local npm proxy running at ${EXPECTED_URL}.`);
 
-  execa('npm', ['config', 'set', 'registry', EXPECTED_URL, '--global']);
+  execa('npm', ['config', 'set', 'registry', EXPECTED_URL]);
   console.log(`Set npm registry to ${EXPECTED_URL}`);
 };
 

--- a/scripts/stop_npm_proxy.ts
+++ b/scripts/stop_npm_proxy.ts
@@ -15,7 +15,7 @@ const main = async () => {
   const pid = Number.parseInt(lsofResult.stdout.toString());
   process.kill(pid);
 
-  await execa('npm', ['config', 'set', 'registry', NPM_REGISTRY, '--global']);
+  await execa('npm', ['config', 'set', 'registry', NPM_REGISTRY]);
 };
 
 main().catch((err) => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Including --global in these scripts only sets the registry for global installs. Instead, we want the local proxy to support local installs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
