### PR TITLE
fix: expand auth types at factory level

### DIFF
--- a/.changeset/shaggy-comics-itch.md
+++ b/.changeset/shaggy-comics-itch.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-auth': patch
+---
+
+Expand types for Auth to provide easier autocompletion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19442,18 +19442,18 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.8.0",
         "@aws-amplify/backend-auth": "^0.2.2",
-        "@aws-amplify/backend-data": "^0.3.2",
-        "@aws-amplify/backend-function": "^0.1.2",
+        "@aws-amplify/backend-data": "^0.4.0",
+        "@aws-amplify/backend-function": "^0.1.4",
         "@aws-amplify/backend-output-schemas": "^0.2.1",
         "@aws-amplify/backend-output-storage": "^0.2.0",
         "@aws-amplify/backend-secret": "^0.2.1",
         "@aws-amplify/backend-storage": "^0.2.1",
-        "@aws-amplify/platform-core": "^0.1.2",
+        "@aws-amplify/platform-core": "^0.1.4",
         "@aws-amplify/plugin-types": "^0.3.1",
         "@aws-sdk/client-amplify": "^3.440.0"
       },
@@ -19486,7 +19486,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/amplify-api-next-types-alpha": "^0.3.0",
@@ -19498,7 +19498,7 @@
       "devDependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.8.0",
         "@aws-amplify/backend-platform-test-stubs": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.1.3"
+        "@aws-amplify/platform-core": "^0.1.4"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19507,10 +19507,10 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.1.2",
+        "@aws-amplify/platform-core": "^0.1.4",
         "@aws-amplify/plugin-types": "^0.3.0",
         "execa": "^7.2.0",
         "tsx": "^3.12.6"
@@ -19522,7 +19522,7 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-storage": "0.2.0",
@@ -19532,7 +19532,7 @@
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.1.3"
+        "@aws-amplify/platform-core": "^0.1.4"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19604,7 +19604,7 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.2.0",
@@ -19614,8 +19614,8 @@
         "@aws-amplify/deployed-backend-client": "^0.2.0",
         "@aws-amplify/form-generator": "^0.3.0",
         "@aws-amplify/model-generator": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.1.1",
-        "@aws-amplify/sandbox": "^0.2.1",
+        "@aws-amplify/platform-core": "^0.1.4",
+        "@aws-amplify/sandbox": "^0.2.4",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@smithy/shared-ini-file-loader": "^2.2.2",
@@ -19776,7 +19776,7 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
@@ -19947,15 +19947,15 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.8.0",
-        "@aws-amplify/backend": "0.3.2",
+        "@aws-amplify/backend": "0.3.3",
         "@aws-amplify/backend-auth": "0.2.3",
         "@aws-amplify/backend-secret": "^0.2.1",
         "@aws-amplify/backend-storage": "0.2.2",
-        "@aws-amplify/platform-core": "^0.1.3",
+        "@aws-amplify/platform-core": "^0.1.4",
         "@aws-sdk/client-amplify": "^3.440.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "execa": "^8.0.1",
@@ -20041,7 +20041,7 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^0.3.0"
@@ -20058,15 +20058,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "0.2.2",
+        "@aws-amplify/backend-deployer": "0.2.3",
         "@aws-amplify/backend-secret": "^0.2.1",
         "@aws-amplify/cli-core": "^0.2.0",
         "@aws-amplify/client-config": "0.2.3",
         "@aws-amplify/deployed-backend-client": "^0.2.1",
-        "@aws-amplify/platform-core": "^0.1.3",
+        "@aws-amplify/platform-core": "^0.1.4",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
         "@aws-sdk/types": "^3.378.0",

--- a/packages/backend-auth/API.md
+++ b/packages/backend-auth/API.md
@@ -25,10 +25,12 @@ export type AmazonProviderFactoryProps = Omit<AmazonProviderProps, 'clientId' | 
     clientSecret: BackendSecret;
 };
 
+// Warning: (ae-forgotten-export) The symbol "Expand" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export type AmplifyAuthFactoryProps = Omit<AuthProps, 'outputStorageStrategy' | 'loginWith'> & TriggerConfig & {
-    loginWith: AuthLoginWithFactoryProps;
-};
+export type AmplifyAuthFactoryProps = Expand<Omit<AuthProps, 'outputStorageStrategy' | 'loginWith'> & TriggerConfig & {
+    loginWith: Expand<AuthLoginWithFactoryProps>;
+}>;
 
 // @public
 export type AppleProviderFactoryProps = Omit<AppleProviderProps, 'clientId' | 'teamId' | 'keyId' | 'privateKey'> & {

--- a/packages/backend-auth/API.md
+++ b/packages/backend-auth/API.md
@@ -25,8 +25,6 @@ export type AmazonProviderFactoryProps = Omit<AmazonProviderProps, 'clientId' | 
     clientSecret: BackendSecret;
 };
 
-// Warning: (ae-forgotten-export) The symbol "Expand" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export type AmplifyAuthFactoryProps = Expand<Omit<AuthProps, 'outputStorageStrategy' | 'loginWith'> & TriggerConfig & {
     loginWith: Expand<AuthLoginWithFactoryProps>;
@@ -47,6 +45,11 @@ export type AuthLoginWithFactoryProps = Omit<AuthProps['loginWith'], 'externalPr
 
 // @public
 export const defineAuth: (props: AmplifyAuthFactoryProps) => ConstructFactory<AmplifyAuth & ResourceProvider<AuthResources>>;
+
+// @public (undocumented)
+export type Expand<T> = T extends infer O ? {
+    [K in keyof O]: O[K];
+} : never;
 
 // @public
 export type ExternalProviderGeneralFactoryProps = Omit<ExternalProviderOptions, 'signInWithApple' | 'loginWithAmazon' | 'facebook' | 'oidc' | 'google'>;

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -18,6 +18,9 @@ import { AuthLoginWithFactoryProps } from './types.js';
 import { translateToAuthConstructLoginWith } from './translate_auth_props.js';
 
 export type TriggerConfig = {
+  /**
+   * Configure custom auth triggers
+   */
   triggers?: Partial<
     Record<TriggerEvent, ConstructFactory<ResourceProvider<FunctionResources>>>
   >;
@@ -27,6 +30,9 @@ type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 export type AmplifyAuthFactoryProps = Expand<
   Omit<AuthProps, 'outputStorageStrategy' | 'loginWith'> &
     TriggerConfig & {
+      /**
+       * Specify how you would like users to log in. You can choose from email, phone, and even external providers such as LoginWithAmazon.
+       */
       loginWith: Expand<AuthLoginWithFactoryProps>;
     }
 >;

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -25,7 +25,7 @@ export type TriggerConfig = {
     Record<TriggerEvent, ConstructFactory<ResourceProvider<FunctionResources>>>
   >;
 };
-type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+export type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 
 export type AmplifyAuthFactoryProps = Expand<
   Omit<AuthProps, 'outputStorageStrategy' | 'loginWith'> &

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -22,14 +22,14 @@ export type TriggerConfig = {
     Record<TriggerEvent, ConstructFactory<ResourceProvider<FunctionResources>>>
   >;
 };
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 
-export type AmplifyAuthFactoryProps = Omit<
-  AuthProps,
-  'outputStorageStrategy' | 'loginWith'
-> &
-  TriggerConfig & {
-    loginWith: AuthLoginWithFactoryProps;
-  };
+export type AmplifyAuthFactoryProps = Expand<
+  Omit<AuthProps, 'outputStorageStrategy' | 'loginWith'> &
+    TriggerConfig & {
+      loginWith: Expand<AuthLoginWithFactoryProps>;
+    }
+>;
 
 /**
  * Singleton factory for AmplifyAuth that can be used in Amplify project files


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Instead of just seeing "AmplifyAuthFactoryProps", this expands to show the underlying types:
![image](https://github.com/aws-amplify/samsara-cli/assets/110861985/0cdb8873-911e-4a7c-a301-19f3833089ef)

<img width="762" alt="image" src="https://github.com/aws-amplify/samsara-cli/assets/110861985/0489fdf3-7c7b-495e-9bb6-f270431c4f3a">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
