### PR TITLE
build: use ubuntu 4 core for e2e tests

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         os:
           [
-            amplify-backend_ubuntu-latest_8-core,
+            amplify-backend_ubuntu-latest_4-core,
             macos-latest-xl,
             amplify-backend_windows-latest_8-core,
           ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change flips from 8 core to 4 core ubuntu worker.

It has been confirmed in https://github.com/aws-amplify/amplify-backend/pull/694 and https://github.com/aws-amplify/amplify-backend/pull/695 . That our e2e test workload is mostly memory and i/o bound, so downgrading to 4 cores that has enough memory to run multiple deployments in parallel. I.e. runtime is ~same on 4,8 and 16 core.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
