### PR TITLE
test: run canary tests every hour

### DIFF
--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -2,7 +2,7 @@ name: canary_checks
 
 on:
   schedule:
-    - cron: '0 12 * * *' # every day 12:00 UTC
+    - cron: '0 */1 * * *' # runs every hour
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increases canary test frequency to every hour


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
