### PR TITLE
add changeset allowing sdk deps 3.329.0

### DIFF
--- a/.changeset/pink-rivers-play.md
+++ b/.changeset/pink-rivers-play.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/deployed-backend-client': patch
+---
+
+allow sdk deps 3.329.0


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

There was an issue with the changeset for this change: https://github.com/aws-amplify/samsara-cli/pull/587

it got merged during a release, so it didn't get picked up in the release, and now it's behind the latest release commit. This is an interesting release edge case where we probably need to block merges while merging the release PR to prevent this issue in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
