### PR TITLE
Change secret name argument to kebab-case

### DIFF
--- a/.changeset/friendly-icons-decide.md
+++ b/.changeset/friendly-icons-decide.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Change secret name argument in secret commands to kebab-case

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.ts
@@ -28,7 +28,7 @@ export class SandboxSecretGetCommand
     private readonly sandboxIdResolver: SandboxBackendIdResolver,
     private readonly secretClient: SecretClient
   ) {
-    this.command = 'get <secretName>';
+    this.command = 'get <secret-name>';
     this.describe = 'Get a sandbox secret';
   }
 

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
@@ -27,7 +27,7 @@ export class SandboxSecretRemoveCommand
     private readonly sandboxIdResolver: SandboxBackendIdResolver,
     private readonly secretClient: SecretClient
   ) {
-    this.command = 'remove <secretName>';
+    this.command = 'remove <secret-name>';
     this.describe = 'Remove a sandbox secret';
   }
 

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
@@ -29,7 +29,7 @@ export class SandboxSecretSetCommand
     private readonly sandboxIdResolver: SandboxBackendIdResolver,
     private readonly secretClient: SecretClient
   ) {
-    this.command = 'set <secretName>';
+    this.command = 'set <secret-name>';
     this.describe = 'Set a sandbox secret';
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change secret name argument to kebab-case

```
 % amplify sandbox secret --help
amplify sandbox secret <command>

Manage sandbox secret

Commands:
  amplify sandbox secret set <secret-name>  Set a sandbox secret
  amplify sandbox secret remove <secret-na  Remove a sandbox secret
  me>
  amplify sandbox secret get <secret-name>  Get a sandbox secret
  amplify sandbox secret list               List all sandbox secrets

Options:
  --profile  An AWS profile name.                                       [string]
  --help     Show help                                                 [boolean]

% amplify sandbox secret set --help
amplify sandbox secret set <secret-name>

Set a sandbox secret

Positionals:
  secret-name  Name of the secret to set                     [string] [required]

Options:
  --profile  An AWS profile name.                                       [string]
  --help     Show help                                                 [boolean]

% amplify sandbox secret set s2   
? Enter secret value

% amplify sandbox secret get s2
 name: s2
 version: 1
 value: s2value
 lastUpdated: Fri Nov 17 2023 15:15:56 GMT-0800 (Pacific Standard Time)

% amplify sandbox secret list
 names: s1,s2

% amplify sandbox secret remove s2

% amplify sandbox secret list     
 names: s1


```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
