### PR TITLE
test: add timeout to e2e test job

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -74,7 +74,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs:
       - do_include_e2e
       - build


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Sometimes e2e test job gets stuck. Decrease timeout from default 360 minutes to 60 minutes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
