### PR TITLE
test: restrict live canary run time

### DIFF
--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -30,6 +30,7 @@ jobs:
           npm run test
   live_dependency_health_checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       # these permissions are required for the configure-aws-credentials action to get a JWT from GitHub
       id-token: write


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Makes live canaries timeout in 15 minutes.

To mitigate this behavior:
![image](https://github.com/aws-amplify/amplify-backend/assets/5849952/bb0b9de3-c79c-4939-be37-471e766fe4c7)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
