### PR TITLE
fix: turn off type checking if amplify/tsconfig.json is not found

### DIFF
--- a/.changeset/few-readers-brush.md
+++ b/.changeset/few-readers-brush.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+turn off type checking if amplify/tsconfig.json is not found

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -155,17 +155,24 @@ void describe('invokeCDKCommand', () => {
       deploymentType: 'branch',
       validateAppSources: true,
     });
-    assert.strictEqual(execaMock.mock.callCount(), 2);
-    assert.equal(execaMock.mock.calls[0].arguments[1]?.length, 5);
+    assert.strictEqual(execaMock.mock.callCount(), 3);
+    assert.equal(execaMock.mock.calls[0].arguments[1]?.length, 4);
     assert.deepStrictEqual(execaMock.mock.calls[0].arguments[1], [
+      'tsc',
+      '--showConfig',
+      '--project',
+      'amplify',
+    ]);
+    assert.equal(execaMock.mock.calls[1].arguments[1]?.length, 5);
+    assert.deepStrictEqual(execaMock.mock.calls[1].arguments[1], [
       'tsc',
       '--noEmit',
       '--skipLibCheck',
       '--project',
       'amplify',
     ]);
-    assert.equal(execaMock.mock.calls[1].arguments[1]?.length, 16);
-    assert.deepStrictEqual(execaMock.mock.calls[1].arguments[1], [
+    assert.equal(execaMock.mock.calls[2].arguments[1]?.length, 16);
+    assert.deepStrictEqual(execaMock.mock.calls[2].arguments[1], [
       'cdk',
       'deploy',
       '--ci',
@@ -190,12 +197,53 @@ void describe('invokeCDKCommand', () => {
       deploymentType: 'sandbox',
       validateAppSources: true,
     });
-    assert.strictEqual(execaMock.mock.callCount(), 2);
-    assert.equal(execaMock.mock.calls[0].arguments[1]?.length, 5);
+    assert.strictEqual(execaMock.mock.callCount(), 3);
+    assert.equal(execaMock.mock.calls[0].arguments[1]?.length, 4);
     assert.deepStrictEqual(execaMock.mock.calls[0].arguments[1], [
+      'tsc',
+      '--showConfig',
+      '--project',
+      'amplify',
+    ]);
+    assert.equal(execaMock.mock.calls[1].arguments[1]?.length, 5);
+    assert.deepStrictEqual(execaMock.mock.calls[1].arguments[1], [
       'tsc',
       '--noEmit',
       '--skipLibCheck',
+      '--project',
+      'amplify',
+    ]);
+    assert.equal(execaMock.mock.calls[2].arguments[1]?.length, 12);
+    assert.deepStrictEqual(execaMock.mock.calls[2].arguments[1], [
+      'cdk',
+      'deploy',
+      '--ci',
+      '--app',
+      "'npx tsx amplify/backend.ts'",
+      '--all',
+      '--output',
+      '.amplify/artifacts/cdk.out',
+      '--context',
+      `amplify-backend-type=sandbox`,
+      '--hotswap-fallback',
+      '--method=direct',
+    ]);
+  });
+
+  void it('disables type checking when tsconfig is not present', async () => {
+    // simulate first execa call as throwing error when checking for tsconfig.json
+    execaMock.mock.mockImplementationOnce(() =>
+      Promise.reject(new Error('some error'))
+    );
+    await invoker.deploy(undefined, {
+      deploymentType: 'sandbox',
+      validateAppSources: true,
+    });
+    assert.strictEqual(execaMock.mock.callCount(), 2);
+    assert.equal(execaMock.mock.calls[0].arguments[1]?.length, 4);
+    assert.deepStrictEqual(execaMock.mock.calls[0].arguments[1], [
+      'tsc',
+      '--showConfig',
       '--project',
       'amplify',
     ]);

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -74,16 +74,28 @@ export class CDKDeployer implements BackendDeployer {
   };
 
   private invokeTsc = async (deployProps?: DeployProps) => {
-    if (deployProps?.validateAppSources) {
+    if (!deployProps?.validateAppSources) {
+      return;
+    }
+    try {
       await this.executeChildProcess('npx', [
         'tsc',
-        '--noEmit',
-        '--skipLibCheck',
-        // pointing the project arg to the amplify backend directory will use the tsconfig present in that directory
+        '--showConfig',
         '--project',
         dirname(this.backendLocator.locate()),
       ]);
+    } catch (error) {
+      // If we cannot load ts config, turn off type checking
+      return;
     }
+    await this.executeChildProcess('npx', [
+      'tsc',
+      '--noEmit',
+      '--skipLibCheck',
+      // pointing the project arg to the amplify backend directory will use the tsconfig present in that directory
+      '--project',
+      dirname(this.backendLocator.locate()),
+    ]);
   };
 
   /**


### PR DESCRIPTION
*Description of changes:* fix: turn off type checking if amplify/tsconfig.json is not found

If the amplify/tsconfig.json is not found, TSC doesn't go to the root or parent director looking for tsconfig rather errors out with `error TS5057: Cannot find a tsconfig.json file at the specified directory: 'amplify'.`
This PR checks if we can load the config before executing TSC. If we cannot, we turn off ts compiler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
