### PR TITLE
change backend.getStack to backend.createStack

### DIFF
--- a/.changeset/loud-boats-yell.md
+++ b/.changeset/loud-boats-yell.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': minor
+---
+
+change backend.getStack to backend.createStack

--- a/packages/backend/API.md
+++ b/packages/backend/API.md
@@ -19,7 +19,7 @@ export { a }
 
 // @public
 export type Backend<T extends Record<string, ConstructFactory<Construct>>> = {
-    getStack: (name: string) => Stack;
+    createStack: (name: string) => Stack;
     readonly resources: {
         [K in keyof T]: ReturnType<T[K]['getInstance']>;
     };

--- a/packages/backend/src/backend.ts
+++ b/packages/backend/src/backend.ts
@@ -7,7 +7,7 @@ import { Stack } from 'aws-cdk-lib';
  * Amplify generated resources and `getStack()` for adding custom resources.
  */
 export type Backend<T extends Record<string, ConstructFactory<Construct>>> = {
-  getStack: (name: string) => Stack;
+  createStack: (name: string) => Stack;
   readonly resources: {
     [K in keyof T]: ReturnType<T[K]['getInstance']>;
   };

--- a/packages/backend/src/backend_factory.test.ts
+++ b/packages/backend/src/backend_factory.test.ts
@@ -150,11 +150,17 @@ void describe('Backend', () => {
     rootStackTemplate.resourceCountIs('Custom::AmplifyBranchLinkerResource', 0);
   });
 
-  void describe('getStack', () => {
+  void describe('createStack', () => {
     void it('returns nested stack', () => {
       const backend = new BackendFactory({}, rootStack);
-      const testStack = backend.getStack('testStack');
+      const testStack = backend.createStack('testStack');
       assert.strictEqual(rootStack.node.findChild('testStack'), testStack);
+    });
+
+    void it('throws if stack has already been created with specified name', () => {
+      const backend = new BackendFactory({}, rootStack);
+      backend.createStack('testStack');
+      assert.throws(() => backend.createStack('testStack'), 'test message');
     });
   });
 });

--- a/packages/backend/src/backend_factory.test.ts
+++ b/packages/backend/src/backend_factory.test.ts
@@ -160,7 +160,9 @@ void describe('Backend', () => {
     void it('throws if stack has already been created with specified name', () => {
       const backend = new BackendFactory({}, rootStack);
       backend.createStack('testStack');
-      assert.throws(() => backend.createStack('testStack'), 'test message');
+      assert.throws(() => backend.createStack('testStack'), {
+        message: 'Custom stack named testStack has already been created',
+      });
     });
   });
 });

--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -104,10 +104,10 @@ export class BackendFactory<
 
   /**
    * Returns a CDK stack within the Amplify project that can be used for creating custom resources.
-   * @returns existing stack if provided name has been used or create new one with the provided name
+   * If a stack has already been created with "name" then an error is thrown.
    */
-  getStack = (name: string): Stack => {
-    return this.stackResolver.getCustomStack(name);
+  createStack = (name: string): Stack => {
+    return this.stackResolver.createCustomStack(name);
   };
 }
 

--- a/packages/backend/src/engine/nested_stack_resolver.test.ts
+++ b/packages/backend/src/engine/nested_stack_resolver.test.ts
@@ -35,7 +35,7 @@ void describe('NestedStackResolver', () => {
       assert.strictEqual(testStack1, testStack2);
     });
   });
-  void describe('getCustomStack', () => {
+  void describe('createCustomStack', () => {
     void it('attaches attribution metadata to stack', () => {
       const app = new App();
       const stack = new Stack(app);
@@ -43,7 +43,7 @@ void describe('NestedStackResolver', () => {
         stack,
         new AttributionMetadataStorage()
       );
-      const customStack = stackResolver.getCustomStack('test1');
+      const customStack = stackResolver.createCustomStack('test1');
       const attributionMetadata = JSON.parse(
         customStack.templateOptions.description || '{}'
       );
@@ -51,17 +51,15 @@ void describe('NestedStackResolver', () => {
       assert.equal(attributionMetadata.createdWith, packageJson.version);
     });
 
-    void it('returns cached stack for existing name', () => {
+    void it('throws if two custom stacks are created with the same name', () => {
       const app = new App();
       const stack = new Stack(app);
       const stackResolver = new NestedStackResolver(
         stack,
         new AttributionMetadataStorage()
       );
-      const testStack1 = stackResolver.getCustomStack('test');
-      const testStack2 = stackResolver.getCustomStack('test');
-
-      assert.strictEqual(testStack1, testStack2);
+      stackResolver.createCustomStack('test');
+      assert.throws(() => stackResolver.createCustomStack('test'));
     });
   });
 });

--- a/packages/backend/src/engine/nested_stack_resolver.ts
+++ b/packages/backend/src/engine/nested_stack_resolver.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
  */
 export type StackResolver = {
   getStackFor: (resourceGroupName: string) => Stack;
-  getCustomStack: (name: string) => Stack;
+  createCustomStack: (name: string) => Stack;
 };
 
 /**
@@ -27,7 +27,10 @@ export class NestedStackResolver implements StackResolver {
   /**
    * Proxy to getStackFor that appends attribution metadata for custom stacks
    */
-  getCustomStack = (name: string): Stack => {
+  createCustomStack = (name: string): Stack => {
+    if (this.stacks[name]) {
+      throw new Error(`Custom stack named ${name} has already been created`);
+    }
     const stack = this.getStackFor(name);
     // this is safe even if stack is cached from an earlier invocation because storeAttributionMetadata is a noop if the stack description already exists
     this.attributionMetadataStorage.storeAttributionMetadata(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously `backend.getStack(name)` would create a new stack if "name" did not already exist and return the existing stack if it did exist. This changes the method to `backend.createStack(name)` and will create a new stack if "name" does not already exist and throw if name does exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
