### PR TITLE
chore: Add --name option to sandbox commands to override the sandbox appname

### DIFF
--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -47,10 +47,21 @@ describe('sandbox command', () => {
   it('starts sandbox without any additional flags', async () => {
     await commandRunner.runCommand('sandbox');
     assert.equal(sandboxStartMock.mock.callCount(), 1);
+    assert.ok(!sandboxStartMock.mock.calls[0].arguments[0].name);
+  });
+
+  it('starts sandbox with user provided app name', async () => {
+    await commandRunner.runCommand('sandbox --name user-app-name');
+    assert.equal(sandboxStartMock.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      sandboxStartMock.mock.calls[0].arguments[0].name,
+      'user-app-name'
+    );
   });
 
   it('shows available options in help output', async () => {
     const output = await commandRunner.runCommand('sandbox --help');
+    assert.match(output, /--name/);
     assert.match(output, /--dirToWatch/);
     assert.match(output, /--exclude/);
   });

--- a/packages/cli/src/commands/sandbox/sandbox_delete/sandbox_delete_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_delete/sandbox_delete_command.test.ts
@@ -39,6 +39,21 @@ describe('sandbox delete command', () => {
     await commandRunner.runCommand('sandbox delete');
 
     assert.equal(sandboxDeleteMock.mock.callCount(), 1);
+    assert.deepStrictEqual(sandboxDeleteMock.mock.calls[0].arguments[0], {
+      name: undefined,
+    });
+  });
+
+  it('deletes sandbox with user provided name', async (contextual) => {
+    contextual.mock.method(AmplifyPrompter, 'yesOrNo', () =>
+      Promise.resolve(true)
+    );
+    await commandRunner.runCommand('sandbox delete --name test-App-Name');
+
+    assert.equal(sandboxDeleteMock.mock.callCount(), 1);
+    assert.deepStrictEqual(sandboxDeleteMock.mock.calls[0].arguments[0], {
+      name: 'test-App-Name',
+    });
   });
 
   it('does not delete sandbox if user said no', async (contextual) => {
@@ -58,6 +73,7 @@ describe('sandbox delete command', () => {
   it('shows available options in help output', async () => {
     const output = await commandRunner.runCommand('sandbox delete --help');
     assert.match(output, /--yes/);
+    assert.match(output, /--name/);
     assert.doesNotMatch(output, /--exclude/);
     assert.doesNotMatch(output, /--dirToWatch/);
   });

--- a/packages/cli/src/commands/sandbox/sandbox_delete/sandbox_delete_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_delete/sandbox_delete_command.ts
@@ -41,7 +41,9 @@ export class SandboxDeleteCommand
     }
 
     if (isConfirmed) {
-      await (await this.sandboxFactory.getInstance()).delete();
+      await (
+        await this.sandboxFactory.getInstance()
+      ).delete({ name: args.name });
     }
   };
 
@@ -58,6 +60,12 @@ export class SandboxDeleteCommand
           array: false,
           alias: 'y',
         })
+        .option('name', {
+          describe:
+            'An optional name to distinguish between different sandbox environments. Default is the name in your package.json',
+          type: 'string',
+          array: false,
+        })
         // kinda hack to "hide" the parent command options from getting displayed in the help
         .option('exclude', {
           hidden: true,
@@ -71,6 +79,14 @@ export class SandboxDeleteCommand
               `--dirToWatch or --exclude are not valid options for delete`
             );
           }
+          if (argv.name) {
+            const projectNameRegex = /^[a-zA-Z0-9-]{1,15}$/;
+            if (!argv.name.match(projectNameRegex)) {
+              throw new Error(
+                `--name should match [a-zA-Z0-9-] and less than 15 characters.`
+              );
+            }
+          }
           return true;
         })
     );
@@ -79,4 +95,5 @@ export class SandboxDeleteCommand
 
 export type SandboxDeleteCommandOptions = {
   yes?: boolean;
+  name?: string;
 };

--- a/packages/sandbox/API.md
+++ b/packages/sandbox/API.md
@@ -8,13 +8,19 @@
 export type Sandbox = {
     start(options: SandboxOptions): Promise<void>;
     stop(): Promise<void>;
-    delete(): Promise<void>;
+    delete(options: SandboxDeleteOptions): Promise<void>;
+};
+
+// @public (undocumented)
+export type SandboxDeleteOptions = {
+    name?: string;
 };
 
 // @public (undocumented)
 export type SandboxOptions = {
     dir?: string;
     exclude?: string[];
+    name?: string;
 };
 
 // @public

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -16,10 +16,15 @@ export type Sandbox = {
   /**
    * Deletes this environment
    */
-  delete(): Promise<void>;
+  delete(options: SandboxDeleteOptions): Promise<void>;
 };
 
 export type SandboxOptions = {
   dir?: string;
   exclude?: string[];
+  name?: string;
+};
+
+export type SandboxDeleteOptions = {
+  name?: string;
 };


### PR DESCRIPTION
*Issue #* 
fix https://github.com/aws-amplify/samsara-cli/issues/109

*Description of changes:*

Add `--name` flag to both sandbox start and delete commands which overrides the default `LocalProjectNameResolver`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
