### PR TITLE
fix(@aws-amplify/backend-data) - Align authorization modes with client

### DIFF
--- a/.changeset/dull-keys-punch.md
+++ b/.changeset/dull-keys-punch.md
@@ -1,6 +1,6 @@
 ---
 'create-amplify': patch
-'@aws-amplify/backend-data': patch
+'@aws-amplify/backend-data': minor
 ---
 
 fix(@aws-amplify/backend-data) - Align with authorization modes used in the aws-amplify client library

--- a/.changeset/dull-keys-punch.md
+++ b/.changeset/dull-keys-punch.md
@@ -3,4 +3,4 @@
 '@aws-amplify/backend-data': patch
 ---
 
-fix(@aws-amplify/backend-data) - Align authorization modes with client
+fix(@aws-amplify/backend-data) - Align authorization modes used in the aws-amplify client library

--- a/.changeset/dull-keys-punch.md
+++ b/.changeset/dull-keys-punch.md
@@ -1,0 +1,6 @@
+---
+'create-amplify': patch
+'@aws-amplify/backend-data': patch
+---
+
+fix(@aws-amplify/backend-data) - Align authorization modes with client

--- a/.changeset/dull-keys-punch.md
+++ b/.changeset/dull-keys-punch.md
@@ -3,4 +3,4 @@
 '@aws-amplify/backend-data': patch
 ---
 
-fix(@aws-amplify/backend-data) - Align authorization modes used in the aws-amplify client library
+fix(@aws-amplify/backend-data) - Align with authorization modes used in the aws-amplify client library

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -35,6 +35,11 @@ export type DataProps = {
 // @public
 export type DataSchema = string | DerivedModelSchema;
 
+// Warning: (ae-forgotten-export) The symbol "AuthorizationModeMapping" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type DefaultAuthorizationMode = keyof typeof AuthorizationModeMapping;
+
 // @public
 export const defineData: (props: DataProps) => ConstructFactory<AmplifyData>;
 
@@ -52,10 +57,6 @@ export type OIDCAuthorizationModeProps = {
     tokenExpiryFromAuthInSeconds: number;
     tokenExpireFromIssueInSeconds: number;
 };
-
-// Warnings were encountered during analysis:
-//
-// src/types.ts:91:3 - (ae-forgotten-export) The symbol "DefaultAuthorizationMode" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -36,7 +36,7 @@ export type DataProps = {
 export type DataSchema = string | DerivedModelSchema;
 
 // @public
-export type DefaultAuthorizationMode = 'AWS_IAM' | 'AMAZON_COGNITO_USER_POOLS' | 'OPENID_CONNECT' | 'API_KEY' | 'AWS_LAMBDA';
+export type DefaultAuthorizationMode = 'iam' | 'userPool' | 'oidc' | 'apiKey' | 'lambda';
 
 // @public
 export const defineData: (props: DataProps) => ConstructFactory<AmplifyData>;

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -35,10 +35,8 @@ export type DataProps = {
 // @public
 export type DataSchema = string | DerivedModelSchema;
 
-// Warning: (ae-forgotten-export) The symbol "AuthorizationModeMapping" needs to be exported by the entry point index.d.ts
-//
 // @public
-export type DefaultAuthorizationMode = keyof typeof AuthorizationModeMapping;
+export type DefaultAuthorizationMode = 'iam' | 'userPool' | 'oidc' | 'apiKey' | 'lambda';
 
 // @public
 export const defineData: (props: DataProps) => ConstructFactory<AmplifyData>;

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -16,13 +16,24 @@ export type ApiKeyAuthorizationModeProps = {
 };
 
 // @public
+export const AuthorizationModeMapping: {
+    readonly iam: "AWS_IAM";
+    readonly userPool: "AMAZON_COGNITO_USER_POOLS";
+    readonly oidc: "OPENID_CONNECT";
+    readonly apiKey: "API_KEY";
+    readonly lambda: "AWS_LAMBDA";
+};
+
+// @public
 export type AuthorizationModes = {
-    defaultAuthorizationMode?: DefaultAuthorizationMode;
     apiKeyAuthorizationMode?: ApiKeyAuthorizationModeProps;
     lambdaAuthorizationMode?: LambdaAuthorizationModeProps;
     oidcAuthorizationMode?: OIDCAuthorizationModeProps;
     allowListedRoleNames?: string[];
-};
+} & DefineDataAuthConfig;
+
+// @public (undocumented)
+export type CdkDefaultAuthorizationMode = (typeof AuthorizationModeMapping)[DefaultAuthorizationMode];
 
 // @public
 export type DataProps = {
@@ -35,11 +46,18 @@ export type DataProps = {
 // @public
 export type DataSchema = string | DerivedModelSchema;
 
-// @public
-export type DefaultAuthorizationMode = 'iam' | 'userPool' | 'oidc' | 'apiKey' | 'lambda';
+// @public (undocumented)
+export type DefaultAuthorizationMode = keyof typeof AuthorizationModeMapping;
 
 // @public
 export const defineData: (props: DataProps) => ConstructFactory<AmplifyData>;
+
+// @public
+export type DefineDataAuthConfig = {
+    defaultAuthorizationMode?: DefaultAuthorizationMode;
+} | {
+    defaultAuthorizationMode?: CdkDefaultAuthorizationMode;
+};
 
 // @public
 export type LambdaAuthorizationModeProps = {

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -15,15 +15,8 @@ export type ApiKeyAuthorizationModeProps = {
     expiresInDays?: number;
 };
 
-// @public
-export const AuthorizationModeMapping: {
-    readonly iam: "AWS_IAM";
-    readonly userPool: "AMAZON_COGNITO_USER_POOLS";
-    readonly oidc: "OPENID_CONNECT";
-    readonly apiKey: "API_KEY";
-    readonly lambda: "AWS_LAMBDA";
-};
-
+// Warning: (ae-forgotten-export) The symbol "DefineDataAuthConfig" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type AuthorizationModes = {
     apiKeyAuthorizationMode?: ApiKeyAuthorizationModeProps;
@@ -31,9 +24,6 @@ export type AuthorizationModes = {
     oidcAuthorizationMode?: OIDCAuthorizationModeProps;
     allowListedRoleNames?: string[];
 } & DefineDataAuthConfig;
-
-// @public (undocumented)
-export type CdkDefaultAuthorizationMode = (typeof AuthorizationModeMapping)[DefaultAuthorizationMode];
 
 // @public
 export type DataProps = {
@@ -46,18 +36,8 @@ export type DataProps = {
 // @public
 export type DataSchema = string | DerivedModelSchema;
 
-// @public (undocumented)
-export type DefaultAuthorizationMode = keyof typeof AuthorizationModeMapping;
-
 // @public
 export const defineData: (props: DataProps) => ConstructFactory<AmplifyData>;
-
-// @public
-export type DefineDataAuthConfig = {
-    defaultAuthorizationMode?: DefaultAuthorizationMode;
-} | {
-    defaultAuthorizationMode?: CdkDefaultAuthorizationMode;
-};
 
 // @public
 export type LambdaAuthorizationModeProps = {

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -15,15 +15,14 @@ export type ApiKeyAuthorizationModeProps = {
     expiresInDays?: number;
 };
 
-// Warning: (ae-forgotten-export) The symbol "DefineDataAuthConfig" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type AuthorizationModes = {
+    defaultAuthorizationMode?: DefaultAuthorizationMode;
     apiKeyAuthorizationMode?: ApiKeyAuthorizationModeProps;
     lambdaAuthorizationMode?: LambdaAuthorizationModeProps;
     oidcAuthorizationMode?: OIDCAuthorizationModeProps;
     allowListedRoleNames?: string[];
-} & DefineDataAuthConfig;
+};
 
 // @public
 export type DataProps = {
@@ -53,6 +52,10 @@ export type OIDCAuthorizationModeProps = {
     tokenExpiryFromAuthInSeconds: number;
     tokenExpireFromIssueInSeconds: number;
 };
+
+// Warnings were encountered during analysis:
+//
+// src/types.ts:91:3 - (ae-forgotten-export) The symbol "DefaultAuthorizationMode" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/backend-data/src/convert_authorization_modes.test.ts
+++ b/packages/backend-data/src/convert_authorization_modes.test.ts
@@ -155,39 +155,6 @@ void describe('convertAuthorizationModesToCDK', () => {
     );
   });
 
-  void it('allows for overriding defaultAuthorizationMode using CDK auth naming and oidc config', () => {
-    const authModes: AuthorizationModes = {
-      defaultAuthorizationMode: 'OPENID_CONNECT',
-      oidcAuthorizationMode: {
-        clientId: 'testClient',
-        oidcProviderName: 'testProvider',
-        oidcIssuerUrl: 'https://test.provider/',
-        tokenExpireFromIssueInSeconds: 60,
-        tokenExpiryFromAuthInSeconds: 90,
-      },
-    };
-
-    const expectedOutput: CDKAuthorizationModes = {
-      defaultAuthorizationMode: 'OPENID_CONNECT',
-      oidcConfig: {
-        clientId: 'testClient',
-        oidcProviderName: 'testProvider',
-        oidcIssuerUrl: 'https://test.provider/',
-        tokenExpiryFromIssue: Duration.seconds(60),
-        tokenExpiryFromAuth: Duration.seconds(90),
-      },
-    };
-
-    assert.deepStrictEqual(
-      convertAuthorizationModesToCDK(
-        functionInstanceProvider,
-        undefined,
-        authModes
-      ),
-      expectedOutput
-    );
-  });
-
   void it('allows for overriding api key config', () => {
     const authModes: AuthorizationModes = {
       apiKeyAuthorizationMode: {

--- a/packages/backend-data/src/convert_authorization_modes.test.ts
+++ b/packages/backend-data/src/convert_authorization_modes.test.ts
@@ -124,6 +124,39 @@ void describe('convertAuthorizationModesToCDK', () => {
 
   void it('allows for overriding defaultAuthorizationMode and oidc config', () => {
     const authModes: AuthorizationModes = {
+      defaultAuthorizationMode: 'oidc',
+      oidcAuthorizationMode: {
+        clientId: 'testClient',
+        oidcProviderName: 'testProvider',
+        oidcIssuerUrl: 'https://test.provider/',
+        tokenExpireFromIssueInSeconds: 60,
+        tokenExpiryFromAuthInSeconds: 90,
+      },
+    };
+
+    const expectedOutput: CDKAuthorizationModes = {
+      defaultAuthorizationMode: 'OPENID_CONNECT',
+      oidcConfig: {
+        clientId: 'testClient',
+        oidcProviderName: 'testProvider',
+        oidcIssuerUrl: 'https://test.provider/',
+        tokenExpiryFromIssue: Duration.seconds(60),
+        tokenExpiryFromAuth: Duration.seconds(90),
+      },
+    };
+
+    assert.deepStrictEqual(
+      convertAuthorizationModesToCDK(
+        functionInstanceProvider,
+        undefined,
+        authModes
+      ),
+      expectedOutput
+    );
+  });
+
+  void it('allows for overriding defaultAuthorizationMode using CDK auth naming and oidc config', () => {
+    const authModes: AuthorizationModes = {
       defaultAuthorizationMode: 'OPENID_CONNECT',
       oidcAuthorizationMode: {
         clientId: 'testClient',

--- a/packages/backend-data/src/convert_authorization_modes.ts
+++ b/packages/backend-data/src/convert_authorization_modes.ts
@@ -11,7 +11,6 @@ import {
 } from '@aws-amplify/data-construct';
 import {
   ApiKeyAuthorizationModeProps,
-  AuthorizationModeMapping,
   AuthorizationModes,
   DefaultAuthorizationMode,
   LambdaAuthorizationModeProps,
@@ -151,9 +150,18 @@ const computeApiKeyAuthFromResource = (
   };
 };
 
+const authorizationModeMapping = {
+  iam: 'AWS_IAM',
+  userPool: 'AMAZON_COGNITO_USER_POOLS',
+  oidc: 'OPENID_CONNECT',
+  apiKey: 'API_KEY',
+  lambda: 'AWS_LAMBDA',
+} as const;
+
 const convertAuthorizationModeToCDK = (mode?: DefaultAuthorizationMode) => {
   if (!mode) return;
-  return AuthorizationModeMapping[mode];
+
+  return authorizationModeMapping[mode];
 };
 
 /**

--- a/packages/backend-data/src/convert_authorization_modes.ts
+++ b/packages/backend-data/src/convert_authorization_modes.ts
@@ -13,7 +13,6 @@ import {
   ApiKeyAuthorizationModeProps,
   AuthorizationModeMapping,
   AuthorizationModes,
-  CdkDefaultAuthorizationMode,
   DefaultAuthorizationMode,
   LambdaAuthorizationModeProps,
   OIDCAuthorizationModeProps,
@@ -152,20 +151,9 @@ const computeApiKeyAuthFromResource = (
   };
 };
 
-const isDefaultAuthorizationMode = (
-  mode: CdkDefaultAuthorizationMode | DefaultAuthorizationMode
-): mode is DefaultAuthorizationMode => {
-  return mode in AuthorizationModeMapping;
-};
-
-const convertAuthorizationModeToCDK = (
-  mode?: CdkDefaultAuthorizationMode | DefaultAuthorizationMode
-): CdkDefaultAuthorizationMode | undefined => {
+const convertAuthorizationModeToCDK = (mode?: DefaultAuthorizationMode) => {
   if (!mode) return;
-  if (isDefaultAuthorizationMode(mode)) {
-    return AuthorizationModeMapping[mode];
-  }
-  return mode;
+  return AuthorizationModeMapping[mode];
 };
 
 /**

--- a/packages/backend-data/src/index.ts
+++ b/packages/backend-data/src/index.ts
@@ -3,6 +3,7 @@ export {
   ApiKeyAuthorizationModeProps,
   LambdaAuthorizationModeProps,
   OIDCAuthorizationModeProps,
+  DefaultAuthorizationMode,
   AuthorizationModes,
   DataSchema,
   DataProps,

--- a/packages/backend-data/src/index.ts
+++ b/packages/backend-data/src/index.ts
@@ -1,2 +1,7 @@
 export * from './factory.js';
-export * from './types.js';
+export {
+  ApiKeyAuthorizationModeProps,
+  LambdaAuthorizationModeProps,
+  OIDCAuthorizationModeProps,
+  AuthorizationModes,
+} from './types.js';

--- a/packages/backend-data/src/index.ts
+++ b/packages/backend-data/src/index.ts
@@ -4,4 +4,6 @@ export {
   LambdaAuthorizationModeProps,
   OIDCAuthorizationModeProps,
   AuthorizationModes,
+  DataSchema,
+  DataProps,
 } from './types.js';

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -26,7 +26,7 @@ export type CdkDefaultAuthorizationMode =
 /**
  * Default auth mode to use in the API, only required if more than one auth mode is specified.
  */
-export type DefineDataAuthConfig =
+type DefineDataAuthConfig =
   | {
       /**
        * Default auth mode to use in the API, only required if more than one auth mode is specified.

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -18,27 +18,6 @@ export const AuthorizationModeMapping = {
 export type DefaultAuthorizationMode = keyof typeof AuthorizationModeMapping;
 
 /**
- * Authorization modes used by CDK represented in all capitalized snake case.
- */
-export type CdkDefaultAuthorizationMode =
-  (typeof AuthorizationModeMapping)[DefaultAuthorizationMode];
-
-type DefineDataAuthConfig =
-  | {
-      /**
-       * Default auth mode to use in the API, only required if more than one auth mode is specified.
-       */
-      defaultAuthorizationMode?: DefaultAuthorizationMode;
-    }
-  | {
-      /**
-       * Default auth mode to use in the API, only required if more than one auth mode is specified.
-       * @deprecated Please migrate to the camelCase equivalent ("iam" | "userPool" | "oidc" | "apiKey" | "lambda")
-       */
-      defaultAuthorizationMode?: CdkDefaultAuthorizationMode;
-    };
-
-/**
  * Props for Api Keys on the Graphql Api.
  */
 export type ApiKeyAuthorizationModeProps = {
@@ -107,6 +86,10 @@ export type OIDCAuthorizationModeProps = {
  */
 export type AuthorizationModes = {
   /**
+   * Default auth mode to use in the API, only required if more than one auth mode is specified.
+   */
+  defaultAuthorizationMode?: DefaultAuthorizationMode;
+  /**
    * Override API Key config if apiKey auth provider is specified in api definition.
    */
   apiKeyAuthorizationMode?: ApiKeyAuthorizationModeProps;
@@ -125,7 +108,7 @@ export type AuthorizationModes = {
    * IAM Role names which are provided full r/w access to the API for models with IAM authorization.
    */
   allowListedRoleNames?: string[];
-} & DefineDataAuthConfig;
+};
 
 /**
  * Schema type definition, can be either a raw Graphql string, or a typed model schema.

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -2,14 +2,44 @@ import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
 import { AmplifyFunction, ConstructFactory } from '@aws-amplify/plugin-types';
 
 /**
- * Determine which auth mode is specified as 'default' in the Appsync API, only required if more than one authorization mode is specified.
+ * The mapping from the camel case Authorization modes to the CDK Authorization modes
  */
-export type DefaultAuthorizationMode =
-  | 'AWS_IAM'
-  | 'AMAZON_COGNITO_USER_POOLS'
-  | 'OPENID_CONNECT'
-  | 'API_KEY'
-  | 'AWS_LAMBDA';
+export const AuthorizationModeMapping = {
+  iam: 'AWS_IAM',
+  userPool: 'AMAZON_COGNITO_USER_POOLS',
+  oidc: 'OPENID_CONNECT',
+  apiKey: 'API_KEY',
+  lambda: 'AWS_LAMBDA',
+} as const;
+
+/**
+ * Authorization modes used in by client side Amplify represented in camelCase.
+ */
+export type DefaultAuthorizationMode = keyof typeof AuthorizationModeMapping;
+
+/**
+ * Authorization modes used by CDK represented in all capitalized snake case.
+ */
+export type CdkDefaultAuthorizationMode =
+  (typeof AuthorizationModeMapping)[DefaultAuthorizationMode];
+
+/**
+ * Default auth mode to use in the API, only required if more than one auth mode is specified.
+ */
+export type DefineDataAuthConfig =
+  | {
+      /**
+       * Default auth mode to use in the API, only required if more than one auth mode is specified.
+       */
+      defaultAuthorizationMode?: DefaultAuthorizationMode;
+    }
+  | {
+      /**
+       * Default auth mode to use in the API, only required if more than one auth mode is specified.
+       * @deprecated Please migrate to the camelCase equivalent ("iam" | "userPool" | "oidc" | "apiKey" | "lambda")
+       */
+      defaultAuthorizationMode?: CdkDefaultAuthorizationMode;
+    };
 
 /**
  * Props for Api Keys on the Graphql Api.
@@ -80,11 +110,6 @@ export type OIDCAuthorizationModeProps = {
  */
 export type AuthorizationModes = {
   /**
-   * Default auth mode to use in the API, only required if more than one auth mode is specified.
-   */
-  defaultAuthorizationMode?: DefaultAuthorizationMode;
-
-  /**
    * Override API Key config if apiKey auth provider is specified in api definition.
    */
   apiKeyAuthorizationMode?: ApiKeyAuthorizationModeProps;
@@ -103,7 +128,7 @@ export type AuthorizationModes = {
    * IAM Role names which are provided full r/w access to the API for models with IAM authorization.
    */
   allowListedRoleNames?: string[];
-};
+} & DefineDataAuthConfig;
 
 /**
  * Schema type definition, can be either a raw Graphql string, or a typed model schema.

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -23,9 +23,6 @@ export type DefaultAuthorizationMode = keyof typeof AuthorizationModeMapping;
 export type CdkDefaultAuthorizationMode =
   (typeof AuthorizationModeMapping)[DefaultAuthorizationMode];
 
-/**
- * Default auth mode to use in the API, only required if more than one auth mode is specified.
- */
 type DefineDataAuthConfig =
   | {
       /**

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -2,20 +2,14 @@ import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
 import { AmplifyFunction, ConstructFactory } from '@aws-amplify/plugin-types';
 
 /**
- * The mapping from the camel case Authorization modes to the CDK Authorization modes
- */
-export const AuthorizationModeMapping = {
-  iam: 'AWS_IAM',
-  userPool: 'AMAZON_COGNITO_USER_POOLS',
-  oidc: 'OPENID_CONNECT',
-  apiKey: 'API_KEY',
-  lambda: 'AWS_LAMBDA',
-} as const;
-
-/**
  * Authorization modes used in by client side Amplify represented in camelCase.
  */
-export type DefaultAuthorizationMode = keyof typeof AuthorizationModeMapping;
+export type DefaultAuthorizationMode =
+  | 'iam'
+  | 'userPool'
+  | 'oidc'
+  | 'apiKey'
+  | 'lambda';
 
 /**
  * Props for Api Keys on the Graphql Api.

--- a/packages/create-amplify/templates/basic-auth-data/amplify/data/resource.ts
+++ b/packages/create-amplify/templates/basic-auth-data/amplify/data/resource.ts
@@ -20,7 +20,7 @@ export type Schema = ClientSchema<typeof schema>;
 export const data = defineData({
   schema,
   authorizationModes: {
-    defaultAuthorizationMode: 'API_KEY',
+    defaultAuthorizationMode: 'apiKey',
     // API Key is used for a.allow.public() rules
     apiKeyAuthorizationMode: {
       expiresInDays: 30,

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -368,7 +368,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/56de761ad888f6e4eb3ce109b1f92bd757787085769e765af604ede3155cad35.json"
+       "/bc335d45f5f3eaaf9af9b95d772b50f0586653ea00c896d3996ad6d0782d4f65.json"
       ]
      ]
     }
@@ -421,7 +421,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/c423bba9bd0727994c0c6b268187d0d64091f329b0d83133e7e9f50abfe64cf8.json"
+       "/30437774f1c71227196609658884b062fb7cc1a490f4a99234540e8a51b2c60b.json"
       ]
      ]
     }

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.1\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "amplifyAuthUserPool4BA7F805": {
    "Type": "AWS::Cognito::UserPool",

--- a/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/create-amplify/templates/basic-auth-data/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -47,7 +47,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1702771230
+    "Expires": 1702847164
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {

--- a/packages/integration-tests/test-projects/data-iterative-deploy/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-iterative-deploy/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -306,7 +306,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/c72b4ba12c8b90f144b90d467b44aa69a529c9ed6fb742e9fcb7b4ebbd4a2243.json"
+       "/d6e0314b1ac09ff28a99badfe9e99092404a3ec665a87b7790a3a7d354d39f88.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-iterative-deploy/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/data-iterative-deploy/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -31,7 +31,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1700784020
+    "Expires": 1700859954
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1bfd9be5c21b17e9e3105636fbe6807b559ac08fb9185776ca9e82c2ab50fbfd.json"
+       "/5c41ca256392cb9a9c61aa6cedbae9fa9a12c5927d30678087511cbea6557158.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.1\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1bfd9be5c21b17e9e3105636fbe6807b559ac08fb9185776ca9e82c2ab50fbfd.json"
+       "/5c41ca256392cb9a9c61aa6cedbae9fa9a12c5927d30678087511cbea6557158.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.1\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -414,7 +414,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/1bfd9be5c21b17e9e3105636fbe6807b559ac08fb9185776ca9e82c2ab50fbfd.json"
+       "/5c41ca256392cb9a9c61aa6cedbae9fa9a12c5927d30678087511cbea6557158.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854aauth473E022C.nested.template.json
@@ -1,5 +1,5 @@
 {
- "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.0\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
+ "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"AmplifyPipelineDeploy\",\"createdWith\":\"0.4.1\",\"stackType\":\"auth-Cognito\",\"metadata\":{}}",
  "Resources": {
   "SecretFetcherResourceProviderLambdaServiceRole5ABAF823": {
    "Type": "AWS::IAM::Role",

--- a/packages/integration-tests/test-projects/standalone-data-auth-modes/amplify/data/resource.ts
+++ b/packages/integration-tests/test-projects/standalone-data-auth-modes/amplify/data/resource.ts
@@ -15,7 +15,7 @@ export const data = defineData({
     }
   `,
   authorizationModes: {
-    defaultAuthorizationMode: 'AWS_LAMBDA',
+    defaultAuthorizationMode: 'lambda',
     lambdaAuthorizationMode: {
       function: Func.fromDir({
         name: 'ApiAuth',

--- a/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -318,7 +318,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/f25f66a8cda79788cc4a6c34f0c9345c27c04c8a1d92e02dff089c121d72cd15.json"
+       "/a1ae1b3815e3a2aa0075b529cf24f525b5274c558ef80670435864e040d30d05.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-auth-modes/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -51,7 +51,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1702771227
+    "Expires": 1702847162
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {

--- a/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplify-testAppId-testBranchName-branch-7d6f6c854a.template.json
@@ -306,7 +306,7 @@
        {
         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
        },
-       "/3c3f9d9057bf2f6984a038fbc53c39cda5925c17b5bba7dbcb14d2699e44d681.json"
+       "/56ff54712934bfae19cc63d8f507aa3814a24d00c53b20fff17034fd3002185a.json"
       ]
      ]
     }

--- a/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
+++ b/packages/integration-tests/test-projects/standalone-data-sandbox-mode/expected-cdk-out/amplifytestAppIdtestBranchNamebranch7d6f6c854adataE67321C2.nested.template.json
@@ -31,7 +31,7 @@
       "ApiId"
      ]
     },
-    "Expires": 1700784028
+    "Expires": 1700859963
    }
   },
   "amplifyDataGraphQLAPINONEDS684BF699": {


### PR DESCRIPTION
*Description of changes:*
> Align the terminology used in defineData and mark UPPER_CASE_FORMAT as deprecated
> In the client it's `authMode: 'userPool', 'apiKey'`
>
> Acceptance criteria:
> Support both camel case and UPPER_SNAKE_CASE format but mark all UPPER_CASE_FORMAT as deprecated
> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

In this review, with product input, we have decided not to support the UPPER_SNAKE_CASE on the schema definition surface, keeping only the camel case values consistent with the `aws-amplify` client library.

This change does the following:
- Introduces `'iam' | 'userPool' | 'oidc' | 'apiKey' | 'lambda'` as DefualtAuthorizationMode options
- Translates these to the corresponding CDK modes 'AWS_IAM' | 'AMAZON_COGNITO_USER_POOLS' | 'OPENID_CONNECT' | 'API_KEY' | 'AWS_LAMBDA'
- Updates tests and templates to use the new modes

*Testing*
Package tests have been update / extended to cover this behavior. Working on manual testing against a sample app now.
