### PR TITLE
add @aws-amplify/backend-cli to envinfo command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,7 +13,7 @@ body:
       description: |
         Please copy and paste output of the following command. This will be automatically formatted into code, so no need for backticks.
         ```bash
-        npx envinfo --system --binaries --npmPackages "@aws-amplify/backend,typescript,aws-cdk,aws-cdk-lib,aws-amplify" --showNotFound
+        npx envinfo --system --binaries --npmPackages "@aws-amplify/backend,@aws-amplify/backend-cli,typescript,aws-cdk,aws-cdk-lib,aws-amplify" --showNotFound
         ```
       render: plain text
     validations:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -13,7 +13,7 @@ body:
       description: |
         Please copy and paste output of the following command. This will be automatically formatted into code, so no need for backticks.
         ```bash
-        npx envinfo --system --binaries --npmPackages "@aws-amplify/backend,typescript,aws-cdk,aws-cdk-lib,aws-amplify" --showNotFound
+        npx envinfo --system --binaries --npmPackages "@aws-amplify/backend,@aws-amplify/backend-cli,typescript,aws-cdk,aws-cdk-lib,aws-amplify" --showNotFound
         ```
       render: plain text
     validations:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

adds missing `@aws-amplify/backend-cli` package to issue templates' `npx envinfo` command


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
