### PR TITLE
feat: use "use client"; directive in generated react components

### DIFF
--- a/.changeset/fuzzy-cooks-battle.md
+++ b/.changeset/fuzzy-cooks-battle.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/form-generator': minor
+---
+
+Use "use client"; directive in generated React components

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,20 +470,20 @@
       "link": true
     },
     "node_modules/@aws-amplify/codegen-ui": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.19.1.tgz",
-      "integrity": "sha512-tmjJr3XXWpRSiqBbBrPg+PlYRafJL8Uk48e424scMsfmlmIIJbeb/FTcwi8aB7rihvgFwe/Z4pCS5OU9gnBciQ==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.19.3.tgz",
+      "integrity": "sha512-Ny9y8QG8BrSDxRlwWoSxxaICyY0PZtvlvOKclDjz3yE6hy3AXA/hzInFA3O3zY1qJ6HQNUQ83+atzJuiBvfT+w==",
       "dependencies": {
         "change-case": "^4.1.2",
         "yup": "^0.32.11"
       }
     },
     "node_modules/@aws-amplify/codegen-ui-react": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.19.1.tgz",
-      "integrity": "sha512-ufnwMF7p3Qi+LiLeCsqrM43LfHWZcuJ23SheXjI9Jmv07Kqeh82k+KNukV5M4pMGJupJdHGQj5ShpV2/91Mk5A==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.19.3.tgz",
+      "integrity": "sha512-u/XlznCqD3oXTgmSO7amK+j6nvrypyzbWmQMXSIEqFHaPPipuU4i2fDmY2fSizRn+GZWa0/+8odBBJ1oGX9dag==",
       "dependencies": {
-        "@aws-amplify/codegen-ui": "2.19.1",
+        "@aws-amplify/codegen-ui": "2.19.3",
         "@typescript/vfs": "~1.3.5",
         "pluralize": "^8.0.0",
         "semver": "^7.5.4",
@@ -19374,12 +19374,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.2.0-alpha.18",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19388,19 +19388,19 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.2.0-alpha.12",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.6.2",
-        "@aws-amplify/backend-auth": "^0.2.0-alpha.15",
-        "@aws-amplify/backend-function": "^0.1.1-alpha.11",
-        "@aws-amplify/backend-graphql": "^0.2.0-alpha.13",
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6",
-        "@aws-amplify/backend-secret": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-storage": "^0.2.0-alpha.10",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.4",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/backend-auth": "^0.2.0",
+        "@aws-amplify/backend-function": "^0.1.1",
+        "@aws-amplify/backend-graphql": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/backend-storage": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
+        "@aws-amplify/plugin-types": "^0.2.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.119",
@@ -19413,15 +19413,15 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.2.0-alpha.15",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.2.0-alpha.18",
-        "@aws-amplify/backend-output-storage": "0.2.0-alpha.6",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/auth-construct-alpha": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "0.2.0",
+        "@aws-amplify/plugin-types": "^0.2.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.1.0"
+        "@aws-amplify/backend-platform-test-stubs": "^0.1.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19430,11 +19430,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.2.0-alpha.11",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11",
+        "@aws-amplify/platform-core": "^0.1.1",
+        "@aws-amplify/plugin-types": "^0.2.0",
         "execa": "^7.2.0",
         "tsx": "^3.12.6"
       },
@@ -19445,16 +19445,16 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.1.1-alpha.11",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "0.2.0-alpha.6",
-        "@aws-amplify/function-construct-alpha": "^0.2.0-alpha.7",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11",
+        "@aws-amplify/backend-output-storage": "0.2.0",
+        "@aws-amplify/function-construct-alpha": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.2.0",
         "execa": "^7.1.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.1.0"
+        "@aws-amplify/backend-platform-test-stubs": "^0.1.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19463,17 +19463,17 @@
     },
     "packages/backend-graphql": {
       "name": "@aws-amplify/backend-graphql",
-      "version": "0.2.0-alpha.13",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/amplify-api-next-types-alpha": "^0.0.4",
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/backend-output-storage": "0.2.0-alpha.6",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "0.2.0",
         "@aws-amplify/graphql-api-construct": "^1.1.4",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/plugin-types": "^0.2.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.1.0"
+        "@aws-amplify/backend-platform-test-stubs": "^0.1.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19482,10 +19482,10 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.2.0-alpha.8",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "0.2.0-alpha.11"
+        "@aws-amplify/plugin-types": "0.2.0"
       },
       "peerDependencies": {
         "zod": "^3.21.4"
@@ -19493,11 +19493,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.2.0-alpha.6",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.4"
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0"
@@ -19505,7 +19505,7 @@
     },
     "packages/backend-platform-test-stubs": {
       "name": "@aws-amplify/backend-platform-test-stubs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -19514,11 +19514,11 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "0.2.0-alpha.6",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.1.1-alpha.2",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9",
+        "@aws-amplify/platform-core": "^0.1.1",
+        "@aws-amplify/plugin-types": "^0.2.0",
         "@aws-sdk/client-ssm": "^3.398.0"
       },
       "devDependencies": {
@@ -19527,15 +19527,15 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.2.0-alpha.10",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11",
-        "@aws-amplify/storage-construct-alpha": "^0.2.0-alpha.11"
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.2.0",
+        "@aws-amplify/storage-construct-alpha": "^0.2.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.1.0"
+        "@aws-amplify/backend-platform-test-stubs": "^0.1.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19552,18 +19552,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.2.0-alpha.15",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
-        "@aws-amplify/backend-secret": "^0.2.0-alpha.6",
-        "@aws-amplify/cli-core": "^0.1.0-alpha.4",
-        "@aws-amplify/client-config": "^0.2.0-alpha.12",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.11",
-        "@aws-amplify/form-generator": "^0.2.0-alpha.4",
-        "@aws-amplify/model-generator": "^0.2.0-alpha.7",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/sandbox": "^0.2.0-alpha.18",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/cli-core": "^0.1.0",
+        "@aws-amplify/client-config": "^0.2.0",
+        "@aws-amplify/deployed-backend-client": "^0.2.0",
+        "@aws-amplify/form-generator": "^0.2.0",
+        "@aws-amplify/model-generator": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
+        "@aws-amplify/sandbox": "^0.2.0",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
         "execa": "^7.2.0",
@@ -19586,7 +19586,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^3.0.0"
@@ -19694,12 +19694,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.2.0-alpha.12",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.6",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.3",
-        "@aws-amplify/model-generator": "^0.2.0-alpha.5",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/deployed-backend-client": "^0.2.0",
+        "@aws-amplify/model-generator": "^0.2.0",
         "@aws-sdk/client-amplify": "^3.376.0",
         "@aws-sdk/client-cloudformation": "^3.376.0",
         "@aws-sdk/client-ssm": "^3.398.0",
@@ -19721,10 +19721,10 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.2.0-alpha.15",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.1.0-alpha.4",
+        "@aws-amplify/cli-core": "^0.1.0",
         "execa": "^7.2.0",
         "yargs": "^17.7.2"
       },
@@ -19847,11 +19847,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.2.0-alpha.11",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.4",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
         "@aws-sdk/client-amplify": "^3.414.0",
         "@aws-sdk/client-cloudformation": "^3.414.0",
         "@aws-sdk/client-s3": "^3.414.0",
@@ -19861,12 +19861,12 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "0.2.0-alpha.4",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
         "@aws-amplify/codegen-ui": "^2.19.1",
-        "@aws-amplify/codegen-ui-react": "^2.19.1",
+        "@aws-amplify/codegen-ui-react": "^2.19.3",
         "@aws-amplify/graphql-docs-generator": "^4.1.0",
         "@aws-sdk/client-amplifyuibuilder": "^3.398.0",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -19880,10 +19880,10 @@
     },
     "packages/function-construct": {
       "name": "@aws-amplify/function-construct-alpha",
-      "version": "0.2.0-alpha.7",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6"
+        "@aws-amplify/backend-output-storage": "^0.2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19892,15 +19892,15 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.2.0-alpha.10",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.3.2",
-        "@aws-amplify/backend": "0.2.0-alpha.12",
-        "@aws-amplify/backend-auth": "0.2.0-alpha.15",
-        "@aws-amplify/backend-secret": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-storage": "0.2.0-alpha.10",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.4",
+        "@aws-amplify/backend": "0.2.0",
+        "@aws-amplify/backend-auth": "0.2.0",
+        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/backend-storage": "0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "execa": "^8.0.1",
         "fs-extra": "^11.1.1",
@@ -19962,11 +19962,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.0-alpha.7",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.11",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/deployed-backend-client": "^0.2.0",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -20230,15 +20230,15 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.1.1-alpha.4",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.7"
+        "@aws-amplify/plugin-types": "^0.2.0"
       }
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.2.0-alpha.11",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20247,15 +20247,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.2.0-alpha.18",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "0.2.0-alpha.11",
-        "@aws-amplify/backend-secret": "^0.2.0-alpha.4",
-        "@aws-amplify/cli-core": "^0.1.0-alpha.3",
-        "@aws-amplify/client-config": "0.2.0-alpha.12",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.3",
+        "@aws-amplify/backend-deployer": "0.2.0",
+        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/cli-core": "^0.1.0",
+        "@aws-amplify/client-config": "0.2.0",
+        "@aws-amplify/deployed-backend-client": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
         "@aws-sdk/types": "^3.378.0",
@@ -20275,14 +20275,14 @@
     },
     "packages/storage-construct": {
       "name": "@aws-amplify/storage-construct-alpha",
-      "version": "0.2.0-alpha.11",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6"
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "^0.2.0"
       },
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/plugin-types": "^0.2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20573,24 +20573,24 @@
     "@aws-amplify/auth-construct-alpha": {
       "version": "file:packages/auth-construct",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.2.0"
       }
     },
     "@aws-amplify/backend": {
       "version": "file:packages/backend",
       "requires": {
         "@aws-amplify/amplify-api-next-alpha": "^0.6.2",
-        "@aws-amplify/backend-auth": "^0.2.0-alpha.15",
-        "@aws-amplify/backend-function": "^0.1.1-alpha.11",
-        "@aws-amplify/backend-graphql": "^0.2.0-alpha.13",
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6",
-        "@aws-amplify/backend-secret": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-storage": "^0.2.0-alpha.10",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.4",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11",
+        "@aws-amplify/backend-auth": "^0.2.0",
+        "@aws-amplify/backend-function": "^0.1.1",
+        "@aws-amplify/backend-graphql": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/backend-storage": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
+        "@aws-amplify/plugin-types": "^0.2.0",
         "@types/aws-lambda": "^8.10.119",
         "aws-lambda": "^1.0.7"
       },
@@ -20608,24 +20608,24 @@
     "@aws-amplify/backend-auth": {
       "version": "file:packages/backend-auth",
       "requires": {
-        "@aws-amplify/auth-construct-alpha": "^0.2.0-alpha.18",
-        "@aws-amplify/backend-output-storage": "0.2.0-alpha.6",
-        "@aws-amplify/backend-platform-test-stubs": "^0.1.0",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/auth-construct-alpha": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "0.2.0",
+        "@aws-amplify/backend-platform-test-stubs": "^0.1.1",
+        "@aws-amplify/plugin-types": "^0.2.0"
       }
     },
     "@aws-amplify/backend-cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.7",
-        "@aws-amplify/backend-secret": "^0.2.0-alpha.6",
-        "@aws-amplify/cli-core": "^0.1.0-alpha.4",
-        "@aws-amplify/client-config": "^0.2.0-alpha.12",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.11",
-        "@aws-amplify/form-generator": "^0.2.0-alpha.4",
-        "@aws-amplify/model-generator": "^0.2.0-alpha.7",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/sandbox": "^0.2.0-alpha.18",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/cli-core": "^0.1.0",
+        "@aws-amplify/client-config": "^0.2.0",
+        "@aws-amplify/deployed-backend-client": "^0.2.0",
+        "@aws-amplify/form-generator": "^0.2.0",
+        "@aws-amplify/model-generator": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
+        "@aws-amplify/sandbox": "^0.2.0",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@types/yargs": "^17.0.24",
@@ -20700,8 +20700,8 @@
     "@aws-amplify/backend-deployer": {
       "version": "file:packages/backend-deployer",
       "requires": {
-        "@aws-amplify/platform-core": "^0.1.1-alpha.3",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11",
+        "@aws-amplify/platform-core": "^0.1.1",
+        "@aws-amplify/plugin-types": "^0.2.0",
         "execa": "^7.2.0",
         "tsx": "^3.12.6"
       }
@@ -20709,10 +20709,10 @@
     "@aws-amplify/backend-function": {
       "version": "file:packages/backend-function",
       "requires": {
-        "@aws-amplify/backend-output-storage": "0.2.0-alpha.6",
-        "@aws-amplify/backend-platform-test-stubs": "^0.1.0",
-        "@aws-amplify/function-construct-alpha": "^0.2.0-alpha.7",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11",
+        "@aws-amplify/backend-output-storage": "0.2.0",
+        "@aws-amplify/backend-platform-test-stubs": "^0.1.1",
+        "@aws-amplify/function-construct-alpha": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.2.0",
         "execa": "^7.1.1"
       }
     },
@@ -20720,24 +20720,24 @@
       "version": "file:packages/backend-graphql",
       "requires": {
         "@aws-amplify/amplify-api-next-types-alpha": "^0.0.4",
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/backend-output-storage": "0.2.0-alpha.6",
-        "@aws-amplify/backend-platform-test-stubs": "^0.1.0",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "0.2.0",
+        "@aws-amplify/backend-platform-test-stubs": "^0.1.1",
         "@aws-amplify/graphql-api-construct": "^1.1.4",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/plugin-types": "^0.2.0"
       }
     },
     "@aws-amplify/backend-output-schemas": {
       "version": "file:packages/backend-output-schemas",
       "requires": {
-        "@aws-amplify/plugin-types": "0.2.0-alpha.11"
+        "@aws-amplify/plugin-types": "0.2.0"
       }
     },
     "@aws-amplify/backend-output-storage": {
       "version": "file:packages/backend-output-storage",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.4"
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1"
       }
     },
     "@aws-amplify/backend-platform-test-stubs": {
@@ -20750,8 +20750,8 @@
     "@aws-amplify/backend-secret": {
       "version": "file:packages/backend-secret",
       "requires": {
-        "@aws-amplify/platform-core": "^0.1.1-alpha.2",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.9",
+        "@aws-amplify/platform-core": "^0.1.1",
+        "@aws-amplify/plugin-types": "^0.2.0",
         "@aws-sdk/client-ssm": "^3.398.0",
         "@aws-sdk/types": "^3.370.0"
       }
@@ -20759,10 +20759,10 @@
     "@aws-amplify/backend-storage": {
       "version": "file:packages/backend-storage",
       "requires": {
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6",
-        "@aws-amplify/backend-platform-test-stubs": "^0.1.0",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11",
-        "@aws-amplify/storage-construct-alpha": "^0.2.0-alpha.11"
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/backend-platform-test-stubs": "^0.1.1",
+        "@aws-amplify/plugin-types": "^0.2.0",
+        "@aws-amplify/storage-construct-alpha": "^0.2.0"
       }
     },
     "@aws-amplify/cli-core": {
@@ -20774,9 +20774,9 @@
     "@aws-amplify/client-config": {
       "version": "file:packages/client-config",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.6",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.3",
-        "@aws-amplify/model-generator": "^0.2.0-alpha.5",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/deployed-backend-client": "^0.2.0",
+        "@aws-amplify/model-generator": "^0.2.0",
         "@aws-sdk/client-amplify": "^3.376.0",
         "@aws-sdk/client-cloudformation": "^3.376.0",
         "@aws-sdk/client-ssm": "^3.398.0",
@@ -20786,20 +20786,20 @@
       }
     },
     "@aws-amplify/codegen-ui": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.19.1.tgz",
-      "integrity": "sha512-tmjJr3XXWpRSiqBbBrPg+PlYRafJL8Uk48e424scMsfmlmIIJbeb/FTcwi8aB7rihvgFwe/Z4pCS5OU9gnBciQ==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.19.3.tgz",
+      "integrity": "sha512-Ny9y8QG8BrSDxRlwWoSxxaICyY0PZtvlvOKclDjz3yE6hy3AXA/hzInFA3O3zY1qJ6HQNUQ83+atzJuiBvfT+w==",
       "requires": {
         "change-case": "^4.1.2",
         "yup": "^0.32.11"
       }
     },
     "@aws-amplify/codegen-ui-react": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.19.1.tgz",
-      "integrity": "sha512-ufnwMF7p3Qi+LiLeCsqrM43LfHWZcuJ23SheXjI9Jmv07Kqeh82k+KNukV5M4pMGJupJdHGQj5ShpV2/91Mk5A==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.19.3.tgz",
+      "integrity": "sha512-u/XlznCqD3oXTgmSO7amK+j6nvrypyzbWmQMXSIEqFHaPPipuU4i2fDmY2fSizRn+GZWa0/+8odBBJ1oGX9dag==",
       "requires": {
-        "@aws-amplify/codegen-ui": "2.19.1",
+        "@aws-amplify/codegen-ui": "2.19.3",
         "@typescript/vfs": "~1.3.5",
         "pluralize": "^8.0.0",
         "prettier": "2.3.2",
@@ -20823,8 +20823,8 @@
     "@aws-amplify/deployed-backend-client": {
       "version": "file:packages/deployed-backend-client",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.4",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
         "@aws-sdk/client-amplify": "^3.414.0",
         "@aws-sdk/client-cloudformation": "^3.414.0",
         "@aws-sdk/client-s3": "^3.414.0",
@@ -20837,7 +20837,7 @@
       "requires": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
         "@aws-amplify/codegen-ui": "^2.19.1",
-        "@aws-amplify/codegen-ui-react": "^2.19.1",
+        "@aws-amplify/codegen-ui-react": "^2.19.3",
         "@aws-amplify/graphql-docs-generator": "^4.1.0",
         "@aws-sdk/client-amplifyuibuilder": "^3.398.0",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -20852,7 +20852,7 @@
     "@aws-amplify/function-construct-alpha": {
       "version": "file:packages/function-construct",
       "requires": {
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6"
+        "@aws-amplify/backend-output-storage": "^0.2.0"
       }
     },
     "@aws-amplify/graphql-api-construct": {
@@ -21592,11 +21592,11 @@
       "version": "file:packages/integration-tests",
       "requires": {
         "@aws-amplify/amplify-api-next-alpha": "^0.3.2",
-        "@aws-amplify/backend": "0.2.0-alpha.12",
-        "@aws-amplify/backend-auth": "0.2.0-alpha.15",
-        "@aws-amplify/backend-secret": "^0.2.0-alpha.5",
-        "@aws-amplify/backend-storage": "0.2.0-alpha.10",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.4",
+        "@aws-amplify/backend": "0.2.0",
+        "@aws-amplify/backend-auth": "0.2.0",
+        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/backend-storage": "0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "execa": "^8.0.1",
         "fs-extra": "^11.1.1",
@@ -21637,8 +21637,8 @@
     "@aws-amplify/model-generator": {
       "version": "file:packages/model-generator",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.11",
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/deployed-backend-client": "^0.2.0",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -21846,7 +21846,7 @@
     "@aws-amplify/platform-core": {
       "version": "file:packages/platform-core",
       "requires": {
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.7"
+        "@aws-amplify/plugin-types": "^0.2.0"
       }
     },
     "@aws-amplify/plugin-types": {
@@ -21856,12 +21856,12 @@
     "@aws-amplify/sandbox": {
       "version": "file:packages/sandbox",
       "requires": {
-        "@aws-amplify/backend-deployer": "0.2.0-alpha.11",
-        "@aws-amplify/backend-secret": "^0.2.0-alpha.4",
-        "@aws-amplify/cli-core": "^0.1.0-alpha.3",
-        "@aws-amplify/client-config": "0.2.0-alpha.12",
-        "@aws-amplify/deployed-backend-client": "^0.2.0-alpha.9",
-        "@aws-amplify/platform-core": "^0.1.1-alpha.3",
+        "@aws-amplify/backend-deployer": "0.2.0",
+        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/cli-core": "^0.1.0",
+        "@aws-amplify/client-config": "0.2.0",
+        "@aws-amplify/deployed-backend-client": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
         "@aws-sdk/types": "^3.378.0",
@@ -21877,9 +21877,9 @@
     "@aws-amplify/storage-construct-alpha": {
       "version": "file:packages/storage-construct",
       "requires": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.8",
-        "@aws-amplify/backend-output-storage": "^0.2.0-alpha.6",
-        "@aws-amplify/plugin-types": "^0.2.0-alpha.11"
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.2.0"
       }
     },
     "@aws-cdk/asset-awscli-v1": {
@@ -28740,7 +28740,7 @@
     "create-amplify": {
       "version": "file:packages/create-amplify",
       "requires": {
-        "@aws-amplify/cli-core": "^0.1.0-alpha.4",
+        "@aws-amplify/cli-core": "^0.1.0",
         "execa": "^7.2.0",
         "yargs": "^17.7.2"
       },

--- a/packages/form-generator/package.json
+++ b/packages/form-generator/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
     "@aws-amplify/codegen-ui": "^2.19.1",
-    "@aws-amplify/codegen-ui-react": "^2.19.1",
+    "@aws-amplify/codegen-ui-react": "^2.19.3",
     "@aws-amplify/graphql-docs-generator": "^4.1.0",
     "@aws-sdk/client-amplifyuibuilder": "^3.398.0",
     "@aws-sdk/client-appsync": "^3.398.0",

--- a/packages/form-generator/src/local_codegen_graphql_form_generator.ts
+++ b/packages/form-generator/src/local_codegen_graphql_form_generator.ts
@@ -94,6 +94,7 @@ export class LocalGraphqlFormGenerator implements GraphqlFormGenerator {
       module: ModuleKind.ES2020,
       target: ScriptTarget.ES2020,
       script: ScriptKind.JSX,
+      includeUseClientDirective: true,
       renderTypeDeclarations: true,
       apiConfiguration: {
         dataApi: 'GraphQL',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Includes `"use client";` directive at the top of generated react components. See https://react.dev/reference/react/use-client.

This makes sure generated react components are treated as client-side components.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
