### PR TITLE
use custom github token in changeset PR workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,5 @@ jobs:
         with:
           publish: npm run publish:alpha
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Based on [this issue](https://github.com/changesets/action/issues/99) GitHub actions has a limitation (perhaps a feature to protect against infinite execution) where a github actions workflow cannot cause another workflow to run. This means that our PR workflow does not execute for PRs created as a result of another workflow (eg the changeset version PR)

To work around this, we can use a custom github token in the changeset GH action. This will make GH think someone else created the PR and it will run the PR workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
