### PR TITLE
Update profile error messages

### DIFF
--- a/.changeset/nine-brooms-sneeze.md
+++ b/.changeset/nine-brooms-sneeze.md
@@ -2,4 +2,4 @@
 '@aws-amplify/backend-cli': patch
 ---
 
-Update profile error messages
+Update profile error messages and a profile configure URL.

--- a/.changeset/nine-brooms-sneeze.md
+++ b/.changeset/nine-brooms-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Update profile error messages

--- a/packages/cli/src/command_middleware.test.ts
+++ b/packages/cli/src/command_middleware.test.ts
@@ -76,7 +76,10 @@ void describe('commandMiddleware', () => {
           );
           assert.fail('expect to throw error');
         } catch (err) {
-          assert.match((err as Error).message, /region setting options/);
+          assert.match(
+            (err as Error).message,
+            /Failed to load default aws region/
+          );
         }
       });
 
@@ -147,7 +150,10 @@ void describe('commandMiddleware', () => {
           );
           assert.fail('expect to throw error');
         } catch (err) {
-          assert.match((err as Error).message, /region setting options/);
+          assert.match(
+            (err as Error).message,
+            /Failed to load default aws region/
+          );
         }
       });
 
@@ -181,13 +187,13 @@ void describe('commandMiddleware', () => {
 
         try {
           await commandMiddleware.ensureAwsCredentialAndRegion({
-            profile: 'someInvalidProfile',
+            profile: testProfile,
           } as ArgumentsCamelCase<{ profile: string | undefined }>);
           assert.fail('expect to throw error');
         } catch (err) {
           assert.match(
             (err as Error).message,
-            /Failed to load aws credentials for profile/
+            /Failed to load aws region for profile/
           );
         }
       });

--- a/packages/cli/src/command_middleware.ts
+++ b/packages/cli/src/command_middleware.ts
@@ -5,7 +5,7 @@ import { loadConfig } from '@smithy/node-config-provider';
 import { NODE_REGION_CONFIG_OPTIONS } from '@aws-sdk/region-config-resolver';
 import { InvalidCredentialError } from './error/credential_error.js';
 
-export const profileSetupInstruction = `To configure a new Amplify profile, use "amplify configure profile".${EOL}To update an existing profile, use "aws configure"`;
+export const profileSetupInstruction = `To configure a new Amplify profile, use "amplify configure profile".`;
 
 /**
  * Contains middleware functions.
@@ -32,10 +32,15 @@ export class CommandMiddleware {
     } catch (err) {
       let errMsg: string;
       if (argv.profile) {
-        errMsg = `Failed to load aws credentials for profile '${argv.profile}'.${EOL}${profileSetupInstruction}`;
+        errMsg = `Failed to load aws credentials for profile '${
+          argv.profile
+        }': ${(err as Error).message}.${EOL}`;
       } else {
-        errMsg = `Failed to load default aws credentials.${EOL}Please refer to https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html.${EOL}${profileSetupInstruction}`;
+        errMsg = `Failed to load default aws credentials: ${
+          (err as Error).message
+        }.${EOL}`;
       }
+      errMsg += profileSetupInstruction;
       throw new InvalidCredentialError(errMsg, { cause: err });
     }
 
@@ -45,9 +50,17 @@ export class CommandMiddleware {
         ignoreCache: true,
       })();
     } catch (err) {
-      const errMsg = `${
-        (err as Error).message
-      }. Please refer to this page for region setting options:${EOL}https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html${EOL}${profileSetupInstruction}`;
+      let errMsg: string;
+      if (argv.profile) {
+        errMsg = `Failed to load aws region for profile '${argv.profile}': ${
+          (err as Error).message
+        }.${EOL}`;
+      } else {
+        errMsg = `Failed to load default aws region: ${
+          (err as Error).message
+        }.${EOL}`;
+      }
+      errMsg += profileSetupInstruction;
       throw new InvalidCredentialError(errMsg, { cause: err });
     }
   };

--- a/packages/cli/src/commands/configure/configure_profile_command.test.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.test.ts
@@ -149,7 +149,7 @@ void describe('configure command', () => {
     assert.equal(mockOpen.mock.callCount(), 1);
     assert.equal(
       mockOpen.mock.calls[0].arguments[0],
-      'https://docs.amplify.aws/cli/start/install/'
+      'http://docs.amplify.aws/gen2/start/configure-account'
     );
     assert.equal(mockAppendAWSFiles.mock.callCount(), 1);
     assert.deepStrictEqual(mockAppendAWSFiles.mock.calls[0].arguments[0], {

--- a/packages/cli/src/commands/configure/configure_profile_command.test.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.test.ts
@@ -149,7 +149,7 @@ void describe('configure command', () => {
     assert.equal(mockOpen.mock.callCount(), 1);
     assert.equal(
       mockOpen.mock.calls[0].arguments[0],
-      'http://docs.amplify.aws/gen2/start/configure-account'
+      'https://docs.amplify.aws/gen2/start/configure-account'
     );
     assert.equal(mockAppendAWSFiles.mock.callCount(), 1);
     assert.deepStrictEqual(mockAppendAWSFiles.mock.calls[0].arguments[0], {

--- a/packages/cli/src/commands/configure/configure_profile_command.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.ts
@@ -7,7 +7,7 @@ import { ArgumentsKebabCase } from '../../kebab_case.js';
 import { ProfileController } from './profile_controller.js';
 
 const configureAccountUrl =
-  'http://docs.amplify.aws/gen2/start/configure-account';
+  'https://docs.amplify.aws/gen2/start/configure-account';
 
 /**
  * Command to configure AWS Amplify profile.

--- a/packages/cli/src/commands/configure/configure_profile_command.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.ts
@@ -9,6 +9,8 @@ import { ProfileController } from './profile_controller.js';
 const configureAccountUrl =
   'https://docs.amplify.aws/gen2/start/configure-account';
 
+const profileSetupInstruction = `Follow the instructions at ${configureAccountUrl}${EOL}to configure Amplify IAM user and credentials.${EOL}`;
+
 /**
  * Command to configure AWS Amplify profile.
  */
@@ -43,7 +45,7 @@ export class ConfigureProfileCommand
     );
     if (profileExists) {
       Printer.print(
-        `Profile '${profileName}' already exists!${EOL}Follow the instructions at ${configureAccountUrl} to configure an Amplify IAM user and credentials.${EOL}`
+        `Profile '${profileName}' already exists!${EOL}${profileSetupInstruction}`
       );
       return;
     }
@@ -52,9 +54,7 @@ export class ConfigureProfileCommand
     });
 
     if (!hasIAMUser) {
-      Printer.print(
-        `Follow the instructions at ${configureAccountUrl}${EOL}to configure Amplify IAM user and credentials.${EOL}`
-      );
+      Printer.print(profileSetupInstruction);
 
       await Open.open(configureAccountUrl, { wait: false });
       await AmplifyPrompter.input({

--- a/packages/cli/src/commands/configure/configure_profile_command.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.ts
@@ -6,9 +6,8 @@ import { Open } from '../open/open.js';
 import { ArgumentsKebabCase } from '../../kebab_case.js';
 import { ProfileController } from './profile_controller.js';
 
-const amplifyInstallUrl = 'https://docs.amplify.aws/cli/start/install/';
-const awsConfigureUrl =
-  'https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html#getting-started-quickstart-new-command';
+const configureAccountUrl =
+  'http://docs.amplify.aws/gen2/start/configure-account';
 
 /**
  * Command to configure AWS Amplify profile.
@@ -44,7 +43,7 @@ export class ConfigureProfileCommand
     );
     if (profileExists) {
       Printer.print(
-        `Profile '${profileName}' already exists!${EOL}Follow the instructions at ${amplifyInstallUrl} to configure an Amplify IAM User.${EOL}Use "aws configure" to complete the profile setup:${EOL}${awsConfigureUrl}${EOL}`
+        `Profile '${profileName}' already exists!${EOL}Follow the instructions at ${configureAccountUrl} to configure an Amplify IAM user and credentials.${EOL}`
       );
       return;
     }
@@ -54,10 +53,10 @@ export class ConfigureProfileCommand
 
     if (!hasIAMUser) {
       Printer.print(
-        `Follow the instructions at ${amplifyInstallUrl}${EOL}to configure Amplify IAM user and credentials.${EOL}`
+        `Follow the instructions at ${configureAccountUrl}${EOL}to configure Amplify IAM user and credentials.${EOL}`
       );
 
-      await Open.open(amplifyInstallUrl, { wait: false });
+      await Open.open(configureAccountUrl, { wait: false });
       await AmplifyPrompter.input({
         message: `Hit [enter] when complete`,
       });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Simplify error messages from profile validation. If a customer already has a profile, they probably know how to fix if seeing credentials or region error. They either use `aws configure` or manual init file editing. Adding all details here is not necessary so simplifying it per PM suggested.
2. Update the URL for `amplify configure profile`- Note that the new URL http://docs.amplify.aws/gen2/start/configure-account is not live yet.

```
% amplify sandbox
Failed to load default aws region: Region is missing.
To configure a new Amplify profile, use "amplify configure profile".


 % amplify sandbox      
Failed to load default aws credentials: Could not load credentials from any providers.
To configure a new Amplify profile, use "amplify configure profile".


 % amplify sandbox --profile invalid
Failed to load aws credentials for profile 'invalid': Could not load credentials from any providers.
To configure a new Amplify profile, use "amplify configure profile".


% amplify sandbox --profile hoang  
Failed to load aws region for profile 'hoang': Region is missing.
To configure a new Amplify profile, use "amplify configure profile".


% amplify configure profile --name hoang2
Profile 'hoang2' already exists!
Follow the instructions at https://docs.amplify.aws/gen2/start/configure-account
to configure Amplify IAM user and credentials.

 % amplify configure profile --name hoang3
? Do you already have IAM User credentials? N
Follow the instructions at https://docs.amplify.aws/gen2/start/configure-account
to configure Amplify IAM user and credentials.

? Hit [enter] when complete
....
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
