### PR TITLE
fix storage dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9880,10 +9880,12 @@
     "packages/storage-factory": {
       "name": "@aws-amplify/storage-factory",
       "version": "0.1.0",
+      "dependencies": {
+        "@aws-amplify/storage-construct": "^0.1.0"
+      },
       "devDependencies": {
         "@aws-amplify/backend-engine": "^0.1.0",
         "@aws-amplify/plugin-types": "^0.1.0",
-        "@aws-amplify/storage-construct": "^0.1.0",
         "aws-cdk-lib": "^2.72.0",
         "constructs": "^10.0.0"
       },

--- a/packages/storage-factory/package.json
+++ b/packages/storage-factory/package.json
@@ -7,10 +7,12 @@
   "scripts": {
     "api:update": "api-extractor run --local"
   },
+  "dependencies": {
+    "@aws-amplify/storage-construct": "^0.1.0"
+  },
   "devDependencies": {
     "@aws-amplify/backend-engine": "^0.1.0",
     "@aws-amplify/plugin-types": "^0.1.0",
-    "@aws-amplify/storage-construct": "^0.1.0",
     "aws-cdk-lib": "^2.72.0",
     "constructs": "^10.0.0"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
storage-construct needs to be a runtime dependency of storage-factory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
