### PR TITLE
add no-console rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
   "plugins": ["@typescript-eslint", "unicorn", "jsdoc", "import"],
   "rules": {
     "@typescript-eslint/switch-exhaustiveness-check": "error",
+    "no-console": "error",
     "no-duplicate-imports": "error",
     "import/no-extraneous-dependencies": "error",
     "unicorn/filename-case": [

--- a/packages/sandbox/.eslintrc.json
+++ b/packages/sandbox/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/scripts/.eslintrc.json
+++ b/scripts/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "off"
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Adds global `no-console` rule, see https://eslint.org/docs/latest/rules/no-console .
2. Adds 2 exceptions:
  - scripts folder, we don't ship that anywhere
  - sandbox, usage of console.log seems to be legit and should be grandfathered until we find better way.
  
To customize rules per package I'm using hierarchical property of eslint config. I.e. nested `.eslintrc` files are merged with top level and nested settings win on conflicts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
