### PR TITLE
test: adjust resource prefix in cleanup script

### DIFF
--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -48,7 +48,7 @@ const s3Client = new S3Client({
   maxAttempts: 5,
 });
 const now = new Date();
-const TEST_RESOURCE_PREFIX = 'amplify-test';
+const TEST_RESOURCE_PREFIX = 'amplify-';
 
 const isStale = (creationDate: Date | undefined): boolean | undefined => {
   if (!creationDate) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The PR https://github.com/aws-amplify/samsara-cli/pull/532 introduced a need to use real Amplify Apps and Branches in pipeline deployments e2e tests.

This means stacks (and some resources) are now created with `amplify-<appId>-` prefix. Therefore this PR adjust test resource prefix used in resource cleanup script to capture them too.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
