### PR TITLE
require node 18.16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "git+https://github.com/aws-amplify/cli.git"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.16.0"
   },
   "author": "AWS Amplify",
   "license": "Apache-2.0",


### PR DESCRIPTION
*Issue #, if available:*

Integration tests run twice and fail on second attempt due to https://github.com/nodejs/node/issues/46887 .
This has been fixed in Node 18.16.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
