### PR TITLE
add prefer parameter-property lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,6 +61,12 @@
     "@typescript-eslint/switch-exhaustiveness-check": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-misused-promises": "error",
+    "@typescript-eslint/parameter-properties": [
+      "error",
+      {
+        "prefer": "parameter-property"
+      }
+    ],
     "check-file/filename-blocklist": [
       "error",
       {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
See https://typescript-eslint.io/rules/parameter-properties/
Basically, prefer the shorthand class property syntax of
```ts
class Thing {
  constructor(private readonly someProp: string) {}
}
```
over the long form
```ts
class Thing {
  private readonly someProp: string
  constructor(someProp: string) {
    this.someProp = someProp
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
