### PR TITLE
test: fix example

### DIFF
--- a/examples/simple_react/package.json
+++ b/examples/simple_react/package.json
@@ -2,6 +2,7 @@
   "name": "simple-react",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@aws-amplify/ui-react": "^5.0.7",
     "@testing-library/jest-dom": "^5.17.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes:

```
amplify/auth/resource.ts:1:28 - error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("@aws-amplify/backend-auth")' call instead.
  To convert this file to an ECMAScript module, change its file extension to '.mts', or add the field `"type": "module"` to '/Users/sobkamil/git/samsara-cli/examples/simple_react/package.json'.

1 import { defineAuth } from '@aws-amplify/backend-auth';
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
