### PR TITLE
chore: update cdk error mapper for case when cognito user attributes cannot be updated

### DIFF
--- a/.changeset/long-books-burn.md
+++ b/.changeset/long-books-burn.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+chore: update cdk error mapper for case when cognito user attributes cannot be updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -19409,12 +19409,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.2.0-alpha.15",
+      "version": "0.2.0-alpha.16",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
+        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.4",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -19423,14 +19423,14 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.2.0-alpha.9",
+      "version": "0.2.0-alpha.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.3",
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
+        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.4",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.5",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.119",
@@ -19443,15 +19443,15 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.2.0-alpha.12",
+      "version": "0.2.0-alpha.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.2.0-alpha.13",
-        "@aws-amplify/backend-output-storage": "0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/auth-construct-alpha": "^0.2.0-alpha.16",
+        "@aws-amplify/backend-output-storage": "0.2.0-alpha.4",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       },
       "devDependencies": {
-        "@aws-amplify/backend": "^0.2.0-alpha.7"
+        "@aws-amplify/backend": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -19475,16 +19475,16 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.1.1-alpha.8",
+      "version": "0.1.1-alpha.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "0.1.1-alpha.3",
+        "@aws-amplify/backend-output-storage": "0.2.0-alpha.4",
         "@aws-amplify/function-construct-alpha": "^0.1.1-alpha.5",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10",
         "execa": "^7.1.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend": "^0.2.0-alpha.7"
+        "@aws-amplify/backend": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -19493,17 +19493,17 @@
     },
     "packages/backend-graphql": {
       "name": "@aws-amplify/backend-graphql",
-      "version": "0.2.0-alpha.10",
+      "version": "0.2.0-alpha.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/amplify-api-next-types-alpha": "^0.0.4",
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-output-storage": "0.1.1-alpha.3",
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
+        "@aws-amplify/backend-output-storage": "0.2.0-alpha.4",
         "@aws-amplify/graphql-api-construct": "^1.1.4",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       },
       "devDependencies": {
-        "@aws-amplify/backend": "^0.2.0-alpha.7"
+        "@aws-amplify/backend": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -19512,10 +19512,10 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.2.0-alpha.6",
+      "version": "0.2.0-alpha.7",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "0.2.0-alpha.9"
+        "@aws-amplify/plugin-types": "0.2.0-alpha.10"
       },
       "peerDependencies": {
         "zod": "^3.21.4"
@@ -19523,10 +19523,10 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.1.1-alpha.3",
+      "version": "0.2.0-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5"
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.100.0"
@@ -19547,15 +19547,15 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.2.0-alpha.7",
+      "version": "0.2.0-alpha.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9",
-        "@aws-amplify/storage-construct-alpha": "^0.1.1-alpha.8"
+        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.4",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10",
+        "@aws-amplify/storage-construct-alpha": "^0.1.1-alpha.9"
       },
       "devDependencies": {
-        "@aws-amplify/backend": "^0.2.0-alpha.7"
+        "@aws-amplify/backend": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -19564,18 +19564,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.2.0-alpha.11",
+      "version": "0.2.0-alpha.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.6",
-        "@aws-amplify/cli-core": "^0.1.0-alpha.2",
+        "@aws-amplify/cli-core": "^0.1.0-alpha.3",
         "@aws-amplify/client-config": "^0.2.0-alpha.11",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.8",
-        "@aws-amplify/form-generator": "^0.2.0-alpha.3",
+        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
+        "@aws-amplify/form-generator": "^0.2.0-alpha.4",
         "@aws-amplify/model-generator": "^0.2.0-alpha.6",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/sandbox": "^0.2.0-alpha.15",
+        "@aws-amplify/sandbox": "^0.2.0-alpha.16",
         "@aws-sdk/credential-providers": "^3.360.0",
         "execa": "^7.2.0",
         "is-ci": "^3.0.1",
@@ -19597,7 +19597,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^3.0.0"
@@ -19722,10 +19722,10 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.2.0-alpha.12",
+      "version": "0.2.0-alpha.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.1.0-alpha.2",
+        "@aws-amplify/cli-core": "^0.1.0-alpha.3",
         "execa": "^7.2.0",
         "yargs": "^17.7.2"
       },
@@ -19848,10 +19848,10 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.2.0-alpha.8",
+      "version": "0.2.0-alpha.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.6",
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
         "@aws-sdk/client-amplify": "^3.414.0",
         "@aws-sdk/client-cloudformation": "^3.414.0",
@@ -19862,7 +19862,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "0.2.0-alpha.3",
+      "version": "0.2.0-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
@@ -19894,9 +19894,9 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.3.2",
-        "@aws-amplify/backend": "0.2.0-alpha.9",
-        "@aws-amplify/backend-auth": "0.2.0-alpha.12",
-        "@aws-amplify/backend-storage": "0.2.0-alpha.7",
+        "@aws-amplify/backend": "0.2.0-alpha.10",
+        "@aws-amplify/backend-auth": "0.2.0-alpha.13",
+        "@aws-amplify/backend-storage": "0.2.0-alpha.8",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "execa": "^8.0.1",
         "fs-extra": "^11.1.1",
@@ -20233,7 +20233,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.2.0-alpha.9",
+      "version": "0.2.0-alpha.10",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -20242,14 +20242,14 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.2.0-alpha.15",
+      "version": "0.2.0-alpha.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "0.2.0-alpha.9",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.4",
-        "@aws-amplify/cli-core": "^0.1.0-alpha.2",
+        "@aws-amplify/cli-core": "^0.1.0-alpha.3",
         "@aws-amplify/client-config": "0.2.0-alpha.11",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.8",
+        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
@@ -20270,14 +20270,14 @@
     },
     "packages/storage-construct": {
       "name": "@aws-amplify/storage-construct-alpha",
-      "version": "0.1.1-alpha.8",
+      "version": "0.1.1-alpha.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.3"
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
+        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.4"
       },
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -20568,19 +20568,19 @@
     "@aws-amplify/auth-construct-alpha": {
       "version": "file:packages/auth-construct",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
+        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.4",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       }
     },
     "@aws-amplify/backend": {
       "version": "file:packages/backend",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.3",
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
+        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.4",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.5",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10",
         "@types/aws-lambda": "^8.10.119",
         "aws-lambda": "^1.0.7"
       }
@@ -20588,24 +20588,24 @@
     "@aws-amplify/backend-auth": {
       "version": "file:packages/backend-auth",
       "requires": {
-        "@aws-amplify/auth-construct-alpha": "^0.2.0-alpha.13",
-        "@aws-amplify/backend": "^0.2.0-alpha.7",
-        "@aws-amplify/backend-output-storage": "0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/auth-construct-alpha": "^0.2.0-alpha.16",
+        "@aws-amplify/backend": "^0.2.0-alpha.10",
+        "@aws-amplify/backend-output-storage": "0.2.0-alpha.4",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       }
     },
     "@aws-amplify/backend-cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.6",
-        "@aws-amplify/cli-core": "^0.1.0-alpha.2",
+        "@aws-amplify/cli-core": "^0.1.0-alpha.3",
         "@aws-amplify/client-config": "^0.2.0-alpha.11",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.8",
-        "@aws-amplify/form-generator": "^0.2.0-alpha.3",
+        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
+        "@aws-amplify/form-generator": "^0.2.0-alpha.4",
         "@aws-amplify/model-generator": "^0.2.0-alpha.6",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/sandbox": "^0.2.0-alpha.15",
+        "@aws-amplify/sandbox": "^0.2.0-alpha.16",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@types/yargs": "^17.0.24",
         "execa": "^7.2.0",
@@ -20688,10 +20688,10 @@
     "@aws-amplify/backend-function": {
       "version": "file:packages/backend-function",
       "requires": {
-        "@aws-amplify/backend": "^0.2.0-alpha.7",
-        "@aws-amplify/backend-output-storage": "0.1.1-alpha.3",
+        "@aws-amplify/backend": "^0.2.0-alpha.10",
+        "@aws-amplify/backend-output-storage": "0.2.0-alpha.4",
         "@aws-amplify/function-construct-alpha": "^0.1.1-alpha.5",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10",
         "execa": "^7.1.1"
       }
     },
@@ -20699,23 +20699,23 @@
       "version": "file:packages/backend-graphql",
       "requires": {
         "@aws-amplify/amplify-api-next-types-alpha": "^0.0.4",
-        "@aws-amplify/backend": "^0.2.0-alpha.7",
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-output-storage": "0.1.1-alpha.3",
+        "@aws-amplify/backend": "^0.2.0-alpha.10",
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
+        "@aws-amplify/backend-output-storage": "0.2.0-alpha.4",
         "@aws-amplify/graphql-api-construct": "^1.1.4",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       }
     },
     "@aws-amplify/backend-output-schemas": {
       "version": "file:packages/backend-output-schemas",
       "requires": {
-        "@aws-amplify/plugin-types": "0.2.0-alpha.9"
+        "@aws-amplify/plugin-types": "0.2.0-alpha.10"
       }
     },
     "@aws-amplify/backend-output-storage": {
       "version": "file:packages/backend-output-storage",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5"
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7"
       }
     },
     "@aws-amplify/backend-secret": {
@@ -20730,10 +20730,10 @@
     "@aws-amplify/backend-storage": {
       "version": "file:packages/backend-storage",
       "requires": {
-        "@aws-amplify/backend": "^0.2.0-alpha.7",
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9",
-        "@aws-amplify/storage-construct-alpha": "^0.1.1-alpha.8"
+        "@aws-amplify/backend": "^0.2.0-alpha.10",
+        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.4",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10",
+        "@aws-amplify/storage-construct-alpha": "^0.1.1-alpha.9"
       }
     },
     "@aws-amplify/cli-core": {
@@ -20794,7 +20794,7 @@
     "@aws-amplify/deployed-backend-client": {
       "version": "file:packages/deployed-backend-client",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.6",
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
         "@aws-sdk/client-amplify": "^3.414.0",
         "@aws-sdk/client-cloudformation": "^3.414.0",
@@ -21561,9 +21561,9 @@
       "version": "file:packages/integration-tests",
       "requires": {
         "@aws-amplify/amplify-api-next-alpha": "^0.3.2",
-        "@aws-amplify/backend": "0.2.0-alpha.9",
-        "@aws-amplify/backend-auth": "0.2.0-alpha.12",
-        "@aws-amplify/backend-storage": "0.2.0-alpha.7",
+        "@aws-amplify/backend": "0.2.0-alpha.10",
+        "@aws-amplify/backend-auth": "0.2.0-alpha.13",
+        "@aws-amplify/backend-storage": "0.2.0-alpha.8",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "execa": "^8.0.1",
         "fs-extra": "^11.1.1",
@@ -21824,9 +21824,9 @@
       "requires": {
         "@aws-amplify/backend-deployer": "0.2.0-alpha.9",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.4",
-        "@aws-amplify/cli-core": "^0.1.0-alpha.2",
+        "@aws-amplify/cli-core": "^0.1.0-alpha.3",
         "@aws-amplify/client-config": "0.2.0-alpha.11",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.8",
+        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
@@ -21843,9 +21843,9 @@
     "@aws-amplify/storage-construct-alpha": {
       "version": "file:packages/storage-construct",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9"
+        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
+        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.4",
+        "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       }
     },
     "@aws-cdk/asset-awscli-v1": {
@@ -28745,7 +28745,7 @@
     "create-amplify": {
       "version": "file:packages/create-amplify",
       "requires": {
-        "@aws-amplify/cli-core": "^0.1.0-alpha.2",
+        "@aws-amplify/cli-core": "^0.1.0-alpha.3",
         "execa": "^7.2.0",
         "yargs": "^17.7.2"
       },

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -37,6 +37,18 @@ const testErrorMappings = [
     expectedString:
       '[CloudFormationFailure]: The CloudFormation deployment has failed. Find more information in the CloudFormation AWS Console for this stack.',
   },
+  {
+    errorMessage:
+      'CFN error happened: Updates are not allowed for property: some property',
+    expectedString:
+      '[UpdateNotSupported]: The changes that you are trying to apply are not supported.',
+  },
+  {
+    errorMessage:
+      'CFN error happened: Invalid AttributeDataType input, consider using the provided AttributeDataType enum',
+    expectedString:
+      '[UpdateNotSupported]: User pool attributes cannot be changed after a user pool has been created.',
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -33,6 +33,15 @@ export class CdkErrorMapper {
         '[UpdateNotSupported]: The changes that you are trying to apply are not supported.',
     },
     {
+      // This error originates from Cognito service when user tries to change UserPool attributes which is not allowed
+      // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html
+      // Remapping to `UpdateNotSupported` will allow sandbox to prompt users for resetting their environment
+      errorRegex:
+        /Invalid AttributeDataType input, consider using the provided AttributeDataType enum/,
+      humanReadableError:
+        '[UpdateNotSupported]: User pool attributes cannot be changed after a user pool has been created.',
+    },
+    {
       // Note that the order matters, this should be the last as it captures generic CFN error
       errorRegex: /ROLLBACK_(COMPLETE|FAILED)/,
       humanReadableError:


### PR DESCRIPTION
*Description of changes:* chore: update cdk error mapper for case when cognito user attributes cannot be updated


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
