### PR TITLE
test: use GH workflow for e2e test of create amplify

### DIFF
--- a/.changeset/small-readers-check.md
+++ b/.changeset/small-readers-check.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/integration-tests': patch
+'create-amplify': patch
+---
+
+- Support yarn, pnpm via env var
+- Add e2e test against yarn, pnpm

--- a/.github/workflows/poc-e2e-flow-test.yml
+++ b/.github/workflows/poc-e2e-flow-test.yml
@@ -42,13 +42,13 @@ jobs:
         include:
           - os: ubuntu-latest
             pkg-manager: yarn-stable
-            node-version: 19
+            node-version: 19 # TODO: use Node 20 once https://github.com/yarnpkg/berry/pull/5961 is released
           - os: macos-latest
             pkg-manager: yarn-stable
-            node-version: 19
+            node-version: 19 # TODO: use Node 20 once https://github.com/yarnpkg/berry/pull/5961 is released
           - os: windows-latest
             pkg-manager: yarn-stable
-            node-version: 19
+            node-version: 19 # TODO: use Node 20 once https://github.com/yarnpkg/berry/pull/5961 is released
     env:
       ACKAGE_MANAGER_EXECUTABLE: ${{ matrix.pkg-manager }} # TODO: remove PACKAGE_MANAGER_EXECUTABLE once CLI is able to getPackageManager().
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/poc-e2e-flow-test.yml
+++ b/.github/workflows/poc-e2e-flow-test.yml
@@ -38,6 +38,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         pkg-manager: [npm, yarn, yarn-stable, pnpm]
+        node-version: [20]
+        exclude:
+          - pkg-manager: yarn-stable
+            node-version: 20
+        include:
+          - pkg-manager: yarn-stable
+            node-version: 19
     env:
       ACKAGE_MANAGER_EXECUTABLE: ${{ matrix.pkg-manager }} # TODO: remove PACKAGE_MANAGER_EXECUTABLE once CLI is able to getPackageManager().
     runs-on: ${{ matrix.os }}
@@ -54,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # version 3.8.1
         with:
-          node-version: 19
+          node-version: ${{ matrix.node-version }}
       - name: Restore Build Cache
         uses: ./.github/actions/restore_build_cache
       - name: Run E2E tests with ${{ matrix.pkg-manager }}

--- a/.github/workflows/poc-e2e-flow-test.yml
+++ b/.github/workflows/poc-e2e-flow-test.yml
@@ -37,11 +37,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        pkg-manager: [npm, yarn, pnpm]
-        node-version: [20]
-        # include:
-        #   - pkg-manager: yarn-stable
-        #     node-version: 19
+        pkg-manager: [npm, yarn, yarn-stable, pnpm]
+        include:
+          - node-version: 20
+          - pkg-manager: yarn-stable
+            node-version: 19
+        exclude:
+          - pkg-manager: yarn-stable
+            node-version: 20
     env:
       ACKAGE_MANAGER_EXECUTABLE: ${{ matrix.pkg-manager }} # TODO: remove PACKAGE_MANAGER_EXECUTABLE once CLI is able to getPackageManager().
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/poc-e2e-flow-test.yml
+++ b/.github/workflows/poc-e2e-flow-test.yml
@@ -37,11 +37,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        pkg-manager: [npm, yarn, yarn-stable, pnpm]
+        pkg-manager: [npm, yarn, pnpm]
         node-version: [20]
-        exclude:
-          - pkg-manager: yarn-stable
-            node-version: 20
         include:
           - pkg-manager: yarn-stable
             node-version: 19

--- a/.github/workflows/poc-e2e-flow-test.yml
+++ b/.github/workflows/poc-e2e-flow-test.yml
@@ -5,53 +5,59 @@ name: 'poc-e2e-flow-test'
 on: # TODO: need to change the trigger
   push:
     branches:
-      - poc/e2e-test
+      - poc/e2e-create-amplify
 
 jobs:
-  create-amplify-project:
+  install:
     strategy:
-      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        node-version: [18]
-        pkg-manager: [npm, yarn, yarn-stable, pnpm]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      PACKAGE_MANAGER_EXECUTABLE: ${{ matrix.pkg-manager }} # TODO: remove PACKAGE_MANAGER_EXECUTABLE once CLI is able to getPackageManager().
     steps:
       - name: Checkout aws-amplify/amplify-cli repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1. TODO: try only fetch .github/workflow
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Setup Node.js
-        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 #4.0.0
+        uses: ./.github/actions/setup_node
+      - name: Install or Restore Cache
+        uses: ./.github/actions/install_with_cache
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - install
+    steps:
+      - name: Checkout aws-amplify/amplify-cli repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Setup Node.js
+        uses: ./.github/actions/setup_node
+      - name: Build or Restore Build Cache
+        uses: ./.github/actions/build_with_cache
+  run_e2e_tests:
+    strategy:
+      # will finish running other test matrices even if one fails
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        pkg-manager: [npm, yarn, yarn-stable, pnpm]
+    env:
+      ACKAGE_MANAGER_EXECUTABLE: ${{ matrix.pkg-manager }} # TODO: remove PACKAGE_MANAGER_EXECUTABLE once CLI is able to getPackageManager().
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    needs:
+      - build
+    permissions:
+      # these permissions are required for the configure-aws-credentials action to get a JWT from GitHub
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout aws-amplify/amplify-cli repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # version 3.8.1
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - name: Local Publish create-amplify
+          node-version: 19
+      - name: Restore Build Cache
+        uses: ./.github/actions/restore_build_cache
+      - name: Run E2E tests with ${{ matrix.pkg-manager }}
         shell: bash
-        run: npm run install:local && npm run build && npm run vend
-      - name: ${{matrix.pkg-manager}}-create-amplify-project
-        if: matrix.pkg-manager != 'yarn-stable'
-        shell: bash
-        run:
-          | # TODO: last step `create amplify` should be replaced by `run e2e`
-          mkdir -p /tmp/amplify-project; cd /tmp/amplify-project
-          npm install -g ${{matrix.pkg-manager}}
-          echo "$(${{matrix.pkg-manager}}) config set registry http://localhost:4873"
-          ${{matrix.pkg-manager}} config set registry http://localhost:4873
-          echo "$(${{matrix.pkg-manager}}) config get registry"
-          ${{matrix.pkg-manager}} config get registry
-          ${{matrix.pkg-manager}} create amplify --yes
-
-      - name: yarn-stable-create-amplify-project
-        if: matrix.pkg-manager == 'yarn-stable'
-        shell: bash
-        run:
-          | # TODO: last step `create amplify` should be replaced by `run e2e`
-          mkdir -p /tmp/amplify-project; cd /tmp/amplify-project
-          corepack enable
-          echo "yarn set version stable"
-          yarn set version stable
-          echo "yarn version $(yarn --version)"
-          yarn config set unsafeHttpWhitelist localhost
-          yarn config set npmRegistryServer http://localhost:4873
-          PACKAGE_MANAGER_EXECUTABLE=yarn yarn create amplify --yes
+        run: |
+          PACKAGE_MANAGER_EXECUTABLE=${{matrix.pkg-manager}} npm run test:dir packages/integration-tests/src/test-e2e/create_amplify.test.ts

--- a/.github/workflows/poc-e2e-flow-test.yml
+++ b/.github/workflows/poc-e2e-flow-test.yml
@@ -39,9 +39,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         pkg-manager: [npm, yarn, pnpm]
         node-version: [20]
-        include:
-          - pkg-manager: yarn-stable
-            node-version: 19
+        # include:
+        #   - pkg-manager: yarn-stable
+        #     node-version: 19
     env:
       ACKAGE_MANAGER_EXECUTABLE: ${{ matrix.pkg-manager }} # TODO: remove PACKAGE_MANAGER_EXECUTABLE once CLI is able to getPackageManager().
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/poc-e2e-flow-test.yml
+++ b/.github/workflows/poc-e2e-flow-test.yml
@@ -37,14 +37,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        pkg-manager: [npm, yarn, yarn-stable, pnpm]
+        pkg-manager: [npm, yarn, pnpm]
+        node-version: [20]
         include:
-          - node-version: 20
-          - pkg-manager: yarn-stable
+          - os: ubuntu-latest
+            pkg-manager: yarn-stable
             node-version: 19
-        exclude:
-          - pkg-manager: yarn-stable
-            node-version: 20
+          - os: macos-latest
+            pkg-manager: yarn-stable
+            node-version: 19
+          - os: windows-latest
+            pkg-manager: yarn-stable
+            node-version: 19
     env:
       ACKAGE_MANAGER_EXECUTABLE: ${{ matrix.pkg-manager }} # TODO: remove PACKAGE_MANAGER_EXECUTABLE once CLI is able to getPackageManager().
     runs-on: ${{ matrix.os }}

--- a/packages/create-amplify/src/npm_package_manager_controller.ts
+++ b/packages/create-amplify/src/npm_package_manager_controller.ts
@@ -15,8 +15,11 @@ export class NpmPackageManagerController implements PackageManagerController {
     private readonly projectRoot: string,
     private readonly execa = _execa
   ) {}
-  private readonly executableName =
-    process.env.PACKAGE_MANAGER_EXECUTABLE || 'npm'; // TODO: replace `process.env.PACKAGE_MANAGER_EXECUTABLE` with `getPackageManagerName()` once the test infra is ready.
+  private readonly executableName = !process.env.PACKAGE_MANAGER_EXECUTABLE
+    ? 'npm'
+    : process.env.PACKAGE_MANAGER_EXECUTABLE === 'yarn-stable'
+    ? 'yarn'
+    : process.env.PACKAGE_MANAGER_EXECUTABLE; // TODO: replace `process.env.PACKAGE_MANAGER_EXECUTABLE` with `getPackageManagerName()` once the test infra is ready.
 
   /**
    * Installs the given package names as devDependencies

--- a/packages/create-amplify/src/npm_package_manager_controller.ts
+++ b/packages/create-amplify/src/npm_package_manager_controller.ts
@@ -37,9 +37,18 @@ export class NpmPackageManagerController implements PackageManagerController {
     }
 
     try {
-      await executeWithDebugLogger(this.projectRoot, 'npm', args, this.execa);
+      await executeWithDebugLogger(
+        this.projectRoot,
+        this.executableName,
+        args,
+        this.execa
+      );
     } catch {
-      throw new Error(`\`npm ${args.join(' ')}\` did not exit successfully.`);
+      throw new Error(
+        `\`${this.executableName} ${args.join(
+          ' '
+        )}\` did not exit successfully.`
+      );
     }
   };
 }

--- a/packages/create-amplify/src/tsconfig_initializer.ts
+++ b/packages/create-amplify/src/tsconfig_initializer.ts
@@ -17,8 +17,11 @@ export class TsConfigInitializer {
     private readonly existsSync = _existsSync,
     private readonly execa = _execa
   ) {}
-  private readonly executableName =
-    process.env.PACKAGE_MANAGER_EXECUTABLE || 'npx'; // TODO: replace `process.env.PACKAGE_MANAGER_EXECUTABLE` with `getPackageManagerName()` once the test infra is ready.
+  private readonly executableName = !process.env.PACKAGE_MANAGER_EXECUTABLE
+    ? 'npx'
+    : process.env.PACKAGE_MANAGER_EXECUTABLE === 'yarn-stable'
+    ? 'yarn'
+    : process.env.PACKAGE_MANAGER_EXECUTABLE; // TODO: replace `process.env.PACKAGE_MANAGER_EXECUTABLE` with `getPackageManagerName()` once the test infra is ready.
 
   /**
    * If tsconfig.json already exists, this is a noop. Otherwise, `npx tsc --init` is executed to create a tsconfig.json file


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a followup PR of https://github.com/aws-amplify/amplify-backend/pull/533

- Use GH Workflow Matrix to run test-e2e/create_amplify.test.ts with different Package Managers
- Temporarily use Env Var as an indicator of Package Managers

*Note*:

- Modern Yarn x Node 18/20 fails for https://github.com/yarnpkg/berry/issues/4694 and  https://github.com/yarnpkg/berry/issues/5951 , so we use Node 19 in this PR. However, Node 19 is already deprecated. I wonder if we should test Node 20 (exclude Modern Yarn) and Node 19 only for Modern Yarn?


*Test*: https://github.com/aws-amplify/amplify-backend/actions/runs/6856166344


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
