### PR TITLE
fix: depandabot alerts by upgrading available packages

### DIFF
--- a/examples/simple_react/frontend/package-lock.json
+++ b/examples/simple_react/frontend/package-lock.json
@@ -98,14 +98,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/eslint-parser": {
       "version": "7.21.8",
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.8.tgz",
@@ -129,14 +121,6 @@
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -193,14 +177,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.21.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.8.tgz",
@@ -223,14 +199,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.21.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.8.tgz",
@@ -247,14 +215,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
@@ -269,14 +229,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0-0"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -1531,14 +1483,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz",
@@ -1743,14 +1687,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -5035,14 +4971,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
@@ -7047,14 +6975,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/eslint-plugin-jest": {
       "version": "25.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz",
@@ -7105,14 +7025,6 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-jsx-a11y/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -7179,14 +7091,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -9263,14 +9167,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -11647,14 +11543,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/makeerror": {
@@ -14751,9 +14639,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },

--- a/examples/simple_react/frontend/package.json
+++ b/examples/simple_react/frontend/package.json
@@ -18,7 +18,8 @@
     "web-vitals": "^2.1.4"
   },
   "overrides": {
-    "nth-check": "^2.0.1"
+    "nth-check": "^2.0.1",
+    "semver": "7.5.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@changesets/cli": "^2.26.1",
+        "@changesets/cli": "^2.26.2",
         "@microsoft/api-extractor": "^7.34.4",
         "@types/fs-extra": "^11.0.1",
         "@types/node": "^18.15.11",
@@ -1495,12 +1495,13 @@
       "license": "MIT"
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "6.1.3",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.4.tgz",
+      "integrity": "sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@changesets/config": "^2.3.0",
+        "@changesets/config": "^2.3.1",
         "@changesets/get-version-range-type": "^0.3.2",
         "@changesets/git": "^2.0.0",
         "@changesets/types": "^5.2.1",
@@ -1511,13 +1512,14 @@
         "outdent": "^0.5.0",
         "prettier": "^2.7.1",
         "resolve-from": "^5.0.0",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
       }
     },
     "node_modules/@changesets/apply-release-plan/node_modules/fs-extra": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -1529,31 +1531,34 @@
     },
     "node_modules/@changesets/apply-release-plan/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@changesets/apply-release-plan/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "5.2.3",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.4.tgz",
+      "integrity": "sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.5",
+        "@changesets/get-dependents-graph": "^1.3.6",
         "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
       }
     },
     "node_modules/@changesets/changelog-git": {
@@ -1565,18 +1570,19 @@
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.26.1",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.2.tgz",
+      "integrity": "sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@changesets/apply-release-plan": "^6.1.3",
-        "@changesets/assemble-release-plan": "^5.2.3",
+        "@changesets/apply-release-plan": "^6.1.4",
+        "@changesets/assemble-release-plan": "^5.2.4",
         "@changesets/changelog-git": "^0.1.14",
-        "@changesets/config": "^2.3.0",
+        "@changesets/config": "^2.3.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.5",
-        "@changesets/get-release-plan": "^3.0.16",
+        "@changesets/get-dependents-graph": "^1.3.6",
+        "@changesets/get-release-plan": "^3.0.17",
         "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
         "@changesets/pre": "^1.0.14",
@@ -1585,7 +1591,7 @@
         "@changesets/write": "^0.2.3",
         "@manypkg/get-packages": "^1.1.3",
         "@types/is-ci": "^3.0.0",
-        "@types/semver": "^6.0.0",
+        "@types/semver": "^7.5.0",
         "ansi-colors": "^4.1.3",
         "chalk": "^2.1.0",
         "enquirer": "^2.3.0",
@@ -1598,7 +1604,7 @@
         "p-limit": "^2.2.0",
         "preferred-pm": "^3.0.0",
         "resolve-from": "^5.0.0",
-        "semver": "^5.4.1",
+        "semver": "^7.5.3",
         "spawndamnit": "^2.0.0",
         "term-size": "^2.1.0",
         "tty-table": "^4.1.5"
@@ -1637,12 +1643,13 @@
       }
     },
     "node_modules/@changesets/config": {
-      "version": "2.3.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.1.tgz",
+      "integrity": "sha512-PQXaJl82CfIXddUOppj4zWu+987GCw2M+eQcOepxN5s+kvnsZOwjEJO3DH9eVy+OP6Pg/KFEWdsECFEYTtbg6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.5",
+        "@changesets/get-dependents-graph": "^1.3.6",
         "@changesets/logger": "^0.0.5",
         "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
@@ -1652,8 +1659,9 @@
     },
     "node_modules/@changesets/config/node_modules/fs-extra": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -1665,44 +1673,49 @@
     },
     "node_modules/@changesets/config/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@changesets/config/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/@changesets/errors": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.1.4.tgz",
+      "integrity": "sha512-HAcqPF7snsUJ/QzkWoKfRfXushHTu+K5KZLJWPb34s4eCZShIf8BFO3fwq6KU8+G7L5KdtN2BzQAXOSXEyiY9Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "extendable-error": "^0.1.5"
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
-      "version": "1.3.5",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.6.tgz",
+      "integrity": "sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
       }
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/fs-extra": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -1714,28 +1727,31 @@
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@changesets/get-dependents-graph/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/@changesets/get-release-plan": {
-      "version": "3.0.16",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.17.tgz",
+      "integrity": "sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@changesets/assemble-release-plan": "^5.2.3",
-        "@changesets/config": "^2.3.0",
+        "@changesets/assemble-release-plan": "^5.2.4",
+        "@changesets/config": "^2.3.1",
         "@changesets/pre": "^1.0.14",
         "@changesets/read": "^0.5.9",
         "@changesets/types": "^5.2.1",
@@ -1744,13 +1760,15 @@
     },
     "node_modules/@changesets/get-version-range-type": {
       "version": "0.3.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.3.2.tgz",
+      "integrity": "sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==",
+      "dev": true
     },
     "node_modules/@changesets/git": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
+      "integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
@@ -1763,16 +1781,18 @@
     },
     "node_modules/@changesets/logger": {
       "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.0.5.tgz",
+      "integrity": "sha512-gJyZHomu8nASHpaANzc6bkQMO9gU/ib20lqew1rVx753FOxffnCrJlGIeQVxNWCqM+o6OOleCo/ivL8UAO5iFw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^2.1.0"
       }
     },
     "node_modules/@changesets/parse": {
       "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
+      "integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@changesets/types": "^5.2.1",
         "js-yaml": "^3.13.1"
@@ -1780,8 +1800,9 @@
     },
     "node_modules/@changesets/pre": {
       "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
+      "integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
@@ -1792,8 +1813,9 @@
     },
     "node_modules/@changesets/pre/node_modules/fs-extra": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -1805,24 +1827,27 @@
     },
     "node_modules/@changesets/pre/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@changesets/pre/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/@changesets/read": {
       "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
+      "integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@changesets/git": "^2.0.0",
@@ -1836,8 +1861,9 @@
     },
     "node_modules/@changesets/read/node_modules/fs-extra": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -1849,16 +1875,18 @@
     },
     "node_modules/@changesets/read/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@changesets/read/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -2135,8 +2163,9 @@
     },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "@types/node": "^12.7.1",
@@ -2146,13 +2175,15 @@
     },
     "node_modules/@manypkg/find-root/node_modules/@types/node": {
       "version": "12.20.55",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true
     },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -2164,24 +2195,27 @@
     },
     "node_modules/@manypkg/find-root/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@manypkg/find-root/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/@manypkg/get-packages": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "@changesets/types": "^4.0.1",
@@ -2193,13 +2227,15 @@
     },
     "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
       "version": "4.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+      "dev": true
     },
     "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -2211,16 +2247,18 @@
     },
     "node_modules/@manypkg/get-packages/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@manypkg/get-packages/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -2259,8 +2297,9 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2270,8 +2309,9 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
       "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2426,8 +2466,9 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2437,8 +2478,9 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/semver": {
       "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2569,9 +2611,10 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "6.2.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -2617,31 +2660,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2750,31 +2768,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.60.1",
       "dev": true,
@@ -2798,36 +2791,6 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@types/semver": {
-      "version": "7.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -2941,8 +2904,9 @@
     },
     "node_modules/@verdaccio/core/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2952,8 +2916,9 @@
     },
     "node_modules/@verdaccio/core/node_modules/semver": {
       "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3202,8 +3167,9 @@
     },
     "node_modules/@verdaccio/utils/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3213,8 +3179,9 @@
     },
     "node_modules/@verdaccio/utils/node_modules/semver": {
       "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3565,7 +3532,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.68.0",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.80.0.tgz",
+      "integrity": "sha512-PoqD3Yms5I0ajuTi071nTW/hpkH3XsdyZzn5gYsPv0qD7mqP3h6Qr+6RiGx+yQ1KcVFyxWdX15uK+DsC0KwvcQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -3575,22 +3544,23 @@
         "minimatch",
         "punycode",
         "semver",
+        "table",
         "yaml"
       ],
-      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.97",
+        "@aws-cdk/asset-awscli-v1": "^2.2.177",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^9.1.0",
+        "fs-extra": "^11.1.1",
         "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
-        "semver": "^7.3.8",
+        "semver": "^7.5.1",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -3606,13 +3576,53 @@
       "license": "Apache-2.0",
       "peer": true
     },
-    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.12.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
@@ -3640,29 +3650,58 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
+      "version": "11.1.1",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
+      "version": "4.2.11",
       "inBundle": true,
       "license": "ISC",
       "peer": true
@@ -3675,6 +3714,21 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
@@ -3696,6 +3750,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3730,8 +3790,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.8",
+      "version": "7.5.1",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -3745,6 +3814,65 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.1",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
       "inBundle": true,
@@ -3752,6 +3880,15 @@
       "peer": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
@@ -3821,8 +3958,9 @@
     },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-windows": "^1.0.0"
       },
@@ -4687,8 +4825,9 @@
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5131,8 +5270,9 @@
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -5169,31 +5309,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-plugin-jsdoc/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.5.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "46.0.1",
       "dev": true,
@@ -5224,31 +5339,6 @@
       },
       "peerDependencies": {
         "eslint": ">=8.28.0"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.5.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-scope": {
@@ -5695,8 +5785,9 @@
     },
     "node_modules/extendable-error": {
       "version": "0.1.7",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+      "dev": true
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -6868,8 +6959,9 @@
     },
     "node_modules/is-subdir": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "better-path-resolve": "1.0.0"
       },
@@ -6927,8 +7019,9 @@
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7146,31 +7239,6 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.5.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jsprim": {
@@ -7488,8 +7556,9 @@
     },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true
     },
     "node_modules/log-update": {
       "version": "4.0.0",
@@ -7645,8 +7714,9 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8018,6 +8088,15 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
@@ -8196,13 +8275,15 @@
     },
     "node_modules/outdent": {
       "version": "0.5.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+      "dev": true
     },
     "node_modules/p-filter": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-map": "^2.0.0"
       },
@@ -8212,8 +8293,9 @@
     },
     "node_modules/p-filter/node_modules/p-map": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8595,8 +8677,9 @@
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -8727,8 +8810,9 @@
     },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.5",
         "js-yaml": "^3.6.1",
@@ -8896,8 +8980,9 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -9045,11 +9130,30 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "5.7.1",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
-      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -9373,8 +9477,9 @@
     },
     "node_modules/spawndamnit": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
+      "integrity": "sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -9382,8 +9487,9 @@
     },
     "node_modules/spawndamnit/node_modules/cross-spawn": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -9392,8 +9498,9 @@
     },
     "node_modules/spawndamnit/node_modules/lru-cache": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -9401,8 +9508,9 @@
     },
     "node_modules/spawndamnit/node_modules/shebang-command": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -9412,16 +9520,18 @@
     },
     "node_modules/spawndamnit/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/spawndamnit/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -9431,8 +9541,9 @@
     },
     "node_modules/spawndamnit/node_modules/yallist": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
@@ -10490,8 +10601,9 @@
     },
     "node_modules/verdaccio/node_modules/semver": {
       "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10504,8 +10616,9 @@
     },
     "node_modules/verdaccio/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10775,8 +10888,9 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.3.1",
@@ -10910,7 +11024,7 @@
         "@aws-amplify/plugin-types": "^0.1.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "~2.68.0",
+        "aws-cdk-lib": "~2.80.0",
         "constructs": "^10.0.0"
       }
     },
@@ -10924,7 +11038,7 @@
         "@aws-amplify/plugin-types": "^0.1.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "~2.68.0",
+        "aws-cdk-lib": "~2.80.0",
         "constructs": "^10.0.0"
       }
     },
@@ -10939,7 +11053,7 @@
         "@aws-amplify/plugin-types": "^0.1.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "~2.68.0",
+        "aws-cdk-lib": "~2.80.0",
         "constructs": "^10.0.0"
       }
     },
@@ -10955,7 +11069,7 @@
         "@aws-amplify/plugin-types": "^0.1.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "~2.68.0",
+        "aws-cdk-lib": "~2.80.0",
         "constructs": "^10.0.0"
       }
     },
@@ -10974,7 +11088,7 @@
         "@aws-sdk/client-cloudformation": "^3.352.0",
         "@aws-sdk/client-ssm": "^3.352.0",
         "@aws-sdk/types": "^3.347.0",
-        "aws-cdk-lib": "~2.68.0",
+        "aws-cdk-lib": "~2.80.0",
         "constructs": "^10.0.0"
       }
     },
@@ -10999,7 +11113,7 @@
         "@aws-amplify/plugin-types": "^0.1.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "~2.68.0",
+        "aws-cdk-lib": "~2.80.0",
         "constructs": "^10.0.0"
       }
     },
@@ -11140,7 +11254,7 @@
       "name": "@aws-amplify/plugin-types",
       "version": "0.1.0",
       "peerDependencies": {
-        "aws-cdk-lib": "~2.68.0",
+        "aws-cdk-lib": "~2.80.0",
         "constructs": "^10.0.0"
       }
     },
@@ -11165,7 +11279,7 @@
         "@aws-amplify/plugin-types": "^0.1.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "~2.68.0",
+        "aws-cdk-lib": "~2.80.0",
         "constructs": "^10.0.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/aws-amplify/cli#readme",
   "devDependencies": {
-    "@changesets/cli": "^2.26.1",
+    "@changesets/cli": "^2.26.2",
     "@microsoft/api-extractor": "^7.34.4",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.15.11",

--- a/packages/auth-construct/package.json
+++ b/packages/auth-construct/package.json
@@ -14,7 +14,7 @@
     "@aws-amplify/plugin-types": "^0.1.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   },
   "imports": {

--- a/packages/backend-auth/package.json
+++ b/packages/backend-auth/package.json
@@ -15,7 +15,7 @@
     "@aws-amplify/plugin-types": "^0.1.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -12,7 +12,7 @@
     "@aws-amplify/plugin-types": "^0.1.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   },
   "files": [

--- a/packages/backend-engine/package.json
+++ b/packages/backend-engine/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-cloudformation": "^3.352.0",
     "@aws-sdk/client-ssm": "^3.352.0",
     "@aws-sdk/types": "^3.347.0",
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   },
   "exports": {

--- a/packages/backend-storage/package.json
+++ b/packages/backend-storage/package.json
@@ -15,7 +15,7 @@
     "@aws-amplify/plugin-types": "^0.1.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,7 +14,7 @@
     "@aws-amplify/plugin-types": "^0.1.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/integration-tests/test-projects/auth-and-storage/expected-cdk-out/testProject-testEnvironment.assets.json
+++ b/packages/integration-tests/test-projects/auth-and-storage/expected-cdk-out/testProject-testEnvironment.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "30.1.0",
+  "version": "31.0.0",
   "files": {
     "14f453302310e8bb66b03b6fd318b25c5cbaa317a5b93b9f7686110ebabf1ae8": {
       "source": {

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -7,7 +7,7 @@
     "update:api": "api-extractor run --local"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   },
   "imports": {

--- a/packages/storage-construct/package.json
+++ b/packages/storage-construct/package.json
@@ -14,7 +14,7 @@
     "@aws-amplify/plugin-types": "^0.1.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   },
   "imports": {

--- a/templates/construct/package.json
+++ b/templates/construct/package.json
@@ -8,11 +8,11 @@
     "update:api": "api-extractor run --local"
   },
   "devDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.0"
   },
   "files": [


### PR DESCRIPTION
fix: depandabot alerts by upgrading available packages with security patches

*Issue #, if available:*
1. https://github.com/aws-amplify/samsara-cli/security/dependabot/7
2. https://github.com/aws-amplify/samsara-cli/security/dependabot/8
3. https://github.com/aws-amplify/samsara-cli/security/dependabot/9
4. https://github.com/aws-amplify/samsara-cli/security/dependabot/10


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
