### PR TITLE
chore: add friction and comment/test about not changing critical config values for AmplifyTable

### DIFF
--- a/.changeset/plenty-maps-doubt.md
+++ b/.changeset/plenty-maps-doubt.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': patch
+---
+
+Add messaging and test about not updating provision strategy

--- a/packages/backend-data/src/convert_schema.test.ts
+++ b/packages/backend-data/src/convert_schema.test.ts
@@ -74,4 +74,22 @@ void describe('convertSchemaToCDK', () => {
       },
     });
   });
+
+  void it('uses the only appropriate dbType and provisioningStrategy', () => {
+    const convertedDefinition = convertSchemaToCDK(
+      'type Todo @model @auth(rules: { allow: public }) { id: ID! }'
+    );
+    assert.equal(
+      Object.values(convertedDefinition.dataSourceStrategies).length,
+      1
+    );
+    assert.deepEqual(
+      Object.values(convertedDefinition.dataSourceStrategies)[0],
+      {
+        dbType: 'DYNAMODB',
+        provisionStrategy: 'AMPLIFY_TABLE',
+      },
+      'dbType should ALWAYS be set to DYNAMODB, and provisionStrategy should ALWAYS be AMPLIFY_TABLE, changing these values will trigger db re-provisioning'
+    );
+  });
 });

--- a/packages/backend-data/src/convert_schema.ts
+++ b/packages/backend-data/src/convert_schema.ts
@@ -26,6 +26,7 @@ const isModelSchema = (schema: DataSchema): schema is DerivedModelSchema => {
 export const convertSchemaToCDK = (
   schema: DataSchema
 ): IAmplifyDataDefinition => {
+  // DO NOT EDIT THE FOLLOWING VALUES, UPDATES TO DB TYPE OR STRATEGY WILL RESULT IN DB REPROVISIONING
   const dbType = 'DYNAMODB';
   const provisionStrategy = 'AMPLIFY_TABLE';
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding comments and friction around the criticality of not changing db provisioning strategy for data.

Plan to add an integration test verifying data continuity across update https://github.com/aws-amplify/amplify-backend/issues/691

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
