### PR TITLE
add aws_project_region to e2e test assert

### DIFF
--- a/.changeset/rotten-fans-smile.md
+++ b/.changeset/rotten-fans-smile.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/integration-tests': patch
+---
+
+Add aws_project_region to e2e test assert

--- a/packages/integration-tests/src/test-e2e/data_storage_auth_with_triggers.ts
+++ b/packages/integration-tests/src/test-e2e/data_storage_auth_with_triggers.ts
@@ -156,6 +156,7 @@ export class DataStorageAuthWithTriggerTestProject extends TestProjectBase {
       'aws_appsync_graphqlEndpoint',
       'aws_appsync_region',
       'aws_cognito_region',
+      'aws_project_region',
       'aws_user_files_s3_bucket',
       'aws_user_files_s3_bucket_region',
       'aws_user_pools_id',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add `aws_project_region` to e2e test assert as a follow up for #545.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
