### PR TITLE
Region validation

### DIFF
--- a/.changeset/sour-weeks-live.md
+++ b/.changeset/sour-weeks-live.md
@@ -2,4 +2,4 @@
 '@aws-amplify/backend-cli': patch
 ---
 
-Add region validation
+Validate aws region config. Besides, remove help output from the credential and region validation error.

--- a/.changeset/sour-weeks-live.md
+++ b/.changeset/sour-weeks-live.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Add region validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -19442,7 +19442,7 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.8.0",
@@ -19604,7 +19604,7 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.2.0",
@@ -19949,11 +19949,11 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.8.0",
-        "@aws-amplify/backend": "0.3.3",
+        "@aws-amplify/backend": "0.3.4",
         "@aws-amplify/backend-auth": "0.2.3",
         "@aws-amplify/backend-secret": "^0.2.1",
         "@aws-amplify/backend-storage": "0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19618,6 +19618,8 @@
         "@aws-amplify/sandbox": "^0.2.4",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
+        "@aws-sdk/region-config-resolver": "^3.433.0",
+        "@smithy/node-config-provider": "^2.1.3",
         "@smithy/shared-ini-file-loader": "^2.2.2",
         "execa": "^7.2.0",
         "is-ci": "^3.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,8 @@
     "@aws-amplify/sandbox": "^0.2.4",
     "@aws-sdk/credential-provider-ini": "^3.360.0",
     "@aws-sdk/credential-providers": "^3.360.0",
+    "@aws-sdk/region-config-resolver": "^3.433.0",
+    "@smithy/node-config-provider": "^2.1.3",
     "@smithy/shared-ini-file-loader": "^2.2.2",
     "execa": "^7.2.0",
     "is-ci": "^3.0.1",

--- a/packages/cli/src/command_failure_handler.test.ts
+++ b/packages/cli/src/command_failure_handler.test.ts
@@ -3,7 +3,7 @@ import { handleCommandFailure } from './command_failure_handler.js';
 import { Argv } from 'yargs';
 import { COLOR, Printer } from '@aws-amplify/cli-core';
 import assert from 'node:assert';
-import { ProfileError } from './error/profile_error.js';
+import { InvalidCredentialError } from './error/credential_error.js';
 
 void describe('handleCommandFailure', () => {
   void it('prints a message', (contextual) => {
@@ -60,7 +60,7 @@ void describe('handleCommandFailure', () => {
     const mockPrint = contextual.mock.method(Printer, 'print');
     handleCommandFailure(
       '',
-      new ProfileError(errMsg),
+      new InvalidCredentialError(errMsg),
       {} as unknown as Argv<object>
     );
     assert.equal(mockPrint.mock.callCount(), 1);

--- a/packages/cli/src/command_failure_handler.test.ts
+++ b/packages/cli/src/command_failure_handler.test.ts
@@ -3,6 +3,7 @@ import { handleCommandFailure } from './command_failure_handler.js';
 import { Argv } from 'yargs';
 import { COLOR, Printer } from '@aws-amplify/cli-core';
 import assert from 'node:assert';
+import { ProfileError } from './error/profile_error.js';
 
 void describe('handleCommandFailure', () => {
   void it('prints a message', (contextual) => {
@@ -52,5 +53,18 @@ void describe('handleCommandFailure', () => {
       {} as unknown as Argv<object>
     );
     assert.equal(mockPrint.mock.callCount(), 0);
+  });
+
+  void it('handles a profile error', (contextual) => {
+    const errMsg = 'some profile error';
+    const mockPrint = contextual.mock.method(Printer, 'print');
+    handleCommandFailure(
+      '',
+      new ProfileError(errMsg),
+      {} as unknown as Argv<object>
+    );
+    assert.equal(mockPrint.mock.callCount(), 1);
+    assert.match(mockPrint.mock.calls[0].arguments[0], new RegExp(errMsg));
+    assert.equal(mockPrint.mock.calls[0].arguments[1], COLOR.RED);
   });
 });

--- a/packages/cli/src/command_failure_handler.ts
+++ b/packages/cli/src/command_failure_handler.ts
@@ -1,5 +1,7 @@
 import { Argv } from 'yargs';
 import { COLOR, Printer } from '@aws-amplify/cli-core';
+import { ProfileError } from './error/profile_error.js';
+import { EOL } from 'os';
 
 /**
  * Format error output when a command fails by displaying the error message in
@@ -10,6 +12,11 @@ import { COLOR, Printer } from '@aws-amplify/cli-core';
  */
 export const handleCommandFailure = (msg: string, err: Error, yargs: Argv) => {
   if (isUserForceClosePromptError(err)) {
+    return;
+  }
+
+  if (err instanceof ProfileError) {
+    Printer.print(err.message + EOL, COLOR.RED);
     return;
   }
 

--- a/packages/cli/src/command_failure_handler.ts
+++ b/packages/cli/src/command_failure_handler.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { COLOR, Printer } from '@aws-amplify/cli-core';
-import { ProfileError } from './error/profile_error.js';
+import { InvalidCredentialError } from './error/credential_error.js';
 import { EOL } from 'os';
 
 /**
@@ -15,8 +15,8 @@ export const handleCommandFailure = (msg: string, err: Error, yargs: Argv) => {
     return;
   }
 
-  if (err instanceof ProfileError) {
-    Printer.print(err.message + EOL, COLOR.RED);
+  if (err instanceof InvalidCredentialError) {
+    Printer.print(`${err.message}${EOL}`, COLOR.RED);
     return;
   }
 

--- a/packages/cli/src/command_middleware.test.ts
+++ b/packages/cli/src/command_middleware.test.ts
@@ -8,35 +8,70 @@ import path from 'path';
 import { ArgumentsCamelCase } from 'yargs';
 
 void describe('commandMiddleware', () => {
-  void describe('profile', () => {
+  void describe('ensureAwsCredentialAndRegion', () => {
     const commandMiddleware = new CommandMiddleware();
     const testAccessKeyId = '124';
     const testSecretAccessKey = '667';
     const testProfile = 'profileA';
+    const testRegion = 'testRegion';
+
+    let testDir: string;
+    let credFilePath: string;
+    let configFilePath: string;
+
+    before(async () => {
+      testDir = await fs.mkdtemp('profile_middleware_test');
+      credFilePath = path.join(process.cwd(), testDir, 'credentials');
+      configFilePath = path.join(process.cwd(), testDir, 'config');
+      process.env.AWS_SHARED_CREDENTIALS_FILE = credFilePath;
+      process.env.AWS_CONFIG_FILE = configFilePath;
+    });
+
+    after(async () => {
+      await fs.rm(testDir, { recursive: true, force: true });
+      delete process.env.AWS_SHARED_CREDENTIALS_FILE;
+      delete process.env.AWS_CONFIG_FILE;
+      delete process.env.AWS_PROFILE;
+      delete process.env.AWS_REGION;
+    });
 
     void describe('from environment variables', () => {
       beforeEach(() => {
         process.env.AWS_ACCESS_KEY_ID = testAccessKeyId;
         process.env.AWS_SECRET_ACCESS_KEY = testSecretAccessKey;
+        process.env.AWS_REGION = testRegion;
       });
 
       afterEach(() => {
         delete process.env.AWS_ACCESS_KEY_ID;
         delete process.env.AWS_SECRET_ACCESS_KEY;
         delete process.env.AWS_PROFILE;
+        delete process.env.AWS_REGION;
       });
 
       void it('loads credentials', async () => {
         await assert.doesNotReject(() =>
-          commandMiddleware.ensureAwsCredentials(
+          commandMiddleware.ensureAwsCredentialAndRegion(
             {} as ArgumentsCamelCase<{ profile: string | undefined }>
           )
         );
       });
 
+      void it('throws error if absent region environment variable', async () => {
+        delete process.env.AWS_REGION;
+        try {
+          await commandMiddleware.ensureAwsCredentialAndRegion(
+            {} as ArgumentsCamelCase<{ profile: string | undefined }>
+          );
+          assert.fail('expect to throw error');
+        } catch (err) {
+          assert.match((err as Error).message, /region setting options/);
+        }
+      });
+
       void it('throws error if a profile is provided and no other credential providers', async () => {
         try {
-          await commandMiddleware.ensureAwsCredentials({
+          await commandMiddleware.ensureAwsCredentialAndRegion({
             profile: testProfile,
           } as ArgumentsCamelCase<{ profile: string | undefined }>);
           assert.fail('expect to throw error');
@@ -50,24 +85,30 @@ void describe('commandMiddleware', () => {
     });
 
     void describe('from ini file', () => {
-      let testDir: string;
-      let credFilePath: string;
-
-      before(async () => {
-        testDir = await fs.mkdtemp('profile_middleware_test');
-        credFilePath = path.join(process.cwd(), testDir, 'credentials');
-        process.env.AWS_SHARED_CREDENTIALS_FILE = credFilePath;
+      beforeEach(async () => {
+        // clear files
+        await fs.writeFile(credFilePath, '', 'utf-8');
+        await fs.writeFile(configFilePath, '', 'utf-8');
       });
 
-      after(async () => {
-        await fs.rm(testDir, { recursive: true, force: true });
-        delete process.env.AWS_SHARED_CREDENTIALS_FILE;
-        delete process.env.AWS_PROFILE;
-      });
+      const writeProfileCredential = async (
+        profile: string = DEFAULT_PROFILE
+      ) => {
+        const credData = `[${profile}]${EOL}aws_access_key_id = 12${EOL}aws_secret_access_key = 23${EOL}`;
+        await fs.writeFile(credFilePath, credData, 'utf-8');
+      };
 
-      void it('throws if missing default profile when no profile input', async () => {
+      const writeProfileRegion = async (profile: string = DEFAULT_PROFILE) => {
+        let configData =
+          profile == DEFAULT_PROFILE ? `[${profile}]` : `[profile ${profile}]`;
+        configData += `${EOL}region = ${testRegion}${EOL}`;
+        await fs.writeFile(configFilePath, configData, 'utf-8');
+      };
+
+      void it('throws if missing default credentials when no profile input', async () => {
+        await writeProfileRegion();
         try {
-          await commandMiddleware.ensureAwsCredentials(
+          await commandMiddleware.ensureAwsCredentialAndRegion(
             {} as ArgumentsCamelCase<{ profile: string | undefined }>
           );
           assert.fail('expect to throw error');
@@ -79,19 +120,49 @@ void describe('commandMiddleware', () => {
         }
       });
 
+      void it('throws if missing the default region when no profile input', async () => {
+        await writeProfileCredential();
+
+        try {
+          await commandMiddleware.ensureAwsCredentialAndRegion(
+            {} as ArgumentsCamelCase<{ profile: string | undefined }>
+          );
+          assert.fail('expect to throw error');
+        } catch (err) {
+          assert.match((err as Error).message, /region setting options/);
+        }
+      });
+
       void it('loads default profile when no profile input', async () => {
-        const defaultCredData = `[${DEFAULT_PROFILE}]${EOL}aws_access_key_id = 12${EOL}aws_secret_access_key = 23${EOL}`;
-        await fs.writeFile(credFilePath, defaultCredData, 'utf-8');
+        await writeProfileCredential();
+        await writeProfileRegion();
         await assert.doesNotReject(() =>
-          commandMiddleware.ensureAwsCredentials(
+          commandMiddleware.ensureAwsCredentialAndRegion(
             {} as ArgumentsCamelCase<{ profile: string | undefined }>
           )
         );
       });
 
-      void it('throws error if an input profile does not exist in a credential file', async () => {
+      void it('throws error if missing credentials of the input profile', async () => {
+        await writeProfileRegion(testProfile);
         try {
-          await commandMiddleware.ensureAwsCredentials({
+          await commandMiddleware.ensureAwsCredentialAndRegion({
+            profile: 'someInvalidProfile',
+          } as ArgumentsCamelCase<{ profile: string | undefined }>);
+          assert.fail('expect to throw error');
+        } catch (err) {
+          assert.match(
+            (err as Error).message,
+            /Failed to load aws credentials for profile/
+          );
+        }
+      });
+
+      void it('throws error if missing a region of the input profile', async () => {
+        await writeProfileCredential(testProfile);
+
+        try {
+          await commandMiddleware.ensureAwsCredentialAndRegion({
             profile: 'someInvalidProfile',
           } as ArgumentsCamelCase<{ profile: string | undefined }>);
           assert.fail('expect to throw error');
@@ -104,11 +175,11 @@ void describe('commandMiddleware', () => {
       });
 
       void it('loads a specific profile', async () => {
-        const testProfileCredData = `[${testProfile}]${EOL}aws_access_key_id = 77${EOL}aws_secret_access_key = 88${EOL}`;
-        await fs.writeFile(credFilePath, testProfileCredData, 'utf-8');
+        await writeProfileRegion(testProfile);
+        await writeProfileCredential(testProfile);
 
         await assert.doesNotReject(() =>
-          commandMiddleware.ensureAwsCredentials({
+          commandMiddleware.ensureAwsCredentialAndRegion({
             profile: testProfile,
           } as ArgumentsCamelCase<{ profile: string | undefined }>)
         );

--- a/packages/cli/src/command_middleware.ts
+++ b/packages/cli/src/command_middleware.ts
@@ -3,7 +3,7 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { EOL } from 'os';
 import { loadConfig } from '@smithy/node-config-provider';
 import { NODE_REGION_CONFIG_OPTIONS } from '@aws-sdk/region-config-resolver';
-import { ProfileError } from './error/profile_error.js';
+import { InvalidCredentialError } from './error/credential_error.js';
 
 export const profileSetupInstruction = `To configure a new Amplify profile, use "amplify configure profile".${EOL}To update an existing profile, use "aws configure"`;
 
@@ -36,7 +36,7 @@ export class CommandMiddleware {
       } else {
         errMsg = `Failed to load default aws credentials.${EOL}Please refer to https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html.${EOL}${profileSetupInstruction}`;
       }
-      throw new ProfileError(errMsg, { cause: err });
+      throw new InvalidCredentialError(errMsg, { cause: err });
     }
 
     // Check region.
@@ -48,7 +48,7 @@ export class CommandMiddleware {
       const errMsg = `${
         (err as Error).message
       }. Please refer to this page for region setting options:${EOL}https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html${EOL}${profileSetupInstruction}`;
-      throw new ProfileError(errMsg, { cause: err });
+      throw new InvalidCredentialError(errMsg, { cause: err });
     }
   };
 }

--- a/packages/cli/src/command_middleware.ts
+++ b/packages/cli/src/command_middleware.ts
@@ -1,23 +1,30 @@
 import { ArgumentsCamelCase } from 'yargs';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { EOL } from 'os';
+import { loadConfig } from '@smithy/node-config-provider';
+import { NODE_REGION_CONFIG_OPTIONS } from '@aws-sdk/region-config-resolver';
+import { ProfileError } from './error/profile_error.js';
 
-const profileSetupInstruction = `To configure a new Amplify profile, use "amplify configure profile".${EOL}To update an existing profile's credentials, use "aws configure"`;
+export const profileSetupInstruction = `To configure a new Amplify profile, use "amplify configure profile".${EOL}To update an existing profile, use "aws configure"`;
+
 /**
  * Contains middleware functions.
  */
 export class CommandMiddleware {
   /**
-   * Ensure AWS credentials of the input profile (or 'default' if undefined) are available in the credential provider chain.
+   * Ensure AWS credentials and region of the input profile (or 'default' if undefined) are available in the provider chain.
    * If the input profile is defined, the environment variable AWS_PROFILE will be set accordingly.
    */
-  ensureAwsCredentials = async <T extends { profile: string | undefined }>(
+  ensureAwsCredentialAndRegion = async <
+    T extends { profile: string | undefined }
+  >(
     argv: ArgumentsCamelCase<T>
   ) => {
     if (argv.profile) {
       process.env.AWS_PROFILE = argv.profile;
     }
 
+    // Check credentials.
     try {
       await fromNodeProviderChain({
         ignoreCache: true,
@@ -29,7 +36,19 @@ export class CommandMiddleware {
       } else {
         errMsg = `Failed to load default aws credentials.${EOL}Please refer to https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html.${EOL}${profileSetupInstruction}`;
       }
-      throw new Error(errMsg, { cause: err });
+      throw new ProfileError(errMsg, { cause: err });
+    }
+
+    // Check region.
+    try {
+      await loadConfig(NODE_REGION_CONFIG_OPTIONS, {
+        ignoreCache: true,
+      })();
+    } catch (err) {
+      const errMsg = `${
+        (err as Error).message
+      }. Please refer to this page for region setting options:${EOL}https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html${EOL}${profileSetupInstruction}`;
+      throw new ProfileError(errMsg, { cause: err });
     }
   };
 }

--- a/packages/cli/src/commands/generate/generate_command.ts
+++ b/packages/cli/src/commands/generate/generate_command.ts
@@ -59,7 +59,7 @@ export class GenerateCommand implements CommandModule {
           type: 'string',
           array: false,
         })
-        .middleware([this.commandMiddleware.ensureAwsCredentials])
+        .middleware([this.commandMiddleware.ensureAwsCredentialAndRegion])
         .fail((msg, err) => {
           handleCommandFailure(msg, err, yargs);
           yargs.exit(1, err);

--- a/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.test.ts
@@ -17,7 +17,7 @@ void describe('sandbox delete command', () => {
   const commandMiddleware = new CommandMiddleware();
   const mockHandleProfile = mock.method(
     commandMiddleware,
-    'ensureAwsCredentials',
+    'ensureAwsCredentialAndRegion',
     () => null
   );
 

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -36,7 +36,7 @@ void describe('sandbox command', () => {
   const commandMiddleware = new CommandMiddleware();
   const mockHandleProfile = mock.method(
     commandMiddleware,
-    'ensureAwsCredentials',
+    'ensureAwsCredentialAndRegion',
     () => null
   );
   const sandboxProfile = 'test-sandbox';

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -182,7 +182,7 @@ export class SandboxCommand
           }
           return true;
         })
-        .middleware([this.commandMiddleware.ensureAwsCredentials])
+        .middleware([this.commandMiddleware.ensureAwsCredentialAndRegion])
         .fail((msg, err) => {
           handleCommandFailure(msg, err, yargs);
           yargs.exit(1, err);

--- a/packages/cli/src/error/credential_error.ts
+++ b/packages/cli/src/error/credential_error.ts
@@ -1,9 +1,9 @@
 /**
- * The aws profile error.
+ * The invalid credential error.
  */
-export class ProfileError extends Error {
+export class InvalidCredentialError extends Error {
   /**
-   * Creates a profile error instance.
+   * Creates a credential error instance.
    */
   constructor(
     message: string,

--- a/packages/cli/src/error/profile_error.ts
+++ b/packages/cli/src/error/profile_error.ts
@@ -1,0 +1,18 @@
+/**
+ * The aws profile error.
+ */
+export class ProfileError extends Error {
+  /**
+   * Creates a profile error instance.
+   */
+  constructor(
+    message: string,
+    options?: {
+      cause?: unknown;
+    }
+  ) {
+    super(message, {
+      cause: options?.cause,
+    });
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://app.asana.com/0/1205484060153101/1205891697777566/f

*Description of changes:*
1. Add region validation for AWS profile.
2. Customize error message (and suppress help output) for validation failure.

```
% amplify sandbox   
Region is missing. Please refer to this page for region setting options:
https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html
To configure a new Amplify profile, use "amplify configure profile".
To update an existing profile, use "aws configure"

% amplify sandbox --profile invalid
Failed to load aws credentials for profile 'invalid'.
To configure a new Amplify profile, use "amplify configure profile".
To update an existing profile, use "aws configure"

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
