### PR TITLE
feat: add missing fields for mobile config

### DIFF
--- a/.changeset/mighty-bottles-deliver.md
+++ b/.changeset/mighty-bottles-deliver.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+add missing graphql fields to mobile config to support dart libs

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -20,6 +20,14 @@ export type ClientConfigMobileApi = {
   };
 };
 
+export type ClientConfigMobileAppsyncAuth = {
+  ApiUrl: string;
+  Region: string | undefined;
+  AuthMode: string | undefined;
+  ApiKey: string | undefined;
+  ClientDatabasePrefix: string | undefined;
+};
+
 export type ClientConfigMobileAuth = {
   plugins: {
     awsCognitoAuthPlugin: {
@@ -55,13 +63,8 @@ export type ClientConfigMobileAuth = {
         };
       };
       AppSync?: {
-        Default: {
-          ApiUrl: string;
-          Region: string | undefined;
-          AuthMode: string | undefined;
-          ApiKey: string | undefined;
-        };
-      };
+        Default: ClientConfigMobileAppsyncAuth;
+      } & Record<string, ClientConfigMobileAppsyncAuth>;
     };
   };
 };

--- a/packages/client-config/src/client-config-writer/client_config_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.test.ts
@@ -134,6 +134,8 @@ void describe('client config converter', () => {
       aws_appsync_graphqlEndpoint: 'https://test_api_endpoint.amazon.com',
       aws_appsync_apiKey: 'test_api_key',
       aws_appsync_authenticationType: 'API_KEY',
+      aws_appsync_additionalAuthenticationTypes:
+        'AMAZON_COGNITO_USER_POOLS,AWS_IAM',
     };
     const expectedMobileConfig: ClientConfigMobile = {
       UserAgent: expectedUserAgent,
@@ -178,6 +180,21 @@ void describe('client config converter', () => {
                 Region: 'test_app_sync_region',
                 AuthMode: 'API_KEY',
                 ApiKey: 'test_api_key',
+                ClientDatabasePrefix: 'data_API_KEY',
+              },
+              data_AWS_IAM: {
+                ApiUrl: 'https://test_api_endpoint.amazon.com',
+                Region: 'test_app_sync_region',
+                AuthMode: 'API_KEY',
+                ApiKey: 'test_api_key',
+                ClientDatabasePrefix: 'data_AWS_IAM',
+              },
+              data_AMAZON_COGNITO_USER_POOLS: {
+                ApiUrl: 'https://test_api_endpoint.amazon.com',
+                Region: 'test_app_sync_region',
+                AuthMode: 'API_KEY',
+                ApiKey: 'test_api_key',
+                ClientDatabasePrefix: 'data_AMAZON_COGNITO_USER_POOLS',
               },
             },
           },

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -91,14 +91,34 @@ export class ClientConfigConverter {
       mobileConfig.api = apiConfig;
 
       if (mobileConfig.auth) {
+        let defaultClientDatabasePrefix = undefined;
+        if (clientConfig.aws_appsync_authenticationType) {
+          defaultClientDatabasePrefix = `data_${clientConfig.aws_appsync_authenticationType}`;
+        }
         mobileConfig.auth.plugins.awsCognitoAuthPlugin.AppSync = {
           Default: {
             ApiUrl: clientConfig.aws_appsync_graphqlEndpoint,
             Region: clientConfig.aws_appsync_region,
             AuthMode: clientConfig.aws_appsync_authenticationType,
             ApiKey: clientConfig.aws_appsync_apiKey,
+            ClientDatabasePrefix: defaultClientDatabasePrefix,
           },
         };
+        if (clientConfig.aws_appsync_additionalAuthenticationTypes) {
+          for (const additionalAuthenticationType of clientConfig.aws_appsync_additionalAuthenticationTypes.split(
+            ','
+          )) {
+            mobileConfig.auth.plugins.awsCognitoAuthPlugin.AppSync[
+              `data_${additionalAuthenticationType}`
+            ] = {
+              ApiUrl: clientConfig.aws_appsync_graphqlEndpoint,
+              Region: clientConfig.aws_appsync_region,
+              AuthMode: clientConfig.aws_appsync_authenticationType,
+              ApiKey: clientConfig.aws_appsync_apiKey,
+              ClientDatabasePrefix: `data_${additionalAuthenticationType}`,
+            };
+          }
+        }
       }
     }
     return mobileConfig;


### PR DESCRIPTION
*Issue #, if available:*

**Description of changes:**

This adds fields that are required by `dart` libs. (These fields are also present in other mobile configs but were ignored by respective platforms).

**Before**
![image](https://github.com/aws-amplify/amplify-backend/assets/5849952/46c6ceb9-826b-4f65-bfe3-67ace96d0e19)


**After**
![image](https://github.com/aws-amplify/amplify-backend/assets/5849952/84fa70f9-6c15-4424-85e0-3ecb14b3102b)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
