### PR TITLE
swap eslint builtin import rule for import plugin, fixes type imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,9 +52,10 @@
     ],
     "@typescript-eslint/switch-exhaustiveness-check": "error",
     "no-console": "error",
-    "no-duplicate-imports": "error",
+    "no-duplicate-imports": "off",
     "no-tabs": "error",
     "import/no-extraneous-dependencies": "error",
+    "import/no-duplicates": "error",
     "unicorn/filename-case": [
       "error",
       {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I encountered an issue where I was not able to import something from a package, then import a type from that same package. This change disables ESLint's built-in `no-duplicate-imports` in favor of the import plugin's rule.

```ts
import { Something } from 'a-package'
import type { SomethingType } from 'a-package'
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
