### PR TITLE
fix: pnpm init and env var

### DIFF
--- a/packages/create-amplify/src/npm_project_initializer.ts
+++ b/packages/create-amplify/src/npm_project_initializer.ts
@@ -33,10 +33,14 @@ export class NpmProjectInitializer {
     );
 
     try {
-      await this.execa(this.executableName, ['init', '--yes'], {
-        stdio: 'inherit',
-        cwd: this.projectRoot,
-      });
+      await this.execa(
+        this.executableName,
+        this.executableName === 'pnpm' ? ['init'] : ['init', '--yes'],
+        {
+          stdio: 'inherit',
+          cwd: this.projectRoot,
+        }
+      );
     } catch {
       throw new Error(
         `\`${this.executableName} init\` did not exit successfully. Initialize a valid JavaScript package before continuing.`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- `pnpm init` doesn't accept any options otherwise, it'd throw
- make packages/create-amplify/src/npm_project_initializer.ts to use env var


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
