### PR TITLE
Fix profile validation unit test

### DIFF
--- a/.changeset/giant-meals-itch.md
+++ b/.changeset/giant-meals-itch.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Fix a profile middleware unit test

--- a/package-lock.json
+++ b/package-lock.json
@@ -19428,12 +19428,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.1",
-        "@aws-amplify/backend-output-storage": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.3.1"
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-storage": "^0.2.1",
+        "@aws-amplify/plugin-types": "^0.4.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19442,19 +19442,19 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.2.2",
-        "@aws-amplify/backend-data": "^0.4.0",
-        "@aws-amplify/backend-function": "^0.1.4",
-        "@aws-amplify/backend-output-schemas": "^0.2.1",
-        "@aws-amplify/backend-output-storage": "^0.2.0",
-        "@aws-amplify/backend-secret": "^0.2.1",
-        "@aws-amplify/backend-storage": "^0.2.1",
+        "@aws-amplify/backend-auth": "^0.3.0",
+        "@aws-amplify/backend-data": "^0.5.0",
+        "@aws-amplify/backend-function": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-storage": "^0.2.1",
+        "@aws-amplify/backend-secret": "^0.3.0",
+        "@aws-amplify/backend-storage": "^0.3.0",
         "@aws-amplify/data-schema": "^0.11.0",
-        "@aws-amplify/platform-core": "^0.1.4",
-        "@aws-amplify/plugin-types": "^0.3.1",
+        "@aws-amplify/platform-core": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.4.0",
         "@aws-sdk/client-amplify": "^3.440.0"
       },
       "devDependencies": {
@@ -19468,16 +19468,16 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.2.2",
-        "@aws-amplify/backend-output-storage": "0.2.0",
-        "@aws-amplify/plugin-types": "^0.3.0"
+        "@aws-amplify/auth-construct-alpha": "^0.3.0",
+        "@aws-amplify/backend-output-storage": "0.2.1",
+        "@aws-amplify/plugin-types": "^0.4.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.1.3"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19486,19 +19486,19 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.1",
-        "@aws-amplify/backend-output-storage": "0.2.0",
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-storage": "0.2.1",
         "@aws-amplify/data-schema-types": "^0.4.2",
         "@aws-amplify/graphql-api-construct": "^1.3.0",
-        "@aws-amplify/plugin-types": "^0.3.1"
+        "@aws-amplify/plugin-types": "^0.4.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.2.0",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
         "@aws-amplify/data-schema": "^0.11.0",
-        "@aws-amplify/platform-core": "^0.1.4"
+        "@aws-amplify/platform-core": "^0.2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19507,11 +19507,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.1.4",
-        "@aws-amplify/plugin-types": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.4.0",
         "execa": "^7.2.0",
         "tsx": "^3.12.6"
       },
@@ -19522,17 +19522,17 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "0.2.0",
+        "@aws-amplify/backend-output-storage": "0.2.1",
         "@aws-amplify/function-construct-alpha": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.3.0",
+        "@aws-amplify/plugin-types": "^0.4.0",
         "execa": "^7.1.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.1.4"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19541,10 +19541,10 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "0.3.1"
+        "@aws-amplify/plugin-types": "0.4.0"
       },
       "peerDependencies": {
         "zod": "^3.21.4"
@@ -19552,11 +19552,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.1.1"
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0"
@@ -19564,7 +19564,7 @@
     },
     "packages/backend-platform-test-stubs": {
       "name": "@aws-amplify/backend-platform-test-stubs",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-cdk-lib": "^2.100.0",
@@ -19573,11 +19573,11 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.1.2",
-        "@aws-amplify/plugin-types": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.2.0",
+        "@aws-amplify/plugin-types": "^0.4.0",
         "@aws-sdk/client-ssm": "^3.398.0"
       },
       "devDependencies": {
@@ -19586,16 +19586,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.3.0",
-        "@aws-amplify/storage-construct-alpha": "^0.2.0"
+        "@aws-amplify/backend-output-storage": "^0.2.1",
+        "@aws-amplify/plugin-types": "^0.4.0",
+        "@aws-amplify/storage-construct-alpha": "^0.2.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.1.3"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19604,18 +19604,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0",
-        "@aws-amplify/backend-secret": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.2.1",
-        "@aws-amplify/deployed-backend-client": "^0.2.0",
+        "@aws-amplify/client-config": "^0.3.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.0",
         "@aws-amplify/form-generator": "^0.3.0",
-        "@aws-amplify/model-generator": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.1.4",
-        "@aws-amplify/sandbox": "^0.2.4",
+        "@aws-amplify/model-generator": "^0.2.1",
+        "@aws-amplify/platform-core": "^0.2.0",
+        "@aws-amplify/sandbox": "^0.3.0",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@aws-sdk/region-config-resolver": "^3.433.0",
@@ -19760,12 +19760,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.1",
-        "@aws-amplify/deployed-backend-client": "^0.2.1",
-        "@aws-amplify/model-generator": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.0",
+        "@aws-amplify/model-generator": "^0.2.1",
         "@aws-sdk/client-amplify": "^3.376.0",
         "@aws-sdk/client-cloudformation": "^3.376.0",
         "@aws-sdk/client-ssm": "^3.398.0",
@@ -19773,12 +19773,12 @@
         "zod": "^3.21.4"
       },
       "devDependencies": {
-        "@aws-amplify/platform-core": "^0.1.3",
+        "@aws-amplify/platform-core": "^0.2.0",
         "@aws-sdk/types": "^3.370.0"
       }
     },
     "packages/create-amplify": {
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
@@ -19904,11 +19904,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.1",
-        "@aws-amplify/platform-core": "^0.1.2",
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.2.0",
         "@aws-sdk/client-amplify": "^3.329.0",
         "@aws-sdk/client-cloudformation": "^3.329.0",
         "@aws-sdk/client-s3": "^3.329.0",
@@ -19949,15 +19949,15 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/backend": "0.3.4",
-        "@aws-amplify/backend-auth": "0.2.3",
-        "@aws-amplify/backend-secret": "^0.2.1",
-        "@aws-amplify/backend-storage": "0.2.2",
+        "@aws-amplify/backend": "0.4.0",
+        "@aws-amplify/backend-auth": "0.3.0",
+        "@aws-amplify/backend-secret": "^0.3.0",
+        "@aws-amplify/backend-storage": "0.3.0",
         "@aws-amplify/data-schema": "^0.11.0",
-        "@aws-amplify/platform-core": "^0.1.4",
+        "@aws-amplify/platform-core": "^0.2.0",
         "@aws-sdk/client-amplify": "^3.440.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "execa": "^8.0.1",
@@ -20023,11 +20023,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0",
-        "@aws-amplify/deployed-backend-client": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.0",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -20043,15 +20043,15 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^0.3.0"
+        "@aws-amplify/plugin-types": "^0.4.0"
       }
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20060,15 +20060,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "0.2.3",
-        "@aws-amplify/backend-secret": "^0.2.1",
+        "@aws-amplify/backend-deployer": "0.3.0",
+        "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "0.2.3",
-        "@aws-amplify/deployed-backend-client": "^0.2.1",
-        "@aws-amplify/platform-core": "^0.1.4",
+        "@aws-amplify/client-config": "0.3.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.2.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
         "@aws-sdk/types": "^3.378.0",
@@ -20116,14 +20116,14 @@
     },
     "packages/storage-construct": {
       "name": "@aws-amplify/storage-construct-alpha",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.1",
-        "@aws-amplify/backend-output-storage": "^0.2.0"
+        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-storage": "^0.2.1"
       },
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.3.0"
+        "@aws-amplify/plugin-types": "^0.4.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",

--- a/packages/cli/src/command_middleware.test.ts
+++ b/packages/cli/src/command_middleware.test.ts
@@ -40,6 +40,7 @@ void describe('commandMiddleware', () => {
         process.env.AWS_ACCESS_KEY_ID = testAccessKeyId;
         process.env.AWS_SECRET_ACCESS_KEY = testSecretAccessKey;
         process.env.AWS_REGION = testRegion;
+        delete process.env.AWS_PROFILE;
       });
 
       afterEach(() => {


### PR DESCRIPTION
*Description of changes:*
The unit test on loading credential from environment variables fail if the running env has AWS_PROFILE set. Why?  `fromNodeProviderChain` will ignore credential envVars (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY...) if `AWS_PROFILE` is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
