### PR TITLE
build: add install:local to @aws-amplify/client-config package

### DIFF
--- a/packages/client-config/package.json
+++ b/packages/client-config/package.json
@@ -14,7 +14,8 @@
   },
   "types": "lib/index.d.ts",
   "scripts": {
-    "update:api": "api-extractor run --local"
+    "update:api": "api-extractor run --local",
+    "install:local": "npm link"
   },
   "dependencies": {
     "@aws-amplify/backend-output-schemas": "^0.1.0",


### PR DESCRIPTION
*Description of changes:*

Add `install:local` script to `@aws-amplify/client-config` package to allow for testing client config without CLI command.

I can make `scripts/generate.js` in my project. Then run `node scripts/generate.js`.

```javascript
import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
import { generateClientConfigToFile } from '@aws-amplify/client-config';

(async () => {
  const credentialProvider = fromNodeProviderChain();
  await generateClientConfigToFile(
    credentialProvider,
    { stackName: 'MyAppStack' },
    'amplifyconfiguration.js'
  );
})();

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
