### PR TITLE
fix: pin graphql api construct dependency temporarily

### DIFF
--- a/.changeset/silly-turtles-float.md
+++ b/.changeset/silly-turtles-float.md
@@ -1,0 +1,6 @@
+---
+'create-amplify': patch
+'@aws-amplify/backend-data': patch
+---
+
+Pin graphql-api-construct dependency to unblock testers.

--- a/examples/simple_react/package-lock.json
+++ b/examples/simple_react/package-lock.json
@@ -83,7 +83,7 @@
         "@aws-amplify/backend-output-schemas": "^0.3.0",
         "@aws-amplify/backend-output-storage": "0.2.1",
         "@aws-amplify/data-schema-types": "^0.4.2",
-        "@aws-amplify/graphql-api-construct": "^1.3.0",
+        "@aws-amplify/graphql-api-construct": "1.3.0",
         "@aws-amplify/plugin-types": "^0.4.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19428,12 +19428,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "^0.2.1",
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "^0.2.2",
+        "@aws-amplify/plugin-types": "^0.4.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -19442,19 +19442,19 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.3.0",
-        "@aws-amplify/backend-data": "^0.5.0",
-        "@aws-amplify/backend-function": "^0.2.0",
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "^0.2.1",
+        "@aws-amplify/backend-auth": "^0.3.1",
+        "@aws-amplify/backend-data": "^0.5.1",
+        "@aws-amplify/backend-function": "^0.2.1",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "^0.2.2",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/backend-storage": "^0.3.0",
         "@aws-amplify/data-schema": "^0.12.1",
         "@aws-amplify/platform-core": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.4.0",
+        "@aws-amplify/plugin-types": "^0.4.1",
         "@aws-sdk/client-amplify": "^3.440.0"
       },
       "devDependencies": {
@@ -19468,12 +19468,12 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "0.2.1",
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/auth-construct-alpha": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "0.2.2",
+        "@aws-amplify/plugin-types": "^0.4.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
@@ -19486,14 +19486,14 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "0.2.1",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "0.2.2",
         "@aws-amplify/data-schema-types": "^0.6.1",
-        "@aws-amplify/graphql-api-construct": "^1.3.0",
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/graphql-api-construct": "1.3.0",
+        "@aws-amplify/plugin-types": "^0.4.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
@@ -19522,12 +19522,12 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "0.2.1",
+        "@aws-amplify/backend-output-storage": "0.2.2",
         "@aws-amplify/function-construct-alpha": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.4.0",
+        "@aws-amplify/plugin-types": "^0.4.1",
         "execa": "^7.1.1"
       },
       "devDependencies": {
@@ -19541,10 +19541,10 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "0.4.0"
+        "@aws-amplify/plugin-types": "0.4.1"
       },
       "peerDependencies": {
         "zod": "^3.21.4"
@@ -19552,10 +19552,10 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/platform-core": "^0.2.0"
       },
       "peerDependencies": {
@@ -19604,18 +19604,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.3.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.0",
+        "@aws-amplify/client-config": "^0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.1",
         "@aws-amplify/form-generator": "^0.3.0",
-        "@aws-amplify/model-generator": "^0.2.1",
+        "@aws-amplify/model-generator": "^0.2.2",
         "@aws-amplify/platform-core": "^0.2.0",
-        "@aws-amplify/sandbox": "^0.3.0",
+        "@aws-amplify/sandbox": "^0.3.1",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@aws-sdk/region-config-resolver": "^3.433.0",
@@ -19760,12 +19760,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.0",
-        "@aws-amplify/model-generator": "^0.2.1",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.1",
+        "@aws-amplify/model-generator": "^0.2.2",
         "@aws-sdk/client-amplify": "^3.376.0",
         "@aws-sdk/client-cloudformation": "^3.376.0",
         "@aws-sdk/client-ssm": "^3.398.0",
@@ -19778,7 +19778,7 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
@@ -19904,10 +19904,10 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-sdk/client-amplify": "^3.329.0",
         "@aws-sdk/client-cloudformation": "^3.329.0",
@@ -19949,11 +19949,11 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/backend": "0.4.0",
-        "@aws-amplify/backend-auth": "0.3.0",
+        "@aws-amplify/backend": "0.5.0",
+        "@aws-amplify/backend-auth": "0.3.1",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/backend-storage": "0.3.0",
         "@aws-amplify/data-schema": "^0.12.1",
@@ -20023,11 +20023,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.0",
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.1",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -20051,7 +20051,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20060,14 +20060,14 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "0.3.0",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "0.3.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.0",
+        "@aws-amplify/client-config": "0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.1",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
@@ -20116,14 +20116,14 @@
     },
     "packages/storage-construct": {
       "name": "@aws-amplify/storage-construct-alpha",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.3.0",
-        "@aws-amplify/backend-output-storage": "^0.2.1"
+        "@aws-amplify/backend-output-schemas": "^0.4.0",
+        "@aws-amplify/backend-output-storage": "^0.2.2"
       },
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/plugin-types": "^0.4.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "0.2.2",
     "@aws-amplify/backend-output-schemas": "^0.4.0",
-    "@aws-amplify/graphql-api-construct": "^1.3.0",
+    "@aws-amplify/graphql-api-construct": "1.3.0",
     "@aws-amplify/plugin-types": "^0.4.1",
     "@aws-amplify/data-schema-types": "^0.6.1"
   }

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -368,7 +368,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/d4bc77b70b9a14715fe10c028d40dc02fda3a5af0b4458d582395d49f4f86412.json"
+       "/568fae1fb1a84acb8009c15dd9862684ea77a601c2e3514a373ac1c1e60adc29.json"
       ]
      ]
     }
@@ -415,7 +415,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/bebe1b734b4216c94b1c53351767d2c5459c97808ca16ef89e2b396f238e0548.json"
+       "/5ec276abf03c8f0b81e70ce439c740dbfb7d709bd8d7856684d7003778f3efd2.json"
       ]
      ]
     }

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.3.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "amplifyAuthUserPool4BA7F805": {
    "Type": "AWS::Cognito::UserPool",

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -47,7 +47,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1702593039
+    "Expires": 1702665734
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/dc45b71e54502110319cb6355d0ac0ff582d85a7aeb7910d2b3b7bf97abde1ec.json"
+       "/1e660998f59c96400b5336cc508ab35e48c9a7d91a9194fc5f3a3270ed8f0566.json"
       ]
      ]
     }
@@ -468,7 +468,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1f6f9dbd53e23970f70c1438f33823b2ed8a7e66402d0f4dbf80a45f62b601a2.json"
+       "/aae2917f7b6aa1fda37678972818215ed49129160005f03acfa90c29ad5f944f.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.3.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.1\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.2\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
  "Resources": {
   "amplifyStorageamplifyStorageBucketC2F702CD": {
    "Type": "AWS::S3::Bucket",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/dc45b71e54502110319cb6355d0ac0ff582d85a7aeb7910d2b3b7bf97abde1ec.json"
+       "/1e660998f59c96400b5336cc508ab35e48c9a7d91a9194fc5f3a3270ed8f0566.json"
       ]
      ]
     }
@@ -468,7 +468,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1f6f9dbd53e23970f70c1438f33823b2ed8a7e66402d0f4dbf80a45f62b601a2.json"
+       "/aae2917f7b6aa1fda37678972818215ed49129160005f03acfa90c29ad5f944f.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.3.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.1\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.2\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
  "Resources": {
   "amplifyStorageamplifyStorageBucketC2F702CD": {
    "Type": "AWS::S3::Bucket",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/dc45b71e54502110319cb6355d0ac0ff582d85a7aeb7910d2b3b7bf97abde1ec.json"
+       "/1e660998f59c96400b5336cc508ab35e48c9a7d91a9194fc5f3a3270ed8f0566.json"
       ]
      ]
     }
@@ -468,7 +468,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1f6f9dbd53e23970f70c1438f33823b2ed8a7e66402d0f4dbf80a45f62b601a2.json"
+       "/aae2917f7b6aa1fda37678972818215ed49129160005f03acfa90c29ad5f944f.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.3.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.1\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.2\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
  "Resources": {
   "amplifyStorageamplifyStorageBucketC2F702CD": {
    "Type": "AWS::S3::Bucket",

--- a/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -266,7 +266,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1f6f9dbd53e23970f70c1438f33823b2ed8a7e66402d0f4dbf80a45f62b601a2.json"
+       "/aae2917f7b6aa1fda37678972818215ed49129160005f03acfa90c29ad5f944f.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
+++ b/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854astorage16B83955.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.1\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.2.2\",\"stackType\":\"storage-S3\",\"metadata\":{}}",
  "Resources": {
   "amplifyStorageamplifyStorageBucketC2F702CD": {
    "Type": "AWS::S3::Bucket",

--- a/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -318,7 +318,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/8d71a7814b6e610543065343fa3519654aefdfbc82b9bef1d09c44cdda79d51f.json"
+       "/e542caa1d089c2a8a108a1456417303c57c6047c0a302e972133371475ca0c24.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -51,7 +51,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1702593038
+    "Expires": 1702665732
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {

--- a/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"root\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.5.0\",\"stackType\":\"root\",\"metadata\":{}}",
  "Metadata": {
   "AWS::Amplify::Platform": {
    "version": "1",
@@ -306,7 +306,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/69d86e15f84f31a9d77d102e8d45a83d6b16d08fd0eb980e0817cb63b16e41b3.json"
+       "/64edaafe49fe23239b9808bda04aeaa2a66ce99706390579dc2264401a9134c8.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -31,7 +31,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1700605839
+    "Expires": 1700678533
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {


### PR DESCRIPTION
*Issue #, if available:*
Current installs of @latest will fail due to mismatch between api-construct and data-types schemas.

*Description of changes:*
Pin to version 1.3.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
