### PR TITLE
fix: add conditions to auth & unauth roles

### DIFF
--- a/.changeset/curvy-hotels-begin.md
+++ b/.changeset/curvy-hotels-begin.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Add conditions to default unauth and auth role

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -187,7 +187,7 @@ export class AmplifyAuth
             'cognito-identity.amazonaws.com:aud': identityPoolId,
           },
           'ForAnyValue:StringLike': {
-            'cognito-identity.amazonaws.com:amr': 'authenticated',
+            'cognito-identity.amazonaws.com:amr': 'unauthenticated',
           },
         }),
       }),

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -126,7 +126,7 @@
        "Action": "sts:AssumeRole",
        "Condition": {
         "ForAnyValue:StringLike": {
-         "cognito-identity.amazonaws.com:amr": "authenticated"
+         "cognito-identity.amazonaws.com:amr": "unauthenticated"
         },
         "StringEquals": {
          "cognito-identity.amazonaws.com:aud": {

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -97,6 +97,16 @@
      "Statement": [
       {
        "Action": "sts:AssumeRole",
+       "Condition": {
+        "ForAnyValue:StringLike": {
+         "cognito-identity.amazonaws.com:amr": "authenticated"
+        },
+        "StringEquals": {
+         "cognito-identity.amazonaws.com:aud": {
+          "Ref": "amplifyAuthIdentityPool3FDE84CC"
+         }
+        }
+       },
        "Effect": "Allow",
        "Principal": {
         "Federated": "cognito-identity.amazonaws.com"
@@ -114,6 +124,16 @@
      "Statement": [
       {
        "Action": "sts:AssumeRole",
+       "Condition": {
+        "ForAnyValue:StringLike": {
+         "cognito-identity.amazonaws.com:amr": "authenticated"
+        },
+        "StringEquals": {
+         "cognito-identity.amazonaws.com:aud": {
+          "Ref": "amplifyAuthIdentityPool3FDE84CC"
+         }
+        }
+       },
        "Effect": "Allow",
        "Principal": {
         "Federated": "cognito-identity.amazonaws.com"

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -525,7 +525,7 @@
        "Action": "sts:AssumeRole",
        "Condition": {
         "ForAnyValue:StringLike": {
-         "cognito-identity.amazonaws.com:amr": "authenticated"
+         "cognito-identity.amazonaws.com:amr": "unauthenticated"
         },
         "StringEquals": {
          "cognito-identity.amazonaws.com:aud": {

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -496,6 +496,16 @@
      "Statement": [
       {
        "Action": "sts:AssumeRole",
+       "Condition": {
+        "ForAnyValue:StringLike": {
+         "cognito-identity.amazonaws.com:amr": "authenticated"
+        },
+        "StringEquals": {
+         "cognito-identity.amazonaws.com:aud": {
+          "Ref": "amplifyAuthIdentityPool3FDE84CC"
+         }
+        }
+       },
        "Effect": "Allow",
        "Principal": {
         "Federated": "cognito-identity.amazonaws.com"
@@ -513,6 +523,16 @@
      "Statement": [
       {
        "Action": "sts:AssumeRole",
+       "Condition": {
+        "ForAnyValue:StringLike": {
+         "cognito-identity.amazonaws.com:amr": "authenticated"
+        },
+        "StringEquals": {
+         "cognito-identity.amazonaws.com:aud": {
+          "Ref": "amplifyAuthIdentityPool3FDE84CC"
+         }
+        }
+       },
        "Effect": "Allow",
        "Principal": {
         "Federated": "cognito-identity.amazonaws.com"

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -525,7 +525,7 @@
        "Action": "sts:AssumeRole",
        "Condition": {
         "ForAnyValue:StringLike": {
-         "cognito-identity.amazonaws.com:amr": "authenticated"
+         "cognito-identity.amazonaws.com:amr": "unauthenticated"
         },
         "StringEquals": {
          "cognito-identity.amazonaws.com:aud": {

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -496,6 +496,16 @@
      "Statement": [
       {
        "Action": "sts:AssumeRole",
+       "Condition": {
+        "ForAnyValue:StringLike": {
+         "cognito-identity.amazonaws.com:amr": "authenticated"
+        },
+        "StringEquals": {
+         "cognito-identity.amazonaws.com:aud": {
+          "Ref": "amplifyAuthIdentityPool3FDE84CC"
+         }
+        }
+       },
        "Effect": "Allow",
        "Principal": {
         "Federated": "cognito-identity.amazonaws.com"
@@ -513,6 +523,16 @@
      "Statement": [
       {
        "Action": "sts:AssumeRole",
+       "Condition": {
+        "ForAnyValue:StringLike": {
+         "cognito-identity.amazonaws.com:amr": "authenticated"
+        },
+        "StringEquals": {
+         "cognito-identity.amazonaws.com:aud": {
+          "Ref": "amplifyAuthIdentityPool3FDE84CC"
+         }
+        }
+       },
        "Effect": "Allow",
        "Principal": {
         "Federated": "cognito-identity.amazonaws.com"

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -525,7 +525,7 @@
        "Action": "sts:AssumeRole",
        "Condition": {
         "ForAnyValue:StringLike": {
-         "cognito-identity.amazonaws.com:amr": "authenticated"
+         "cognito-identity.amazonaws.com:amr": "unauthenticated"
         },
         "StringEquals": {
          "cognito-identity.amazonaws.com:aud": {

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -496,6 +496,16 @@
      "Statement": [
       {
        "Action": "sts:AssumeRole",
+       "Condition": {
+        "ForAnyValue:StringLike": {
+         "cognito-identity.amazonaws.com:amr": "authenticated"
+        },
+        "StringEquals": {
+         "cognito-identity.amazonaws.com:aud": {
+          "Ref": "amplifyAuthIdentityPool3FDE84CC"
+         }
+        }
+       },
        "Effect": "Allow",
        "Principal": {
         "Federated": "cognito-identity.amazonaws.com"
@@ -513,6 +523,16 @@
      "Statement": [
       {
        "Action": "sts:AssumeRole",
+       "Condition": {
+        "ForAnyValue:StringLike": {
+         "cognito-identity.amazonaws.com:amr": "authenticated"
+        },
+        "StringEquals": {
+         "cognito-identity.amazonaws.com:aud": {
+          "Ref": "amplifyAuthIdentityPool3FDE84CC"
+         }
+        }
+       },
        "Effect": "Allow",
        "Principal": {
         "Federated": "cognito-identity.amazonaws.com"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The default authenticated roles that were being created were overly permissive and was not tied to the specific identity pool. This will leave the created app to be vulnerable as it can be exploited.

This change will apply condition to these roles so its tied down to specific identity pools created when auth construct is deployed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
