### PR TITLE
fix: isCleanWorkingTree improperly passing test

### DIFF
--- a/scripts/publish_local.ts
+++ b/scripts/publish_local.ts
@@ -6,7 +6,6 @@ const isCleanWorkingTree = async (): Promise<boolean> => {
 };
 const isCleanTree = await isCleanWorkingTree();
 if (!isCleanTree) {
-  // non-zero exit code indicates working tree is dirty
   throw new Error(
     `Detected a dirty working tree. Commit or stash changes before publishing a snapshot`
   );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`git diff --quiet` does not exit with code 0 with a dirty working tree. 
This solution will correctly verify that the working tree is clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
