### PR TITLE
fix: Auth types and documentation

### DIFF
--- a/.changeset/clever-snails-guess.md
+++ b/.changeset/clever-snails-guess.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Update OAuthScope types to string union.

--- a/.changeset/shaggy-bears-smile.md
+++ b/.changeset/shaggy-bears-smile.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Update the documentation for phone number 'verificationMessage'.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19442,7 +19442,7 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.8.0",
@@ -19604,7 +19604,7 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.2.0",
@@ -19947,11 +19947,11 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/amplify-api-next-alpha": "^0.8.0",
-        "@aws-amplify/backend": "0.3.3",
+        "@aws-amplify/backend": "0.3.4",
         "@aws-amplify/backend-auth": "0.2.3",
         "@aws-amplify/backend-secret": "^0.2.1",
         "@aws-amplify/backend-storage": "0.2.2",

--- a/packages/auth-construct/API.md
+++ b/packages/auth-construct/API.md
@@ -59,7 +59,7 @@ export type ExternalProviderOptions = {
     signInWithApple?: AppleProviderProps;
     oidc?: OidcProviderProps;
     saml?: SamlProviderProps;
-    scopes?: aws_cognito.OAuthScope[];
+    scopes?: ('PHONE' | 'EMAIL' | 'OPENID' | 'PROFILE' | 'COGNITO_ADMIN')[];
     callbackUrls?: string[];
     logoutUrls?: string[];
 };

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -11,7 +11,6 @@ import {
 import {
   CfnIdentityPool,
   CfnUserPoolClient,
-  OAuthScope,
   UserPool,
   UserPoolClient,
   UserPoolIdentityProviderSamlMetadataType,

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -1188,7 +1188,7 @@ void describe('Auth construct', () => {
               clientId: googleClientId,
               clientSecret: SecretValue.unsafePlainText(googleClientSecret),
             },
-            scopes: [OAuthScope.EMAIL, OAuthScope.PROFILE],
+            scopes: ['EMAIL', 'PROFILE'],
             callbackUrls: ['http://localhost'],
             logoutUrls: ['http://localhost'],
           },

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -23,7 +23,12 @@ import {
 } from 'aws-cdk-lib/aws-cognito';
 import { FederatedPrincipal, Role } from 'aws-cdk-lib/aws-iam';
 import { AuthOutput, authOutputKey } from '@aws-amplify/backend-output-schemas';
-import { AuthProps, EmailLoginSettings, TriggerEvent } from './types.js';
+import {
+  AuthProps,
+  EmailLoginSettings,
+  ExternalProviderOptions,
+  TriggerEvent,
+} from './types.js';
 import { DEFAULTS } from './defaults.js';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import {
@@ -119,7 +124,7 @@ export class AmplifyAuth
             ? { logoutUrls: externalProviders.logoutUrls }
             : {}),
           ...(externalProviders?.scopes
-            ? { scopes: externalProviders.scopes }
+            ? { scopes: this.getOAuthScopes(externalProviders.scopes) }
             : {}),
         },
       }
@@ -545,6 +550,24 @@ export class AmplifyAuth
         userPool,
         ...external.saml,
       });
+    }
+    return result;
+  };
+
+  /**
+   * Convert scopes from string list to OAuthScopes.
+   * @param scopes - scope list
+   * @returns cognito OAuthScopes
+   */
+  private getOAuthScopes = (
+    scopes: ExternalProviderOptions['scopes']
+  ): cognito.OAuthScope[] => {
+    if (scopes === undefined) {
+      return [];
+    }
+    const result: cognito.OAuthScope[] = [];
+    for (const scope of scopes) {
+      result.push(cognito.OAuthScope[scope]);
     }
     return result;
   };

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -256,13 +256,13 @@ export type AuthProps = {
    *
    * For details about each option, see below.
    *
-   * 'EMAIL_AND_PHONE_WITHOUT_MFA' - Email if available, otherwise phone, but don’t allow a user to reset their password via phone if they are also using it for MFA
+   * 'EMAIL_AND_PHONE_WITHOUT_MFA' - Email if available, otherwise phone, but does not allow a user to reset their password via phone if they are also using it for MFA
    *
-   * 'PHONE_WITHOUT_MFA_AND_EMAIL' - Phone if available, otherwise email, but don’t allow a user to reset their password via phone if they are also using it for MFA
+   * 'PHONE_WITHOUT_MFA_AND_EMAIL' - Phone if available, otherwise email, but does not allow a user to reset their password via phone if they are also using it for MFA
    *
    * 'EMAIL_ONLY' - Email only
    *
-   * 'PHONE_ONLY_WITHOUT_MFA' - Phone only, but don’t allow a user to reset their password via phone if they are also using it for MFA
+   * 'PHONE_ONLY_WITHOUT_MFA' - Phone only, but does not allow a user to reset their password via phone if they are also using it for MFA
    *
    * 'PHONE_AND_EMAIL' - (Not Recommended) Phone if available, otherwise email, and do allow a user to reset their password via phone if they are also using it for MFA.
    *

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -46,9 +46,11 @@ export type PhoneNumberLogin =
   | {
       /**
        * The message template for the verification SMS sent to the user upon sign up.
-       * Use the code parameter in the template where Cognito should insert the verification code.
-       * @default - verificationMessage: (code: string) => `The verification code to your new account is ${code}` if VerificationEmailStyle.CODE is chosen,
-       * not configured if VerificationEmailStyle.LINK is chosen
+       * @default
+       * // If VerificationEmailStyle.LINK is chosen, verificationMessage will not be configured by default.
+       *
+       * // If VerificationEmailStyle.CODE is chosen, the default function will be as follows:
+       * (code) => `The verification code to your new account is ${code}`
        */
       verificationMessage?: (code: string) => string;
     };

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -175,8 +175,25 @@ export type ExternalProviderOptions = {
   saml?: SamlProviderProps;
   /**
    * OAuth scopes that will be allowed with the app client.
+   * @example ['PROFILE']
+   *
+   * For details about each scope, see below.
+   *
+   * 'PHONE' - Grants access to the 'phone_number' and 'phone_number_verified' claims.
+   * Automatically includes access to `OAuthScope.OPENID`.
+   *
+   * 'EMAIL' - Grants access to the 'email' and 'email_verified' claims.
+   * Automatically includes access to `OAuthScope.OPENID`.
+   *
+   * 'OPENID' - Returns all user attributes in the ID token that are readable by the client
+   *
+   * 'PROFILE' - Grants access to all user attributes that are readable by the client
+   * Automatically includes access to `OAuthScope.OPENID`.
+   *
+   * 'COGNITO_ADMIN' - Grants access to Amazon Cognito User Pool API operations that require access tokens,
+   * such as UpdateUserAttributes and VerifyUserAttribute.
    */
-  scopes?: cognito.OAuthScope[];
+  scopes?: ('PHONE' | 'EMAIL' | 'OPENID' | 'PROFILE' | 'COGNITO_ADMIN')[];
   /**
    * List of allowed redirect URLs for the identity providers.
    */
@@ -234,6 +251,22 @@ export type AuthProps = {
    * If no setting is provided, a default will be set based on the enabled login methods.
    * When email and phone login methods are both enabled, email will be the default recovery method.
    * If only email or phone are enabled, they will be the default recovery methods.
+   * @example
+   * "EMAIL_ONLY"
+   *
+   * For details about each option, see below.
+   *
+   * 'EMAIL_AND_PHONE_WITHOUT_MFA' - Email if available, otherwise phone, but don’t allow a user to reset their password via phone if they are also using it for MFA
+   *
+   * 'PHONE_WITHOUT_MFA_AND_EMAIL' - Phone if available, otherwise email, but don’t allow a user to reset their password via phone if they are also using it for MFA
+   *
+   * 'EMAIL_ONLY' - Email only
+   *
+   * 'PHONE_ONLY_WITHOUT_MFA' - Phone only, but don’t allow a user to reset their password via phone if they are also using it for MFA
+   *
+   * 'PHONE_AND_EMAIL' - (Not Recommended) Phone if available, otherwise email, and do allow a user to reset their password via phone if they are also using it for MFA.
+   *
+   * 'NONE' - None – users will have to contact an administrator to reset their passwords
    */
   accountRecovery?: keyof typeof cognito.AccountRecovery;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Converts to string union, so that it does not require importing Cognito.OAuthScopes:
![image](https://github.com/aws-amplify/amplify-backend/assets/110861985/21ad352d-51b0-4c04-a3ff-25badd8f33b1)

Also, improve documentation for verificationMessage:
![image](https://github.com/aws-amplify/amplify-backend/assets/110861985/53eeb3a2-b1d5-4608-8190-ddca1da683f2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
