### PR TITLE
fix: remove id input validations in order to fall back to stack id

### DIFF
--- a/.changeset/green-keys-cough.md
+++ b/.changeset/green-keys-cough.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Remove input validations on generate commands so they fall back to the stack id

--- a/packages/cli/src/commands/generate/config/generate_config_command.test.ts
+++ b/packages/cli/src/commands/generate/config/generate_config_command.test.ts
@@ -7,6 +7,8 @@ import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
+import { BackendIdentifierResolverWithFallback } from '../../../backend-identifier/backend_identifier_with_sandbox_fallback.js';
+import { SandboxBackendIdResolver } from '../../sandbox/sandbox_id_resolver.js';
 
 void describe('generate config command', () => {
   const clientConfigGeneratorAdapter = new ClientConfigGeneratorAdapter(
@@ -19,9 +21,22 @@ void describe('generate config command', () => {
     () => Promise.resolve()
   );
 
-  const backendIdResolver = new AppBackendIdentifierResolver({
+  const namespaceResolver = {
     resolve: () => Promise.resolve('testAppName'),
-  });
+  };
+
+  const defaultResolver = new AppBackendIdentifierResolver(namespaceResolver);
+
+  const sandboxIdResolver = new SandboxBackendIdResolver(namespaceResolver);
+  const fakeSandboxId = 'my-fake-app-my-fake-username';
+  const mockedSandboxIdResolver = mock.method(sandboxIdResolver, 'resolve');
+  mockedSandboxIdResolver.mock.mockImplementation(() => fakeSandboxId);
+
+  const backendIdResolver = new BackendIdentifierResolverWithFallback(
+    defaultResolver,
+    sandboxIdResolver
+  );
+
   const generateConfigCommand = new GenerateConfigCommand(
     clientConfigGeneratorAdapter,
     backendIdResolver
@@ -33,6 +48,16 @@ void describe('generate config command', () => {
 
   beforeEach(() => {
     generateClientConfigMock.mock.resetCalls();
+  });
+
+  void it('uses the sandbox id by default if stack or branch are not provided', async () => {
+    const handlerSpy = mock.method(
+      clientConfigGeneratorAdapter,
+      'generateClientConfigToFile'
+    );
+    await commandRunner.runCommand('config');
+
+    assert.equal(handlerSpy.mock.calls[0].arguments[0], fakeSandboxId);
   });
 
   void it('generates and writes config for stack', async () => {

--- a/packages/cli/src/commands/generate/config/generate_config_command.ts
+++ b/packages/cli/src/commands/generate/config/generate_config_command.ts
@@ -101,12 +101,6 @@ export class GenerateConfigCommand
         type: 'string',
         array: false,
       })
-      .check((argv) => {
-        if (!argv.stack && !argv.branch) {
-          throw new Error('Either --stack or --branch must be provided');
-        }
-        return true;
-      })
       .fail((msg, err) => {
         handleCommandFailure(msg, err, yargs);
         yargs.exit(1, err);

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
@@ -4,6 +4,7 @@ import { GenerateGraphqlClientCodeCommand } from './generate_graphql_client_code
 import yargs, { CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import path from 'path';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { GenerateApiCodeAdapter } from './generate_api_code_adapter.js';
@@ -13,6 +14,8 @@ import {
   GenerateApiCodeStatementTarget,
   GenerateApiCodeTypeTarget,
 } from '@aws-amplify/model-generator';
+import { SandboxBackendIdResolver } from '../../sandbox/sandbox_id_resolver.js';
+import { BackendIdentifierResolverWithFallback } from '../../../backend-identifier/backend_identifier_with_sandbox_fallback.js';
 
 void describe('generate graphql-client-code command', () => {
   const generateApiCodeAdapter = new GenerateApiCodeAdapter(
@@ -28,10 +31,24 @@ void describe('generate graphql-client-code command', () => {
         writeToDirectory: writeToDirectoryMock,
       })
   );
-
-  const backendIdentifierResolver = new AppBackendIdentifierResolver({
+  const namespaceResolver = {
     resolve: () => Promise.resolve('testAppName'),
-  });
+  };
+
+  const defaultResolver = new AppBackendIdentifierResolver(namespaceResolver);
+
+  const sandboxIdResolver = new SandboxBackendIdResolver(namespaceResolver);
+  const fakeSandboxId = 'my-fake-app-my-fake-username';
+  const mockedSandboxIdResolver = mock.method(sandboxIdResolver, 'resolve');
+  mockedSandboxIdResolver.mock.mockImplementation(() => ({
+    name: fakeSandboxId,
+  }));
+
+  const backendIdentifierResolver = new BackendIdentifierResolverWithFallback(
+    defaultResolver,
+    sandboxIdResolver
+  );
+
   const generateGraphqlClientCodeCommand = new GenerateGraphqlClientCodeCommand(
     generateApiCodeAdapter,
     backendIdentifierResolver
@@ -46,6 +63,18 @@ void describe('generate graphql-client-code command', () => {
     writeToDirectoryMock.mock.resetCalls();
   });
 
+  void it('uses the sandbox id by default if stack or branch are not provided', async () => {
+    const handlerSpy = mock.method(
+      generateApiCodeAdapter,
+      'invokeGenerateApiCode'
+    );
+    await commandRunner.runCommand('graphql-client-code');
+
+    assert.equal(
+      (handlerSpy.mock.calls[0].arguments[0] as BackendIdentifier).name,
+      fakeSandboxId
+    );
+  });
   void it('generates and writes graphql client code for stack', async () => {
     await commandRunner.runCommand('graphql-client-code --stack stack_name');
     assert.equal(invokeGenerateApiCodeMock.mock.callCount(), 1);

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
@@ -322,12 +322,6 @@ export class GenerateGraphqlClientCodeCommand
         hidden: true,
       })
       .showHidden('all')
-      .check((argv) => {
-        if (!argv.stack && !argv.branch) {
-          throw new Error('Either --stack or --branch must be provided');
-        }
-        return true;
-      })
       .fail((msg, err) => {
         handleCommandFailure(msg, err, yargs);
         yargs.exit(1, err);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removes requirement to pass in stack or app-id to Config and Model generation commands. The CLI will fall back to using the stack identifier when no identifier is explicitly provided.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
