### PR TITLE
update generic type on data factory

### DIFF
--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -4,8 +4,8 @@
 
 ```ts
 
+import { AmplifyGraphqlApi } from 'agqlac';
 import { AmplifyGraphqlApiProps } from 'agqlac';
-import { Construct } from 'constructs';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
 
@@ -13,9 +13,9 @@ import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
 export const Data: typeof DataFactory;
 
 // @public
-export class DataFactory implements ConstructFactory<Construct> {
+export class DataFactory implements ConstructFactory<AmplifyGraphqlApi> {
     constructor(props: DataProps);
-    getInstance({ constructContainer, outputStorageStrategy, importPathVerifier, }: ConstructFactoryGetInstanceProps): Construct;
+    getInstance({ constructContainer, outputStorageStrategy, importPathVerifier, }: ConstructFactoryGetInstanceProps): AmplifyGraphqlApi;
 }
 
 // @public (undocumented)

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -19,7 +19,7 @@ export type DataProps = Pick<AmplifyGraphqlApiProps, 'schema'>;
 /**
  * Singleton factory for AmplifyGraphqlApi constructs that can be used in Amplify project files
  */
-export class DataFactory implements ConstructFactory<Construct> {
+export class DataFactory implements ConstructFactory<AmplifyGraphqlApi> {
   private generator: ConstructContainerEntryGenerator;
   private readonly importStack: string | undefined;
 
@@ -37,7 +37,7 @@ export class DataFactory implements ConstructFactory<Construct> {
     constructContainer,
     outputStorageStrategy,
     importPathVerifier,
-  }: ConstructFactoryGetInstanceProps): Construct {
+  }: ConstructFactoryGetInstanceProps): AmplifyGraphqlApi {
     importPathVerifier?.verify(
       this.importStack,
       'data',
@@ -56,7 +56,7 @@ export class DataFactory implements ConstructFactory<Construct> {
         outputStorageStrategy
       );
     }
-    return constructContainer.getOrCompute(this.generator);
+    return constructContainer.getOrCompute(this.generator) as AmplifyGraphqlApi;
   }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates the getInstance return type on the data factory to be the specific construct type. This allows type inferences of backend resources to work properly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
