### PR TITLE
add npx to "get started" command in create-amplify

### DIFF
--- a/.changeset/cool-mirrors-protect.md
+++ b/.changeset/cool-mirrors-protect.md
@@ -1,0 +1,5 @@
+---
+'create-amplify': patch
+---
+
+add npx to "get started" command in create-amplify

--- a/packages/create-amplify/src/amplify_project_creator.test.ts
+++ b/packages/create-amplify/src/amplify_project_creator.test.ts
@@ -43,7 +43,7 @@ void describe('AmplifyProjectCreator', () => {
     );
     assert.equal(
       logMock.log.mock.calls[4].arguments[0],
-      'Welcome to AWS Amplify! \nRun `amplify help` for a list of available commands. \nGet started by running `amplify sandbox`.'
+      'Welcome to AWS Amplify! \nRun `npx amplify help` for a list of available commands. \nGet started by running `npx amplify sandbox`.'
     );
   });
 
@@ -74,7 +74,7 @@ void describe('AmplifyProjectCreator', () => {
 
     assert.equal(
       logMock.log.mock.calls[4].arguments[0],
-      'Welcome to AWS Amplify! \nRun `amplify help` for a list of available commands. \nGet started by running `cd ./project/root; amplify sandbox`.'
+      'Welcome to AWS Amplify! \nRun `npx amplify help` for a list of available commands. \nGet started by running `cd ./project/root; npx amplify sandbox`.'
     );
   });
 });

--- a/packages/create-amplify/src/amplify_project_creator.ts
+++ b/packages/create-amplify/src/amplify_project_creator.ts
@@ -64,13 +64,13 @@ export class AmplifyProjectCreator {
 
     const cdCommand =
       process.cwd() === this.projectRoot
-        ? '`'
-        : `\`cd .${this.projectRoot.replace(process.cwd(), '')}; `;
+        ? ''
+        : `cd .${this.projectRoot.replace(process.cwd(), '')}; `;
 
     logger.log(
       `Welcome to AWS Amplify! 
-Run \`amplify help\` for a list of available commands. 
-Get started by running ${cdCommand}amplify sandbox\`.`
+Run \`npx amplify help\` for a list of available commands. 
+Get started by running \`${cdCommand}npx amplify sandbox\`.`
     );
   };
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adds `npx` to `amplify` commands that print at the end of create-amplify

In its current state it can be confused for gen1 CLI that is installed globally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
