### PR TITLE
chore: add data store to example

### DIFF
--- a/examples/simple_react/amplify/backend.ts
+++ b/examples/simple_react/amplify/backend.ts
@@ -1,6 +1,8 @@
 import { Backend } from '@aws-amplify/backend';
 import { auth } from './auth.js';
+import { data } from './data.js';
 
 new Backend({
   auth,
+  data,
 });

--- a/examples/simple_react/amplify/data.ts
+++ b/examples/simple_react/amplify/data.ts
@@ -1,0 +1,11 @@
+import { Data } from '@aws-amplify/backend-graphql';
+
+const schema = `
+  type Todo @model @auth(rules: [{ allow: private }]) {
+    id: ID!
+    name: String!
+    description: String
+  }
+`;
+
+export const data = new Data({ schema });

--- a/examples/simple_react/package-lock.json
+++ b/examples/simple_react/package-lock.json
@@ -21,10 +21,12 @@
       "devDependencies": {
         "@aws-amplify/backend": "file:../../packages/backend",
         "@aws-amplify/backend-auth": "file:../../packages/backend-auth",
+        "@aws-amplify/backend-graphql": "file:../../packages/backend-graphql",
         "@aws-amplify/cli": "file:../../packages/cli"
       }
     },
     "../../packages/backend": {
+      "name": "@aws-amplify/backend",
       "version": "0.1.0",
       "dev": true,
       "dependencies": {
@@ -39,6 +41,7 @@
       }
     },
     "../../packages/backend-auth": {
+      "name": "@aws-amplify/backend-auth",
       "version": "0.1.0",
       "dev": true,
       "dependencies": {
@@ -53,7 +56,24 @@
         "constructs": "^10.0.0"
       }
     },
+    "../../packages/backend-graphql": {
+      "version": "0.1.0",
+      "dev": true,
+      "dependencies": {
+        "@aws-amplify/backend-output-schemas": "^0.1.0",
+        "@aws-amplify/graphql-construct-alpha": "^0.3.1"
+      },
+      "devDependencies": {
+        "@aws-amplify/backend": "^0.1.0",
+        "@aws-amplify/plugin-types": "^0.1.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "~2.80.0",
+        "constructs": "^10.0.0"
+      }
+    },
     "../../packages/cli": {
+      "name": "@aws-amplify/cli",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -236,6 +256,10 @@
     },
     "node_modules/@aws-amplify/backend-auth": {
       "resolved": "../../packages/backend-auth",
+      "link": true
+    },
+    "node_modules/@aws-amplify/backend-graphql": {
+      "resolved": "../../packages/backend-graphql",
       "link": true
     },
     "node_modules/@aws-amplify/cache": {

--- a/examples/simple_react/package.json
+++ b/examples/simple_react/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@aws-amplify/backend": "file:../../packages/backend",
     "@aws-amplify/backend-auth": "file:../../packages/backend-auth",
+    "@aws-amplify/backend-graphql": "file:../../packages/backend-graphql",
     "@aws-amplify/cli": "file:../../packages/cli"
   },
   "scripts": {

--- a/examples/simple_react/src/App.js
+++ b/examples/simple_react/src/App.js
@@ -1,20 +1,80 @@
-import React from 'react';
-import { Amplify } from 'aws-amplify';
+import React, { useEffect, useState } from 'react';
+import { Amplify, DataStore } from 'aws-amplify';
 import { withAuthenticator, Button, Heading } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
+import { Todo } from './models';
 
 import amplifyConfiguration from './amplifyconfiguration.json';
 
 Amplify.configure(amplifyConfiguration);
 
+const initialState = { name: '', description: '' };
+
 function App({ signOut, user }) {
+  const [formState, setFormState] = useState(initialState);
+  const [todos, setTodos] = useState([]);
+  useEffect(() => {
+    fetchTodos();
+  }, []);
+
+  function setInput(key, value) {
+    setFormState({ ...formState, [key]: value });
+  }
+
+  async function fetchTodos() {
+    try {
+      const todos = await DataStore.query(Todo);
+      setTodos(todos);
+    } catch (err) {
+      console.log('error fetching todos');
+      console.log(err);
+    }
+  }
+
+  async function addTodo() {
+    try {
+      if (!formState.name || !formState.description) return;
+      const todo = { ...formState };
+      setTodos([...todos, todo]);
+      setFormState(initialState);
+      await DataStore.save(
+        new Todo({
+          ...todo,
+        })
+      );
+    } catch (err) {
+      console.log('error creating todo:', err);
+    }
+  }
+
   return (
     <div style={styles.container}>
       <Heading level={1}>Hello {user.username}</Heading>
       <Button onClick={signOut} style={styles.button}>
         Sign out
       </Button>
-      <h2>Amplify App</h2>
+      <h2>Amplify Todos</h2>
+      <input
+        onChange={(event) => setInput('name', event.target.value)}
+        style={styles.input}
+        value={formState.name}
+        placeholder="Name"
+      />
+      <input
+        onChange={(event) => setInput('description', event.target.value)}
+        style={styles.input}
+        value={formState.description}
+        placeholder="Description"
+      />
+      <button style={styles.button} onClick={addTodo}>
+        Create Todo
+      </button>
+      {todos.map((todo, index) => (
+        <div key={todo.id ? todo.id : index} style={styles.todo}>
+          <p style={styles.todoName}>{todo.name}</p>
+          <p style={styles.todoDescription}>{todo.description}</p>
+        </div>
+      ))}
     </div>
   );
 }

--- a/examples/simple_react/src/models/index.d.ts
+++ b/examples/simple_react/src/models/index.d.ts
@@ -1,0 +1,43 @@
+import {
+  ModelInit,
+  MutableModel,
+  __modelMeta__,
+  ManagedIdentifier,
+} from '@aws-amplify/datastore';
+// @ts-ignore
+import { LazyLoading, LazyLoadingDisabled } from '@aws-amplify/datastore';
+
+type EagerTodo = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Todo, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+};
+
+type LazyTodo = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Todo, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+};
+
+export declare type Todo = LazyLoading extends LazyLoadingDisabled
+  ? EagerTodo
+  : LazyTodo;
+
+export declare const Todo: (new (init: ModelInit<Todo>) => Todo) & {
+  copyOf(
+    source: Todo,
+    mutator: (draft: MutableModel<Todo>) => MutableModel<Todo> | void
+  ): Todo;
+};

--- a/examples/simple_react/src/models/index.js
+++ b/examples/simple_react/src/models/index.js
@@ -1,0 +1,7 @@
+// @ts-check
+import { initSchema } from '@aws-amplify/datastore';
+import { schema } from './schema';
+
+const { Todo } = initSchema(schema);
+
+export { Todo };

--- a/examples/simple_react/src/models/schema.d.ts
+++ b/examples/simple_react/src/models/schema.d.ts
@@ -1,0 +1,3 @@
+import { Schema } from '@aws-amplify/datastore';
+
+export declare const schema: Schema;

--- a/examples/simple_react/src/models/schema.js
+++ b/examples/simple_react/src/models/schema.js
@@ -1,0 +1,58 @@
+export const schema = {
+  models: {
+    Todo: {
+      name: 'Todo',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        name: {
+          name: 'name',
+          isArray: false,
+          type: 'String',
+          isRequired: true,
+          attributes: [],
+        },
+        description: {
+          name: 'description',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'Todos',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+      ],
+    },
+  },
+  enums: {},
+  nonModels: {},
+  codegenVersion: '3.4.4',
+  version: '4401034582a70c60713e1f7f9da3b752',
+};

--- a/packages/backend-graphql/src/factory.ts
+++ b/packages/backend-graphql/src/factory.ts
@@ -110,6 +110,10 @@ class DataGenerator implements ConstructContainerEntryGenerator {
         dataConstruct.resources.cfnApiKey?.attrApiKey;
     }
 
+    if (authConfig.defaultAuthMode) {
+      dataOutput.payload.authenticationType = authConfig.defaultAuthMode;
+    }
+
     this.outputStorageStrategy.addBackendOutputEntry(dataOutputKey, dataOutput);
     return dataConstruct;
   }

--- a/packages/backend-output-schemas/API.md
+++ b/packages/backend-output-schemas/API.md
@@ -88,24 +88,29 @@ export const unifiedBackendOutputSchema: z.ZodObject<{
         payload: z.ZodObject<{
             appSyncApiEndpoint: z.ZodString;
             appSyncApiKey: z.ZodOptional<z.ZodString>;
+            authenticationType: z.ZodOptional<z.ZodString>;
         }, "strip", z.ZodTypeAny, {
             appSyncApiEndpoint: string;
             appSyncApiKey?: string | undefined;
+            authenticationType?: string | undefined;
         }, {
             appSyncApiEndpoint: string;
             appSyncApiKey?: string | undefined;
+            authenticationType?: string | undefined;
         }>;
     }, "strip", z.ZodTypeAny, {
         version: "1";
         payload: {
             appSyncApiEndpoint: string;
             appSyncApiKey?: string | undefined;
+            authenticationType?: string | undefined;
         };
     }, {
         version: "1";
         payload: {
             appSyncApiEndpoint: string;
             appSyncApiKey?: string | undefined;
+            authenticationType?: string | undefined;
         };
     }>]>>;
     storageOutput: z.ZodOptional<z.ZodDiscriminatedUnion<"version", [z.ZodObject<{
@@ -147,6 +152,7 @@ export const unifiedBackendOutputSchema: z.ZodObject<{
         payload: {
             appSyncApiEndpoint: string;
             appSyncApiKey?: string | undefined;
+            authenticationType?: string | undefined;
         };
     } | undefined;
     storageOutput?: {
@@ -170,6 +176,7 @@ export const unifiedBackendOutputSchema: z.ZodObject<{
         payload: {
             appSyncApiEndpoint: string;
             appSyncApiKey?: string | undefined;
+            authenticationType?: string | undefined;
         };
     } | undefined;
     storageOutput?: {

--- a/packages/backend-output-schemas/src/data/v1.ts
+++ b/packages/backend-output-schemas/src/data/v1.ts
@@ -5,5 +5,6 @@ export const dataOutputSchema = z.object({
   payload: z.object({
     appSyncApiEndpoint: z.string(),
     appSyncApiKey: z.string().optional(),
+    authenticationType: z.string().optional(),
   }),
 });

--- a/packages/client-config/src/client-config-contributor/data_client_config_contributor.test.ts
+++ b/packages/client-config/src/client-config-contributor/data_client_config_contributor.test.ts
@@ -29,12 +29,14 @@ describe('DataClientConfigContributor', () => {
           payload: {
             appSyncApiEndpoint: 'testApiEndpoint',
             appSyncApiKey: 'testApiKey',
+            authenticationType: 'testAuthType',
           },
         },
       }),
       {
         aws_appsync_apiKey: 'testApiKey',
         aws_appsync_graphqlEndpoint: 'testApiEndpoint',
+        aws_appsync_authenticationType: 'testAuthType',
       }
     );
   });

--- a/packages/client-config/src/client-config-contributor/data_client_config_contributor.ts
+++ b/packages/client-config/src/client-config-contributor/data_client_config_contributor.ts
@@ -18,6 +18,7 @@ export class DataClientConfigContributor implements ClientConfigContributor {
     return {
       aws_appsync_graphqlEndpoint: dataOutput.payload.appSyncApiEndpoint,
       aws_appsync_apiKey: dataOutput.payload.appSyncApiKey,
+      aws_appsync_authenticationType: dataOutput.payload.authenticationType,
     };
   }
 }

--- a/packages/client-config/src/unified_client_config_generator.test.ts
+++ b/packages/client-config/src/unified_client_config_generator.test.ts
@@ -23,6 +23,7 @@ describe('UnifiedClientConfigGenerator', () => {
           version: '1',
           payload: {
             appSyncApiEndpoint: 'testAppSyncEndpoint',
+            authenticationType: 'testAuthType',
           },
         },
       };
@@ -45,6 +46,7 @@ describe('UnifiedClientConfigGenerator', () => {
         aws_user_pools_web_client_id: 'testWebClientId',
         aws_cognito_region: 'testRegion',
         aws_appsync_graphqlEndpoint: 'testAppSyncEndpoint',
+        aws_appsync_authenticationType: 'testAuthType',
       };
       assert.deepStrictEqual(result, expectedClientConfig);
     });

--- a/packages/integration-tests/test-projects/basic-auth-data-storage-function/expected-cdk-out/amplify-testAppName-1234-testBranchName.assets.json
+++ b/packages/integration-tests/test-projects/basic-auth-data-storage-function/expected-cdk-out/amplify-testAppName-1234-testBranchName.assets.json
@@ -261,7 +261,7 @@
         }
       }
     },
-    "78961c55827dea7ca56fd4efb45197dcafb659a2b998e582eed7cd9b3df3a760": {
+    "1c408cbe4c14dc5713ba07a4868366b63f0520b5c95bfecd5c206d070aaa3053": {
       "source": {
         "path": "amplify-testAppName-1234-testBranchName.template.json",
         "packaging": "file"
@@ -269,7 +269,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "78961c55827dea7ca56fd4efb45197dcafb659a2b998e582eed7cd9b3df3a760.json",
+          "objectKey": "1c408cbe4c14dc5713ba07a4868366b63f0520b5c95bfecd5c206d070aaa3053.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/packages/integration-tests/test-projects/basic-auth-data-storage-function/expected-cdk-out/amplify-testAppName-1234-testBranchName.template.json
+++ b/packages/integration-tests/test-projects/basic-auth-data-storage-function/expected-cdk-out/amplify-testAppName-1234-testBranchName.template.json
@@ -19,7 +19,8 @@
    "dataOutput": {
     "version": "1",
     "stackOutputs": [
-     "appSyncApiEndpoint"
+     "appSyncApiEndpoint",
+     "authenticationType"
     ]
    }
   }
@@ -196,6 +197,9 @@
      "Outputs.amplifytestAppName1234testBranchNamedataamplifyDataRootStackGraphQLAPI58B0BABDGraphQLUrl"
     ]
    }
+  },
+  "authenticationType": {
+   "Value": "AMAZON_COGNITO_USER_POOLS"
   }
  },
  "Parameters": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds graphql and DataStore to example:

Note.
`models` are borrowed from classic modelgen output.


Tested locally. works.
<img width="501" alt="image" src="https://github.com/aws-amplify/samsara-cli/assets/5849952/9bc6b765-8f30-4690-8cb5-d0680aa0e941">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
