### PR TITLE
feat(formgen): default to sandbox identifier when branch or stack is not passed to formgen CLI

### DIFF
--- a/.changeset/giant-dolls-lick.md
+++ b/.changeset/giant-dolls-lick.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+Defaults to the sandbox identifier when no branch or stack is passed in the CLI

--- a/packages/cli/src/backend-identifier/backend_identifier_resolver.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_resolver.ts
@@ -17,9 +17,10 @@ export class BackendIdentifierResolver {
    * Instantiates BackendIdentifierResolver
    */
   constructor(private appNameResolver: AppNameResolver) {}
-  resolve = async (
-    args: BackendIdentifierParameters
-  ): Promise<BackendIdentifier> => {
+  /**
+   * resolves the backendId
+   */
+  async resolve(args: BackendIdentifierParameters): Promise<BackendIdentifier> {
     if (args.stack) {
       return { stackName: args.stack };
     } else if (args.appId && args.branch) {
@@ -35,5 +36,5 @@ export class BackendIdentifierResolver {
     throw new Error(
       'Unable to resolve BackendIdentifier with provided parameters'
     );
-  };
+  }
 }

--- a/packages/cli/src/commands/generate/forms/backend_identifier_with_sandbox_fallback.test.ts
+++ b/packages/cli/src/commands/generate/forms/backend_identifier_with_sandbox_fallback.test.ts
@@ -22,9 +22,13 @@ void it('uses the sandbox id if the default identifier resolver fails', async ()
     resolve: async () => Promise.resolve(appName),
   };
   const username = 'test-user';
-  const sandboxResolver = new SandboxIdResolver(appNameResolver, () => ({
-    username,
-  }));
+  const sandboxResolver = new SandboxIdResolver(
+    appNameResolver,
+    () =>
+      ({
+        username,
+      } as never)
+  );
   const backendIdResolver = new BackendIdentifierResolverWithSandboxFallback(
     appNameResolver,
     sandboxResolver

--- a/packages/cli/src/commands/generate/forms/backend_identifier_with_sandbox_fallback.test.ts
+++ b/packages/cli/src/commands/generate/forms/backend_identifier_with_sandbox_fallback.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import { it } from 'node:test';
+import { SandboxIdResolver } from '../../sandbox/sandbox_id_resolver.js';
+import { BackendIdentifierResolverWithSandboxFallback } from './backend_identifier_with_sandbox_fallback.js';
+
+void it('if backend identifier resolves without error, the resolved id is returned', async () => {
+  const appNameResolver = {
+    resolve: async () => Promise.resolve('testAppName'),
+  };
+  const sandboxResolver = new SandboxIdResolver(appNameResolver);
+  const backendIdResolver = new BackendIdentifierResolverWithSandboxFallback(
+    appNameResolver,
+    sandboxResolver
+  );
+  const resolvedId = await backendIdResolver.resolve({ branch: 'test' });
+  assert.deepEqual(resolvedId, { appName: 'testAppName', branchName: 'test' });
+});
+
+void it('uses the sandbox id if the default identifier resolver fails', async () => {
+  const appName = 'testAppName';
+  const appNameResolver = {
+    resolve: async () => Promise.resolve(appName),
+  };
+  const username = 'test-user';
+  const sandboxResolver = new SandboxIdResolver(appNameResolver, () => ({
+    username,
+  }));
+  const backendIdResolver = new BackendIdentifierResolverWithSandboxFallback(
+    appNameResolver,
+    sandboxResolver
+  );
+  const resolvedId = await backendIdResolver.resolve({});
+  assert.deepEqual(resolvedId, {
+    backendId: `${appName}-${username}`,
+    disambiguator: 'sandbox',
+  });
+});

--- a/packages/cli/src/commands/generate/forms/backend_identifier_with_sandbox_fallback.ts
+++ b/packages/cli/src/commands/generate/forms/backend_identifier_with_sandbox_fallback.ts
@@ -1,0 +1,35 @@
+import { SandboxBackendIdentifier } from '@aws-amplify/platform-core';
+import { BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
+import { AppNameResolver } from '../../../backend-identifier/local_app_name_resolver.js';
+import { SandboxIdResolver } from '../../sandbox/sandbox_id_resolver.js';
+
+/**
+ * Resolves the backend id when branch or stack is passed as an arg, otherwise returns a sandbox backend identifier
+ */
+export class BackendIdentifierResolverWithSandboxFallback extends BackendIdentifierResolver {
+  /**
+   * Accepts the sandbox id resolver as a parameter
+   */
+  constructor(
+    appNameResolver: AppNameResolver,
+    private sandboxIdResolver: SandboxIdResolver
+  ) {
+    super(appNameResolver);
+  }
+  /**
+   * resolves the backend id, falling back to the sandbox id if there is an error
+   */
+  override resolve = async (args: {
+    stack?: string | undefined;
+    appId?: string | undefined;
+    branch?: string | undefined;
+  }) => {
+    try {
+      return await super.resolve(args);
+    } catch (e) {
+      return new SandboxBackendIdentifier(
+        await this.sandboxIdResolver.resolve()
+      );
+    }
+  };
+}

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -50,6 +50,10 @@ export class GenerateFormsCommand
     this.describe = 'Generates UI forms';
   }
 
+  getBackendIdentifier = async (args: GenerateFormsCommandOptions) => {
+    return await this.backendIdentifierResolver.resolve(args);
+  };
+
   /**
    * @inheritDoc
    */
@@ -132,12 +136,6 @@ export class GenerateFormsCommand
         type: 'string',
         array: true,
         group: 'Form Generation',
-      })
-      .check((argv) => {
-        if (!argv.stack && !argv.branch) {
-          throw new Error('Either --stack or --branch must be provided');
-        }
-        return true;
       })
       .fail((msg, err) => {
         handleCommandFailure(msg, err, yargs);

--- a/packages/cli/src/commands/generate/generate_command_factory.ts
+++ b/packages/cli/src/commands/generate/generate_command_factory.ts
@@ -6,11 +6,12 @@ import { GenerateFormsCommand } from './forms/generate_forms_command.js';
 import { CwdPackageJsonLoader } from '../../cwd_package_json_loader.js';
 import { GenerateGraphqlClientCodeCommand } from './graphql-client-code/generate_graphql_client_code_command.js';
 import { LocalAppNameResolver } from '../../backend-identifier/local_app_name_resolver.js';
-import { BackendIdentifierResolver } from '../../backend-identifier/backend_identifier_resolver.js';
 import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
 import { GenerateApiCodeAdapter } from './graphql-client-code/generate_api_code_adapter.js';
 import { FormGenerationHandler } from '../../form-generation/form_generation_handler.js';
 import { BackendOutputClientFactory } from '@aws-amplify/deployed-backend-client';
+import { BackendIdentifierResolverWithSandboxFallback } from './forms/backend_identifier_with_sandbox_fallback.js';
+import { SandboxIdResolver } from '../sandbox/sandbox_id_resolver.js';
 
 /**
  * Creates wired generate command.
@@ -24,9 +25,11 @@ export const createGenerateCommand = (): CommandModule => {
     new CwdPackageJsonLoader()
   );
 
-  const backendIdentifierResolver = new BackendIdentifierResolver(
-    localAppNameResolver
-  );
+  const backendIdentifierResolver =
+    new BackendIdentifierResolverWithSandboxFallback(
+      localAppNameResolver,
+      new SandboxIdResolver(localAppNameResolver)
+    );
 
   const generateConfigCommand = new GenerateConfigCommand(
     clientConfigGenerator,


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

When an app name or stack identifier is not passed to the formgen command, the stack identifier will now be used by default. This will allow users to run the command:
```
amplify generate forms
```
without being required to pass in the stack name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
