### PR TITLE
fix: Force colors to not be stripped off when piping child process stdout

### DIFF
--- a/.changeset/ninety-days-kick.md
+++ b/.changeset/ninety-days-kick.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Force colors to not be stripped off when piping child process stdout

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -170,14 +170,15 @@ export class CDKDeployer implements BackendDeployer {
       done();
     };
 
-    // Piping the output by default strips off the color. This is a workaround to
-    // preserve the color being piped to parent process. Later we reset it to whatever it was before.
-    const oldForceColorValue = process.env['FORCE_COLOR'];
-    process.env['FORCE_COLOR'] = '1';
     const childProcess = execa(command, cdkCommandArgs, {
       stdin: 'inherit',
       stdout: 'pipe',
       stderr: 'pipe',
+
+      // Piping the output by default strips off the color. This is a workaround to
+      // preserve the color being piped to parent process.
+      extendEnv: true,
+      env: { FORCE_COLOR: '1' },
     });
     childProcess.stderr?.pipe(aggregatorStderrStream);
     childProcess.stdout?.pipe(process.stdout);
@@ -189,7 +190,6 @@ export class CDKDeployer implements BackendDeployer {
 
     try {
       await childProcess;
-      process.env['FORCE_COLOR'] = oldForceColorValue;
       return cdkOutput;
     } catch (error) {
       // swallow execa error which is not really helpful, rather throw stderr

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -169,6 +169,11 @@ export class CDKDeployer implements BackendDeployer {
       aggregatedStderr += chunk;
       done();
     };
+
+    // Piping the output by default strips off the color. This is a workaround to
+    // preserve the color being piped to parent process. Later we reset it to whatever it was before.
+    const oldForceColorValue = process.env['FORCE_COLOR'];
+    process.env['FORCE_COLOR'] = '1';
     const childProcess = execa(command, cdkCommandArgs, {
       stdin: 'inherit',
       stdout: 'pipe',
@@ -184,6 +189,7 @@ export class CDKDeployer implements BackendDeployer {
 
     try {
       await childProcess;
+      process.env['FORCE_COLOR'] = oldForceColorValue;
       return cdkOutput;
     } catch (error) {
       // swallow execa error which is not really helpful, rather throw stderr


### PR DESCRIPTION
*Description of changes:* Piping the child process output by default strips off the color for consuming streams. This is a workaround to preserve the color being piped to parent process. See https://github.com/Marak/colors.js/issues/127#issuecomment-392249836


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
