### PR TITLE
fix(form-generator): update form renderer to render amplify js v6 code

### DIFF
--- a/.changeset/rich-carrots-rule.md
+++ b/.changeset/rich-carrots-rule.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/form-generator': minor
+---
+
+updates the form renderer to generate amplify js v6 compatible code

--- a/package-lock.json
+++ b/package-lock.json
@@ -20532,8 +20532,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
-        "@aws-amplify/codegen-ui": "^2.19.1",
-        "@aws-amplify/codegen-ui-react": "^2.19.3",
+        "@aws-amplify/codegen-ui": "^2.19.4",
+        "@aws-amplify/codegen-ui-react": "^2.19.4",
         "@aws-amplify/graphql-docs-generator": "^4.1.0",
         "@aws-sdk/client-amplifyuibuilder": "^3.398.0",
         "@aws-sdk/client-appsync": "^3.398.0",

--- a/packages/form-generator/package.json
+++ b/packages/form-generator/package.json
@@ -19,8 +19,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
-    "@aws-amplify/codegen-ui": "^2.19.1",
-    "@aws-amplify/codegen-ui-react": "^2.19.3",
+    "@aws-amplify/codegen-ui": "^2.19.4",
+    "@aws-amplify/codegen-ui-react": "^2.19.4",
     "@aws-amplify/graphql-docs-generator": "^4.1.0",
     "@aws-sdk/client-amplifyuibuilder": "^3.398.0",
     "@aws-sdk/client-appsync": "^3.398.0",

--- a/packages/form-generator/src/local_codegen_graphql_form_generator.ts
+++ b/packages/form-generator/src/local_codegen_graphql_form_generator.ts
@@ -115,6 +115,10 @@ export class LocalGraphqlFormGenerator implements GraphqlFormGenerator {
         subscriptionsFilePath: this.renderGraphqlPath('subscriptions'),
         typesFilePath: this.renderGraphqlPath('types'),
       },
+      dependencies: {
+        // Tell the renderer to generate amplify js v6 compatible code
+        'aws-amplify': '^6.0.0',
+      },
     };
   }
   private createUiBuilderForm = (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

update form renderer to render amplify js v6 code.

upgrades `@aws-amplify/codegen-ui` and `@aws-amplify/codegen-ui-react` to get the latest code generation version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
