### PR TITLE
fix: handling !pattern in gitignore to avoid excluding everything from watching in sandbox

### DIFF
--- a/.changeset/pretty-mice-camp.md
+++ b/.changeset/pretty-mice-camp.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+fix: handling \!pattern in gitignore to avoid excluding everything from watching in sandbox

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -251,7 +251,18 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
         .parse(gitIgnoreFilePath)
         .patterns.map((pattern: string) =>
           pattern.startsWith('/') ? pattern.substring(1) : pattern
-        );
+        )
+        .filter((pattern: string) => {
+          if (pattern.startsWith('!')) {
+            console.log(
+              `[Sandbox] Pattern ${pattern} found in .gitignore. "${pattern.substring(
+                1
+              )}" will not be watched if other patterns in .gitignore are excluding it.`
+            );
+            return false;
+          }
+          return true;
+        });
     }
     return [];
   };


### PR DESCRIPTION
*Description of changes:*
A `!` pattern have different meanings for .gitignore and glob pattern (used in sandbox excludes). 

The `!` pattern in gitignore means explicitly to add back (i.e. include) the file/folder immediately followed by `!` if other more generic patterns are excluding it.

However in glob patterns, `!` pattern means include everything **but** the file/folder immediately followed by `!`

As an example for a .gitignore file
```ignore
...
output
!output/file-i-want-to-check-in.ts
...
```

If this file is fed to the [sandbox's watcher](https://github.com/parcel-bundler/watcher) exclude, it will essentially means exclude everything but `file-i-want-to-check-in.ts` overriding the `src`, `amplify` directories and everything else.

[sandbox's watcher](https://github.com/parcel-bundler/watcher) include doesn't allow glob patterns, so we can't add these patterns in the include section.

As a short term solution, in this PR, we detect presence of `!` and ignore them such that it gets neither "specifically included" or exclude everything from watching and we tell customers that we are explicitly not watching a certain set of files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
