### PR TITLE
fix: add required fields to mobile config

### DIFF
--- a/.changeset/spicy-carrots-shave.md
+++ b/.changeset/spicy-carrots-shave.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+include additional fields in mobile config generation

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -43,8 +43,10 @@ export type ClientConfigMobileAuth = {
       Auth: {
         Default: {
           authenticationFlowType: 'USER_SRP_AUTH';
+          mfaConfiguration: string | undefined;
+          mfaTypes: Array<string> | undefined;
           passwordProtectionSettings: {
-            passwordPolicyMinLength: number;
+            passwordPolicyMinLength: number | undefined;
             passwordPolicyCharacters: Array<string>;
           };
           signupAttributes: Array<string>;

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -43,6 +43,13 @@ export type ClientConfigMobileAuth = {
       Auth: {
         Default: {
           authenticationFlowType: 'USER_SRP_AUTH';
+          passwordProtectionSettings: {
+            passwordPolicyMinLength: number;
+            passwordPolicyCharacters: Array<string>;
+          };
+          signupAttributes: Array<string>;
+          usernameAttributes: Array<string>;
+          verificationMechanisms: Array<string>;
         };
       };
       AppSync?: {

--- a/packages/client-config/src/client-config-writer/client_config_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.test.ts
@@ -18,6 +18,22 @@ void describe('client config converter', () => {
       aws_cognito_region: 'test_cognito_region',
       aws_user_pools_id: 'test_user_pool_id',
       aws_user_pools_web_client_id: 'test_user_pool_app_client_id',
+      aws_cognito_signup_attributes: [
+        'test_signup_attribute_1',
+        'test_signup_attribute_2',
+      ],
+      aws_cognito_username_attributes: [
+        'test_username_attribute_1',
+        'test_username_attribute_2',
+      ],
+      aws_cognito_password_protection_settings: {
+        passwordPolicyMinLength: 1234,
+        passwordPolicyCharacters: ['a', 'b', 'c'],
+      },
+      aws_cognito_verification_mechanisms: [
+        'test_verification_mechanism_1',
+        'test_verification_mechanism_2',
+      ],
     };
     const expectedMobileConfig: ClientConfigMobile = {
       UserAgent: expectedUserAgent,
@@ -45,6 +61,22 @@ void describe('client config converter', () => {
             Auth: {
               Default: {
                 authenticationFlowType: 'USER_SRP_AUTH',
+                signupAttributes: [
+                  'test_signup_attribute_1',
+                  'test_signup_attribute_2',
+                ],
+                usernameAttributes: [
+                  'test_username_attribute_1',
+                  'test_username_attribute_2',
+                ],
+                passwordProtectionSettings: {
+                  passwordPolicyMinLength: 1234,
+                  passwordPolicyCharacters: ['a', 'b', 'c'],
+                },
+                verificationMechanisms: [
+                  'test_verification_mechanism_1',
+                  'test_verification_mechanism_2',
+                ],
               },
             },
           },
@@ -123,6 +155,13 @@ void describe('client config converter', () => {
             Auth: {
               Default: {
                 authenticationFlowType: 'USER_SRP_AUTH',
+                signupAttributes: [],
+                usernameAttributes: [],
+                passwordProtectionSettings: {
+                  passwordPolicyCharacters: [],
+                  passwordPolicyMinLength: 8,
+                },
+                verificationMechanisms: [],
               },
             },
             AppSync: {

--- a/packages/client-config/src/client-config-writer/client_config_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.test.ts
@@ -34,6 +34,8 @@ void describe('client config converter', () => {
         'test_verification_mechanism_1',
         'test_verification_mechanism_2',
       ],
+      aws_cognito_mfa_configuration: 'test_mfa_configuration',
+      aws_cognito_mfa_types: ['test_mfa_type_1', 'test_mfa_type_2'],
     };
     const expectedMobileConfig: ClientConfigMobile = {
       UserAgent: expectedUserAgent,
@@ -61,6 +63,8 @@ void describe('client config converter', () => {
             Auth: {
               Default: {
                 authenticationFlowType: 'USER_SRP_AUTH',
+                mfaConfiguration: 'test_mfa_configuration',
+                mfaTypes: ['test_mfa_type_1', 'test_mfa_type_2'],
                 signupAttributes: [
                   'test_signup_attribute_1',
                   'test_signup_attribute_2',
@@ -155,11 +159,13 @@ void describe('client config converter', () => {
             Auth: {
               Default: {
                 authenticationFlowType: 'USER_SRP_AUTH',
+                mfaConfiguration: undefined,
+                mfaTypes: undefined,
                 signupAttributes: [],
                 usernameAttributes: [],
                 passwordProtectionSettings: {
                   passwordPolicyCharacters: [],
-                  passwordPolicyMinLength: 8,
+                  passwordPolicyMinLength: undefined,
                 },
                 verificationMechanisms: [],
               },

--- a/packages/client-config/src/client-config-writer/client_config_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.test.ts
@@ -18,6 +18,7 @@ void describe('client config converter', () => {
       aws_cognito_region: 'test_cognito_region',
       aws_user_pools_id: 'test_user_pool_id',
       aws_user_pools_web_client_id: 'test_user_pool_app_client_id',
+      aws_cognito_identity_pool_id: 'test_identity_pool_id',
       aws_cognito_signup_attributes: [
         'test_signup_attribute_1',
         'test_signup_attribute_2',
@@ -55,7 +56,7 @@ void describe('client config converter', () => {
             CredentialsProvider: {
               CognitoIdentity: {
                 Default: {
-                  PoolId: 'test_user_pool_id',
+                  PoolId: 'test_identity_pool_id',
                   Region: 'test_cognito_region',
                 },
               },
@@ -127,6 +128,7 @@ void describe('client config converter', () => {
     const clientConfig: ClientConfig = {
       aws_cognito_region: 'test_cognito_region',
       aws_user_pools_id: 'test_user_pool_id',
+      aws_cognito_identity_pool_id: 'test_identity_pool_id',
       aws_user_pools_web_client_id: 'test_user_pool_app_client_id',
       aws_appsync_region: 'test_app_sync_region',
       aws_appsync_graphqlEndpoint: 'https://test_api_endpoint.amazon.com',
@@ -151,7 +153,7 @@ void describe('client config converter', () => {
             CredentialsProvider: {
               CognitoIdentity: {
                 Default: {
-                  PoolId: 'test_user_pool_id',
+                  PoolId: 'test_identity_pool_id',
                   Region: 'test_cognito_region',
                 },
               },

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -50,10 +50,12 @@ export class ClientConfigConverter {
             Auth: {
               Default: {
                 authenticationFlowType: 'USER_SRP_AUTH',
+                mfaConfiguration: clientConfig.aws_cognito_mfa_configuration,
+                mfaTypes: clientConfig.aws_cognito_mfa_types,
                 passwordProtectionSettings: {
                   passwordPolicyMinLength:
                     clientConfig.aws_cognito_password_protection_settings
-                      ?.passwordPolicyMinLength ?? 8,
+                      ?.passwordPolicyMinLength,
                   passwordPolicyCharacters:
                     clientConfig.aws_cognito_password_protection_settings
                       ?.passwordPolicyCharacters ?? [],

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -42,7 +42,7 @@ export class ClientConfigConverter {
             CredentialsProvider: {
               CognitoIdentity: {
                 Default: {
-                  PoolId: clientConfig.aws_user_pools_id,
+                  PoolId: clientConfig.aws_cognito_identity_pool_id,
                   Region: clientConfig.aws_cognito_region,
                 },
               },

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -50,6 +50,20 @@ export class ClientConfigConverter {
             Auth: {
               Default: {
                 authenticationFlowType: 'USER_SRP_AUTH',
+                passwordProtectionSettings: {
+                  passwordPolicyMinLength:
+                    clientConfig.aws_cognito_password_protection_settings
+                      ?.passwordPolicyMinLength ?? 8,
+                  passwordPolicyCharacters:
+                    clientConfig.aws_cognito_password_protection_settings
+                      ?.passwordPolicyCharacters ?? [],
+                },
+                signupAttributes:
+                  clientConfig.aws_cognito_signup_attributes ?? [],
+                usernameAttributes:
+                  clientConfig.aws_cognito_username_attributes ?? [],
+                verificationMechanisms:
+                  clientConfig.aws_cognito_verification_mechanisms ?? [],
               },
             },
           },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds necessary fields for mobile authenticator to work.

Tested with the following app.

```
package dev.salih.myamplifyapp

import android.app.Application
import android.util.Log
import com.amplifyframework.AmplifyException
import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
import com.amplifyframework.core.Amplify

class MyAmplifyApp: Application() {
    override fun onCreate() {
        super.onCreate()

        try {
            Log.i("MyAmplifyApp", "Before initializing Amplify")
            Amplify.addPlugin(AWSCognitoAuthPlugin())
            Amplify.configure(applicationContext)
            Log.i("MyAmplifyApp", "Initialized Amplify")
        } catch (error: AmplifyException) {
            Log.e("MyAmplifyApp", "Could not initialize Amplify", error)
        }
    }
}
```


```
package dev.salih.myamplifyapp

import android.os.Bundle
import androidx.activity.ComponentActivity
import androidx.activity.compose.setContent
import androidx.compose.foundation.layout.fillMaxSize
import androidx.compose.material3.MaterialTheme
import androidx.compose.material3.Surface
import androidx.compose.material3.Text
import androidx.compose.runtime.Composable
import androidx.compose.ui.Modifier
import androidx.compose.ui.tooling.preview.Preview
import com.amplifyframework.ui.authenticator.ui.Authenticator
import dev.salih.myamplifyapp.ui.theme.MyAmplifyAppTheme

class MainActivity : ComponentActivity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContent {
            MyAmplifyAppTheme {
                // A surface container using the 'background' color from the theme
                Surface(
                    modifier = Modifier.fillMaxSize(),
                    color = MaterialTheme.colorScheme.background
                ) {
                    Authenticator { state ->
                        Greeting(state.user.username)
                    }
                }
            }
        }
    }
}

@Composable
fun Greeting(name: String, modifier: Modifier = Modifier) {
    Text(
        text = "Hello $name!",
        modifier = modifier
    )
}

@Preview(showBackground = true)
@Composable
fun GreetingPreview() {
    MyAmplifyAppTheme {
        Greeting("Android")
    }
}
```

Authenticator rendered and appears to be working:
![image](https://github.com/aws-amplify/amplify-backend/assets/5849952/a41e0996-aa49-4cc9-af3a-8e6219069a44)
![image](https://github.com/aws-amplify/amplify-backend/assets/5849952/af7d6627-5998-48d7-ad88-7ec99fdfe931)
![image](https://github.com/aws-amplify/amplify-backend/assets/5849952/3b5a57c1-3b7a-44b1-81ac-00049d08b71e)


Log after change:
```
2023-11-15 20:39:22.185 21285-21285 ziparchive              dev.salih.myamplifyapp               W  Unable to open '/data/app/~~vgkWezzuBqrE8HTQU552UQ==/dev.salih.myamplifyapp-CXTcKrhVgOlk6Dlqg0INfg==/base.dm': No such file or directory
2023-11-15 20:39:22.185 21285-21285 ziparchive              dev.salih.myamplifyapp               W  Unable to open '/data/app/~~vgkWezzuBqrE8HTQU552UQ==/dev.salih.myamplifyapp-CXTcKrhVgOlk6Dlqg0INfg==/base.dm': No such file or directory
2023-11-15 20:39:22.505 21285-21285 nativeloader            dev.salih.myamplifyapp               D  Configuring clns-6 for other apk /data/app/~~vgkWezzuBqrE8HTQU552UQ==/dev.salih.myamplifyapp-CXTcKrhVgOlk6Dlqg0INfg==/base.apk. target_sdk_version=33, uses_libraries=, library_path=/data/app/~~vgkWezzuBqrE8HTQU552UQ==/dev.salih.myamplifyapp-CXTcKrhVgOlk6Dlqg0INfg==/lib/arm64, permitted_path=/data:/mnt/expand:/data/user/0/dev.salih.myamplifyapp
2023-11-15 20:39:22.512 21285-21285 GraphicsEnvironment     dev.salih.myamplifyapp               V  Currently set values for:
2023-11-15 20:39:22.512 21285-21285 GraphicsEnvironment     dev.salih.myamplifyapp               V    angle_gl_driver_selection_pkgs=[]
2023-11-15 20:39:22.513 21285-21285 GraphicsEnvironment     dev.salih.myamplifyapp               V    angle_gl_driver_selection_values=[]
2023-11-15 20:39:22.516 21285-21285 GraphicsEnvironment     dev.salih.myamplifyapp               V  ANGLE GameManagerService for dev.salih.myamplifyapp: false
2023-11-15 20:39:22.516 21285-21285 GraphicsEnvironment     dev.salih.myamplifyapp               V  dev.salih.myamplifyapp is not listed in per-application setting
2023-11-15 20:39:22.516 21285-21285 GraphicsEnvironment     dev.salih.myamplifyapp               V  Neither updatable production driver nor prerelease driver is supported.
2023-11-15 20:39:22.528 21285-21285 MyAmplifyApp            dev.salih.myamplifyapp               I  Before initializing Amplify
2023-11-15 20:39:22.621 21285-21285 MyAmplifyApp            dev.salih.myamplifyapp               I  Initialized Amplify
2023-11-15 20:39:22.653 21285-21307 libEGL                  dev.salih.myamplifyapp               D  loaded /vendor/lib64/egl/libEGL_emulation.so
2023-11-15 20:39:22.658 21285-21307 libEGL                  dev.salih.myamplifyapp               D  loaded /vendor/lib64/egl/libGLESv1_CM_emulation.so
2023-11-15 20:39:22.660 21285-21285 Compatibil...geReporter dev.salih.myamplifyapp               D  Compat change id reported: 237531167; UID 10191; state: DISABLED
2023-11-15 20:39:22.662 21285-21285 OpenGLRenderer          dev.salih.myamplifyapp               W  Unknown dataspace 0
2023-11-15 20:39:22.666 21285-21307 libEGL                  dev.salih.myamplifyapp               D  loaded /vendor/lib64/egl/libGLESv2_emulation.so
2023-11-15 20:39:22.732 21285-21285 ih.myamplifyapp         dev.salih.myamplifyapp               W  Method java.lang.Object androidx.compose.runtime.snapshots.SnapshotStateMap.mutate(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
                                                                                                    Common causes for lock verification issues are non-optimized dex code
                                                                                                    and incorrect proguard optimizations.
2023-11-15 20:39:22.733 21285-21285 ih.myamplifyapp         dev.salih.myamplifyapp               W  Method void androidx.compose.runtime.snapshots.SnapshotStateMap.update(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
2023-11-15 20:39:22.734 21285-21285 ih.myamplifyapp         dev.salih.myamplifyapp               W  Method boolean androidx.compose.runtime.snapshots.SnapshotStateMap.removeIf$runtime_release(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
2023-11-15 20:39:22.813 21285-21302 EngineFactory           dev.salih.myamplifyapp               I  Provider GmsCore_OpenSSL not available
2023-11-15 20:39:22.828 21285-21285 ih.myamplifyapp         dev.salih.myamplifyapp               W  Method boolean androidx.compose.runtime.snapshots.SnapshotStateList.conditionalUpdate(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
2023-11-15 20:39:22.829 21285-21285 ih.myamplifyapp         dev.salih.myamplifyapp               W  Method java.lang.Object androidx.compose.runtime.snapshots.SnapshotStateList.mutate(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
2023-11-15 20:39:22.829 21285-21285 ih.myamplifyapp         dev.salih.myamplifyapp               W  Method void androidx.compose.runtime.snapshots.SnapshotStateList.update(kotlin.jvm.functions.Function1) failed lock verification and will run slower.
2023-11-15 20:39:22.844 21285-21285 Compatibil...geReporter dev.salih.myamplifyapp               D  Compat change id reported: 171228096; UID 10191; state: ENABLED
2023-11-15 20:39:22.907 21285-21305 OpenGLRenderer          dev.salih.myamplifyapp               W  Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED, retrying without...
2023-11-15 20:39:22.908 21285-21305 OpenGLRenderer          dev.salih.myamplifyapp               W  Failed to initialize 101010-2 format, error = EGL_SUCCESS
2023-11-15 20:39:22.920 21285-21305 Gralloc4                dev.salih.myamplifyapp               I  mapper 4.x is not supported
2023-11-15 20:39:22.928 21285-21305 OpenGLRenderer          dev.salih.myamplifyapp               E  Unable to match the desired swap behavior.
2023-11-15 20:39:23.027 21285-21301 System.err              dev.salih.myamplifyapp               W  SLF4J: No SLF4J providers were found.
2023-11-15 20:39:23.042 21285-21301 System.err              dev.salih.myamplifyapp               W  SLF4J: Defaulting to no-operation (NOP) logger implementation
2023-11-15 20:39:23.043 21285-21301 System.err              dev.salih.myamplifyapp               W  SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
2023-11-15 20:39:23.446 21285-21301 ih.myamplifyapp         dev.salih.myamplifyapp               W  Verification of java.util.List kotlin.text.StringsKt___StringsKt.windowed(java.lang.CharSequence, int, int, boolean) took 185.969ms (75.28 bytecodes/s) (1704B approximate peak alloc)
2023-11-15 20:39:23.665 21285-21331 TrafficStats            dev.salih.myamplifyapp               D  tagSocket(97) with statsTag=0xffffffff, statsUid=-1
2023-11-15 20:39:23.678 21285-21331 TrafficStats            dev.salih.myamplifyapp               D  tagSocket(97) with statsTag=0xffffffff, statsUid=-1
2023-11-15 20:39:23.989 21285-21285 Compatibil...geReporter dev.salih.myamplifyapp               D  Compat change id reported: 289878283; UID 10191; state: DISABLED
2023-11-15 20:39:24.187 21285-21305 EGL_emulation           dev.salih.myamplifyapp               D  app_time_stats: avg=18.86ms min=0.88ms max=237.74ms count=39

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
