### PR TITLE
feat: generate mobile friendly config

### DIFF
--- a/.changeset/wet-emus-smile.md
+++ b/.changeset/wet-emus-smile.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/client-config': patch
+'@aws-amplify/backend-cli': patch
+---
+
+handle client config formats used in mobile app development

--- a/package-lock.json
+++ b/package-lock.json
@@ -19778,7 +19778,7 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
@@ -19949,7 +19949,7 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/backend": "0.4.0",

--- a/packages/cli/src/commands/generate/config/generate_config_command.test.ts
+++ b/packages/cli/src/commands/generate/config/generate_config_command.test.ts
@@ -135,6 +135,20 @@ void describe('generate config command', () => {
     ]);
   });
 
+  void it('can generate config in json mobile format', async () => {
+    await commandRunner.runCommand(
+      'config --stack stack_name --out-dir foo/bar --format json-mobile'
+    );
+    assert.equal(generateClientConfigMock.mock.callCount(), 1);
+    assert.deepStrictEqual(generateClientConfigMock.mock.calls[0].arguments, [
+      {
+        stackName: 'stack_name',
+      },
+      'foo/bar',
+      ClientConfigFormat.JSON_MOBILE,
+    ]);
+  });
+
   void it('shows available options in help output', async () => {
     const output = await commandRunner.runCommand('config --help');
     assert.match(output, /--stack/);

--- a/packages/client-config/API.md
+++ b/packages/client-config/API.md
@@ -26,6 +26,8 @@ export enum ClientConfigFormat {
     // (undocumented)
     JSON = "json",
     // (undocumented)
+    JSON_MOBILE = "json-mobile",
+    // (undocumented)
     MJS = "mjs",
     // (undocumented)
     TS = "ts"

--- a/packages/client-config/src/client-config-types/client_config.ts
+++ b/packages/client-config/src/client-config-types/client_config.ts
@@ -16,6 +16,7 @@ export type ClientConfig = Partial<
 export enum ClientConfigFormat {
   MJS = 'mjs',
   JSON = 'json',
+  JSON_MOBILE = 'json-mobile',
   TS = 'ts',
   DART = 'dart',
 }

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -1,0 +1,76 @@
+export type ClientConfigMobile = {
+  UserAgent: 'aws-amplify-cli/2.0';
+  Version: '1.0';
+  api?: ClientConfigMobileApi;
+  auth?: ClientConfigMobileAuth;
+};
+
+export type ClientConfigMobileApi = {
+  plugins: {
+    awsAPIPlugin: Record<
+      string,
+      {
+        endpointType: 'GraphQL';
+        endpoint: string;
+        region: string;
+        authorizationType: string;
+        apiKey?: string;
+      }
+    >;
+  };
+};
+
+export type ClientConfigMobileAuth = {
+  plugins: {
+    awsCognitoAuthPlugin: {
+      UserAgent: 'aws-amplify-cli/2.0';
+      Version: '1.0';
+      CredentialsProvider: {
+        CognitoIdentity: {
+          Default: {
+            PoolId: string;
+            Region: string;
+          };
+        };
+      };
+      CognitoUserPool: {
+        Default: {
+          PoolId: string;
+          AppClientId: string;
+          Region: string;
+        };
+      };
+      Auth: {
+        Default: {
+          OAuth: {
+            WebDomain: string;
+            AppClientId: string;
+            SignInRedirectURI: string;
+            SignOutRedirectURI: string;
+            Scopes: Array<string>;
+          };
+          authenticationFlowType: string;
+          socialProviders: Array<string>;
+          usernameAttributes: Array<string>;
+          signupAttributes: Array<string>;
+          passwordProtectionSettings: {
+            passwordPolicyMinLength: number;
+            passwordPolicyCharacters: Array<string>;
+          };
+          mfaConfiguration: string;
+          mfaTypes: Array<string>;
+          verificationMechanisms: Array<string>;
+        };
+      };
+      AppSync?: {
+        Default: {
+          ApiUrl: string;
+          Region: string;
+          AuthMode: string;
+          ApiKey?: string;
+          ClientDatabasePrefix: string;
+        };
+      };
+    };
+  };
+};

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -12,9 +12,9 @@ export type ClientConfigMobileApi = {
       {
         endpointType: 'GraphQL';
         endpoint: string;
-        region: string;
-        authorizationType: string;
-        apiKey?: string;
+        region: string | undefined;
+        authorizationType: string | undefined;
+        apiKey: string | undefined;
       }
     >;
   };
@@ -28,47 +28,29 @@ export type ClientConfigMobileAuth = {
       CredentialsProvider: {
         CognitoIdentity: {
           Default: {
-            PoolId: string;
-            Region: string;
+            PoolId: string | undefined;
+            Region: string | undefined;
           };
         };
       };
       CognitoUserPool: {
         Default: {
-          PoolId: string;
-          AppClientId: string;
-          Region: string;
+          PoolId: string | undefined;
+          AppClientId: string | undefined;
+          Region: string | undefined;
         };
       };
       Auth: {
         Default: {
-          OAuth: {
-            WebDomain: string;
-            AppClientId: string;
-            SignInRedirectURI: string;
-            SignOutRedirectURI: string;
-            Scopes: Array<string>;
-          };
-          authenticationFlowType: string;
-          socialProviders: Array<string>;
-          usernameAttributes: Array<string>;
-          signupAttributes: Array<string>;
-          passwordProtectionSettings: {
-            passwordPolicyMinLength: number;
-            passwordPolicyCharacters: Array<string>;
-          };
-          mfaConfiguration: string;
-          mfaTypes: Array<string>;
-          verificationMechanisms: Array<string>;
+          authenticationFlowType: 'USER_SRP_AUTH';
         };
       };
       AppSync?: {
         Default: {
           ApiUrl: string;
-          Region: string;
-          AuthMode: string;
-          ApiKey?: string;
-          ClientDatabasePrefix: string;
+          Region: string | undefined;
+          AuthMode: string | undefined;
+          ApiKey: string | undefined;
         };
       };
     };

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -1,5 +1,5 @@
 export type ClientConfigMobile = {
-  UserAgent: 'aws-amplify-cli/2.0';
+  UserAgent: string;
   Version: '1.0';
   api?: ClientConfigMobileApi;
   auth?: ClientConfigMobileAuth;
@@ -23,7 +23,7 @@ export type ClientConfigMobileApi = {
 export type ClientConfigMobileAuth = {
   plugins: {
     awsCognitoAuthPlugin: {
-      UserAgent: 'aws-amplify-cli/2.0';
+      UserAgent: string;
       Version: '1.0';
       CredentialsProvider: {
         CognitoIdentity: {

--- a/packages/client-config/src/client-config-writer/client_config_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.test.ts
@@ -1,0 +1,158 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { ClientConfigConverter } from './client_config_converter.js';
+import { ClientConfigMobile } from '../client-config-types/mobile/client_config_mobile_types.js';
+import { ClientConfig } from '../client-config-types/client_config.js';
+
+void describe('client config converter', () => {
+  const testPackageName = 'test_package_name';
+  const testPackageVersion = 'test_package_version;';
+  const converter = new ClientConfigConverter(
+    testPackageName,
+    testPackageVersion
+  );
+  const expectedUserAgent = `${testPackageName}/${testPackageVersion}`;
+
+  void it('converts auth only config', () => {
+    const clientConfig: ClientConfig = {
+      aws_cognito_region: 'test_cognito_region',
+      aws_user_pools_id: 'test_user_pool_id',
+      aws_user_pools_web_client_id: 'test_user_pool_app_client_id',
+    };
+    const expectedMobileConfig: ClientConfigMobile = {
+      UserAgent: expectedUserAgent,
+      Version: '1.0',
+      auth: {
+        plugins: {
+          awsCognitoAuthPlugin: {
+            UserAgent: expectedUserAgent,
+            Version: '1.0',
+            CognitoUserPool: {
+              Default: {
+                PoolId: 'test_user_pool_id',
+                AppClientId: 'test_user_pool_app_client_id',
+                Region: 'test_cognito_region',
+              },
+            },
+            CredentialsProvider: {
+              CognitoIdentity: {
+                Default: {
+                  PoolId: 'test_user_pool_id',
+                  Region: 'test_cognito_region',
+                },
+              },
+            },
+            Auth: {
+              Default: {
+                authenticationFlowType: 'USER_SRP_AUTH',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const actualMobileConfig = converter.convertToMobileConfig(clientConfig);
+
+    assert.deepStrictEqual(expectedMobileConfig, actualMobileConfig);
+  });
+
+  void it('converts data only config', () => {
+    const clientConfig: ClientConfig = {
+      aws_appsync_region: 'test_app_sync_region',
+      aws_appsync_graphqlEndpoint: 'https://test_api_endpoint.amazon.com',
+      aws_appsync_apiKey: 'test_api_key',
+      aws_appsync_authenticationType: 'API_KEY',
+    };
+    const expectedMobileConfig: ClientConfigMobile = {
+      UserAgent: expectedUserAgent,
+      Version: '1.0',
+      api: {
+        plugins: {
+          awsAPIPlugin: {
+            data: {
+              endpointType: 'GraphQL',
+              endpoint: 'https://test_api_endpoint.amazon.com',
+              region: 'test_app_sync_region',
+              authorizationType: 'API_KEY',
+              apiKey: 'test_api_key',
+            },
+          },
+        },
+      },
+    };
+
+    const actualMobileConfig = converter.convertToMobileConfig(clientConfig);
+
+    assert.deepStrictEqual(expectedMobileConfig, actualMobileConfig);
+  });
+
+  void it('converts auth with data config', () => {
+    const clientConfig: ClientConfig = {
+      aws_cognito_region: 'test_cognito_region',
+      aws_user_pools_id: 'test_user_pool_id',
+      aws_user_pools_web_client_id: 'test_user_pool_app_client_id',
+      aws_appsync_region: 'test_app_sync_region',
+      aws_appsync_graphqlEndpoint: 'https://test_api_endpoint.amazon.com',
+      aws_appsync_apiKey: 'test_api_key',
+      aws_appsync_authenticationType: 'API_KEY',
+    };
+    const expectedMobileConfig: ClientConfigMobile = {
+      UserAgent: expectedUserAgent,
+      Version: '1.0',
+      auth: {
+        plugins: {
+          awsCognitoAuthPlugin: {
+            UserAgent: expectedUserAgent,
+            Version: '1.0',
+            CognitoUserPool: {
+              Default: {
+                PoolId: 'test_user_pool_id',
+                AppClientId: 'test_user_pool_app_client_id',
+                Region: 'test_cognito_region',
+              },
+            },
+            CredentialsProvider: {
+              CognitoIdentity: {
+                Default: {
+                  PoolId: 'test_user_pool_id',
+                  Region: 'test_cognito_region',
+                },
+              },
+            },
+            Auth: {
+              Default: {
+                authenticationFlowType: 'USER_SRP_AUTH',
+              },
+            },
+            AppSync: {
+              Default: {
+                ApiUrl: 'https://test_api_endpoint.amazon.com',
+                Region: 'test_app_sync_region',
+                AuthMode: 'API_KEY',
+                ApiKey: 'test_api_key',
+              },
+            },
+          },
+        },
+      },
+      api: {
+        plugins: {
+          awsAPIPlugin: {
+            data: {
+              endpointType: 'GraphQL',
+              endpoint: 'https://test_api_endpoint.amazon.com',
+              region: 'test_app_sync_region',
+              authorizationType: 'API_KEY',
+              apiKey: 'test_api_key',
+            },
+          },
+        },
+      },
+    };
+
+    const actualMobileConfig = converter.convertToMobileConfig(clientConfig);
+
+    assert.deepStrictEqual(expectedMobileConfig, actualMobileConfig);
+  });
+});

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -1,0 +1,11 @@
+import { ClientConfig } from '../client-config-types/client_config.js';
+
+/**
+ * Converts client config to a different shapes.
+ */
+export class ClientConfigConverter {
+  /**
+   * Converts client config to a shape consumable by mobile libraries.
+   */
+  convertToMobileConfig = (clientConfig: ClientConfig) => {};
+}

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -58,7 +58,7 @@ export class ClientConfigConverter {
               endpoint: clientConfig.aws_appsync_graphqlEndpoint,
               region: clientConfig.aws_appsync_region,
               authorizationType: clientConfig.aws_appsync_authenticationType,
-              apiKey: clientConfig.aws_appsync_region,
+              apiKey: clientConfig.aws_appsync_apiKey,
             },
           },
         },
@@ -71,7 +71,7 @@ export class ClientConfigConverter {
             ApiUrl: clientConfig.aws_appsync_graphqlEndpoint,
             Region: clientConfig.aws_appsync_region,
             AuthMode: clientConfig.aws_appsync_authenticationType,
-            ApiKey: clientConfig.aws_appsync_region,
+            ApiKey: clientConfig.aws_appsync_apiKey,
           },
         };
       }

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -10,18 +10,27 @@ import {
  */
 export class ClientConfigConverter {
   /**
+   * Creates client config converter
+   */
+  constructor(
+    private readonly packageName: string,
+    private readonly packageVersion: string
+  ) {}
+  /**
    * Converts client config to a shape consumable by mobile libraries.
    */
   convertToMobileConfig = (clientConfig: ClientConfig): ClientConfigMobile => {
+    const userAgent = `${this.packageName}/${this.packageVersion}`;
+
     const mobileConfig: ClientConfigMobile = {
-      UserAgent: 'aws-amplify-cli/2.0',
+      UserAgent: userAgent,
       Version: '1.0',
     };
     if (clientConfig.aws_user_pools_id) {
       const authConfig: ClientConfigMobileAuth = {
         plugins: {
           awsCognitoAuthPlugin: {
-            UserAgent: 'aws-amplify-cli/2.0',
+            UserAgent: userAgent,
             Version: '1.0',
             CognitoUserPool: {
               Default: {

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -1,5 +1,9 @@
 import { ClientConfig } from '../client-config-types/client_config.js';
-import { ClientConfigMobile } from '../client-config-types/mobile/client_config_mobile_types.js';
+import {
+  ClientConfigMobile,
+  ClientConfigMobileApi,
+  ClientConfigMobileAuth,
+} from '../client-config-types/mobile/client_config_mobile_types.js';
 
 /**
  * Converts client config to a different shapes.
@@ -9,9 +13,69 @@ export class ClientConfigConverter {
    * Converts client config to a shape consumable by mobile libraries.
    */
   convertToMobileConfig = (clientConfig: ClientConfig): ClientConfigMobile => {
-    return {
+    const mobileConfig: ClientConfigMobile = {
       UserAgent: 'aws-amplify-cli/2.0',
       Version: '1.0',
     };
+    if (clientConfig.aws_user_pools_id) {
+      const authConfig: ClientConfigMobileAuth = {
+        plugins: {
+          awsCognitoAuthPlugin: {
+            UserAgent: 'aws-amplify-cli/2.0',
+            Version: '1.0',
+            CognitoUserPool: {
+              Default: {
+                PoolId: clientConfig.aws_user_pools_id,
+                AppClientId: clientConfig.aws_user_pools_web_client_id,
+                Region: clientConfig.aws_cognito_region,
+              },
+            },
+            CredentialsProvider: {
+              CognitoIdentity: {
+                Default: {
+                  PoolId: clientConfig.aws_user_pools_id,
+                  Region: clientConfig.aws_cognito_region,
+                },
+              },
+            },
+            Auth: {
+              Default: {
+                authenticationFlowType: 'USER_SRP_AUTH',
+              },
+            },
+          },
+        },
+      };
+      mobileConfig.auth = authConfig;
+    }
+
+    if (clientConfig.aws_appsync_graphqlEndpoint) {
+      const apiConfig: ClientConfigMobileApi = {
+        plugins: {
+          awsAPIPlugin: {
+            data: {
+              endpointType: 'GraphQL',
+              endpoint: clientConfig.aws_appsync_graphqlEndpoint,
+              region: clientConfig.aws_appsync_region,
+              authorizationType: clientConfig.aws_appsync_authenticationType,
+              apiKey: clientConfig.aws_appsync_region,
+            },
+          },
+        },
+      };
+      mobileConfig.api = apiConfig;
+
+      if (mobileConfig.auth) {
+        mobileConfig.auth.plugins.awsCognitoAuthPlugin.AppSync = {
+          Default: {
+            ApiUrl: clientConfig.aws_appsync_graphqlEndpoint,
+            Region: clientConfig.aws_appsync_region,
+            AuthMode: clientConfig.aws_appsync_authenticationType,
+            ApiKey: clientConfig.aws_appsync_region,
+          },
+        };
+      }
+    }
+    return mobileConfig;
   };
 }

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -1,4 +1,5 @@
 import { ClientConfig } from '../client-config-types/client_config.js';
+import { ClientConfigMobile } from '../client-config-types/mobile/client_config_mobile_types.js';
 
 /**
  * Converts client config to a different shapes.
@@ -7,5 +8,10 @@ export class ClientConfigConverter {
   /**
    * Converts client config to a shape consumable by mobile libraries.
    */
-  convertToMobileConfig = (clientConfig: ClientConfig) => {};
+  convertToMobileConfig = (clientConfig: ClientConfig): ClientConfigMobile => {
+    return {
+      UserAgent: 'aws-amplify-cli/2.0',
+      Version: '1.0',
+    };
+  };
 }

--- a/packages/client-config/src/client-config-writer/client_config_formatter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { ClientConfigFormatter } from './client_config_formatter.js';
+import {
+  ClientConfig,
+  ClientConfigFormat,
+} from '../client-config-types/client_config.js';
+import assert from 'node:assert';
+import fsp from 'fs/promises';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { randomUUID } from 'crypto';
+
+void describe('client config formatter', () => {
+  const sampleUserPoolId = randomUUID();
+  const clientConfig: ClientConfig = {
+    aws_user_pools_id: sampleUserPoolId,
+  };
+
+  let clientConfigFormatter: ClientConfigFormatter;
+
+  beforeEach(() => {
+    clientConfigFormatter = new ClientConfigFormatter();
+  });
+
+  void it('formats config as json', () => {
+    const formattedConfig = clientConfigFormatter.format(
+      clientConfig,
+      ClientConfigFormat.JSON
+    );
+
+    assert.deepEqual(JSON.parse(formattedConfig), clientConfig);
+  });
+
+  void describe('for js/ts', () => {
+    let targetDirectory: string;
+
+    beforeEach(async () => {
+      targetDirectory = await fsp.mkdtemp('config_formatter_test');
+    });
+
+    afterEach(async () => {
+      await fsp.rm(targetDirectory, { recursive: true, force: true });
+    });
+
+    ([ClientConfigFormat.TS, ClientConfigFormat.MJS] as const).forEach(
+      (format) => {
+        void it(`formats config as ${format}`, async () => {
+          const formattedConfig = clientConfigFormatter.format(
+            clientConfig,
+            format
+          );
+
+          // write to file and check if dynamic import can read it
+          const filePath = path.join(targetDirectory, 'config.mjs');
+          await fsp.writeFile(filePath, formattedConfig);
+          // importing absolute paths on windows only works by passing through pathToFileURL which prepends `file://` to the path
+          const { default: actualConfig } = await import(
+            pathToFileURL(filePath).toString()
+          );
+          assert.deepEqual(actualConfig, clientConfig);
+        });
+      }
+    );
+  });
+
+  void it('formats config as dart', () => {
+    const formattedConfig = clientConfigFormatter.format(
+      clientConfig,
+      ClientConfigFormat.DART
+    );
+
+    assert.ok(formattedConfig.includes('aws_user_pools_id'));
+    assert.ok(formattedConfig.includes(sampleUserPoolId));
+    assert.ok(
+      formattedConfig.includes('final Map<String, dynamic> amplifyConfig')
+    );
+  });
+});

--- a/packages/client-config/src/client-config-writer/client_config_formatter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter.test.ts
@@ -22,7 +22,10 @@ void describe('client config formatter', () => {
     UserAgent: 'aws-amplify-cli/2.0',
   };
 
-  const clientConfigConverter = new ClientConfigConverter();
+  const clientConfigConverter = new ClientConfigConverter(
+    undefined as never,
+    undefined as never
+  );
   const clientConfigConverterMock = mock.method(
     clientConfigConverter,
     'convertToMobileConfig',

--- a/packages/client-config/src/client-config-writer/client_config_formatter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter.ts
@@ -9,6 +9,9 @@ import { ClientConfigConverter } from './client_config_converter.js';
  * Formats client config to desired format.
  */
 export class ClientConfigFormatter {
+  /**
+   * Creates new client config formatter.
+   */
   constructor(private readonly configConverter: ClientConfigConverter) {}
 
   format = (clientConfig: ClientConfig, format: ClientConfigFormat): string => {

--- a/packages/client-config/src/client-config-writer/client_config_formatter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter.ts
@@ -3,11 +3,14 @@ import {
   ClientConfigFormat,
 } from '../client-config-types/client_config.js';
 import os from 'os';
+import { ClientConfigConverter } from './client_config_converter.js';
 
 /**
  * Formats client config to desired format.
  */
 export class ClientConfigFormatter {
+  constructor(private readonly configConverter: ClientConfigConverter) {}
+
   format = (clientConfig: ClientConfig, format: ClientConfigFormat): string => {
     switch (format) {
       case ClientConfigFormat.TS:
@@ -17,16 +20,22 @@ export class ClientConfigFormatter {
         }export default amplifyConfig;${os.EOL}`;
       }
       case ClientConfigFormat.DART: {
-        return `final Map<String, dynamic> amplifyConfig = ${JSON.stringify(
-          clientConfig,
+        return `const amplifyConfig = '''${JSON.stringify(
+          this.configConverter.convertToMobileConfig(clientConfig),
           null,
           2
-        )}`;
+        )}''';`;
       }
+      case ClientConfigFormat.JSON_MOBILE:
+        return JSON.stringify(
+          this.configConverter.convertToMobileConfig(clientConfig),
+          null,
+          2
+        );
       case ClientConfigFormat.JSON:
         return JSON.stringify(clientConfig, null, 2);
       default:
-        throw new Error(`Unknown client config format ${format}`);
+        throw new Error(`Unknown client config format`);
     }
   };
 }

--- a/packages/client-config/src/client-config-writer/client_config_formatter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter.ts
@@ -1,0 +1,32 @@
+import {
+  ClientConfig,
+  ClientConfigFormat,
+} from '../client-config-types/client_config.js';
+import os from 'os';
+
+/**
+ * Formats client config to desired format.
+ */
+export class ClientConfigFormatter {
+  format = (clientConfig: ClientConfig, format: ClientConfigFormat): string => {
+    switch (format) {
+      case ClientConfigFormat.TS:
+      case ClientConfigFormat.MJS: {
+        return `const amplifyConfig = ${JSON.stringify(clientConfig, null, 2)}${
+          os.EOL
+        }export default amplifyConfig;${os.EOL}`;
+      }
+      case ClientConfigFormat.DART: {
+        return `final Map<String, dynamic> amplifyConfig = ${JSON.stringify(
+          clientConfig,
+          null,
+          2
+        )}`;
+      }
+      case ClientConfigFormat.JSON:
+        return JSON.stringify(clientConfig, null, 2);
+      default:
+        throw new Error(`Unknown client config format ${format}`);
+    }
+  };
+}

--- a/packages/client-config/src/client-config-writer/client_config_writer.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_writer.test.ts
@@ -13,7 +13,7 @@ import { randomUUID } from 'crypto';
 
 void describe('client config writer', () => {
   const pathResolverMock = mock.fn<ClientConfigPathResolver>();
-  const clientFormatter = new ClientConfigFormatter();
+  const clientFormatter = new ClientConfigFormatter(undefined as never);
   const fspMock = {
     writeFile: mock.fn<(path: string, content: string) => Promise<void>>(() =>
       Promise.resolve()

--- a/packages/client-config/src/client-config-writer/client_config_writer.ts
+++ b/packages/client-config/src/client-config-writer/client_config_writer.ts
@@ -1,47 +1,37 @@
-import fsp from 'fs/promises';
-import { ClientConfig } from '../client-config-types/client_config.js';
-import path from 'path';
-import * as os from 'os';
+import _fsp from 'fs/promises';
+import {
+  ClientConfig,
+  ClientConfigFormat,
+} from '../client-config-types/client_config.js';
+import { ClientConfigFormatter } from './client_config_formatter.js';
+
+export type ClientConfigPathResolver = (
+  outDir?: string,
+  format?: ClientConfigFormat
+) => Promise<string>;
 
 /**
  * A class that persists client config to disk.
  */
 export class ClientConfigWriter {
   /**
+   * Creates client config writer
+   */
+  constructor(
+    private readonly pathResolver: ClientConfigPathResolver,
+    private readonly formatter: ClientConfigFormatter,
+    private readonly fsp = _fsp
+  ) {}
+  /**
    * Persists provided client config as json file to target path.
    */
   writeClientConfig = async (
     clientConfig: ClientConfig,
-    targetPath: string
+    outDir?: string,
+    format: ClientConfigFormat = ClientConfigFormat.JSON
   ): Promise<void> => {
-    const fileExtension = path.parse(targetPath).ext;
-    switch (fileExtension) {
-      case '.ts':
-      case '.mjs': {
-        const fileContent = `const amplifyConfig = ${JSON.stringify(
-          clientConfig,
-          null,
-          2
-        )}${os.EOL}export default amplifyConfig;${os.EOL}`;
-        await fsp.writeFile(targetPath, fileContent);
-        break;
-      }
-      case '.dart': {
-        const fileContent = `final Map<String, dynamic> amplifyConfig = ${JSON.stringify(
-          clientConfig,
-          null,
-          2
-        )}`;
-        await fsp.writeFile(targetPath, fileContent);
-        break;
-      }
-      case '.json':
-        await fsp.writeFile(targetPath, JSON.stringify(clientConfig, null, 2));
-        break;
-      default:
-        throw new Error(
-          `Unknown client config file extension ${fileExtension}`
-        );
-    }
+    const targetPath = await this.pathResolver(outDir, format);
+    const fileContent = this.formatter.format(clientConfig, format);
+    await this.fsp.writeFile(targetPath, fileContent);
   };
 }

--- a/packages/client-config/src/generate_client_config_to_file.ts
+++ b/packages/client-config/src/generate_client_config_to_file.ts
@@ -5,6 +5,7 @@ import { ClientConfigFormat } from './client-config-types/client_config.js';
 import { getClientConfigPath } from './paths/index.js';
 import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 import { ClientConfigFormatter } from './client-config-writer/client_config_formatter.js';
+import { ClientConfigConverter } from './client-config-writer/client_config_converter.js';
 
 /**
  * Main entry point for generating client config and writing to a file
@@ -17,7 +18,7 @@ export const generateClientConfigToFile = async (
 ): Promise<void> => {
   const clientConfigWriter = new ClientConfigWriter(
     getClientConfigPath,
-    new ClientConfigFormatter()
+    new ClientConfigFormatter(new ClientConfigConverter())
   );
 
   const clientConfig = await generateClientConfig(

--- a/packages/client-config/src/generate_client_config_to_file.ts
+++ b/packages/client-config/src/generate_client_config_to_file.ts
@@ -4,6 +4,7 @@ import { ClientConfigWriter } from './client-config-writer/client_config_writer.
 import { ClientConfigFormat } from './client-config-types/client_config.js';
 import { getClientConfigPath } from './paths/index.js';
 import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { ClientConfigFormatter } from './client-config-writer/client_config_formatter.js';
 
 /**
  * Main entry point for generating client config and writing to a file
@@ -14,12 +15,14 @@ export const generateClientConfigToFile = async (
   outDir?: string,
   format?: ClientConfigFormat
 ): Promise<void> => {
-  const clientConfigWriter = new ClientConfigWriter();
+  const clientConfigWriter = new ClientConfigWriter(
+    getClientConfigPath,
+    new ClientConfigFormatter()
+  );
 
   const clientConfig = await generateClientConfig(
     credentialProvider,
     backendIdentifier
   );
-  const targetPath = await getClientConfigPath(outDir, format);
-  await clientConfigWriter.writeClientConfig(clientConfig, targetPath);
+  await clientConfigWriter.writeClientConfig(clientConfig, outDir, format);
 };

--- a/packages/client-config/src/paths/get_client_config_path.test.ts
+++ b/packages/client-config/src/paths/get_client_config_path.test.ts
@@ -98,4 +98,34 @@ void describe('getClientConfigPath', () => {
       )
     );
   });
+
+  const expectedFileExtensions = [
+    {
+      format: ClientConfigFormat.MJS,
+      expectedFileExtension: '.mjs',
+    },
+    {
+      format: ClientConfigFormat.TS,
+      expectedFileExtension: '.ts',
+    },
+    {
+      format: ClientConfigFormat.DART,
+      expectedFileExtension: '.dart',
+    },
+    {
+      format: ClientConfigFormat.JSON,
+      expectedFileExtension: '.json',
+    },
+    {
+      format: ClientConfigFormat.JSON_MOBILE,
+      expectedFileExtension: '.json',
+    },
+  ] as const;
+  expectedFileExtensions.forEach((entry) => {
+    void it(`path for ${entry.format} should have ${entry.expectedFileExtension} suffix`, async () => {
+      const configPath = await getClientConfigPath(undefined, entry.format);
+
+      assert.ok(configPath.endsWith(entry.expectedFileExtension));
+    });
+  });
 });

--- a/packages/client-config/src/paths/get_client_config_path.ts
+++ b/packages/client-config/src/paths/get_client_config_path.ts
@@ -18,6 +18,7 @@ export const getClientConfigPath = async (
     out: process.cwd(),
     format: ClientConfigFormat.JSON,
   };
+  format = format || defaultArgs.format;
 
   let targetPath = defaultArgs.out;
 
@@ -30,9 +31,16 @@ export const getClientConfigPath = async (
     }
   }
 
-  targetPath = path.resolve(
-    targetPath,
-    `${configFileName}.${format || defaultArgs.format}`
-  );
+  let extension: string;
+  switch (format) {
+    case ClientConfigFormat.JSON_MOBILE:
+      extension = 'json';
+      break;
+    default:
+      extension = format;
+      break;
+  }
+
+  targetPath = path.resolve(targetPath, `${configFileName}.${extension}`);
   return targetPath;
 };


### PR DESCRIPTION

**Issue #, if available:**

https://app.asana.com/0/1205484060153101/1205931466811581/f

**Description of changes:**

This PR 
1. adds initial version of iOS/Android config by transforming JS config into desired schema
2. adds `json-mobile` format
3. fixes dart format to conform to the same format as other mobile platform

**Assumptions**

1. This is a solution until frontend format is unified in https://app.asana.com/0/1205484060153101/1205931466811588/f 
2. Data parity between JS and mobile format can be achieved by adding necessary fields to JS config and transforming them into mobile.

**Out of scope**

This PR does not attempt to unify format across JS and mobile libraries. Neither it tries to change "config contributors" to use "generalized format" and keeps using JS as externally facing (what generateConfig returns) format.

**Testing**

1. Added unit test
4. Manual sanity check with android app.
    1. Created android app using gen1 tutorials
    5. Replaced amplify configuration using Samsara generated config

The android app has been created using these tutorials:
https://docs.amplify.aws/lib/auth/getting-started/q/platform/android/
https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/android/#query-item

data.ts
```
import { type ClientSchema, a, defineData } from '@aws-amplify/backend';

const schema = `
enum Priority {
  LOW
  NORMAL
  HIGH
}

type Todo @model
@auth(rules: [{ allow: public}]) {
  id: ID!
  name: String!
  priority: Priority!
  createdAt: AWSDateTime!
  completedAt: AWSDateTime
}
`
//
// export type Schema = ClientSchema<typeof schema>;

export const data = defineData({ schema,   authorizationModes: {
        defaultAuthorizationMode: "API_KEY",
        apiKeyAuthorizationMode: {
            expiresInDays: 7
        }
    }  });

```

auth.ts
```
import { defineAuth } from '@aws-amplify/backend';

export const auth = defineAuth({
  loginWith: {
    email: true,
  },
});

```


MyAmplifyApp.kt
```
package com.example.todo

import android.app.Application
import android.util.Log
import com.amplifyframework.AmplifyException
import com.amplifyframework.core.Amplify
import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
import com.amplifyframework.api.aws.AWSApiPlugin

class MyAmplifyApp: Application() {

    override fun onCreate() {
        super.onCreate()

        try {
            Amplify.addPlugin(AWSCognitoAuthPlugin())
            Amplify.addPlugin(AWSApiPlugin())
            Amplify.configure(applicationContext)

            Log.i("Tutorial", "Initialized Amplify")
        } catch (error: AmplifyException) {
            Log.e("Tutorial", "Could not initialize Amplify", error)
        }
    }
}
```


MainActivity.kt
```
package com.example.todo

import android.util.Log
import com.amplifyframework.core.Amplify
import com.amplifyframework.core.model.temporal.Temporal
import com.amplifyframework.datastore.generated.model.Priority
import com.amplifyframework.datastore.generated.model.Todo
import java.util.*
import java.util.concurrent.TimeUnit

import android.os.Bundle
import androidx.activity.ComponentActivity
import androidx.activity.compose.setContent
import androidx.compose.foundation.layout.fillMaxSize
import androidx.compose.material3.MaterialTheme
import androidx.compose.material3.Surface
import androidx.compose.material3.Text
import androidx.compose.runtime.Composable
import androidx.compose.ui.Modifier
import androidx.compose.ui.tooling.preview.Preview
import com.amplifyframework.api.graphql.model.ModelMutation
import com.amplifyframework.api.graphql.model.ModelQuery
import com.amplifyframework.auth.cognito.result.AWSCognitoAuthSignOutResult
import com.amplifyframework.core.model.query.Where
import com.example.todo.ui.theme.TodoTheme

class MainActivity : ComponentActivity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContent {
            TodoTheme {
                // A surface container using the 'background' color from the theme
                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
                    Greeting("Android")
                }
            }
        }

        Log.i("AuthQuickstart", "================================")
        Log.i("AuthQuickstart", "================================")
        Log.i("AuthQuickstart", "================================")
        Log.i("AuthQuickstart", "================================")



//        val options = AuthSignUpOptions.builder()
//            .userAttribute(AuthUserAttributeKey.email(), "REDACTED@amazon.com")
//            .build()
//        Amplify.Auth.signUp("REDACTED@amazon.com", "REDACTED", options,
//            { Log.i("AuthQuickStart", "Sign up succeeded: $it") },
//            { Log.e ("AuthQuickStart", "Sign up failed", it) }
//        )

//        Amplify.Auth.confirmSignUp(
//            "REDACTED@amazon.com", "REDACTED",
//            { result ->
//                if (result.isSignUpComplete) {
//                    Log.i("AuthQuickstart", "Confirm signUp succeeded")
//                } else {
//                    Log.i("AuthQuickstart","Confirm sign up not complete")
//                }
//            },
//            { Log.e("AuthQuickstart", "Failed to confirm sign up", it) }
//        )

        Amplify.Auth.signOut { signOutResult ->
            when(signOutResult) {
                is AWSCognitoAuthSignOutResult.CompleteSignOut -> {
                    // Sign Out completed fully and without errors.
                    Log.i("AuthQuickStart", "Signed out successfully")
                }
                is AWSCognitoAuthSignOutResult.PartialSignOut -> {
                    // Sign Out completed with some errors. User is signed out of the device.
                    signOutResult.hostedUIError?.let {
                        Log.e("AuthQuickStart", "HostedUI Error", it.exception)
                        // Optional: Re-launch it.url in a Custom tab to clear Cognito web session.

                    }
                    signOutResult.globalSignOutError?.let {
                        Log.e("AuthQuickStart", "GlobalSignOut Error", it.exception)
                        // Optional: Use escape hatch to retry revocation of it.accessToken.
                    }
                    signOutResult.revokeTokenError?.let {
                        Log.e("AuthQuickStart", "RevokeToken Error", it.exception)
                        // Optional: Use escape hatch to retry revocation of it.refreshToken.
                    }
                }
                is AWSCognitoAuthSignOutResult.FailedSignOut -> {
                    // Sign Out failed with an exception, leaving the user signed in.
                    Log.e("AuthQuickStart", "Sign out Failed", signOutResult.exception)
                }
            }
        }

        Amplify.Auth.signIn("REDACTED@amazon.com", "REDACTED",
            { result ->
                if (result.isSignedIn) {
                    Log.i("AuthQuickstart", "Sign in succeeded")
                } else {
                    Log.i("AuthQuickstart", "Sign in not complete")
                }
            },
            { Log.e("AuthQuickstart", "Failed to sign in", it) }
        )

        Amplify.Auth.fetchAuthSession(
            { Log.i("AmplifyQuickstart", "Auth session = $it") },
            { error -> Log.e("AmplifyQuickstart", "Failed to fetch auth session", error) }
        )

        val todo = Todo.builder()
            .name("My todo " + UUID.randomUUID().toString())
            .priority(Priority.HIGH)
            .build()

        Amplify.API.query(
            ModelQuery.list(Todo::class.java),
            { response ->
                response.data.forEach { todo ->
                    Log.i("MyAmplifyApp", todo.name)
                }
            },
            { Log.e("MyAmplifyApp", "Query failure", it) }
        )

        Amplify.API.mutate(
            ModelMutation.create(todo),
            { Log.i("MyAmplifyApp", "Added Todo with id: ${it.data.id}") },
            { Log.e("MyAmplifyApp", "Create failed", it) }
        )
    }
}

@Composable
fun Greeting(name: String, modifier: Modifier = Modifier) {
    Text(
            text = "Hello $name!",
            modifier = modifier
    )
}

@Preview(showBackground = true)
@Composable
fun GreetingPreview() {
    TodoTheme {
        Greeting("Android")
    }
}
```

Log:
```
023-11-14 10:11:05.626  9463-9463  ziparchive              com.example.todo                     W  Unable to open '/data/data/com.example.todo/code_cache/.overlay/base.apk/classes3.dm': No such file or directory
2023-11-14 10:11:05.627  9463-9463  ziparchive              com.example.todo                     W  Unable to open '/data/app/~~6TbJyN45kfJlJ1PvTTe5Jg==/com.example.todo-enHcEHt0ElKqYNGxv1drDw==/base.dm': No such file or directory
2023-11-14 10:11:05.627  9463-9463  ziparchive              com.example.todo                     W  Unable to open '/data/app/~~6TbJyN45kfJlJ1PvTTe5Jg==/com.example.todo-enHcEHt0ElKqYNGxv1drDw==/base.dm': No such file or directory
2023-11-14 10:11:05.956  9463-9463  nativeloader            com.example.todo                     D  Configuring clns-6 for other apk /data/app/~~6TbJyN45kfJlJ1PvTTe5Jg==/com.example.todo-enHcEHt0ElKqYNGxv1drDw==/base.apk. target_sdk_version=33, uses_libraries=, library_path=/data/app/~~6TbJyN45kfJlJ1PvTTe5Jg==/com.example.todo-enHcEHt0ElKqYNGxv1drDw==/lib/arm64, permitted_path=/data:/mnt/expand:/data/user/0/com.example.todo
2023-11-14 10:11:05.969  9463-9463  GraphicsEnvironment     com.example.todo                     V  Currently set values for:
2023-11-14 10:11:05.969  9463-9463  GraphicsEnvironment     com.example.todo                     V    angle_gl_driver_selection_pkgs=[]
2023-11-14 10:11:05.970  9463-9463  GraphicsEnvironment     com.example.todo                     V    angle_gl_driver_selection_values=[]
2023-11-14 10:11:05.970  9463-9463  GraphicsEnvironment     com.example.todo                     V  ANGLE GameManagerService for com.example.todo: false
2023-11-14 10:11:05.970  9463-9463  GraphicsEnvironment     com.example.todo                     V  com.example.todo is not listed in per-application setting
2023-11-14 10:11:05.971  9463-9463  GraphicsEnvironment     com.example.todo                     V  Neither updatable production driver nor prerelease driver is supported.
2023-11-14 10:11:06.116  9463-9463  Tutorial                com.example.todo                     I  Initialized Amplify
2023-11-14 10:11:06.141  9463-9489  libEGL                  com.example.todo                     D  loaded /vendor/lib64/egl/libEGL_emulation.so
2023-11-14 10:11:06.171  9463-9489  libEGL                  com.example.todo                     D  loaded /vendor/lib64/egl/libGLESv1_CM_emulation.so
2023-11-14 10:11:06.173  9463-9489  libEGL                  com.example.todo                     D  loaded /vendor/lib64/egl/libGLESv2_emulation.so
2023-11-14 10:11:06.175  9463-9463  AuthQuickstart          com.example.todo                     I  ================================
2023-11-14 10:11:06.175  9463-9463  AuthQuickstart          com.example.todo                     I  ================================
2023-11-14 10:11:06.175  9463-9463  AuthQuickstart          com.example.todo                     I  ================================
2023-11-14 10:11:06.176  9463-9463  AuthQuickstart          com.example.todo                     I  ================================
2023-11-14 10:11:06.268  9463-9482  EngineFactory           com.example.todo                     I  Provider GmsCore_OpenSSL not available
2023-11-14 10:11:06.323  9463-9463  Compatibil...geReporter com.example.todo                     D  Compat change id reported: 237531167; UID 10190; state: DISABLED
2023-11-14 10:11:06.327  9463-9463  OpenGLRenderer          com.example.todo                     W  Unknown dataspace 0
2023-11-14 10:11:06.394  9463-9463  om.example.todo         com.example.todo                     W  Method java.lang.Object androidx.compose.runtime.snapshots.SnapshotStateMap.mutate(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
                                                                                                    Common causes for lock verification issues are non-optimized dex code
                                                                                                    and incorrect proguard optimizations.
2023-11-14 10:11:06.395  9463-9463  om.example.todo         com.example.todo                     W  Method void androidx.compose.runtime.snapshots.SnapshotStateMap.update(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
2023-11-14 10:11:06.395  9463-9463  om.example.todo         com.example.todo                     W  Method boolean androidx.compose.runtime.snapshots.SnapshotStateMap.removeIf$runtime_release(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
2023-11-14 10:11:06.474  9463-9483  System.err              com.example.todo                     W  SLF4J: No SLF4J providers were found.
2023-11-14 10:11:06.487  9463-9483  System.err              com.example.todo                     W  SLF4J: Defaulting to no-operation (NOP) logger implementation
2023-11-14 10:11:06.488  9463-9483  System.err              com.example.todo                     W  SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
2023-11-14 10:11:06.518  9463-9487  OpenGLRenderer          com.example.todo                     W  Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED, retrying without...
2023-11-14 10:11:06.518  9463-9487  OpenGLRenderer          com.example.todo                     W  Failed to initialize 101010-2 format, error = EGL_SUCCESS
2023-11-14 10:11:06.527  9463-9487  Gralloc4                com.example.todo                     I  mapper 4.x is not supported
2023-11-14 10:11:06.534  9463-9487  OpenGLRenderer          com.example.todo                     E  Unable to match the desired swap behavior.
2023-11-14 10:11:06.640  9463-9513  TrafficStats            com.example.todo                     D  tagSocket(91) with statsTag=0xffffffff, statsUid=-1
2023-11-14 10:11:06.731  9463-9513  TrafficStats            com.example.todo                     D  tagSocket(93) with statsTag=0xffffffff, statsUid=-1
2023-11-14 10:11:06.877  9463-9518  TrafficStats            com.example.todo                     D  tagSocket(109) with statsTag=0xffffffff, statsUid=-1
2023-11-14 10:11:06.895  9463-9513  TrafficStats            com.example.todo                     D  tagSocket(109) with statsTag=0xffffffff, statsUid=-1
2023-11-14 10:11:07.266  9463-9500  MyAmplifyApp            com.example.todo                     I  Added Todo with id: ae086b7e-2488-41c6-87e9-fe88e35d784e
2023-11-14 10:11:07.269  9463-9483  AuthQuickStart          com.example.todo                     I  Signed out successfully
2023-11-14 10:11:07.328  9463-9499  MyAmplifyApp            com.example.todo                     I  My todo de2866d2-7823-48d3-a351-9fc4179f7132
2023-11-14 10:11:07.328  9463-9499  MyAmplifyApp            com.example.todo                     I  My first todo
2023-11-14 10:11:07.328  9463-9499  MyAmplifyApp            com.example.todo                     I  My first todo
2023-11-14 10:11:07.328  9463-9499  MyAmplifyApp            com.example.todo                     I  My first todo
2023-11-14 10:11:07.329  9463-9499  MyAmplifyApp            com.example.todo                     I  My todo 6d42618f-5728-48dd-9507-84b65bda09dc
2023-11-14 10:11:07.700  9463-9524  TrafficStats            com.example.todo                     D  tagSocket(115) with statsTag=0xffffffff, statsUid=-1
2023-11-14 10:11:07.706  9463-9528  TrafficStats            com.example.todo                     D  tagSocket(115) with statsTag=0xffffffff, statsUid=-1
2023-11-14 10:11:07.812  9463-9532  AuthQuickstart          com.example.todo                     I  Sign in succeeded
2023-11-14 10:11:07.820  9463-9482  AmplifyQuickstart       com.example.todo                     I  Auth session = AWSCognitoAuthSession(isSignedIn=true, identityIdResult=AuthSessionResult{value=null, error=ConfigurationException{message=Could not retrieve Identity ID, cause=null, recoverySuggestion=Cognito Identity not configured. Please check amplifyconfiguration.json file.}, type=FAILURE}, awsCredentialsResult=AuthSessionResult{value=null, error=ConfigurationException{message=Could not fetch AWS Cognito credentials, cause=null, recoverySuggestion=Cognito Identity not configured. Please check amplifyconfiguration.json file.}, type=FAILURE}, userSubResult=AuthSessionResult{value=f18f8906-937b-4ab8-b9ca-206cfd0a12c7, error=null, type=SUCCESS}, userPoolTokensResult=AuthSessionResult{value=AWSCognitoUserPoolTokens(accessToken=eyJraWQiOiJRMldBR0JDQmtwbFwvbDJabko1R29JMkZGTHFVTHAzYUZIRDE3M29uTW84OD0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmMThmODkwNi05MzdiLTRhYjgtYjljYS0yMDZjZmQwYTEyYzciLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAudXMtd2VzdC0yLmFtYXpvbmF3cy5jb21cL3VzLXdlc3QtMl9kb2dMZ3VzNFIiLCJjbGllbnRfaWQiOiJqc29sb2U5ZGZ2aTNtdThmc3BjcWUyYzRxIiwib3JpZ2luX2p0aSI6ImZhYjA2NDdlLWIwZTgtNGM3Zi04NWU0LTE4YWQ1OGU2YjhlYSIsImV2ZW50X2lkIjoiNjBiM2Q5NzEtNDRlNi00ZDc1LTk3Y2EtNTY0MGMxZWY0ZmYxIiwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJhd3MuY29nbml0by5zaWduaW4udXNlci5hZG1pbiIsImF1dGhfdGltZSI6MTY5OTk4NTQ2NywiZXhwIjoxNjk5OTg5MDY3LCJpYXQiOjE2OTk5ODU0NjgsImp0aSI6ImE4NDYwMTU5LWRjMDMtNGFiNi1iMzhhLWYzN2VlOWFjMTg4ZCIsInVzZXJuYW1lIjoiZjE4Zjg5MDYtOTM3Yi00YWI4LWI5Y2EtMjA2Y2ZkMGExMmM3In0.p6gdINAbz_9y65rLYCNkJ_eqIeXQsVd100xPI1b2H4g8VrqNlRlC24fcXol3pgQiFz6F3KKiUtB4qWAv_df_uA8oSjb0rR7sljPOMIBl7zl967f7_R_g_ZO_3DZwGakNmy7r4ma_Smo8ZdhXos_WOk2lAtE_NzxQZjshc1BKDaLmHXv-qJUPVJfX6YZVyCA9mutXUnD4bysnHwTpzF1ZqY6Sw_un_xY_CzDiEdpCFi9wnhdet1xkPeq4jxW60KWwV2cyoCEOEdyQhkj_kMhkdb0JvTFZp0wFUzza2jDBQB4h3nEVtP8fuJfp4Dd2RMIu62Fb7YZjNq0A9TgQOTnfXw, idToken=eyJraWQiOiJCOFYzYlhrYmcxWGtYRlwvYTB6VXFxQlJRRysxZzZwdVU3bytNRDdjRGE4OD0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmMThmODkwNi05MzdiLTRhYjgtYjljYS0yMDZjZmQwYTEyYzciLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tXC91cy13ZXN0LTJfZG9nTGd1czRSIiwiY29nbml0bzp1c2VybmFtZSI6ImYxOGY4OTA2LTkzN2ItNGFiOC1iOWNhLTIwNmNmZDBhMTJjNyIsIm9yaWdpbl9qdGkiOiJmYWIwNjQ3ZS1iMGU4LTRjN2YtODVlNC0xOGFkNThlNmI4ZWEiLCJhdWQiOiJqc29sb2U5ZGZ2aTNtdThmc3BjcWUyYzRxIiwiZXZlbnRfaWQiOiI2MGIzZDk3MS00NGU2LTRkNzUtOTdjYS01NjQwYzFlZjRmZjEiLCJ0b2tlbl91c2UiOiJpZCIsImF1dGhfdGltZSI6MTY5OTk4NTQ2NywiZXhwIjoxNjk5OTg5MDY3LCJpYXQiOjE2OTk5ODU0NjgsImp0aSI6IjdmZjI1YjBhLWZjMjktNDZlNy05N2FmLWM0OGJhZTc4ZGQ1OSIsImVtYWlsIjoic29ia2FtaWwrYW5kcm9pZEBhbWF6b24uY29tIn0.nF6JAD5d_1Kmp1XC400yvloO2PjhWy8IFLjOLHQ5PeVA7eW04JJ428t3-iuuwReETeGohuHGrVl1ZY6gxKlJTE0tKwaSSDxhRr8dws_xid5iVjXkEAEQY3HcE7Y8VIPqWTBHkCPS5kQiUFrl6DTcxUPuaKyHVuR9emuH8CXmco6B_WCsDRk8R_sbSnhNPp3fwmaPsNcscgdNWP_bwyMfHSi8tAy-rC2w3ZIrGjtPnPmx-t_zFldHiU5Uze9jSGx02XdZpZ3pibTYSLHQ3dC6xMt8E-GIFHC_N3BWMwgwsDbKmJsHxylB-cVhHjrJE7Jw895z2HGwf8PmEh4g9PWHgQ, refreshToken=eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.JJcjoADpwfrcZuoKoevuhKSD2rHUXrB3MCUrdKGUlqxgqSHYraBLT_d5M2lZJtQopAfHazXOJ2GQpmDeQfsCmu2XE9CevTU-EPu32sNCQHmHb_0eOsTczgtdBSvzFtzYwX8dIi23Q_DXKIuvPHF6cvzqafISjz5VpQ7AjX27QKY_piqflDUDrNc0nFR6eCpik13Cp34ti5lN4ZRikXv3vzjNmLftKETbO4pN5B844Ub_YbVS0NS92p0SaZbiLwIdoRsZtPRYP48_auzxkxtBA4LqxTuOeKFLzMvfa3j4oCxcxNCwLZzY-SWGRNw9GtdATvmJbW1iO9bs9VvCGCvlXw.LDCS7e3VrBKiE0MI.311goQ6RQuFgmDGCpJWQ96stwCqmyzUlFjaDqJmum_68OVao8LyFYazr-6huUhaR8vkMafJNG3p-UMVQJIO-HBzRfcQ6_hB5FlX1e9ea1y6kqfrgMH1oRbeZTC6HNsmUnyQEkZAAStmOC2lmydyHchHNXCTGC0JdgIoBC2LoFz4MRiJ6_rNb5vxp2qeFH2vaKWzdQaH5dmBqX_iiFgI7JPx9XqkEj0djwWj9OgdCCLCIlBa9ILuu24IgDXVGpN-IAiBIHm_oTPaMAd_QFdDvnzSqHzaleoFEz89ecdK6BjJ10Z85pSlJmROofCuzaG8Q1QceGcZnAnRJbtc7-Ym5EF25w8p4ui_VWn-1efc75VNlRQMpCp9oZrZzD8mL1ZZoKVy9rcLuYv1mY9X14lo9S1MGdC1Nu9fsLkhqn9UDLA5Y3aT7OK3YpoDHI7OKZFKB9dzN9HCv8cZT4_BAtmuMqqOF4GA5zgLc5vBC8VkHY-bSdSKluaAvbjmUQWHUccmhLZstWlHRYbKTl6ixzwWezyNJ447lchg96TpQrSlWRMm6LGs5RZ5ChGlQledWfupRP2gE8UcbP_xPWF_jaY1-P2zJD9Oa2sxdAg_uf45k9GClKwS1tzOUeO4DRoVTCz118N4hTcx10TwJrTJEBD-K31VeFf3UmTWpe5sjiBVQmFc-ZI1fgp6fGXQreX
2023-11-14 10:11:11.637  9463-9537  ProfileInstaller        com.example.todo                     D  Installing profile for com.example.todo
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
