### PR TITLE
fix: update descriptions for verification message

### DIFF
--- a/.changeset/twenty-adults-compete.md
+++ b/.changeset/twenty-adults-compete.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Update description for verification message.

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -47,8 +47,8 @@ export type PhoneNumberLogin =
       /**
        * The message template for the verification SMS sent to the user upon sign up.
        * Use the code parameter in the template where Cognito should insert the verification code.
-       * @default - verificationMessage: (code: string) => `The verification code to your new account is ${code}` if VerificationEmailStyle.CODE is chosen,
-       * not configured if VerificationEmailStyle.LINK is chosen
+       * @default - verificationMessage: If VerificationEmailStyle.CODE is chosen, the verification message template will be `The verification code to your new account is ${code}`.
+       * If VerificationEmailStyle.LINK is chosen, a verification message will not be configured by default.
        */
       verificationMessage?: (code: string) => string;
     };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This clears up what the default value for verificationMessage is:
![image](https://github.com/aws-amplify/samsara-cli/assets/110861985/4e0354d9-db44-4a1a-af2c-d848c3d907e6)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
