### PR TITLE
chore: upgrade aws-cdk to 2.103.0

### DIFF
--- a/.changeset/proud-hairs-smash.md
+++ b/.changeset/proud-hairs-smash.md
@@ -1,0 +1,16 @@
+---
+'@aws-amplify/backend-output-storage': patch
+'@aws-amplify/function-construct-alpha': patch
+'@aws-amplify/storage-construct-alpha': patch
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend-graphql': patch
+'@aws-amplify/backend-storage': patch
+'@aws-amplify/auth-construct-alpha': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/plugin-types': patch
+'@aws-amplify/backend': patch
+'@aws-amplify/sandbox': patch
+---
+
+chore: upgrade aws-cdk to 2.103.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -9147,9 +9147,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.100.0.tgz",
-      "integrity": "sha512-Gt/4wPuEiBYw2tl0+cN0EbLxxJEvltcJxSQAcVHgNbqvDj49KUJ/oCbZ335dF0gK/hrVVb70xfNiYbBSPOsmvg==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.103.0.tgz",
+      "integrity": "sha512-M0WCCr3zHDK4zUM8hHhwPMWF6sZ/kBxn9SzREIANd8gYzukQq9eWKaqJZzsvZQ1IAhamb3PN/6i9WU4e4K4TGQ==",
       "peer": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -9162,9 +9162,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.101.1.tgz",
-      "integrity": "sha512-kKrJ0CcD82IyohjB3TRy34whf22GI6Y2bIrkBmui+fCb2t13+ToJb7zKBRmL6C090OsoiU/q+H6/WIZWOoYDvQ==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.103.0.tgz",
+      "integrity": "sha512-8shdI77+mq1VkpM6/OjlDh8wXMR2+G0pgL0eZ0UXmH6+oa8OQl/3LlA1OfJOZT90q71gzgL9huXGQC+wfw3hbA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -19417,7 +19417,7 @@
         "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
+        "aws-cdk-lib": "^2.103.0",
         "constructs": "^10.0.0"
       }
     },
@@ -19437,7 +19437,7 @@
         "aws-lambda": "^1.0.7"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "~2.101.0",
+        "aws-cdk-lib": "~2.103.0",
         "constructs": "^10.0.0"
       }
     },
@@ -19454,13 +19454,13 @@
         "@aws-amplify/backend": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
+        "aws-cdk-lib": "^2.103.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.2.0-alpha.9",
+      "version": "0.2.0-alpha.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
@@ -19469,7 +19469,7 @@
         "tsx": "^3.12.6"
       },
       "peerDependencies": {
-        "aws-cdk": "^2.0.0",
+        "aws-cdk": "^2.103.0",
         "typescript": "^5.0.0"
       }
     },
@@ -19487,7 +19487,7 @@
         "@aws-amplify/backend": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
+        "aws-cdk-lib": "^2.103.0",
         "constructs": "^10.0.0"
       }
     },
@@ -19506,7 +19506,7 @@
         "@aws-amplify/backend": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
+        "aws-cdk-lib": "^2.103.0",
         "constructs": "^10.0.0"
       }
     },
@@ -19529,7 +19529,7 @@
         "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0"
+        "aws-cdk-lib": "^2.103.0"
       }
     },
     "packages/backend-secret": {
@@ -19558,24 +19558,24 @@
         "@aws-amplify/backend": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
+        "aws-cdk-lib": "^2.103.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.2.0-alpha.12",
+      "version": "0.2.0-alpha.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.6",
         "@aws-amplify/cli-core": "^0.1.0-alpha.3",
-        "@aws-amplify/client-config": "^0.2.0-alpha.11",
+        "@aws-amplify/client-config": "^0.2.0-alpha.12",
         "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
         "@aws-amplify/form-generator": "^0.2.0-alpha.4",
         "@aws-amplify/model-generator": "^0.2.0-alpha.6",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/sandbox": "^0.2.0-alpha.16",
+        "@aws-amplify/sandbox": "^0.2.0-alpha.17",
         "@aws-sdk/credential-providers": "^3.360.0",
         "execa": "^7.2.0",
         "is-ci": "^3.0.1",
@@ -19705,7 +19705,7 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.2.0-alpha.11",
+      "version": "0.2.0-alpha.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.6",
@@ -19722,7 +19722,7 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.2.0-alpha.13",
+      "version": "0.2.0-alpha.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.1.0-alpha.3",
@@ -19884,13 +19884,13 @@
       "version": "0.1.1-alpha.5",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
+        "aws-cdk-lib": "^2.103.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.2.0-alpha.8",
+      "version": "0.2.0-alpha.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.3.2",
@@ -20236,19 +20236,19 @@
       "version": "0.2.0-alpha.10",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
+        "aws-cdk-lib": "^2.103.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.2.0-alpha.16",
+      "version": "0.2.0-alpha.17",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "0.2.0-alpha.9",
+        "@aws-amplify/backend-deployer": "0.2.0-alpha.10",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.4",
         "@aws-amplify/cli-core": "^0.1.0-alpha.3",
-        "@aws-amplify/client-config": "0.2.0-alpha.11",
+        "@aws-amplify/client-config": "0.2.0-alpha.12",
         "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
         "@aws-sdk/client-cloudformation": "^3.421.0",
@@ -20265,7 +20265,7 @@
         "@types/parse-gitignore": "^1.0.0"
       },
       "peerDependencies": {
-        "aws-cdk": "^2.100.0"
+        "aws-cdk": "^2.103.0"
       }
     },
     "packages/storage-construct": {
@@ -20280,7 +20280,7 @@
         "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
+        "aws-cdk-lib": "^2.103.0",
         "constructs": "^10.0.0"
       }
     }
@@ -20600,12 +20600,12 @@
         "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.6",
         "@aws-amplify/cli-core": "^0.1.0-alpha.3",
-        "@aws-amplify/client-config": "^0.2.0-alpha.11",
+        "@aws-amplify/client-config": "^0.2.0-alpha.12",
         "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
         "@aws-amplify/form-generator": "^0.2.0-alpha.4",
         "@aws-amplify/model-generator": "^0.2.0-alpha.6",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/sandbox": "^0.2.0-alpha.16",
+        "@aws-amplify/sandbox": "^0.2.0-alpha.17",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@types/yargs": "^17.0.24",
         "execa": "^7.2.0",
@@ -21822,10 +21822,10 @@
     "@aws-amplify/sandbox": {
       "version": "file:packages/sandbox",
       "requires": {
-        "@aws-amplify/backend-deployer": "0.2.0-alpha.9",
+        "@aws-amplify/backend-deployer": "0.2.0-alpha.10",
         "@aws-amplify/backend-secret": "^0.2.0-alpha.4",
         "@aws-amplify/cli-core": "^0.1.0-alpha.3",
-        "@aws-amplify/client-config": "0.2.0-alpha.11",
+        "@aws-amplify/client-config": "0.2.0-alpha.12",
         "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
         "@aws-amplify/platform-core": "^0.1.1-alpha.3",
         "@aws-sdk/client-cloudformation": "^3.421.0",
@@ -27539,9 +27539,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-cdk": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.100.0.tgz",
-      "integrity": "sha512-Gt/4wPuEiBYw2tl0+cN0EbLxxJEvltcJxSQAcVHgNbqvDj49KUJ/oCbZ335dF0gK/hrVVb70xfNiYbBSPOsmvg==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.103.0.tgz",
+      "integrity": "sha512-M0WCCr3zHDK4zUM8hHhwPMWF6sZ/kBxn9SzREIANd8gYzukQq9eWKaqJZzsvZQ1IAhamb3PN/6i9WU4e4K4TGQ==",
       "peer": true,
       "requires": {
         "fsevents": "2.3.2"
@@ -27557,9 +27557,9 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.101.1.tgz",
-      "integrity": "sha512-kKrJ0CcD82IyohjB3TRy34whf22GI6Y2bIrkBmui+fCb2t13+ToJb7zKBRmL6C090OsoiU/q+H6/WIZWOoYDvQ==",
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.103.0.tgz",
+      "integrity": "sha512-8shdI77+mq1VkpM6/OjlDh8wXMR2+G0pgL0eZ0UXmH6+oa8OQl/3LlA1OfJOZT90q71gzgL9huXGQC+wfw3hbA==",
       "peer": true,
       "requires": {
         "@aws-cdk/asset-awscli-v1": "^2.2.200",

--- a/packages/auth-construct/package.json
+++ b/packages/auth-construct/package.json
@@ -23,7 +23,7 @@
     "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0",
+    "aws-cdk-lib": "^2.103.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-auth/package.json
+++ b/packages/backend-auth/package.json
@@ -26,7 +26,7 @@
     "@aws-amplify/backend": "^0.2.0-alpha.10"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0",
+    "aws-cdk-lib": "^2.103.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-deployer/package.json
+++ b/packages/backend-deployer/package.json
@@ -24,7 +24,7 @@
     "tsx": "^3.12.6"
   },
   "peerDependencies": {
-    "aws-cdk": "^2.0.0",
+    "aws-cdk": "^2.103.0",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/backend-function/package.json
+++ b/packages/backend-function/package.json
@@ -27,7 +27,7 @@
     "@aws-amplify/backend": "^0.2.0-alpha.10"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0",
+    "aws-cdk-lib": "^2.103.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-graphql/package.json
+++ b/packages/backend-graphql/package.json
@@ -21,7 +21,7 @@
     "@aws-amplify/backend": "^0.2.0-alpha.10"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0",
+    "aws-cdk-lib": "^2.103.0",
     "constructs": "^10.0.0"
   },
   "dependencies": {

--- a/packages/backend-output-storage/package.json
+++ b/packages/backend-output-storage/package.json
@@ -22,6 +22,6 @@
     "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0"
+    "aws-cdk-lib": "^2.103.0"
   }
 }

--- a/packages/backend-storage/package.json
+++ b/packages/backend-storage/package.json
@@ -26,7 +26,7 @@
     "@aws-amplify/backend": "^0.2.0-alpha.10"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0",
+    "aws-cdk-lib": "^2.103.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -30,7 +30,7 @@
     "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "~2.101.0",
+    "aws-cdk-lib": "~2.103.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/function-construct/package.json
+++ b/packages/function-construct/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0",
+    "aws-cdk-lib": "^2.103.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -11,7 +11,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0",
+    "aws-cdk-lib": "^2.103.0",
     "constructs": "^10.0.0"
   },
   "imports": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -38,6 +38,6 @@
     "@types/parse-gitignore": "^1.0.0"
   },
   "peerDependencies": {
-    "aws-cdk": "^2.100.0"
+    "aws-cdk": "^2.103.0"
   }
 }

--- a/packages/storage-construct/package.json
+++ b/packages/storage-construct/package.json
@@ -25,7 +25,7 @@
     "@aws-amplify/plugin-types": "^0.2.0-alpha.10"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.100.0",
+    "aws-cdk-lib": "^2.103.0",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
*Description of changes:* chore: upgrade aws-cdk to 2.103.0

Brings in AppSync hotswap fixes and API_Key hotswap https://github.com/aws/aws-cdk/pull/27559


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
