### PR TITLE
chore: avoid crashing sandbox on failing to retrieve metadata

### DIFF
--- a/.changeset/khaki-pumas-cover.md
+++ b/.changeset/khaki-pumas-cover.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/deployed-backend-client': patch
+'@aws-amplify/backend-cli': patch
+---
+
+chore: avoid crashing sandbox on failing to retrieve metadata

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
@@ -10,7 +10,7 @@ import fsp from 'fs/promises';
 import path from 'node:path';
 import { Printer } from '@aws-amplify/cli-core';
 
-void describe(() => {
+void describe('sandbox_event_handler_factory', () => {
   // client config mocks
   const generateClientConfigMock =
     mock.fn<ClientConfigGeneratorAdapter['generateClientConfigToFile']>();

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
@@ -121,7 +121,7 @@ void describe('sandbox_event_handler_factory', () => {
 
     assert.deepStrictEqual(
       printerMock.mock.calls[0].arguments[0],
-      'Amplify configuration could not be generated/updated.'
+      'Amplify configuration could not be generated.'
     );
 
     assert.deepStrictEqual(

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.ts
@@ -44,13 +44,19 @@ export class SandboxEventHandlerFactory {
           } catch (error) {
             // Don't crash sandbox if config cannot be generated, but print the error message
             Printer.print(
-              'Amplify configuration could not be generated/updated.',
+              'Amplify configuration could not be generated.',
               COLOR.RED
             );
             if (error instanceof Error) {
               Printer.print(error.message, COLOR.RED);
             } else {
-              Printer.print(JSON.stringify(error, null, 2), COLOR.RED);
+              try {
+                Printer.print(JSON.stringify(error, null, 2), COLOR.RED);
+              } catch {
+                // fallback in case there's an error stringify the error
+                // like with circular references.
+                Printer.print('Unknown error', COLOR.RED);
+              }
             }
           }
         },

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
@@ -58,8 +58,19 @@ export class StackMetadataBackendOutputRetrievalStrategy
     const stackDescription = await this.cfnClient.send(
       new DescribeStacksCommand({ StackName: stackName })
     );
+
     const outputs = stackDescription?.Stacks?.[0]?.Outputs;
     if (outputs === undefined) {
+      if (stackDescription.Stacks?.[0].StackStatus?.endsWith('_IN_PROGRESS')) {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR,
+          `${
+            stackDescription.Stacks?.[0].StackName ?? 'Stack'
+          } is currently in ${
+            stackDescription.Stacks?.[0].StackStatus
+          }. Metadata will be available after stack completes processing.`
+        );
+      }
       throw new BackendOutputClientError(
         BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR,
         'Stack outputs are undefined'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Avoid crashing sandbox on failure to generate client config but print that we couldn't
2. If the metadata cannot be retrieved because stack is in progress, let the customers know
3. Backfill tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
