### PR TITLE
Change account setup URL

### DIFF
--- a/.changeset/strange-pandas-know.md
+++ b/.changeset/strange-pandas-know.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Update account setup URL

--- a/packages/cli/src/commands/configure/configure_profile_command.test.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.test.ts
@@ -149,7 +149,7 @@ void describe('configure command', () => {
     assert.equal(mockOpen.mock.callCount(), 1);
     assert.equal(
       mockOpen.mock.calls[0].arguments[0],
-      'https://docs.amplify.aws/gen2/start/configure-account'
+      'https://docs.amplify.aws/gen2/start/account-setup/'
     );
     assert.equal(mockAppendAWSFiles.mock.callCount(), 1);
     assert.deepStrictEqual(mockAppendAWSFiles.mock.calls[0].arguments[0], {

--- a/packages/cli/src/commands/configure/configure_profile_command.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.ts
@@ -7,7 +7,7 @@ import { ArgumentsKebabCase } from '../../kebab_case.js';
 import { ProfileController } from './profile_controller.js';
 
 const configureAccountUrl =
-  'https://docs.amplify.aws/gen2/start/configure-account';
+  'https://docs.amplify.aws/gen2/start/account-setup/';
 
 const profileSetupInstruction = `Follow the instructions at ${configureAccountUrl}${EOL}to configure Amplify IAM user and credentials.${EOL}`;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The account setup URL has changed to `https://docs.amplify.aws/gen2/start/account-setup/`
Confirmed with @josefaidt  `https://next-docs.amplify.aws/gen2/start/account-setup/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
