### PR TITLE
test: defer direct deletion in cleanup script

### DIFF
--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -50,11 +50,34 @@ const s3Client = new S3Client({
 const now = new Date();
 const TEST_RESOURCE_PREFIX = 'amplify-';
 
+/**
+ * Stacks are considered stale after 2 hours.
+ * Other resources are considered stale after 3 hours.
+ *
+ * Stack deletion triggers asynchronous resource deletion while this script is running.
+ * In order to not interfere with normal stack deletion process we defer
+ * direct deletions by additional hour, so that it covers cases where
+ * stack deletion failed or left orphan resources.
+ */
+const stackStaleDurationInMilliseconds = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
+const staleDurationInMilliseconds = 3 * 60 * 60 * 1000; // 3 hours in milliseconds
+
+const isStackStale = (
+  stackSummary: StackSummary | undefined
+): boolean | undefined => {
+  if (!stackSummary?.CreationTime) {
+    return;
+  }
+  return (
+    now.getTime() - stackSummary.CreationTime.getTime() >
+    stackStaleDurationInMilliseconds
+  );
+};
+
 const isStale = (creationDate: Date | undefined): boolean | undefined => {
   if (!creationDate) {
     return;
   }
-  const staleDurationInMilliseconds = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
   return now.getTime() - creationDate.getTime() > staleDurationInMilliseconds;
 };
 
@@ -74,7 +97,7 @@ const listAllStaleTestStacks = async (): Promise<Array<StackSummary>> => {
     listStacksResponse.StackSummaries?.filter(
       (stackSummary) =>
         stackSummary.StackName?.startsWith(TEST_RESOURCE_PREFIX) &&
-        isStale(stackSummary.CreationTime)
+        isStackStale(stackSummary)
     ).forEach((item) => {
       stackSummaries.push(item);
     });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This assumes that cleanup script runs every hour. see https://github.com/aws-amplify/samsara-cli/blob/848aea1119f78d125a51bd4556073f46c8ba7a5b/.github/workflows/e2e_resource_cleanup.yml#L10

I noticed that sometimes first attempt to delete stack fails if cleanup script happened to delete resources before CFN did.
Stack deletion is kicked off and not awaited in the script. I.e. it was running into race conditions.
This didn't stop the script from deleting resources eventually as another attempt to delete stack would skip already deleted resources, so the state was eventually correct, but if race condition happened AWS Console in test account could show for a while that bunch of stacks landed in DELETE_FAILED state, potentially confusing operator and masking other potential problems.


This change defers direct resource deletion by another hour so that stack deletion process has a chance to run undisturbed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
