### PR TITLE
add mapping for deleting stack status

### DIFF
--- a/.changeset/warm-moons-reflect.md
+++ b/.changeset/warm-moons-reflect.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/deployed-backend-client': patch
+---
+
+add DELETING backend deployment status

--- a/packages/deployed-backend-client/API.md
+++ b/packages/deployed-backend-client/API.md
@@ -38,6 +38,8 @@ export enum BackendDeploymentStatus {
     // (undocumented)
     DELETED = "DELETED",
     // (undocumented)
+    DELETING = "DELETING",
+    // (undocumented)
     DEPLOYED = "DEPLOYED",
     // (undocumented)
     DEPLOYING = "DEPLOYING",

--- a/packages/deployed-backend-client/src/deployed-backend-client/stack_status_mapper.test.ts
+++ b/packages/deployed-backend-client/src/deployed-backend-client/stack_status_mapper.test.ts
@@ -46,7 +46,6 @@ void describe('translateStackStatus', () => {
   void it('translates deploying', async () => {
     const deployingStatuses = [
       StackStatus.CREATE_IN_PROGRESS,
-      StackStatus.DELETE_IN_PROGRESS,
       StackStatus.IMPORT_IN_PROGRESS,
       StackStatus.IMPORT_ROLLBACK_IN_PROGRESS,
       StackStatus.REVIEW_IN_PROGRESS,
@@ -61,6 +60,17 @@ void describe('translateStackStatus', () => {
     );
     const assertion = translated.every(
       (status) => status === BackendDeploymentStatus.DEPLOYING
+    );
+    assert.equal(assertion, true);
+  });
+
+  void it('translates deleting', async () => {
+    const deletedStatuses = [StackStatus.DELETE_IN_PROGRESS];
+    const translated = deletedStatuses.map((status) =>
+      mapper.translateStackStatus(status)
+    );
+    const assertion = translated.every(
+      (status) => status === BackendDeploymentStatus.DELETING
     );
     assert.equal(assertion, true);
   });

--- a/packages/deployed-backend-client/src/deployed-backend-client/stack_status_mapper.ts
+++ b/packages/deployed-backend-client/src/deployed-backend-client/stack_status_mapper.ts
@@ -29,7 +29,6 @@ export class StackStatusMapper {
         return BackendDeploymentStatus.FAILED;
 
       case StackStatus.CREATE_IN_PROGRESS:
-      case StackStatus.DELETE_IN_PROGRESS:
       case StackStatus.IMPORT_IN_PROGRESS:
       case StackStatus.IMPORT_ROLLBACK_IN_PROGRESS:
       case StackStatus.REVIEW_IN_PROGRESS:
@@ -39,6 +38,9 @@ export class StackStatusMapper {
       case StackStatus.UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS:
       case StackStatus.UPDATE_ROLLBACK_IN_PROGRESS:
         return BackendDeploymentStatus.DEPLOYING;
+
+      case StackStatus.DELETE_IN_PROGRESS:
+        return BackendDeploymentStatus.DELETING;
 
       case StackStatus.DELETE_COMPLETE:
         return BackendDeploymentStatus.DELETED;

--- a/packages/deployed-backend-client/src/deployed_backend_client_factory.ts
+++ b/packages/deployed-backend-client/src/deployed_backend_client_factory.ts
@@ -87,6 +87,7 @@ export enum BackendDeploymentStatus {
   DEPLOYED = 'DEPLOYED',
   FAILED = 'FAILED',
   DEPLOYING = 'DEPLOYING',
+  DELETING = 'DELETING',
   DELETED = 'DELETED',
   UNKNOWN = 'UNKNOWN',
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Currently, do not differentiate between `DEPLOYING` and `DELETING` but this is confusing for building a ui that communicates these statuses in two different ways.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
