### PR TITLE
fix codeql config

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -179,9 +179,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    strategy:
-      matrix:
-        language: [javascript]
     steps:
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
@@ -191,9 +188,9 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4262713b504983e61c7728f5452be240d9385a7 # version 2.14.3
         with:
-          languages: ${{ matrix.language }}
+          languages: javascript
           queries: +security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e4262713b504983e61c7728f5452be240d9385a7 # version 2.14.3
         with:
-          category: /language:${{ matrix.language }}
+          category: /language:javascript


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix codeql config. Looking at recent PRs, it looks like the scan was still run but the integration with the GH security tab was messed up. This should get things working right again

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
