### PR TITLE
chore: bump to latest data cdk construct, and explicitly set deploy strategy for tables

### DIFF
--- a/.changeset/spicy-spies-divide.md
+++ b/.changeset/spicy-spies-divide.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': minor
+---
+
+Update backend-data to use new data-construct and explicitly specific default ddb strategy.

--- a/examples/simple_react/package-lock.json
+++ b/examples/simple_react/package-lock.json
@@ -83,7 +83,7 @@
         "@aws-amplify/backend-output-schemas": "^0.3.0",
         "@aws-amplify/backend-output-storage": "0.2.1",
         "@aws-amplify/data-schema-types": "^0.4.2",
-        "@aws-amplify/graphql-api-construct": "^1.3.0",
+        "@aws-amplify/data-construct": "^1.4.0",
         "@aws-amplify/plugin-types": "^0.4.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -508,6 +508,566 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/@aws-amplify/data-construct": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.4.0.tgz",
+      "integrity": "sha512-9i/o+LmR90QaxtZDlOfgPKUDQKNQwt9qKaX/ioXipI534qvb4GuCPDt6dulC2qP+lOSGLQc2X/mksilnm+fseA==",
+      "bundleDependencies": [
+        "@aws-amplify/backend-output-schemas",
+        "@aws-amplify/backend-output-storage",
+        "@aws-amplify/graphql-transformer",
+        "@aws-amplify/graphql-transformer-core",
+        "@aws-amplify/graphql-transformer-interfaces",
+        "zod",
+        "@aws-amplify/graphql-auth-transformer",
+        "@aws-amplify/graphql-default-value-transformer",
+        "@aws-amplify/graphql-function-transformer",
+        "@aws-amplify/graphql-http-transformer",
+        "@aws-amplify/graphql-index-transformer",
+        "@aws-amplify/graphql-maps-to-transformer",
+        "@aws-amplify/graphql-model-transformer",
+        "@aws-amplify/graphql-predictions-transformer",
+        "@aws-amplify/graphql-relational-transformer",
+        "@aws-amplify/graphql-searchable-transformer",
+        "@aws-amplify/graphql-sql-transformer",
+        "@aws-amplify/platform-core",
+        "@aws-amplify/plugin-types",
+        "fs-extra",
+        "graphql",
+        "graphql-transformer-common",
+        "hjson",
+        "lodash",
+        "md5",
+        "object-hash",
+        "ts-dedent",
+        "charenc",
+        "crypt",
+        "graceful-fs",
+        "graphql-mapping-template",
+        "immer",
+        "is-buffer",
+        "jsonfile",
+        "libphonenumber-js",
+        "pluralize",
+        "universalify"
+      ],
+      "dependencies": {
+        "@aws-amplify/backend-output-schemas": "^0.2.1",
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/graphql-api-construct": "1.4.0",
+        "@aws-amplify/graphql-auth-transformer": "3.2.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.1.9",
+        "@aws-amplify/graphql-function-transformer": "2.1.8",
+        "@aws-amplify/graphql-http-transformer": "2.1.8",
+        "@aws-amplify/graphql-index-transformer": "2.2.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.3.0",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.8",
+        "@aws-amplify/graphql-relational-transformer": "2.2.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.3.0",
+        "@aws-amplify/graphql-sql-transformer": "0.1.0",
+        "@aws-amplify/graphql-transformer": "1.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "@aws-amplify/platform-core": "^0.1.3",
+        "@aws-amplify/plugin-types": "^0.3.0",
+        "charenc": "^0.0.2",
+        "crypt": "^0.0.2",
+        "fs-extra": "^8.1.0",
+        "graceful-fs": "^4.2.11",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0",
+        "hjson": "^3.2.2",
+        "immer": "^9.0.12",
+        "is-buffer": "^2.0.5",
+        "jsonfile": "^6.1.0",
+        "libphonenumber-js": "1.9.47",
+        "lodash": "^4.17.21",
+        "md5": "^2.3.0",
+        "object-hash": "^3.0.0",
+        "pluralize": "^8.0.0",
+        "ts-dedent": "^2.0.0",
+        "universalify": "^2.0.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-schemas": {
+      "version": "0.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-storage": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.103.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-storage/node_modules/@aws-amplify/platform-core": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^0.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
+      "version": "3.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-relational-transformer": "2.2.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0",
+        "lodash": "^4.17.21",
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
+      "version": "2.1.9",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0",
+        "libphonenumber-js": "1.9.47"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
+      "version": "2.1.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
+      "version": "2.1.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
+      "version": "3.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
+      "version": "2.1.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-index-transformer": "2.2.0",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0",
+        "immer": "^9.0.12"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-auth-transformer": "3.2.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.1.9",
+        "@aws-amplify/graphql-function-transformer": "2.1.8",
+        "@aws-amplify/graphql-http-transformer": "2.1.8",
+        "@aws-amplify/graphql-index-transformer": "2.2.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.3.0",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.8",
+        "@aws-amplify/graphql-relational-transformer": "2.2.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.3.0",
+        "@aws-amplify/graphql-sql-transformer": "0.1.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "fs-extra": "^8.1.0",
+        "graphql": "^15.5.0",
+        "graphql-transformer-common": "4.26.0",
+        "hjson": "^3.2.2",
+        "lodash": "^4.17.21",
+        "md5": "^2.3.0",
+        "object-hash": "^3.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
+      "version": "3.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "graphql": "^15.5.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core": {
+      "version": "0.1.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^0.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/plugin-types": {
+      "version": "0.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.103.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/charenc": {
+      "version": "0.0.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/crypt": {
+      "version": "0.0.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/fs-extra/node_modules/universalify": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/graphql": {
+      "version": "15.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/graphql-mapping-template": {
+      "version": "4.20.12",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/graphql-transformer-common": {
+      "version": "4.26.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "md5": "^2.2.1",
+        "pluralize": "8.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/hjson": {
+      "version": "3.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "hjson": "bin/hjson"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/immer": {
+      "version": "9.0.21",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/libphonenumber-js": {
+      "version": "1.9.47",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/lodash": {
+      "version": "4.17.21",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/md5": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/md5/node_modules/is-buffer": {
+      "version": "1.1.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/object-hash": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/pluralize": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/universalify": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/zod": {
+      "version": "3.22.4",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@aws-amplify/data-schema": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.12.1.tgz",
@@ -537,16 +1097,12 @@
       "link": true
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.3.0.tgz",
-      "integrity": "sha512-udWbLj7giTFL3nhmtN/ZEm/ceQhHM6ht0fAEzdms3q1JW7vcgdzyafnDQq3B4qGhmRiOPqKKnfWHRd/aDvaW5A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.4.0.tgz",
+      "integrity": "sha512-yiZo0NHB5kfdV+6gaNkq97DJqa78o61oyBSPHm5R6Kv4e5xx3cvnNJJSinO6CFIh7WyIfpezm98CqSTPPT4xhg==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
-        "@aws-amplify/graphql-transformer",
-        "@aws-amplify/graphql-transformer-core",
-        "@aws-amplify/graphql-transformer-interfaces",
-        "zod",
         "@aws-amplify/graphql-auth-transformer",
         "@aws-amplify/graphql-default-value-transformer",
         "@aws-amplify/graphql-function-transformer",
@@ -557,48 +1113,58 @@
         "@aws-amplify/graphql-predictions-transformer",
         "@aws-amplify/graphql-relational-transformer",
         "@aws-amplify/graphql-searchable-transformer",
-        "fs-extra",
-        "graphql",
-        "graphql-transformer-common",
-        "hjson",
-        "lodash",
-        "md5",
-        "object-hash",
-        "ts-dedent",
+        "@aws-amplify/graphql-sql-transformer",
+        "@aws-amplify/graphql-transformer",
+        "@aws-amplify/graphql-transformer-core",
+        "@aws-amplify/graphql-transformer-interfaces",
+        "@aws-amplify/platform-core",
+        "@aws-amplify/plugin-types",
         "charenc",
         "crypt",
+        "fs-extra",
         "graceful-fs",
+        "graphql",
         "graphql-mapping-template",
+        "graphql-transformer-common",
+        "hjson",
         "immer",
         "is-buffer",
         "jsonfile",
         "libphonenumber-js",
+        "lodash",
+        "md5",
+        "object-hash",
         "pluralize",
-        "universalify"
+        "ts-dedent",
+        "universalify",
+        "zod"
       ],
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.6",
-        "@aws-amplify/backend-output-storage": "^0.1.1-alpha.2",
-        "@aws-amplify/graphql-auth-transformer": "3.1.10",
-        "@aws-amplify/graphql-default-value-transformer": "2.1.8",
-        "@aws-amplify/graphql-function-transformer": "2.1.7",
-        "@aws-amplify/graphql-http-transformer": "2.1.7",
-        "@aws-amplify/graphql-index-transformer": "2.1.8",
-        "@aws-amplify/graphql-maps-to-transformer": "3.2.5",
-        "@aws-amplify/graphql-model-transformer": "2.2.4",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.7",
-        "@aws-amplify/graphql-relational-transformer": "2.1.8",
-        "@aws-amplify/graphql-searchable-transformer": "2.2.4",
-        "@aws-amplify/graphql-transformer": "1.2.6",
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/backend-output-schemas": "^0.2.1",
+        "@aws-amplify/backend-output-storage": "^0.2.0",
+        "@aws-amplify/graphql-auth-transformer": "3.2.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.1.9",
+        "@aws-amplify/graphql-function-transformer": "2.1.8",
+        "@aws-amplify/graphql-http-transformer": "2.1.8",
+        "@aws-amplify/graphql-index-transformer": "2.2.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.3.0",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.8",
+        "@aws-amplify/graphql-relational-transformer": "2.2.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.3.0",
+        "@aws-amplify/graphql-sql-transformer": "0.1.0",
+        "@aws-amplify/graphql-transformer": "1.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "@aws-amplify/platform-core": "^0.1.3",
+        "@aws-amplify/plugin-types": "^0.3.0",
         "charenc": "^0.0.2",
         "crypt": "^0.0.2",
         "fs-extra": "^8.1.0",
         "graceful-fs": "^4.2.11",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1",
+        "graphql-transformer-common": "4.26.0",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
         "is-buffer": "^2.0.5",
@@ -618,7 +1184,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "0.2.0-alpha.6",
+      "version": "0.2.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -626,28 +1192,37 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-storage": {
-      "version": "0.1.1-alpha.2",
+      "version": "0.2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.2.0-alpha.5"
+        "@aws-amplify/backend-output-schemas": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.1.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0"
+        "aws-cdk-lib": "^2.103.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-storage/node_modules/@aws-amplify/platform-core": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^0.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.1.10",
+      "version": "3.2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-model-transformer": "2.2.4",
-        "@aws-amplify/graphql-relational-transformer": "2.1.8",
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-relational-transformer": "2.2.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1",
+        "graphql-transformer-common": "4.26.0",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
@@ -657,28 +1232,28 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.1.8",
+      "version": "2.1.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1",
+        "graphql-transformer-common": "4.26.0",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.7",
+      "version": "2.1.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1"
+        "graphql-transformer-common": "4.26.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -686,15 +1261,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.7",
+      "version": "2.1.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1"
+        "graphql-transformer-common": "4.26.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -702,16 +1277,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.1.8",
+      "version": "2.2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-model-transformer": "2.2.4",
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1"
+        "graphql-transformer-common": "4.26.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -719,14 +1294,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.2.5",
+      "version": "3.3.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1"
+        "graphql-transformer-common": "4.26.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -734,15 +1309,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.2.4",
+      "version": "2.3.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1"
+        "graphql-transformer-common": "4.26.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -750,15 +1325,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.7",
+      "version": "2.1.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1"
+        "graphql-transformer-common": "4.26.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -766,17 +1341,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.1.8",
+      "version": "2.2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-index-transformer": "2.1.8",
-        "@aws-amplify/graphql-model-transformer": "2.2.4",
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-index-transformer": "2.2.0",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1",
+        "graphql-transformer-common": "4.26.0",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
@@ -785,16 +1360,33 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.2.4",
+      "version": "2.3.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-model-transformer": "2.2.4",
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.12",
-        "graphql-transformer-common": "4.25.1"
+        "graphql-transformer-common": "4.26.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.80.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.12",
+        "graphql-transformer-common": "4.26.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -802,22 +1394,23 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.2.6",
+      "version": "1.3.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.1.10",
-        "@aws-amplify/graphql-default-value-transformer": "2.1.8",
-        "@aws-amplify/graphql-function-transformer": "2.1.7",
-        "@aws-amplify/graphql-http-transformer": "2.1.7",
-        "@aws-amplify/graphql-index-transformer": "2.1.8",
-        "@aws-amplify/graphql-maps-to-transformer": "3.2.5",
-        "@aws-amplify/graphql-model-transformer": "2.2.4",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.7",
-        "@aws-amplify/graphql-relational-transformer": "2.1.8",
-        "@aws-amplify/graphql-searchable-transformer": "2.2.4",
-        "@aws-amplify/graphql-transformer-core": "2.2.4",
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2"
+        "@aws-amplify/graphql-auth-transformer": "3.2.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.1.9",
+        "@aws-amplify/graphql-function-transformer": "2.1.8",
+        "@aws-amplify/graphql-http-transformer": "2.1.8",
+        "@aws-amplify/graphql-index-transformer": "2.2.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.3.0",
+        "@aws-amplify/graphql-model-transformer": "2.3.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.8",
+        "@aws-amplify/graphql-relational-transformer": "2.2.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.3.0",
+        "@aws-amplify/graphql-sql-transformer": "0.1.0",
+        "@aws-amplify/graphql-transformer-core": "2.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -825,14 +1418,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.2.4",
+      "version": "2.3.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-interfaces": "3.2.2",
+        "@aws-amplify/graphql-transformer-interfaces": "3.3.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.25.1",
+        "graphql-transformer-common": "4.26.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -845,7 +1438,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.2.2",
+      "version": "3.3.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -854,6 +1447,23 @@
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
         "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core": {
+      "version": "0.1.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^0.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/plugin-types": {
+      "version": "0.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.103.0",
+        "constructs": "^10.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/charenc": {
@@ -920,7 +1530,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql-transformer-common": {
-      "version": "4.25.1",
+      "version": "4.26.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12870,7 +13480,6 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
       "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -14336,7 +14945,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -18612,7 +19220,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -19428,12 +20035,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "^0.2.1",
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "^0.2.2",
+        "@aws-amplify/plugin-types": "^0.4.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19442,19 +20049,19 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.3.0",
-        "@aws-amplify/backend-data": "^0.5.0",
-        "@aws-amplify/backend-function": "^0.2.0",
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "^0.2.1",
+        "@aws-amplify/backend-auth": "^0.3.1",
+        "@aws-amplify/backend-data": "^0.5.1",
+        "@aws-amplify/backend-function": "^0.2.1",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "^0.2.2",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/backend-storage": "^0.3.0",
         "@aws-amplify/data-schema": "^0.12.1",
         "@aws-amplify/platform-core": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.4.0",
+        "@aws-amplify/plugin-types": "^0.4.1",
         "@aws-sdk/client-amplify": "^3.440.0"
       },
       "devDependencies": {
@@ -19468,12 +20075,12 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "0.2.1",
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/auth-construct-alpha": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "0.2.2",
+        "@aws-amplify/plugin-types": "^0.4.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
@@ -19486,14 +20093,14 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "0.2.1",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "0.2.2",
+        "@aws-amplify/data-construct": "^1.4.0",
         "@aws-amplify/data-schema-types": "^0.6.1",
-        "@aws-amplify/graphql-api-construct": "^1.3.0",
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/plugin-types": "^0.4.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
@@ -19522,12 +20129,12 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "0.2.1",
+        "@aws-amplify/backend-output-storage": "0.2.2",
         "@aws-amplify/function-construct-alpha": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.4.0",
+        "@aws-amplify/plugin-types": "^0.4.1",
         "execa": "^7.1.1"
       },
       "devDependencies": {
@@ -19541,10 +20148,10 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "0.4.0"
+        "@aws-amplify/plugin-types": "0.4.1"
       },
       "peerDependencies": {
         "zod": "^3.21.4"
@@ -19552,10 +20159,10 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/platform-core": "^0.2.0"
       },
       "peerDependencies": {
@@ -19604,18 +20211,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.3.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.0",
+        "@aws-amplify/client-config": "^0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.1",
         "@aws-amplify/form-generator": "^0.3.0",
-        "@aws-amplify/model-generator": "^0.2.1",
+        "@aws-amplify/model-generator": "^0.2.2",
         "@aws-amplify/platform-core": "^0.2.0",
-        "@aws-amplify/sandbox": "^0.3.0",
+        "@aws-amplify/sandbox": "^0.3.1",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@aws-sdk/region-config-resolver": "^3.433.0",
@@ -19760,12 +20367,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.0",
-        "@aws-amplify/model-generator": "^0.2.1",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.1",
+        "@aws-amplify/model-generator": "^0.2.2",
         "@aws-sdk/client-amplify": "^3.376.0",
         "@aws-sdk/client-cloudformation": "^3.376.0",
         "@aws-sdk/client-ssm": "^3.398.0",
@@ -19778,7 +20385,7 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
@@ -19904,10 +20511,10 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-sdk/client-amplify": "^3.329.0",
         "@aws-sdk/client-cloudformation": "^3.329.0",
@@ -19949,11 +20556,11 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/backend": "0.4.0",
-        "@aws-amplify/backend-auth": "0.3.0",
+        "@aws-amplify/backend": "0.5.0",
+        "@aws-amplify/backend-auth": "0.3.1",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/backend-storage": "0.3.0",
         "@aws-amplify/data-schema": "^0.12.1",
@@ -20023,11 +20630,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.0",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.1",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -20051,7 +20658,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20060,14 +20667,14 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "0.3.0",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "0.3.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.0",
+        "@aws-amplify/client-config": "0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.1",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
@@ -20116,14 +20723,14 @@
     },
     "packages/storage-construct": {
       "name": "@aws-amplify/storage-construct-alpha",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "^0.2.1"
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "^0.2.2"
       },
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/plugin-types": "^0.4.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13480,6 +13480,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
       "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -14945,6 +14946,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -19220,6 +19222,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -4,8 +4,8 @@
 
 ```ts
 
+import { AmplifyData } from '@aws-amplify/data-construct';
 import { AmplifyFunction } from '@aws-amplify/plugin-types';
-import { AmplifyGraphqlApi } from '@aws-amplify/graphql-api-construct';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
 
@@ -39,7 +39,7 @@ export type DataSchema = string | DerivedModelSchema;
 export type DefaultAuthorizationMode = 'AWS_IAM' | 'AMAZON_COGNITO_USER_POOLS' | 'OPENID_CONNECT' | 'API_KEY' | 'AWS_LAMBDA';
 
 // @public
-export const defineData: (props: DataProps) => ConstructFactory<AmplifyGraphqlApi>;
+export const defineData: (props: DataProps) => ConstructFactory<AmplifyData>;
 
 // @public
 export type LambdaAuthorizationModeProps = {

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "0.2.2",
     "@aws-amplify/backend-output-schemas": "^0.4.0",
-    "@aws-amplify/graphql-api-construct": "^1.3.0",
+    "@aws-amplify/data-construct": "^1.4.0",
     "@aws-amplify/plugin-types": "^0.4.1",
     "@aws-amplify/data-schema-types": "^0.6.1"
   }

--- a/packages/backend-data/src/convert_authorization_modes.test.ts
+++ b/packages/backend-data/src/convert_authorization_modes.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { Duration, Stack } from 'aws-cdk-lib';
 import { UserPool } from 'aws-cdk-lib/aws-cognito';
 import { IRole, Role } from 'aws-cdk-lib/aws-iam';
-import { AuthorizationModes as CDKAuthorizationModes } from '@aws-amplify/graphql-api-construct';
+import { AuthorizationModes as CDKAuthorizationModes } from '@aws-amplify/data-construct';
 import { AuthorizationModes } from './types.js';
 import {
   ProvidedAuthConfig,

--- a/packages/backend-data/src/convert_authorization_modes.ts
+++ b/packages/backend-data/src/convert_authorization_modes.ts
@@ -8,7 +8,7 @@ import {
   LambdaAuthorizationConfig as CDKLambdaAuthorizationConfig,
   OIDCAuthorizationConfig as CDKOIDCAuthorizationConfig,
   UserPoolAuthorizationConfig as CDKUserPoolAuthorizationConfig,
-} from '@aws-amplify/graphql-api-construct';
+} from '@aws-amplify/data-construct';
 import {
   ApiKeyAuthorizationModeProps,
   AuthorizationModes,

--- a/packages/backend-data/src/convert_schema.ts
+++ b/packages/backend-data/src/convert_schema.ts
@@ -1,8 +1,8 @@
 import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
 import {
-  AmplifyGraphqlDefinition,
-  IAmplifyGraphqlDefinition,
-} from '@aws-amplify/graphql-api-construct';
+  AmplifyDataDefinition,
+  IAmplifyDataDefinition,
+} from '@aws-amplify/data-construct';
 import { DataSchema } from './types.js';
 
 /**
@@ -25,9 +25,33 @@ const isModelSchema = (schema: DataSchema): schema is DerivedModelSchema => {
  */
 export const convertSchemaToCDK = (
   schema: DataSchema
-): IAmplifyGraphqlDefinition => {
+): IAmplifyDataDefinition => {
+  const dbType = 'DYNAMODB';
+  const provisionStrategy = 'DEFAULT';
+
   if (isModelSchema(schema)) {
-    return schema.transform();
+    /**
+     * This is not super obvious, but the IAmplifyDataDefinition interface requires a record of each model type to a
+     * data source strategy (how it should be deployed and managed). Normally this is handled for customers by static
+     * methods on AmplifyDataDefinition, but since the data-schema-types don't produce that today, we use the builder
+     * to generate that argument for us (so it's consistent with a customer using normal Graphql strings), then
+     * apply that value back into the final IAmplifyDataDefinition output for data-schema users.
+     */
+    const generatedModelDataSourceStrategies = AmplifyDataDefinition.fromString(
+      schema.transform().schema,
+      {
+        dbType,
+        provisionStrategy,
+      }
+    ).dataSourceStrategies;
+    return {
+      ...schema.transform(),
+      dataSourceStrategies: generatedModelDataSourceStrategies,
+    };
   }
-  return AmplifyGraphqlDefinition.fromString(schema);
+
+  return AmplifyDataDefinition.fromString(schema, {
+    dbType,
+    provisionStrategy,
+  });
 };

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -25,7 +25,7 @@ import {
 } from 'aws-cdk-lib/aws-cognito';
 import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
-import { AmplifyGraphqlApi } from '@aws-amplify/graphql-api-construct';
+import { AmplifyData } from '@aws-amplify/data-construct';
 import {
   ConstructContainerStub,
   ImportPathVerifierStub,
@@ -54,7 +54,7 @@ void describe('DataFactory', () => {
   let constructContainer: ConstructContainer;
   let outputStorageStrategy: BackendOutputStorageStrategy<BackendOutputEntry>;
   let importPathVerifier: ImportPathVerifier;
-  let dataFactory: ConstructFactory<AmplifyGraphqlApi>;
+  let dataFactory: ConstructFactory<AmplifyData>;
   let getInstanceProps: ConstructFactoryGetInstanceProps;
 
   beforeEach(() => {

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -7,7 +7,7 @@ import {
   ConstructFactoryGetInstanceProps,
   ResourceProvider,
 } from '@aws-amplify/plugin-types';
-import { AmplifyGraphqlApi } from '@aws-amplify/graphql-api-construct';
+import { AmplifyData } from '@aws-amplify/data-construct';
 import { GraphqlOutput } from '@aws-amplify/backend-output-schemas';
 import * as path from 'path';
 import { DataProps } from './types.js';
@@ -28,7 +28,7 @@ import { validateAuthorizationModes } from './validate_authorization_modes.js';
 /**
  * Singleton factory for AmplifyGraphqlApi constructs that can be used in Amplify project files
  */
-class DataFactory implements ConstructFactory<AmplifyGraphqlApi> {
+class DataFactory implements ConstructFactory<AmplifyData> {
   private generator: ConstructContainerEntryGenerator;
 
   /**
@@ -42,9 +42,7 @@ class DataFactory implements ConstructFactory<AmplifyGraphqlApi> {
   /**
    * Gets an instance of the Data construct
    */
-  getInstance = (
-    props: ConstructFactoryGetInstanceProps
-  ): AmplifyGraphqlApi => {
+  getInstance = (props: ConstructFactoryGetInstanceProps): AmplifyData => {
     const { constructContainer, outputStorageStrategy, importPathVerifier } =
       props;
     importPathVerifier?.verify(
@@ -66,7 +64,7 @@ class DataFactory implements ConstructFactory<AmplifyGraphqlApi> {
         outputStorageStrategy
       );
     }
-    return constructContainer.getOrCompute(this.generator) as AmplifyGraphqlApi;
+    return constructContainer.getOrCompute(this.generator) as AmplifyData;
   };
 }
 
@@ -103,7 +101,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
       this.props.functions ?? {}
     );
 
-    return new AmplifyGraphqlApi(scope, this.defaultName, {
+    return new AmplifyData(scope, this.defaultName, {
       apiName: this.props.name,
       definition: convertSchemaToCDK(this.props.schema),
       authorizationModes,
@@ -117,7 +115,5 @@ class DataGenerator implements ConstructContainerEntryGenerator {
 /**
  * Creates a factory that implements ConstructFactory<AmplifyGraphqlApi>
  */
-export const defineData = (
-  props: DataProps
-): ConstructFactory<AmplifyGraphqlApi> =>
+export const defineData = (props: DataProps): ConstructFactory<AmplifyData> =>
   new DataFactory(props, new Error().stack);

--- a/packages/backend-data/src/validate_authorization_modes.ts
+++ b/packages/backend-data/src/validate_authorization_modes.ts
@@ -1,4 +1,4 @@
-import { AuthorizationModes as CDKAuthorizationModes } from '@aws-amplify/graphql-api-construct';
+import { AuthorizationModes as CDKAuthorizationModes } from '@aws-amplify/data-construct';
 import { AuthorizationModes } from './types.js';
 
 type AuthorizationModeValidator = (

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -368,7 +368,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/d4bc77b70b9a14715fe10c028d40dc02fda3a5af0b4458d582395d49f4f86412.json"
+       "/568fae1fb1a84acb8009c15dd9862684ea77a601c2e3514a373ac1c1e60adc29.json"
       ]
      ]
     }
@@ -415,7 +415,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/bebe1b734b4216c94b1c53351767d2c5459c97808ca16ef89e2b396f238e0548.json"
+       "/cdc70780a2391e1bdd7949b974db4fa26ff6ff33b0a78bb0e167fb2ce6bd0406.json"
       ]
      ]
     }

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.3.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "amplifyAuthUserPool4BA7F805": {
    "Type": "AWS::Cognito::UserPool",

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.3.0\",\"stackType\":\"api-AppSync\"}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.4.0\",\"stackType\":\"api-AppSync\",\"metadata\":{}}",
  "Resources": {
   "amplifyDataGraphQLAPI42A6FA33": {
    "Type": "AWS::AppSync::GraphQLApi",
@@ -47,7 +47,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1702593039
+    "Expires": 1702659169
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/dc45b71e54502110319cb6355d0ac0ff582d85a7aeb7910d2b3b7bf97abde1ec.json"
+       "/1e660998f59c96400b5336cc508ab35e48c9a7d91a9194fc5f3a3270ed8f0566.json"
       ]
      ]
     }
@@ -468,7 +468,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1f6f9dbd53e23970f70c1438f33823b2ed8a7e66402d0f4dbf80a45f62b601a2.json"
+       "/aae2917f7b6aa1fda37678972818215ed49129160005f03acfa90c29ad5f944f.json"
       ]
      ]
     }
@@ -527,7 +527,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/6afdc42f81bc9739b0dd6e4e25ef5ef0152e5f970dad4a7b96926b6ba906b94c.json"
+       "/c237c401fa18805b83ef4248fe13bcc12d57fd6e9593e0a1e3e8e57a2f1c449b.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.3.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.3.0\",\"stackType\":\"api-AppSync\"}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.4.0\",\"stackType\":\"api-AppSync\",\"metadata\":{}}",
  "Resources": {
   "amplifyDataGraphQLAPI42A6FA33": {
    "Type": "AWS::AppSync::GraphQLApi",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.1\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.2\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
  "Resources": {
   "amplifyStorageamplifyStorageBucketC2F702CD": {
    "Type": "AWS::S3::Bucket",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/dc45b71e54502110319cb6355d0ac0ff582d85a7aeb7910d2b3b7bf97abde1ec.json"
+       "/1e660998f59c96400b5336cc508ab35e48c9a7d91a9194fc5f3a3270ed8f0566.json"
       ]
      ]
     }
@@ -468,7 +468,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1f6f9dbd53e23970f70c1438f33823b2ed8a7e66402d0f4dbf80a45f62b601a2.json"
+       "/aae2917f7b6aa1fda37678972818215ed49129160005f03acfa90c29ad5f944f.json"
       ]
      ]
     }
@@ -527,7 +527,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/6afdc42f81bc9739b0dd6e4e25ef5ef0152e5f970dad4a7b96926b6ba906b94c.json"
+       "/c237c401fa18805b83ef4248fe13bcc12d57fd6e9593e0a1e3e8e57a2f1c449b.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.3.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.3.0\",\"stackType\":\"api-AppSync\"}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.4.0\",\"stackType\":\"api-AppSync\",\"metadata\":{}}",
  "Resources": {
   "amplifyDataGraphQLAPI42A6FA33": {
    "Type": "AWS::AppSync::GraphQLApi",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.1\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.2\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
  "Resources": {
   "amplifyStorageamplifyStorageBucketC2F702CD": {
    "Type": "AWS::S3::Bucket",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/dc45b71e54502110319cb6355d0ac0ff582d85a7aeb7910d2b3b7bf97abde1ec.json"
+       "/1e660998f59c96400b5336cc508ab35e48c9a7d91a9194fc5f3a3270ed8f0566.json"
       ]
      ]
     }
@@ -468,7 +468,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1f6f9dbd53e23970f70c1438f33823b2ed8a7e66402d0f4dbf80a45f62b601a2.json"
+       "/aae2917f7b6aa1fda37678972818215ed49129160005f03acfa90c29ad5f944f.json"
       ]
      ]
     }
@@ -527,7 +527,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/718b9b3ef0a72b420d83d039ff1624763232f4bef5c06f2d173966cbf86bcebe.json"
+       "/143c8113de56e87dad79a5f2007db4eda85f7495f5986372cc845a5ccc5dc14c.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.3.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.3.0\",\"stackType\":\"api-AppSync\"}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.4.0\",\"stackType\":\"api-AppSync\",\"metadata\":{}}",
  "Resources": {
   "amplifyDataGraphQLAPI42A6FA33": {
    "Type": "AWS::AppSync::GraphQLApi",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.1\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.2\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
  "Resources": {
   "amplifyStorageamplifyStorageBucketC2F702CD": {
    "Type": "AWS::S3::Bucket",

--- a/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -266,7 +266,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1f6f9dbd53e23970f70c1438f33823b2ed8a7e66402d0f4dbf80a45f62b601a2.json"
+       "/aae2917f7b6aa1fda37678972818215ed49129160005f03acfa90c29ad5f944f.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
+++ b/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.1\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.2\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
  "Resources": {
   "amplifyStorageamplifyStorageBucketC2F702CD": {
    "Type": "AWS::S3::Bucket",

--- a/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -318,7 +318,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/8d71a7814b6e610543065343fa3519654aefdfbc82b9bef1d09c44cdda79d51f.json"
+       "/1fee52907d9fe91b72b08137b1802bbbfdd90a58fc4276536c0968e65a5ec614.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.3.0\",\"stackType\":\"api-AppSync\"}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.4.0\",\"stackType\":\"api-AppSync\",\"metadata\":{}}",
  "Resources": {
   "amplifyDataGraphQLAPI42A6FA33": {
    "Type": "AWS::AppSync::GraphQLApi",
@@ -51,7 +51,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1702593038
+    "Expires": 1702659167
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {

--- a/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -306,7 +306,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/69d86e15f84f31a9d77d102e8d45a83d6b16d08fd0eb980e0817cb63b16e41b3.json"
+       "/9e4774ce3821892bd277df65337866f1e6bb94f08bbd838ef38b20410c68b32f.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.3.0\",\"stackType\":\"api-AppSync\"}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyCDK\",\"createdWith\":\"1.4.0\",\"stackType\":\"api-AppSync\",\"metadata\":{}}",
  "Resources": {
   "amplifyDataGraphQLAPI42A6FA33": {
    "Type": "AWS::AppSync::GraphQLApi",
@@ -31,7 +31,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1700605839
+    "Expires": 1700671968
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Flip to use the freshly minted `data-construct` instead of the `graphql-api-construct` directly.
* Update imports and class names accordingly.
* Update `transformerSchema` method and tests to use default DDB strategy builder (parity with what we have today, but being explicit since we plan to change that in an upcoming PR).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
