### PR TITLE
chore: add no-only rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,13 @@
     "sourceType": "module",
     "project": ["tsconfig.base.json"]
   },
-  "plugins": ["@typescript-eslint", "unicorn", "jsdoc", "import"],
+  "plugins": [
+    "@typescript-eslint",
+    "unicorn",
+    "jsdoc",
+    "import",
+    "no-only-tests"
+  ],
   "rules": {
     "@typescript-eslint/naming-convention": [
       "error",
@@ -53,6 +59,7 @@
     "@typescript-eslint/switch-exhaustiveness-check": "error",
     "no-console": "error",
     "no-duplicate-imports": "error",
+    "no-only-tests/no-only-tests": "error",
     "no-tabs": "error",
     "import/no-extraneous-dependencies": "error",
     "unicorn/filename-case": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-config-xo-typescript": "^0.57.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsdoc": "^43.0.6",
+        "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-unicorn": "^46.0.0",
         "execa": "^7.1.1",
         "fs-extra": "^11.1.1",
@@ -7011,7 +7012,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -7117,6 +7119,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7696,7 +7699,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/constructs": {
       "version": "10.2.69",
@@ -8541,6 +8545,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "dev": true,
+      "engines": {
+        "node": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "46.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-46.0.1.tgz",
@@ -9352,6 +9365,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
       "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -9940,6 +9954,7 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -10571,6 +10586,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -11145,6 +11161,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -12008,6 +12025,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12519,6 +12537,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12533,6 +12552,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13905,6 +13925,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -14421,12 +14442,14 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
       "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -14596,7 +14619,7 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.1.0",
+      "version": "0.1.1-alpha.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^0.1.1-alpha.0",
         "execa": "^7.2.0",
@@ -14665,7 +14688,7 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.1.1-alpha.0",
+      "version": "0.2.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.360.0",
@@ -14685,8 +14708,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-amplify/client-config": "^0.1.1-alpha.0",
-        "@aws-amplify/sandbox": "^0.1.1-alpha.0",
+        "@aws-amplify/client-config": "^0.1.1-alpha.1",
+        "@aws-amplify/sandbox": "^0.1.1-alpha.1",
         "@aws-sdk/types": "^3.347.0"
       }
     },
@@ -14792,7 +14815,7 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.1.1-alpha.0",
+      "version": "0.1.1-alpha.1",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.1.1-alpha.0",
         "@aws-sdk/client-amplify": "^3.376.0",
@@ -14806,7 +14829,7 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.1.1-alpha.0",
+      "version": "0.2.0-alpha.1",
       "dependencies": {
         "execa": "^7.2.0"
       },
@@ -14846,10 +14869,10 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.1.1-alpha.0",
+      "version": "0.1.1-alpha.1",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "0.1.0",
-        "@aws-amplify/client-config": "0.1.1-alpha.0",
+        "@aws-amplify/backend-deployer": "0.1.1-alpha.0",
+        "@aws-amplify/client-config": "0.1.1-alpha.1",
         "@aws-sdk/credential-providers": "^3.382.0",
         "@aws-sdk/types": "^3.378.0",
         "@parcel/watcher": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-config-xo-typescript": "^0.57.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^43.0.6",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-unicorn": "^46.0.0",
     "execa": "^7.1.1",
     "fs-extra": "^11.1.1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add no-only rule to prevent `.only` in tests when we merge PRs.

Tested:
![image](https://github.com/aws-amplify/samsara-cli/assets/5849952/f12b86a5-a05d-42e9-b38f-bfb77919ce15)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
