### PR TITLE
enable eslint rules to enforce type import/export style

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -81,6 +81,11 @@ module.exports = {
       },
     ],
     '@typescript-eslint/restrict-template-expressions': 'error',
+    '@typescript-eslint/consistent-type-exports': 'error',
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { fixStyle: 'inline-type-imports' },
+    ],
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     '@shopify/prefer-early-return': 'error',
     'check-file/filename-blocklist': [
@@ -118,6 +123,7 @@ module.exports = {
     'prefer-promise-reject-errors': 'error',
     'promise/prefer-await-to-then': 'error',
     'import/no-extraneous-dependencies': 'error',
+    'import/consistent-type-specifier-style': ['error', 'prefer-inline'],
     'sort-imports': [
       'error',
       {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,8 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:jsdoc/recommended-typescript-error',
     'plugin:promise/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
     'prettier',
   ],
   overrides: [
@@ -37,6 +39,12 @@ module.exports = {
     'promise',
     '@shopify',
   ],
+  settings: {
+    'import/resolver': {
+      typescript: true,
+      node: true,
+    },
+  },
   rules: {
     '@typescript-eslint/naming-convention': [
       'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-config-xo-typescript": "^0.57.0",
+        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-check-file": "^2.6.2",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsdoc": "^43.0.6",
@@ -11801,6 +11802,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -12107,6 +12121,31 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -18499,6 +18538,15 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -20014,11 +20062,11 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^0.3.2",
-        "@aws-amplify/backend-data": "^0.7.0",
+        "@aws-amplify/backend-data": "^0.8.0",
         "@aws-amplify/backend-function": "^0.2.2",
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.3",
@@ -20058,7 +20106,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
@@ -20378,7 +20426,7 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
@@ -20543,7 +20591,7 @@
       "version": "0.3.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/backend": "0.5.2",
+        "@aws-amplify/backend": "0.5.3",
         "@aws-amplify/backend-auth": "0.3.3",
         "@aws-amplify/backend-secret": "^0.3.0",
         "@aws-amplify/backend-storage": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-config-xo-typescript": "^0.57.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-check-file": "^2.6.2",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^43.0.6",

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -4,15 +4,15 @@ import { App, SecretValue, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import assert from 'node:assert';
 import {
-  AmplifyFunction,
-  BackendOutputEntry,
-  BackendOutputStorageStrategy,
+  type AmplifyFunction,
+  type BackendOutputEntry,
+  type BackendOutputStorageStrategy,
 } from '@aws-amplify/plugin-types';
 import {
-  CfnIdentityPool,
-  CfnUserPoolClient,
-  UserPool,
-  UserPoolClient,
+  type CfnIdentityPool,
+  type CfnUserPoolClient,
+  type UserPool,
+  type UserPoolClient,
   UserPoolIdentityProviderSamlMetadataType,
 } from 'aws-cdk-lib/aws-cognito';
 import { authOutputKey } from '@aws-amplify/backend-output-schemas';

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -1,36 +1,39 @@
 import { Construct } from 'constructs';
 import { RemovalPolicy, Stack, aws_cognito as cognito } from 'aws-cdk-lib';
 import {
-  AmplifyFunction,
-  AuthResources,
-  BackendOutputStorageStrategy,
-  ResourceProvider,
+  type AmplifyFunction,
+  type AuthResources,
+  type BackendOutputStorageStrategy,
+  type ResourceProvider,
 } from '@aws-amplify/plugin-types';
 import {
-  CfnUserPool,
-  CfnUserPoolClient,
+  type CfnUserPool,
+  type CfnUserPoolClient,
   Mfa,
-  UserPool,
-  UserPoolClient,
-  UserPoolIdentityProviderAmazon,
-  UserPoolIdentityProviderApple,
-  UserPoolIdentityProviderFacebook,
-  UserPoolIdentityProviderGoogle,
-  UserPoolIdentityProviderOidc,
-  UserPoolIdentityProviderSaml,
+  type UserPool,
+  type UserPoolClient,
+  type UserPoolIdentityProviderAmazon,
+  type UserPoolIdentityProviderApple,
+  type UserPoolIdentityProviderFacebook,
+  type UserPoolIdentityProviderGoogle,
+  type UserPoolIdentityProviderOidc,
+  type UserPoolIdentityProviderSaml,
   UserPoolOperation,
-  UserPoolProps,
+  type UserPoolProps,
 } from 'aws-cdk-lib/aws-cognito';
 import { FederatedPrincipal, Role } from 'aws-cdk-lib/aws-iam';
-import { AuthOutput, authOutputKey } from '@aws-amplify/backend-output-schemas';
 import {
-  AuthProps,
-  EmailLoginSettings,
-  ExternalProviderOptions,
-  TriggerEvent,
+  type AuthOutput,
+  authOutputKey,
+} from '@aws-amplify/backend-output-schemas';
+import {
+  type AuthProps,
+  type EmailLoginSettings,
+  type ExternalProviderOptions,
+  type TriggerEvent,
 } from './types.js';
 import { DEFAULTS } from './defaults.js';
-import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import { type IFunction } from 'aws-cdk-lib/aws-lambda';
 import {
   AttributionMetadataStorage,
   StackMetadataBackendOutputStorageStrategy,

--- a/packages/auth-construct/src/defaults.ts
+++ b/packages/auth-construct/src/defaults.ts
@@ -1,4 +1,4 @@
-import { AuthProps } from './types.js';
+import { type AuthProps } from './types.js';
 
 /**
  * These are the Amplify provided default values for Auth.

--- a/packages/auth-construct/src/index.ts
+++ b/packages/auth-construct/src/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   AuthProps,
   EmailLogin,
   EmailLoginSettings,

--- a/packages/auth-construct/src/string_maps.ts
+++ b/packages/auth-construct/src/string_maps.ts
@@ -1,4 +1,4 @@
-import { StandardAttributes } from 'aws-cdk-lib/aws-cognito';
+import { type StandardAttributes } from 'aws-cdk-lib/aws-cognito';
 
 // refer: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html
 const coreAttributeNameMap: {

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -1,8 +1,8 @@
-import { SecretValue, aws_cognito as cognito } from 'aws-cdk-lib';
-import { triggerEvents } from './trigger_events.js';
-import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
-import { AuthOutput } from '@aws-amplify/backend-output-schemas';
-import { StandardAttributes } from 'aws-cdk-lib/aws-cognito';
+import { type SecretValue, type aws_cognito as cognito } from 'aws-cdk-lib';
+import { type triggerEvents } from './trigger_events.js';
+import { type BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
+import { type AuthOutput } from '@aws-amplify/backend-output-schemas';
+import { type StandardAttributes } from 'aws-cdk-lib/aws-cognito';
 
 /**
  * Email login settings object

--- a/packages/backend-auth/src/factory.test.ts
+++ b/packages/backend-auth/src/factory.test.ts
@@ -4,15 +4,18 @@ import { App, Stack, aws_lambda } from 'aws-cdk-lib';
 import assert from 'node:assert';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import {
-  BackendOutputEntry,
-  BackendOutputStorageStrategy,
-  ConstructContainer,
-  ConstructFactory,
-  FunctionResources,
-  ImportPathVerifier,
-  ResourceProvider,
+  type BackendOutputEntry,
+  type BackendOutputStorageStrategy,
+  type ConstructContainer,
+  type ConstructFactory,
+  type FunctionResources,
+  type ImportPathVerifier,
+  type ResourceProvider,
 } from '@aws-amplify/plugin-types';
-import { AmplifyAuth, triggerEvents } from '@aws-amplify/auth-construct-alpha';
+import {
+  type AmplifyAuth,
+  triggerEvents,
+} from '@aws-amplify/auth-construct-alpha';
 import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
 import {
   ConstructContainerStub,

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -1,20 +1,20 @@
 import {
   AmplifyAuth,
-  AuthProps,
-  TriggerEvent,
+  type AuthProps,
+  type TriggerEvent,
 } from '@aws-amplify/auth-construct-alpha';
-import { Construct } from 'constructs';
+import { type Construct } from 'constructs';
 import {
-  AuthResources,
-  BackendSecretResolver,
-  ConstructContainerEntryGenerator,
-  ConstructFactory,
-  ConstructFactoryGetInstanceProps,
-  FunctionResources,
-  ResourceProvider,
+  type AuthResources,
+  type BackendSecretResolver,
+  type ConstructContainerEntryGenerator,
+  type ConstructFactory,
+  type ConstructFactoryGetInstanceProps,
+  type FunctionResources,
+  type ResourceProvider,
 } from '@aws-amplify/plugin-types';
 import * as path from 'path';
-import { AuthLoginWithFactoryProps, Expand } from './types.js';
+import { type AuthLoginWithFactoryProps, type Expand } from './types.js';
 import { translateToAuthConstructLoginWith } from './translate_auth_props.js';
 
 export type AmplifyAuthProps = Expand<

--- a/packages/backend-auth/src/translate_auth_props.test.ts
+++ b/packages/backend-auth/src/translate_auth_props.test.ts
@@ -1,12 +1,15 @@
 import {
-  BackendIdentifier,
-  BackendSecret,
-  BackendSecretResolver,
+  type BackendIdentifier,
+  type BackendSecret,
+  type BackendSecretResolver,
 } from '@aws-amplify/plugin-types';
 import { describe, it } from 'node:test';
-import { AuthLoginWithFactoryProps } from './types.js';
-import { Construct } from 'constructs';
-import { AuthProps, PhoneNumberLogin } from '@aws-amplify/auth-construct-alpha';
+import { type AuthLoginWithFactoryProps } from './types.js';
+import { type Construct } from 'constructs';
+import {
+  type AuthProps,
+  type PhoneNumberLogin,
+} from '@aws-amplify/auth-construct-alpha';
 import { SecretValue } from 'aws-cdk-lib';
 import assert from 'node:assert';
 import { translateToAuthConstructLoginWith } from './translate_auth_props.js';

--- a/packages/backend-auth/src/translate_auth_props.ts
+++ b/packages/backend-auth/src/translate_auth_props.ts
@@ -1,20 +1,20 @@
 import {
-  AmazonProviderProps,
-  AppleProviderProps,
-  AuthProps,
-  FacebookProviderProps,
-  GoogleProviderProps,
-  OidcProviderProps,
+  type AmazonProviderProps,
+  type AppleProviderProps,
+  type AuthProps,
+  type FacebookProviderProps,
+  type GoogleProviderProps,
+  type OidcProviderProps,
 } from '@aws-amplify/auth-construct-alpha';
-import { BackendSecretResolver } from '@aws-amplify/plugin-types';
+import { type BackendSecretResolver } from '@aws-amplify/plugin-types';
 import {
-  AmazonProviderFactoryProps,
-  AppleProviderFactoryProps,
-  AuthLoginWithFactoryProps,
-  ExternalProviderGeneralFactoryProps,
-  FacebookProviderFactoryProps,
-  GoogleProviderFactoryProps,
-  OidcProviderFactoryProps,
+  type AmazonProviderFactoryProps,
+  type AppleProviderFactoryProps,
+  type AuthLoginWithFactoryProps,
+  type ExternalProviderGeneralFactoryProps,
+  type FacebookProviderFactoryProps,
+  type GoogleProviderFactoryProps,
+  type OidcProviderFactoryProps,
 } from './types.js';
 
 /**

--- a/packages/backend-auth/src/types.ts
+++ b/packages/backend-auth/src/types.ts
@@ -1,13 +1,13 @@
 import {
-  AmazonProviderProps,
-  AppleProviderProps,
-  AuthProps,
-  ExternalProviderOptions,
-  FacebookProviderProps,
-  GoogleProviderProps,
-  OidcProviderProps,
+  type AmazonProviderProps,
+  type AppleProviderProps,
+  type AuthProps,
+  type ExternalProviderOptions,
+  type FacebookProviderProps,
+  type GoogleProviderProps,
+  type OidcProviderProps,
 } from '@aws-amplify/auth-construct-alpha';
-import { BackendSecret } from '@aws-amplify/plugin-types';
+import { type BackendSecret } from '@aws-amplify/plugin-types';
 
 /**
  * This utility allows us to expand nested types in auto complete prompts.

--- a/packages/backend-data/src/convert_authorization_modes.test.ts
+++ b/packages/backend-data/src/convert_authorization_modes.test.ts
@@ -2,22 +2,27 @@ import { beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert';
 import { Duration, Stack } from 'aws-cdk-lib';
 import { UserPool } from 'aws-cdk-lib/aws-cognito';
-import { IRole, Role } from 'aws-cdk-lib/aws-iam';
-import { AuthorizationModes as CDKAuthorizationModes } from '@aws-amplify/data-construct';
-import { AuthorizationModes } from './types.js';
+import { type IRole, Role } from 'aws-cdk-lib/aws-iam';
+import { type AuthorizationModes as CDKAuthorizationModes } from '@aws-amplify/data-construct';
+import { type AuthorizationModes } from './types.js';
 import {
-  ProvidedAuthConfig,
+  type ProvidedAuthConfig,
   buildConstructFactoryProvidedAuthConfig,
   convertAuthorizationModesToCDK,
   isUsingDefaultApiKeyAuth,
 } from './convert_authorization_modes.js';
-import { Code, Function, IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
-import { FunctionInstanceProvider } from './convert_functions.js';
 import {
-  AmplifyFunction,
-  AuthResources,
-  ConstructFactory,
-  ResourceProvider,
+  Code,
+  Function,
+  type IFunction,
+  Runtime,
+} from 'aws-cdk-lib/aws-lambda';
+import { type FunctionInstanceProvider } from './convert_functions.js';
+import {
+  type AmplifyFunction,
+  type AuthResources,
+  type ConstructFactory,
+  type ResourceProvider,
 } from '@aws-amplify/plugin-types';
 
 void describe('buildConstructFactoryProvidedAuthConfig', () => {

--- a/packages/backend-data/src/convert_authorization_modes.ts
+++ b/packages/backend-data/src/convert_authorization_modes.ts
@@ -1,23 +1,26 @@
 import { Duration } from 'aws-cdk-lib';
-import { IUserPool } from 'aws-cdk-lib/aws-cognito';
-import { IRole } from 'aws-cdk-lib/aws-iam';
+import { type IUserPool } from 'aws-cdk-lib/aws-cognito';
+import { type IRole } from 'aws-cdk-lib/aws-iam';
 import {
-  ApiKeyAuthorizationConfig as CDKApiKeyAuthorizationConfig,
-  AuthorizationModes as CDKAuthorizationModes,
-  IAMAuthorizationConfig as CDKIAMAuthorizationConfig,
-  LambdaAuthorizationConfig as CDKLambdaAuthorizationConfig,
-  OIDCAuthorizationConfig as CDKOIDCAuthorizationConfig,
-  UserPoolAuthorizationConfig as CDKUserPoolAuthorizationConfig,
+  type ApiKeyAuthorizationConfig as CDKApiKeyAuthorizationConfig,
+  type AuthorizationModes as CDKAuthorizationModes,
+  type IAMAuthorizationConfig as CDKIAMAuthorizationConfig,
+  type LambdaAuthorizationConfig as CDKLambdaAuthorizationConfig,
+  type OIDCAuthorizationConfig as CDKOIDCAuthorizationConfig,
+  type UserPoolAuthorizationConfig as CDKUserPoolAuthorizationConfig,
 } from '@aws-amplify/data-construct';
 import {
-  ApiKeyAuthorizationModeProps,
-  AuthorizationModes,
-  DefaultAuthorizationMode,
-  LambdaAuthorizationModeProps,
-  OIDCAuthorizationModeProps,
+  type ApiKeyAuthorizationModeProps,
+  type AuthorizationModes,
+  type DefaultAuthorizationMode,
+  type LambdaAuthorizationModeProps,
+  type OIDCAuthorizationModeProps,
 } from './types.js';
-import { FunctionInstanceProvider } from './convert_functions.js';
-import { AuthResources, ResourceProvider } from '@aws-amplify/plugin-types';
+import { type FunctionInstanceProvider } from './convert_functions.js';
+import {
+  type AuthResources,
+  type ResourceProvider,
+} from '@aws-amplify/plugin-types';
 
 const DEFAULT_API_KEY_EXPIRATION_DAYS = 7;
 const DEFAULT_LAMBDA_AUTH_TIME_TO_LIVE_SECONDS = 60;

--- a/packages/backend-data/src/convert_functions.test.ts
+++ b/packages/backend-data/src/convert_functions.test.ts
@@ -1,16 +1,21 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { Stack } from 'aws-cdk-lib';
-import { Code, Function, IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
 import {
-  AmplifyFunction,
-  BackendOutputEntry,
-  BackendOutputStorageStrategy,
-  ConstructContainer,
-  ConstructFactory,
+  Code,
+  Function,
+  type IFunction,
+  Runtime,
+} from 'aws-cdk-lib/aws-lambda';
+import {
+  type AmplifyFunction,
+  type BackendOutputEntry,
+  type BackendOutputStorageStrategy,
+  type ConstructContainer,
+  type ConstructFactory,
 } from '@aws-amplify/plugin-types';
 import {
-  FunctionInstanceProvider,
+  type FunctionInstanceProvider,
   buildConstructFactoryFunctionInstanceProvider,
   convertFunctionNameMapToCDK,
 } from './convert_functions.js';

--- a/packages/backend-data/src/convert_functions.ts
+++ b/packages/backend-data/src/convert_functions.ts
@@ -1,8 +1,8 @@
-import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import { type IFunction } from 'aws-cdk-lib/aws-lambda';
 import {
-  AmplifyFunction,
-  ConstructFactory,
-  ConstructFactoryGetInstanceProps,
+  type AmplifyFunction,
+  type ConstructFactory,
+  type ConstructFactoryGetInstanceProps,
 } from '@aws-amplify/plugin-types';
 
 /**

--- a/packages/backend-data/src/convert_schema.ts
+++ b/packages/backend-data/src/convert_schema.ts
@@ -1,9 +1,9 @@
-import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
+import { type DerivedModelSchema } from '@aws-amplify/data-schema-types';
 import {
   AmplifyDataDefinition,
-  IAmplifyDataDefinition,
+  type IAmplifyDataDefinition,
 } from '@aws-amplify/data-construct';
-import { DataSchema } from './types.js';
+import { type DataSchema } from './types.js';
 
 /**
  * Determine if the input schema is a derived model schema, and perform type narrowing.

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -4,15 +4,15 @@ import { defineData } from './factory.js';
 import { App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import {
-  AmplifyFunction,
-  AuthResources,
-  BackendOutputEntry,
-  BackendOutputStorageStrategy,
-  ConstructContainer,
-  ConstructFactory,
-  ConstructFactoryGetInstanceProps,
-  ImportPathVerifier,
-  ResourceProvider,
+  type AmplifyFunction,
+  type AuthResources,
+  type BackendOutputEntry,
+  type BackendOutputStorageStrategy,
+  type ConstructContainer,
+  type ConstructFactory,
+  type ConstructFactoryGetInstanceProps,
+  type ImportPathVerifier,
+  type ResourceProvider,
 } from '@aws-amplify/plugin-types';
 import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import {
@@ -25,7 +25,7 @@ import {
 } from 'aws-cdk-lib/aws-cognito';
 import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
-import { AmplifyData } from '@aws-amplify/data-construct';
+import { type AmplifyData } from '@aws-amplify/data-construct';
 import {
   ConstructContainerStub,
   ImportPathVerifierStub,

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -1,24 +1,24 @@
-import { Construct } from 'constructs';
+import { type Construct } from 'constructs';
 import {
-  AuthResources,
-  BackendOutputStorageStrategy,
-  ConstructContainerEntryGenerator,
-  ConstructFactory,
-  ConstructFactoryGetInstanceProps,
-  ResourceProvider,
+  type AuthResources,
+  type BackendOutputStorageStrategy,
+  type ConstructContainerEntryGenerator,
+  type ConstructFactory,
+  type ConstructFactoryGetInstanceProps,
+  type ResourceProvider,
 } from '@aws-amplify/plugin-types';
 import { AmplifyData } from '@aws-amplify/data-construct';
-import { GraphqlOutput } from '@aws-amplify/backend-output-schemas';
+import { type GraphqlOutput } from '@aws-amplify/backend-output-schemas';
 import * as path from 'path';
-import { DataProps } from './types.js';
+import { type DataProps } from './types.js';
 import { convertSchemaToCDK } from './convert_schema.js';
 import {
-  FunctionInstanceProvider,
+  type FunctionInstanceProvider,
   buildConstructFactoryFunctionInstanceProvider,
   convertFunctionNameMapToCDK,
 } from './convert_functions.js';
 import {
-  ProvidedAuthConfig,
+  type ProvidedAuthConfig,
   buildConstructFactoryProvidedAuthConfig,
   convertAuthorizationModesToCDK,
   isUsingDefaultApiKeyAuth,

--- a/packages/backend-data/src/index.ts
+++ b/packages/backend-data/src/index.ts
@@ -1,5 +1,5 @@
 export * from './factory.js';
-export {
+export type {
   ApiKeyAuthorizationModeProps,
   LambdaAuthorizationModeProps,
   OIDCAuthorizationModeProps,

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -1,5 +1,8 @@
-import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
-import { AmplifyFunction, ConstructFactory } from '@aws-amplify/plugin-types';
+import { type DerivedModelSchema } from '@aws-amplify/data-schema-types';
+import {
+  type AmplifyFunction,
+  type ConstructFactory,
+} from '@aws-amplify/plugin-types';
 
 /**
  * Authorization modes used in by client side Amplify represented in camelCase.

--- a/packages/backend-data/src/validate_authorization_modes.ts
+++ b/packages/backend-data/src/validate_authorization_modes.ts
@@ -1,5 +1,5 @@
-import { AuthorizationModes as CDKAuthorizationModes } from '@aws-amplify/data-construct';
-import { AuthorizationModes } from './types.js';
+import { type AuthorizationModes as CDKAuthorizationModes } from '@aws-amplify/data-construct';
+import { type AuthorizationModes } from './types.js';
 
 type AuthorizationModeValidator = (
   inputAuthorizationModes: AuthorizationModes | undefined,

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -1,10 +1,10 @@
 import { after, beforeEach, describe, it, mock } from 'node:test';
 import { CDKDeployer } from './cdk_deployer.js';
 import assert from 'node:assert';
-import { BackendLocator } from '@aws-amplify/platform-core';
-import { DeployProps } from './cdk_deployer_singleton_factory.js';
+import { type BackendLocator } from '@aws-amplify/platform-core';
+import { type DeployProps } from './cdk_deployer_singleton_factory.js';
 import { CdkErrorMapper } from './cdk_error_mapper.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 void describe('invokeCDKCommand', () => {
   const backendId: BackendIdentifier = {

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -2,15 +2,18 @@ import { execa } from 'execa';
 import stream from 'stream';
 import readline from 'readline';
 import {
-  BackendDeployer,
-  DeployProps,
-  DeployResult,
-  DestroyProps,
-  DestroyResult,
+  type BackendDeployer,
+  type DeployProps,
+  type DeployResult,
+  type DestroyProps,
+  type DestroyResult,
 } from './cdk_deployer_singleton_factory.js';
-import { CdkErrorMapper } from './cdk_error_mapper.js';
-import { BackendIdentifier, DeploymentType } from '@aws-amplify/plugin-types';
-import { BackendLocator, CDKContextKey } from '@aws-amplify/platform-core';
+import { type CdkErrorMapper } from './cdk_error_mapper.js';
+import {
+  type BackendIdentifier,
+  type DeploymentType,
+} from '@aws-amplify/plugin-types';
+import { type BackendLocator, CDKContextKey } from '@aws-amplify/platform-core';
 import { dirname } from 'path';
 
 /**

--- a/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
+++ b/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
@@ -1,4 +1,7 @@
-import { BackendIdentifier, DeploymentType } from '@aws-amplify/plugin-types';
+import {
+  type BackendIdentifier,
+  type DeploymentType,
+} from '@aws-amplify/plugin-types';
 import { CDKDeployer } from './cdk_deployer.js';
 import { CdkErrorMapper } from './cdk_error_mapper.js';
 import { BackendLocator } from '@aws-amplify/platform-core';

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import { Func } from './factory.js';
 import { App, Stack } from 'aws-cdk-lib';
-import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
+import { type ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
 import assert from 'node:assert';
 import { fileURLToPath } from 'url';
 import * as path from 'path';

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -1,13 +1,13 @@
 import {
-  ConstructContainerEntryGenerator,
-  ConstructFactory,
-  ConstructFactoryGetInstanceProps,
+  type ConstructContainerEntryGenerator,
+  type ConstructFactory,
+  type ConstructFactoryGetInstanceProps,
 } from '@aws-amplify/plugin-types';
 import {
-  AmplifyFunctionProps,
+  type AmplifyFunctionProps,
   AmplifyLambdaFunction,
 } from '@aws-amplify/function-construct-alpha';
-import { Construct } from 'constructs';
+import { type Construct } from 'constructs';
 import { execaCommand } from 'execa';
 import * as path from 'path';
 import { getCallerDirectory } from './get_caller_directory.js';

--- a/packages/backend-output-schemas/src/graphql/index.ts
+++ b/packages/backend-output-schemas/src/graphql/index.ts
@@ -1,10 +1,8 @@
 import { z } from 'zod';
 import { graphqlOutputSchema as graphqlOutputSchemaV1 } from './v1.js';
 
-export {
-  AwsAppsyncAuthenticationType,
-  AwsAppsyncAuthenticationZodEnum,
-} from './v1.js';
+export type { AwsAppsyncAuthenticationType } from './v1.js';
+export { AwsAppsyncAuthenticationZodEnum } from './v1.js';
 
 export const versionedGraphqlOutputSchema = z.discriminatedUnion('version', [
   graphqlOutputSchemaV1,

--- a/packages/backend-output-storage/src/stack_metadata_output_storage_strategy.ts
+++ b/packages/backend-output-storage/src/stack_metadata_output_storage_strategy.ts
@@ -1,8 +1,8 @@
 import {
-  BackendOutputEntry,
-  BackendOutputStorageStrategy,
+  type BackendOutputEntry,
+  type BackendOutputStorageStrategy,
 } from '@aws-amplify/plugin-types';
-import { CfnOutput, Stack } from 'aws-cdk-lib';
+import { CfnOutput, type Stack } from 'aws-cdk-lib';
 
 /**
  * Implementation of BackendOutputStorageStrategy that stores config data in stack metadata and outputs

--- a/packages/backend-output-storage/src/store_attribution_metadata.test.ts
+++ b/packages/backend-output-storage/src/store_attribution_metadata.test.ts
@@ -2,12 +2,12 @@ import { describe, it, mock } from 'node:test';
 import { App, Stack } from 'aws-cdk-lib';
 import * as os from 'os';
 import {
-  AttributionMetadata,
+  type AttributionMetadata,
   AttributionMetadataStorage,
 } from './store_attribution_metadata.js';
 
 import assert from 'node:assert';
-import { PackageJsonReader } from '@aws-amplify/platform-core';
+import { type PackageJsonReader } from '@aws-amplify/platform-core';
 
 void describe('storeAttributionMetadata', () => {
   const packageJsonReaderMock = mock.fn(() => {

--- a/packages/backend-output-storage/src/store_attribution_metadata.ts
+++ b/packages/backend-output-storage/src/store_attribution_metadata.ts
@@ -1,7 +1,7 @@
-import { Stack } from 'aws-cdk-lib';
+import { type Stack } from 'aws-cdk-lib';
 import * as _os from 'os';
 import { CDKContextKey, PackageJsonReader } from '@aws-amplify/platform-core';
-import { DeploymentType } from '@aws-amplify/plugin-types';
+import { type DeploymentType } from '@aws-amplify/plugin-types';
 
 /**
  * Stores BI metrics information in stack descriptions

--- a/packages/backend-platform-test-stubs/src/amplify_stack_stub.ts
+++ b/packages/backend-platform-test-stubs/src/amplify_stack_stub.ts
@@ -1,4 +1,4 @@
-import { CfnElement, Stack } from 'aws-cdk-lib';
+import { type CfnElement, Stack } from 'aws-cdk-lib';
 
 /**
  * Test implementation of AmplifyStack. Currently copied from the real implementation of AmplifyStack but the implementations do not need to match going forward

--- a/packages/backend-platform-test-stubs/src/backend_secret_resolver_stub.ts
+++ b/packages/backend-platform-test-stubs/src/backend_secret_resolver_stub.ts
@@ -1,10 +1,10 @@
 import {
-  BackendIdentifier,
-  BackendSecret,
-  BackendSecretResolver,
+  type BackendIdentifier,
+  type BackendSecret,
+  type BackendSecretResolver,
 } from '@aws-amplify/plugin-types';
-import { SecretValue } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
+import { type SecretValue } from 'aws-cdk-lib';
+import { type Construct } from 'constructs';
 
 /**
  * Stub implementation of BackendSecretResolver. Currently, it is copied from @aws-amplify/backend, but it does not need to be kept in sync moving forward

--- a/packages/backend-platform-test-stubs/src/construct_container_stub.ts
+++ b/packages/backend-platform-test-stubs/src/construct_container_stub.ts
@@ -1,10 +1,10 @@
-import { Construct } from 'constructs';
-import { StackResolver } from './stack_resolver_stub.js';
+import { type Construct } from 'constructs';
+import { type StackResolver } from './stack_resolver_stub.js';
 import {
-  BackendIdentifier,
-  ConstructContainer,
-  ConstructContainerEntryGenerator,
-  ConstructFactory,
+  type BackendIdentifier,
+  type ConstructContainer,
+  type ConstructContainerEntryGenerator,
+  type ConstructFactory,
 } from '@aws-amplify/plugin-types';
 import { BackendSecretResolverStub } from './backend_secret_resolver_stub.js';
 

--- a/packages/backend-platform-test-stubs/src/import_path_verifier_stub.ts
+++ b/packages/backend-platform-test-stubs/src/import_path_verifier_stub.ts
@@ -1,4 +1,4 @@
-import { ImportPathVerifier } from '@aws-amplify/plugin-types';
+import { type ImportPathVerifier } from '@aws-amplify/plugin-types';
 
 /**
  * Stub implementation of ImportPathVerifier

--- a/packages/backend-platform-test-stubs/src/stack_resolver_stub.ts
+++ b/packages/backend-platform-test-stubs/src/stack_resolver_stub.ts
@@ -1,4 +1,4 @@
-import { NestedStack, Stack } from 'aws-cdk-lib';
+import { NestedStack, type Stack } from 'aws-cdk-lib';
 
 /**
  * Vends stacks for a resource grouping

--- a/packages/backend-secret/src/secret.ts
+++ b/packages/backend-secret/src/secret.ts
@@ -1,7 +1,7 @@
 import { SSMSecretClient } from './ssm_secret.js';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { SSM } from '@aws-sdk/client-ssm';
-import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type AppId, type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 /**
  * The unique identifier of the secret.

--- a/packages/backend-secret/src/ssm_secret.test.ts
+++ b/packages/backend-secret/src/ssm_secret.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import {
-  GetParameterCommandOutput,
-  GetParametersByPathCommandOutput,
+  type GetParameterCommandOutput,
+  type GetParametersByPathCommandOutput,
   InternalServerError,
   ParameterNotFound,
   SSM,
@@ -9,8 +9,12 @@ import {
 import { SSMSecretClient } from './ssm_secret.js';
 import assert from 'node:assert';
 import { SecretError } from './secret_error.js';
-import { Secret, SecretIdentifier, SecretListItem } from './secret.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import {
+  type Secret,
+  type SecretIdentifier,
+  type SecretListItem,
+} from './secret.js';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 const shared = 'shared';
 const testBackendId = 'testBackendId';

--- a/packages/backend-secret/src/ssm_secret.ts
+++ b/packages/backend-secret/src/ssm_secret.ts
@@ -1,12 +1,12 @@
-import { SSM } from '@aws-sdk/client-ssm';
+import { type SSM } from '@aws-sdk/client-ssm';
 import { SecretError } from './secret_error.js';
 import {
-  Secret,
-  SecretClient,
-  SecretIdentifier,
-  SecretListItem,
+  type Secret,
+  type SecretClient,
+  type SecretIdentifier,
+  type SecretListItem,
 } from './secret.js';
-import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type AppId, type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 const SHARED_SECRET = 'shared';
 

--- a/packages/backend-storage/src/factory.test.ts
+++ b/packages/backend-storage/src/factory.test.ts
@@ -4,15 +4,15 @@ import { App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import assert from 'node:assert';
 import {
-  BackendOutputEntry,
-  BackendOutputStorageStrategy,
-  ConstructContainer,
-  ConstructFactory,
-  ConstructFactoryGetInstanceProps,
-  ImportPathVerifier,
+  type BackendOutputEntry,
+  type BackendOutputStorageStrategy,
+  type ConstructContainer,
+  type ConstructFactory,
+  type ConstructFactoryGetInstanceProps,
+  type ImportPathVerifier,
 } from '@aws-amplify/plugin-types';
 import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
-import { AmplifyStorage } from '@aws-amplify/storage-construct-alpha';
+import { type AmplifyStorage } from '@aws-amplify/storage-construct-alpha';
 import {
   ConstructContainerStub,
   ImportPathVerifierStub,

--- a/packages/backend-storage/src/factory.ts
+++ b/packages/backend-storage/src/factory.ts
@@ -1,14 +1,14 @@
-import { Construct } from 'constructs';
+import { type Construct } from 'constructs';
 import {
-  BackendOutputEntry,
-  BackendOutputStorageStrategy,
-  ConstructContainerEntryGenerator,
-  ConstructFactory,
-  ConstructFactoryGetInstanceProps,
+  type BackendOutputEntry,
+  type BackendOutputStorageStrategy,
+  type ConstructContainerEntryGenerator,
+  type ConstructFactory,
+  type ConstructFactoryGetInstanceProps,
 } from '@aws-amplify/plugin-types';
 import {
   AmplifyStorage,
-  AmplifyStorageProps,
+  type AmplifyStorageProps,
 } from '@aws-amplify/storage-construct-alpha';
 import * as path from 'path';
 

--- a/packages/backend/src/backend.ts
+++ b/packages/backend/src/backend.ts
@@ -1,6 +1,6 @@
-import { ConstructFactory } from '@aws-amplify/plugin-types';
-import { Construct } from 'constructs';
-import { Stack } from 'aws-cdk-lib';
+import { type ConstructFactory } from '@aws-amplify/plugin-types';
+import { type Construct } from 'constructs';
+import { type Stack } from 'aws-cdk-lib';
 
 /**
  * Top level type for instance returned from `defineBackend`. Contains property `resources` for overriding

--- a/packages/backend/src/backend_factory.test.ts
+++ b/packages/backend/src/backend_factory.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, it } from 'node:test';
-import { ConstructFactory, DeploymentType } from '@aws-amplify/plugin-types';
+import {
+  type ConstructFactory,
+  type DeploymentType,
+} from '@aws-amplify/plugin-types';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { Construct } from 'constructs';
+import { type Construct } from 'constructs';
 import { BackendFactory } from './backend_factory.js';
 import { App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';

--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -1,9 +1,9 @@
-import { Construct } from 'constructs';
-import { ConstructFactory } from '@aws-amplify/plugin-types';
-import { Stack } from 'aws-cdk-lib';
+import { type Construct } from 'constructs';
+import { type ConstructFactory } from '@aws-amplify/plugin-types';
+import { type Stack } from 'aws-cdk-lib';
 import {
   NestedStackResolver,
-  StackResolver,
+  type StackResolver,
 } from './engine/nested_stack_resolver.js';
 import { SingletonConstructContainer } from './engine/singleton_construct_container.js';
 import { ToggleableImportPathVerifier } from './engine/toggleable_import_path_verifier.js';
@@ -15,7 +15,7 @@ import { createDefaultStack } from './default_stack_factory.js';
 import { getBackendIdentifier } from './backend_identifier.js';
 import { platformOutputKey } from '@aws-amplify/backend-output-schemas';
 import { fileURLToPath } from 'url';
-import { Backend } from './backend.js';
+import { type Backend } from './backend.js';
 import { AmplifyBranchLinkerConstruct } from './engine/branch-linker/branch_linker_construct.js';
 
 // Be very careful editing this value. It is the value used in the BI metrics to attribute stacks as Amplify root stacks

--- a/packages/backend/src/backend_identifier.ts
+++ b/packages/backend/src/backend_identifier.ts
@@ -1,6 +1,9 @@
-import { Construct } from 'constructs';
+import { type Construct } from 'constructs';
 import { CDKContextKey } from '@aws-amplify/platform-core';
-import { BackendIdentifier, DeploymentType } from '@aws-amplify/plugin-types';
+import {
+  type BackendIdentifier,
+  type DeploymentType,
+} from '@aws-amplify/plugin-types';
 
 /**
  * Populates a backend identifier based on CDK context values.

--- a/packages/backend/src/default_stack_factory.ts
+++ b/packages/backend/src/default_stack_factory.ts
@@ -1,4 +1,4 @@
-import { App, Stack } from 'aws-cdk-lib';
+import { App, type Stack } from 'aws-cdk-lib';
 import { ProjectEnvironmentMainStackCreator } from './project_environment_main_stack_creator.js';
 import { getBackendIdentifier } from './backend_identifier.js';
 

--- a/packages/backend/src/engine/amplify_stack.ts
+++ b/packages/backend/src/engine/amplify_stack.ts
@@ -1,4 +1,4 @@
-import { CfnElement, Stack } from 'aws-cdk-lib';
+import { type CfnElement, Stack } from 'aws-cdk-lib';
 
 /**
  * Amplify-specific Stack implementation to handle cross-cutting concerns for all Amplify stacks

--- a/packages/backend/src/engine/backend-secret/backend_secret.test.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret.test.ts
@@ -4,7 +4,7 @@ import { CfnTokenBackendSecret } from './backend_secret.js';
 import { App, SecretValue, Stack } from 'aws-cdk-lib';
 import { BackendSecretFetcherProviderFactory } from './backend_secret_fetcher_provider_factory.js';
 import { BackendSecretFetcherFactory } from './backend_secret_fetcher_factory.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 const namespace = 'testId';
 const name = 'testBranch';

--- a/packages/backend/src/engine/backend-secret/backend_secret.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret.ts
@@ -1,6 +1,9 @@
-import { BackendIdentifier, BackendSecret } from '@aws-amplify/plugin-types';
-import { Construct } from 'constructs';
-import { BackendSecretFetcherFactory } from './backend_secret_fetcher_factory.js';
+import {
+  type BackendIdentifier,
+  type BackendSecret,
+} from '@aws-amplify/plugin-types';
+import { type Construct } from 'constructs';
+import { type BackendSecretFetcherFactory } from './backend_secret_fetcher_factory.js';
 import { SecretValue } from 'aws-cdk-lib';
 
 /**

--- a/packages/backend/src/engine/backend-secret/backend_secret_fetcher_factory.test.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_fetcher_factory.test.ts
@@ -7,7 +7,7 @@ import {
   BackendSecretFetcherFactory,
   SECRET_RESOURCE_PROVIDER_ID,
 } from './backend_secret_fetcher_factory.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 const secretResourceType = 'Custom::SecretFetcherResource';
 const namespace = 'testId';

--- a/packages/backend/src/engine/backend-secret/backend_secret_fetcher_factory.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_fetcher_factory.ts
@@ -1,8 +1,8 @@
-import { Construct } from 'constructs';
-import { BackendSecretFetcherProviderFactory } from './backend_secret_fetcher_provider_factory.js';
+import { type Construct } from 'constructs';
+import { type BackendSecretFetcherProviderFactory } from './backend_secret_fetcher_provider_factory.js';
 import { CustomResource } from 'aws-cdk-lib';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
-import { SecretResourceProps } from './lambda/backend_secret_fetcher_types.js';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type SecretResourceProps } from './lambda/backend_secret_fetcher_types.js';
 
 /**
  * Resource provider ID for the backend secret resource.

--- a/packages/backend/src/engine/backend-secret/backend_secret_fetcher_provider_factory.test.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_fetcher_provider_factory.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 import { BackendSecretFetcherProviderFactory } from './backend_secret_fetcher_provider_factory.js';
 import { Template } from 'aws-cdk-lib/assertions';
 import assert from 'node:assert';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 const testProviderId1 = 'testProvider1';
 const testProviderId2 = 'testProvider2';

--- a/packages/backend/src/engine/backend-secret/backend_secret_fetcher_provider_factory.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_fetcher_provider_factory.ts
@@ -1,4 +1,4 @@
-import { Construct } from 'constructs';
+import { type Construct } from 'constructs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Duration } from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { Runtime as LambdaRuntime } from 'aws-cdk-lib/aws-lambda';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { fileURLToPath } from 'url';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);

--- a/packages/backend/src/engine/backend-secret/backend_secret_resolver.test.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_resolver.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, mock } from 'node:test';
 import { DefaultBackendSecretResolver } from './backend_secret_resolver.js';
 import { CfnTokenBackendSecret } from './backend_secret.js';
-import { BackendSecretFetcherFactory } from './backend_secret_fetcher_factory.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendSecretFetcherFactory } from './backend_secret_fetcher_factory.js';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 import { App, Stack } from 'aws-cdk-lib';
 import assert from 'node:assert';
 

--- a/packages/backend/src/engine/backend-secret/backend_secret_resolver.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_resolver.ts
@@ -1,10 +1,10 @@
 import {
-  BackendIdentifier,
-  BackendSecret,
-  BackendSecretResolver,
+  type BackendIdentifier,
+  type BackendSecret,
+  type BackendSecretResolver,
 } from '@aws-amplify/plugin-types';
-import { SecretValue } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
+import { type SecretValue } from 'aws-cdk-lib';
+import { type Construct } from 'constructs';
 
 /**
  * DefaultBackendSecretResolver resolves a backend secret.

--- a/packages/backend/src/engine/backend-secret/lambda/backend_secret_fetcher.test.ts
+++ b/packages/backend/src/engine/backend-secret/lambda/backend_secret_fetcher.test.ts
@@ -2,17 +2,17 @@ import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { handleCreateUpdateEvent, handler } from './backend_secret_fetcher.js';
 import {
-  CloudFormationCustomResourceEvent,
-  CloudFormationCustomResourceSuccessResponse,
+  type CloudFormationCustomResourceEvent,
+  type CloudFormationCustomResourceSuccessResponse,
 } from 'aws-lambda';
 import {
-  Secret,
-  SecretClient,
+  type Secret,
+  type SecretClient,
   SecretError,
-  SecretIdentifier,
+  type SecretIdentifier,
   getSecretClient,
 } from '@aws-amplify/backend-secret';
-import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type AppId, type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 const testBackendId = 'testBackendId';
 const testBranchName = 'testBranchName';

--- a/packages/backend/src/engine/backend-secret/lambda/backend_secret_fetcher.ts
+++ b/packages/backend/src/engine/backend-secret/lambda/backend_secret_fetcher.ts
@@ -1,14 +1,14 @@
 import {
-  CloudFormationCustomResourceEvent,
-  CloudFormationCustomResourceSuccessResponse,
+  type CloudFormationCustomResourceEvent,
+  type CloudFormationCustomResourceSuccessResponse,
 } from 'aws-lambda';
 import {
-  SecretClient,
-  SecretError,
+  type SecretClient,
+  type SecretError,
   getSecretClient,
 } from '@aws-amplify/backend-secret';
 import { randomUUID } from 'node:crypto';
-import { SecretResourceProps } from './backend_secret_fetcher_types.js';
+import { type SecretResourceProps } from './backend_secret_fetcher_types.js';
 
 const secretClient = getSecretClient();
 

--- a/packages/backend/src/engine/branch-linker/branch_linker_construct.test.ts
+++ b/packages/backend/src/engine/branch-linker/branch_linker_construct.test.ts
@@ -3,7 +3,7 @@ import { Template } from 'aws-cdk-lib/assertions';
 import { Stack } from 'aws-cdk-lib';
 import { AmplifyBranchLinkerConstruct } from './branch_linker_construct.js';
 import { BackendEnvironmentVariables } from '../../environment_variables.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 void describe('Branch Linker Construct', () => {
   const appId = 'test-app-id';

--- a/packages/backend/src/engine/branch-linker/branch_linker_construct.ts
+++ b/packages/backend/src/engine/branch-linker/branch_linker_construct.ts
@@ -5,10 +5,10 @@ import { CustomResource, Duration } from 'aws-cdk-lib';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { Provider } from 'aws-cdk-lib/custom-resources';
-import { AmplifyBranchLinkerCustomResourceProps } from './lambda/branch_linker_types.js';
+import { type AmplifyBranchLinkerCustomResourceProps } from './lambda/branch_linker_types.js';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { BackendEnvironmentVariables } from '../../environment_variables.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);

--- a/packages/backend/src/engine/branch-linker/lambda/branch_linker.test.ts
+++ b/packages/backend/src/engine/branch-linker/lambda/branch_linker.test.ts
@@ -3,14 +3,14 @@ import assert from 'node:assert';
 import { AmplifyBranchLinkerCustomResourceEventHandler } from './branch_linker.js';
 import {
   AmplifyClient,
-  Branch,
+  type Branch,
   GetBranchCommand,
-  GetBranchCommandOutput,
+  type GetBranchCommandOutput,
   NotFoundException,
-  UpdateBranchCommandInput,
+  type UpdateBranchCommandInput,
 } from '@aws-sdk/client-amplify';
-import { CloudFormationCustomResourceEvent } from 'aws-lambda';
-import { AmplifyBranchLinkerCustomResourceProps } from './branch_linker_types.js';
+import { type CloudFormationCustomResourceEvent } from 'aws-lambda';
+import { type AmplifyBranchLinkerCustomResourceProps } from './branch_linker_types.js';
 
 const amplifyClient: AmplifyClient = new AmplifyClient();
 

--- a/packages/backend/src/engine/branch-linker/lambda/branch_linker.ts
+++ b/packages/backend/src/engine/branch-linker/lambda/branch_linker.ts
@@ -1,17 +1,17 @@
 import {
-  CloudFormationCustomResourceEvent,
-  CloudFormationCustomResourceSuccessResponse,
+  type CloudFormationCustomResourceEvent,
+  type CloudFormationCustomResourceSuccessResponse,
 } from 'aws-lambda';
 import { randomUUID } from 'node:crypto';
 import {
   AmplifyClient,
-  Branch,
+  type Branch,
   GetBranchCommand,
   NotFoundException,
   UpdateBranchCommand,
-  UpdateBranchCommandInput,
+  type UpdateBranchCommandInput,
 } from '@aws-sdk/client-amplify';
-import { AmplifyBranchLinkerCustomResourceProps } from './branch_linker_types.js';
+import { type AmplifyBranchLinkerCustomResourceProps } from './branch_linker_types.js';
 
 /**
  * Handles custom resource events.

--- a/packages/backend/src/engine/nested_stack_resolver.ts
+++ b/packages/backend/src/engine/nested_stack_resolver.ts
@@ -1,5 +1,5 @@
-import { NestedStack, Stack } from 'aws-cdk-lib';
-import { AttributionMetadataStorage } from '@aws-amplify/backend-output-storage';
+import { NestedStack, type Stack } from 'aws-cdk-lib';
+import { type AttributionMetadataStorage } from '@aws-amplify/backend-output-storage';
 import { fileURLToPath } from 'url';
 
 /**

--- a/packages/backend/src/engine/singleton_construct_container.test.ts
+++ b/packages/backend/src/engine/singleton_construct_container.test.ts
@@ -3,13 +3,13 @@ import { SingletonConstructContainer } from './singleton_construct_container.js'
 import { App, Stack } from 'aws-cdk-lib';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import assert from 'node:assert';
-import { Construct } from 'constructs';
+import { type Construct } from 'constructs';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { NestedStackResolver } from './nested_stack_resolver.js';
 import {
-  ConstructContainer,
-  ConstructContainerEntryGenerator,
-  ConstructFactory,
+  type ConstructContainer,
+  type ConstructContainerEntryGenerator,
+  type ConstructFactory,
 } from '@aws-amplify/plugin-types';
 import { AttributionMetadataStorage } from '@aws-amplify/backend-output-storage';
 

--- a/packages/backend/src/engine/singleton_construct_container.ts
+++ b/packages/backend/src/engine/singleton_construct_container.ts
@@ -1,9 +1,9 @@
-import { Construct } from 'constructs';
-import { StackResolver } from './nested_stack_resolver.js';
+import { type Construct } from 'constructs';
+import { type StackResolver } from './nested_stack_resolver.js';
 import {
-  ConstructContainer,
-  ConstructContainerEntryGenerator,
-  ConstructFactory,
+  type ConstructContainer,
+  type ConstructContainerEntryGenerator,
+  type ConstructFactory,
 } from '@aws-amplify/plugin-types';
 import { getBackendIdentifier } from '../backend_identifier.js';
 import { DefaultBackendSecretResolver } from './backend-secret/backend_secret_resolver.js';

--- a/packages/backend/src/engine/toggleable_import_path_verifier.ts
+++ b/packages/backend/src/engine/toggleable_import_path_verifier.ts
@@ -1,4 +1,4 @@
-import { ImportPathVerifier } from '@aws-amplify/plugin-types';
+import { type ImportPathVerifier } from '@aws-amplify/plugin-types';
 import path from 'path';
 import * as os from 'os';
 import { FilePathExtractor } from '@aws-amplify/platform-core';

--- a/packages/backend/src/project_environment_main_stack_creator.ts
+++ b/packages/backend/src/project_environment_main_stack_creator.ts
@@ -1,6 +1,9 @@
-import { BackendIdentifier, MainStackCreator } from '@aws-amplify/plugin-types';
-import { Construct } from 'constructs';
-import { Stack } from 'aws-cdk-lib';
+import {
+  type BackendIdentifier,
+  type MainStackCreator,
+} from '@aws-amplify/plugin-types';
+import { type Construct } from 'constructs';
+import { type Stack } from 'aws-cdk-lib';
 import { AmplifyStack } from './engine/amplify_stack.js';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 

--- a/packages/backend/src/secret.ts
+++ b/packages/backend/src/secret.ts
@@ -1,4 +1,4 @@
-import { BackendSecret } from '@aws-amplify/plugin-types';
+import { type BackendSecret } from '@aws-amplify/plugin-types';
 import { CfnTokenBackendSecret } from './engine/backend-secret/backend_secret.js';
 import { BackendSecretFetcherProviderFactory } from './engine/backend-secret/backend_secret_fetcher_provider_factory.js';
 import { BackendSecretFetcherFactory } from './engine/backend-secret/backend_secret_fetcher_factory.js';

--- a/packages/cli-core/src/printer/printer.ts
+++ b/packages/cli-core/src/printer/printer.ts
@@ -1,4 +1,4 @@
-import { COLOR, color } from '../colors.js';
+import { type COLOR, color } from '../colors.js';
 import { EOL } from 'os';
 
 export type RecordValue = string | number | string[] | Date;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/aws-amplify/cli#readme",
   "dependencies": {
+    "@aws-amplify/backend-deployer": "^0.3.2",
     "@aws-amplify/backend-output-schemas": "^0.4.0",
     "@aws-amplify/backend-secret": "^0.3.0",
     "@aws-amplify/cli-core": "^0.2.0",

--- a/packages/cli/src/backend-identifier/backend_identifier_resolver.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_resolver.ts
@@ -1,5 +1,5 @@
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
-import { NamespaceResolver } from './local_namespace_resolver.js';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type NamespaceResolver } from './local_namespace_resolver.js';
 
 export type BackendIdentifierParameters = {
   stack?: string;

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
@@ -1,7 +1,7 @@
-import { SandboxBackendIdResolver } from '../commands/sandbox/sandbox_id_resolver.js';
+import { type SandboxBackendIdResolver } from '../commands/sandbox/sandbox_id_resolver.js';
 import {
-  BackendIdentifierParameters,
-  BackendIdentifierResolver,
+  type BackendIdentifierParameters,
+  type BackendIdentifierResolver,
 } from './backend_identifier_resolver.js';
 
 /**

--- a/packages/cli/src/backend-identifier/local_namespace_resolver.ts
+++ b/packages/cli/src/backend-identifier/local_namespace_resolver.ts
@@ -1,4 +1,4 @@
-import { PackageJsonReader } from '@aws-amplify/platform-core';
+import { type PackageJsonReader } from '@aws-amplify/platform-core';
 
 export type NamespaceResolver = {
   resolve: () => Promise<string>;

--- a/packages/cli/src/client-config/client_config_generator_adapter.ts
+++ b/packages/cli/src/client-config/client_config_generator_adapter.ts
@@ -1,11 +1,11 @@
 import {
-  ClientConfig,
-  ClientConfigFormat,
+  type ClientConfig,
+  type ClientConfigFormat,
   generateClientConfig,
   generateClientConfigToFile,
 } from '@aws-amplify/client-config';
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 
 /**
  * Adapts static generateClientConfigToFile from @aws-amplify/client-config call to make it injectable and testable.

--- a/packages/cli/src/client-config/client_config_lifecycle_handler.ts
+++ b/packages/cli/src/client-config/client_config_lifecycle_handler.ts
@@ -1,9 +1,9 @@
 import {
-  ClientConfigFormat,
+  type ClientConfigFormat,
   getClientConfigPath,
 } from '@aws-amplify/client-config';
-import { ClientConfigGeneratorAdapter } from './client_config_generator_adapter.js';
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type ClientConfigGeneratorAdapter } from './client_config_generator_adapter.js';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 import fsp from 'fs/promises';
 
 /**

--- a/packages/cli/src/command_failure_handler.test.ts
+++ b/packages/cli/src/command_failure_handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import { handleCommandFailure } from './command_failure_handler.js';
-import { Argv } from 'yargs';
+import { type Argv } from 'yargs';
 import { COLOR, Printer } from '@aws-amplify/cli-core';
 import assert from 'node:assert';
 import { InvalidCredentialError } from './error/credential_error.js';

--- a/packages/cli/src/command_failure_handler.ts
+++ b/packages/cli/src/command_failure_handler.ts
@@ -1,4 +1,4 @@
-import { Argv } from 'yargs';
+import { type Argv } from 'yargs';
 import { COLOR, Printer } from '@aws-amplify/cli-core';
 import { InvalidCredentialError } from './error/credential_error.js';
 import { EOL } from 'os';

--- a/packages/cli/src/command_middleware.test.ts
+++ b/packages/cli/src/command_middleware.test.ts
@@ -5,7 +5,7 @@ import { EOL } from 'node:os';
 import { DEFAULT_PROFILE } from '@smithy/shared-ini-file-loader';
 import fs from 'fs/promises';
 import path from 'path';
-import { ArgumentsCamelCase } from 'yargs';
+import { type ArgumentsCamelCase } from 'yargs';
 
 const restoreEnv = (restoreVal: string | undefined, envVar: string) => {
   if (restoreVal) {

--- a/packages/cli/src/command_middleware.ts
+++ b/packages/cli/src/command_middleware.ts
@@ -1,4 +1,4 @@
-import { ArgumentsCamelCase } from 'yargs';
+import { type ArgumentsCamelCase } from 'yargs';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { EOL } from 'os';
 import { loadConfig } from '@smithy/node-config-provider';

--- a/packages/cli/src/commands/configure/configure_command.ts
+++ b/packages/cli/src/commands/configure/configure_command.ts
@@ -1,4 +1,4 @@
-import { Argv, CommandModule } from 'yargs';
+import { type Argv, type CommandModule } from 'yargs';
 import { handleCommandFailure } from '../../command_failure_handler.js';
 
 /**

--- a/packages/cli/src/commands/configure/configure_command_factory.ts
+++ b/packages/cli/src/commands/configure/configure_command_factory.ts
@@ -1,4 +1,4 @@
-import { CommandModule } from 'yargs';
+import { type CommandModule } from 'yargs';
 import { ConfigureProfileCommand } from './configure_profile_command.js';
 import { ProfileController } from './profile_controller.js';
 import { ConfigureCommand } from './configure_command.js';

--- a/packages/cli/src/commands/configure/configure_profile_command.test.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, mock } from 'node:test';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { ConfigureProfileCommand } from './configure_profile_command.js';

--- a/packages/cli/src/commands/configure/configure_profile_command.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.ts
@@ -1,10 +1,10 @@
-import { Argv, CommandModule } from 'yargs';
+import { type Argv, type CommandModule } from 'yargs';
 import { AmplifyPrompter, Printer } from '@aws-amplify/cli-core';
 import { DEFAULT_PROFILE } from '@smithy/shared-ini-file-loader';
 import { EOL } from 'os';
 import { Open } from '../open/open.js';
-import { ArgumentsKebabCase } from '../../kebab_case.js';
-import { ProfileController } from './profile_controller.js';
+import { type ArgumentsKebabCase } from '../../kebab_case.js';
+import { type ProfileController } from './profile_controller.js';
 
 const configureAccountUrl =
   'https://docs.amplify.aws/gen2/start/account-setup/';

--- a/packages/cli/src/commands/generate/config/generate_config_command.test.ts
+++ b/packages/cli/src/commands/generate/config/generate_config_command.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, it, mock } from 'node:test';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { GenerateConfigCommand } from './generate_config_command.js';
 import { ClientConfigFormat } from '@aws-amplify/client-config';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';

--- a/packages/cli/src/commands/generate/config/generate_config_command.ts
+++ b/packages/cli/src/commands/generate/config/generate_config_command.ts
@@ -1,8 +1,8 @@
-import { Argv, CommandModule } from 'yargs';
+import { type Argv, type CommandModule } from 'yargs';
 import { ClientConfigFormat } from '@aws-amplify/client-config';
-import { BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
-import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
-import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { type BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
+import { type ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
+import { type ArgumentsKebabCase } from '../../../kebab_case.js';
 import { handleCommandFailure } from '../../../command_failure_handler.js';
 
 export type GenerateConfigCommandOptions =

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
@@ -4,7 +4,7 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import assert from 'node:assert';
 import path from 'node:path';
 import { describe, it, mock } from 'node:test';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { BackendIdentifierResolverWithFallback } from '../../../backend-identifier/backend_identifier_with_sandbox_fallback.js';
 import { FormGenerationHandler } from '../../../form-generation/form_generation_handler.js';

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -1,11 +1,11 @@
 import path from 'path';
-import { Argv, CommandModule } from 'yargs';
-import { BackendOutputClient } from '@aws-amplify/deployed-backend-client';
+import { type Argv, type CommandModule } from 'yargs';
+import { type BackendOutputClient } from '@aws-amplify/deployed-backend-client';
 import { graphqlOutputKey } from '@aws-amplify/backend-output-schemas';
-import { BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
+import { type BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { DEFAULT_UI_PATH } from '../../../form-generation/default_form_generation_output_paths.js';
-import { FormGenerationHandler } from '../../../form-generation/form_generation_handler.js';
-import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { type FormGenerationHandler } from '../../../form-generation/form_generation_handler.js';
+import { type ArgumentsKebabCase } from '../../../kebab_case.js';
 import { handleCommandFailure } from '../../../command_failure_handler.js';
 
 export type GenerateFormsCommandOptions =

--- a/packages/cli/src/commands/generate/generate_command.ts
+++ b/packages/cli/src/commands/generate/generate_command.ts
@@ -1,9 +1,9 @@
-import { Argv, CommandModule } from 'yargs';
-import { GenerateConfigCommand } from './config/generate_config_command.js';
-import { GenerateFormsCommand } from './forms/generate_forms_command.js';
-import { GenerateGraphqlClientCodeCommand } from './graphql-client-code/generate_graphql_client_code_command.js';
+import { type Argv, type CommandModule } from 'yargs';
+import { type GenerateConfigCommand } from './config/generate_config_command.js';
+import { type GenerateFormsCommand } from './forms/generate_forms_command.js';
+import { type GenerateGraphqlClientCodeCommand } from './graphql-client-code/generate_graphql_client_code_command.js';
 import { handleCommandFailure } from '../../command_failure_handler.js';
-import { CommandMiddleware } from '../../command_middleware.js';
+import { type CommandMiddleware } from '../../command_middleware.js';
 
 /**
  * An entry point for generate command.

--- a/packages/cli/src/commands/generate/generate_command_factory.ts
+++ b/packages/cli/src/commands/generate/generate_command_factory.ts
@@ -1,4 +1,4 @@
-import { CommandModule } from 'yargs';
+import { type CommandModule } from 'yargs';
 import { GenerateCommand } from './generate_command.js';
 import { GenerateConfigCommand } from './config/generate_config_command.js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_api_code_adapter.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_api_code_adapter.ts
@@ -1,11 +1,11 @@
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 import {
-  GenerateApiCodeProps,
-  GenerateOptions,
-  GenerationResult,
+  type GenerateApiCodeProps,
+  type GenerateOptions,
+  type GenerationResult,
   generateApiCode,
 } from '@aws-amplify/model-generator';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 
 // For some reason using `omit` is causing type errors, so reconstructing without the credentialProvider.
 export type InvokeGenerateApiCodeProps = GenerateOptions &

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { GenerateGraphqlClientCodeCommand } from './generate_graphql_client_code_command.js';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 import path from 'path';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { GenerateApiCodeAdapter } from './generate_api_code_adapter.js';

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
@@ -1,20 +1,20 @@
-import { Argv, CommandModule } from 'yargs';
-import { BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
+import { type Argv, type CommandModule } from 'yargs';
+import { type BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { isAbsolute, resolve } from 'path';
 import {
-  GenerateApiCodeAdapter,
-  InvokeGenerateApiCodeProps,
+  type GenerateApiCodeAdapter,
+  type InvokeGenerateApiCodeProps,
 } from './generate_api_code_adapter.js';
 import {
   GenerateApiCodeFormat,
   GenerateApiCodeModelTarget,
   GenerateApiCodeStatementTarget,
   GenerateApiCodeTypeTarget,
-  GenerateGraphqlCodegenOptions,
-  GenerateIntrospectionOptions,
-  GenerateModelsOptions,
+  type GenerateGraphqlCodegenOptions,
+  type GenerateIntrospectionOptions,
+  type GenerateModelsOptions,
 } from '@aws-amplify/model-generator';
-import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { type ArgumentsKebabCase } from '../../../kebab_case.js';
 import { handleCommandFailure } from '../../../command_failure_handler.js';
 
 type GenerateOptions =

--- a/packages/cli/src/commands/open/open.ts
+++ b/packages/cli/src/commands/open/open.ts
@@ -1,5 +1,5 @@
 import opn from 'open';
-import { ChildProcess } from 'child_process';
+import { type ChildProcess } from 'child_process';
 import { Printer } from '@aws-amplify/cli-core';
 
 /**

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, it, mock } from 'node:test';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import {
-  TestCommandError,
+  type TestCommandError,
   TestCommandRunner,
 } from '../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import {
   PipelineDeployCommand,
-  PipelineDeployCommandOptions,
+  type PipelineDeployCommandOptions,
 } from './pipeline_deploy_command.js';
 import { BackendDeployerFactory } from '@aws-amplify/backend-deployer';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -1,10 +1,10 @@
 import _isCI from 'is-ci';
-import { Argv, CommandModule } from 'yargs';
-import { BackendDeployer } from '@aws-amplify/backend-deployer';
-import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
-import { ArgumentsKebabCase } from '../../kebab_case.js';
+import { type Argv, type CommandModule } from 'yargs';
+import { type BackendDeployer } from '@aws-amplify/backend-deployer';
+import { type ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
+import { type ArgumentsKebabCase } from '../../kebab_case.js';
 import { handleCommandFailure } from '../../command_failure_handler.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 export type PipelineDeployCommandOptions =
   ArgumentsKebabCase<PipelineDeployCommandOptionsCamelCase>;

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command_factory.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command_factory.ts
@@ -1,9 +1,9 @@
-import { CommandModule } from 'yargs';
+import { type CommandModule } from 'yargs';
 import { BackendDeployerFactory } from '@aws-amplify/backend-deployer';
 
 import {
   PipelineDeployCommand,
-  PipelineDeployCommandOptions,
+  type PipelineDeployCommandOptions,
 } from './pipeline_deploy_command.js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';

--- a/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { SandboxDeleteCommand } from './sandbox_delete_command.js';
 import { SandboxCommand } from '../sandbox_command.js';
 import { SandboxSingletonFactory } from '@aws-amplify/sandbox';
 import { createSandboxSecretCommand } from '../sandbox-secret/sandbox_secret_command_factory.js';
-import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
+import { type ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
 import { CommandMiddleware } from '../../../command_middleware.js';
 
 void describe('sandbox delete command', () => {

--- a/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.ts
@@ -1,5 +1,5 @@
-import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
-import { SandboxSingletonFactory } from '@aws-amplify/sandbox';
+import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs';
+import { type SandboxSingletonFactory } from '@aws-amplify/sandbox';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
 import { handleCommandFailure } from '../../../command_failure_handler.js';
 

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command.ts
@@ -1,4 +1,4 @@
-import { Argv, CommandModule } from 'yargs';
+import { type Argv, type CommandModule } from 'yargs';
 import { handleCommandFailure } from '../../../command_failure_handler.js';
 
 /**

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command_factory.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command_factory.ts
@@ -1,4 +1,4 @@
-import { CommandModule } from 'yargs';
+import { type CommandModule } from 'yargs';
 
 import { LocalNamespaceResolver } from '../../../backend-identifier/local_namespace_resolver.js';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, it, mock } from 'node:test';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
-import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import { type SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import {
-  Secret,
-  SecretIdentifier,
+  type Secret,
+  type SecretIdentifier,
   getSecretClient,
 } from '@aws-amplify/backend-secret';
 import { SandboxSecretGetCommand } from './sandbox_secret_get_command.js';

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.ts
@@ -1,8 +1,8 @@
-import { Argv, CommandModule } from 'yargs';
-import { SecretClient } from '@aws-amplify/backend-secret';
-import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import { type Argv, type CommandModule } from 'yargs';
+import { type SecretClient } from '@aws-amplify/backend-secret';
+import { type SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { Printer } from '@aws-amplify/cli-core';
-import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { type ArgumentsKebabCase } from '../../../kebab_case.js';
 import { handleCommandFailure } from '../../../command_failure_handler.js';
 
 /**

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, it, mock } from 'node:test';
 import yargs from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
-import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { Secret, getSecretClient } from '@aws-amplify/backend-secret';
+import { type SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import { type Secret, getSecretClient } from '@aws-amplify/backend-secret';
 import { SandboxSecretListCommand } from './sandbox_secret_list_command.js';
 import { Printer } from '@aws-amplify/cli-core';
 

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.ts
@@ -1,6 +1,6 @@
-import { CommandModule } from 'yargs';
-import { SecretClient } from '@aws-amplify/backend-secret';
-import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import { type CommandModule } from 'yargs';
+import { type SecretClient } from '@aws-amplify/backend-secret';
+import { type SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { Printer } from '@aws-amplify/cli-core';
 
 /**

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, it, mock } from 'node:test';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
-import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import { type SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { getSecretClient } from '@aws-amplify/backend-secret';
 import { SandboxSecretRemoveCommand } from './sandbox_secret_remove_command.js';
 

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
@@ -1,7 +1,7 @@
-import { Argv, CommandModule } from 'yargs';
-import { SecretClient } from '@aws-amplify/backend-secret';
-import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { type Argv, type CommandModule } from 'yargs';
+import { type SecretClient } from '@aws-amplify/backend-secret';
+import { type SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import { type ArgumentsKebabCase } from '../../../kebab_case.js';
 import { handleCommandFailure } from '../../../command_failure_handler.js';
 
 /**

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
-import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { SecretIdentifier, getSecretClient } from '@aws-amplify/backend-secret';
+import { type SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import {
+  type SecretIdentifier,
+  getSecretClient,
+} from '@aws-amplify/backend-secret';
 import { SandboxSecretSetCommand } from './sandbox_secret_set_command.js';
 
 const testSecretName = 'testSecretName';

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
@@ -1,9 +1,9 @@
-import { Argv, CommandModule } from 'yargs';
-import { SecretClient } from '@aws-amplify/backend-secret';
-import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import { type Argv, type CommandModule } from 'yargs';
+import { type SecretClient } from '@aws-amplify/backend-secret';
+import { type SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
 
-import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { type ArgumentsKebabCase } from '../../../kebab_case.js';
 import { handleCommandFailure } from '../../../command_failure_handler.js';
 
 /**

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -1,19 +1,19 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
-import yargs, { CommandModule } from 'yargs';
+import yargs, { type CommandModule } from 'yargs';
 import {
-  TestCommandError,
+  type TestCommandError,
   TestCommandRunner,
 } from '../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import fs from 'fs';
 import fsp from 'fs/promises';
-import { EventHandler, SandboxCommand } from './sandbox_command.js';
+import { type EventHandler, SandboxCommand } from './sandbox_command.js';
 import { createSandboxCommand } from './sandbox_command_factory.js';
 import { SandboxDeleteCommand } from './sandbox-delete/sandbox_delete_command.js';
-import { Sandbox, SandboxSingletonFactory } from '@aws-amplify/sandbox';
+import { type Sandbox, SandboxSingletonFactory } from '@aws-amplify/sandbox';
 import { createSandboxSecretCommand } from './sandbox-secret/sandbox_secret_command_factory.js';
-import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
+import { type ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
 import { CommandMiddleware } from '../../command_middleware.js';
 import path from 'path';
 

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -1,16 +1,16 @@
-import { Argv, CommandModule } from 'yargs';
+import { type Argv, type CommandModule } from 'yargs';
 import fsp from 'fs/promises';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
-import { SandboxSingletonFactory } from '@aws-amplify/sandbox';
+import { type SandboxSingletonFactory } from '@aws-amplify/sandbox';
 import {
   ClientConfigFormat,
   getClientConfigPath,
 } from '@aws-amplify/client-config';
-import { ArgumentsKebabCase } from '../../kebab_case.js';
+import { type ArgumentsKebabCase } from '../../kebab_case.js';
 import { handleCommandFailure } from '../../command_failure_handler.js';
 import { ClientConfigLifecycleHandler } from '../../client-config/client_config_lifecycle_handler.js';
-import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
-import { CommandMiddleware } from '../../command_middleware.js';
+import { type ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
+import { type CommandMiddleware } from '../../command_middleware.js';
 
 export type SandboxCommandOptions =
   ArgumentsKebabCase<SandboxCommandOptionsCamelCase>;

--- a/packages/cli/src/commands/sandbox/sandbox_command_factory.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command_factory.ts
@@ -1,5 +1,8 @@
-import { CommandModule } from 'yargs';
-import { SandboxCommand, SandboxCommandOptions } from './sandbox_command.js';
+import { type CommandModule } from 'yargs';
+import {
+  SandboxCommand,
+  type SandboxCommandOptions,
+} from './sandbox_command.js';
 import { SandboxSingletonFactory } from '@aws-amplify/sandbox';
 import { SandboxDeleteCommand } from './sandbox-delete/sandbox_delete_command.js';
 import { SandboxBackendIdResolver } from './sandbox_id_resolver.js';

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
@@ -1,8 +1,8 @@
 import { ClientConfigFormat } from '@aws-amplify/client-config';
-import { UsageDataEmitter } from '@aws-amplify/platform-core';
+import { type UsageDataEmitter } from '@aws-amplify/platform-core';
 import assert from 'node:assert';
 import { afterEach, describe, it, mock } from 'node:test';
-import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
+import { type ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
 import { SandboxEventHandlerFactory } from './sandbox_event_handler_factory.js';
 import { ClientConfigLifecycleHandler } from '../../client-config/client_config_lifecycle_handler.js';
 import fs from 'fs';

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.ts
@@ -1,7 +1,7 @@
-import { SandboxEventHandlerCreator } from './sandbox_command.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
-import { UsageDataEmitter } from '@aws-amplify/platform-core';
-import { DeployResult } from '@aws-amplify/backend-deployer';
+import { type SandboxEventHandlerCreator } from './sandbox_command.js';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type UsageDataEmitter } from '@aws-amplify/platform-core';
+import { type DeployResult } from '@aws-amplify/backend-deployer';
 import { COLOR, Printer } from '@aws-amplify/cli-core';
 
 /**

--- a/packages/cli/src/commands/sandbox/sandbox_id_resolver.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_id_resolver.ts
@@ -1,6 +1,6 @@
 import { userInfo as _userInfo } from 'os';
-import { NamespaceResolver } from '../../backend-identifier/local_namespace_resolver.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type NamespaceResolver } from '../../backend-identifier/local_namespace_resolver.js';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 /**
  * Resolves an ID that can be used to uniquely identify sandbox environments

--- a/packages/cli/src/form-generation/form_generation_handler.ts
+++ b/packages/cli/src/form-generation/form_generation_handler.ts
@@ -1,7 +1,7 @@
 import { createLocalGraphqlFormGenerator } from '@aws-amplify/form-generator';
 import { createGraphqlDocumentGenerator } from '@aws-amplify/model-generator';
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 
 type FormGenerationParams = {
   modelsOutDir: string;

--- a/packages/cli/src/main_parser_factory.test.ts
+++ b/packages/cli/src/main_parser_factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import {
-  TestCommandError,
+  type TestCommandError,
   TestCommandRunner,
 } from './test-utils/command_runner.js';
 import { createMainParser } from './main_parser_factory.js';

--- a/packages/cli/src/main_parser_factory.ts
+++ b/packages/cli/src/main_parser_factory.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'url';
-import yargs, { Argv } from 'yargs';
+import yargs, { type Argv } from 'yargs';
 import { PackageJsonReader } from '@aws-amplify/platform-core';
 import { createGenerateCommand } from './commands/generate/generate_command_factory.js';
 import { createSandboxCommand } from './commands/sandbox/sandbox_command_factory.js';

--- a/packages/cli/src/test-utils/command_runner.ts
+++ b/packages/cli/src/test-utils/command_runner.ts
@@ -1,4 +1,4 @@
-import { Argv } from 'yargs';
+import { type Argv } from 'yargs';
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 class OutputInterceptor {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
   "references": [
+    { "path": "../backend-deployer" },
     { "path": "../backend-output-schemas" },
     { "path": "../backend-secret" },
     { "path": "../cli-core" },

--- a/packages/client-config/src/client-config-contributor/auth_client_config_contributor.ts
+++ b/packages/client-config/src/client-config-contributor/auth_client_config_contributor.ts
@@ -1,9 +1,9 @@
-import { ClientConfigContributor } from './client_config_contributor.js';
+import { type ClientConfigContributor } from './client_config_contributor.js';
 import {
-  UnifiedBackendOutput,
+  type UnifiedBackendOutput,
   authOutputKey,
 } from '@aws-amplify/backend-output-schemas';
-import { AuthClientConfig } from '../client-config-types/auth_client_config.js';
+import { type AuthClientConfig } from '../client-config-types/auth_client_config.js';
 
 /**
  * Translator for the Auth portion of ClientConfig

--- a/packages/client-config/src/client-config-contributor/client_config_contributor.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor.ts
@@ -1,5 +1,5 @@
-import { ClientConfig } from '../client-config-types/client_config.js';
-import { UnifiedBackendOutput } from '@aws-amplify/backend-output-schemas';
+import { type ClientConfig } from '../client-config-types/client_config.js';
+import { type UnifiedBackendOutput } from '@aws-amplify/backend-output-schemas';
 
 export type ClientConfigContributor = {
   contribute: (

--- a/packages/client-config/src/client-config-contributor/graphql_client_config_contributor.ts
+++ b/packages/client-config/src/client-config-contributor/graphql_client_config_contributor.ts
@@ -1,10 +1,10 @@
-import { ClientConfigContributor } from './client_config_contributor.js';
+import { type ClientConfigContributor } from './client_config_contributor.js';
 import {
-  UnifiedBackendOutput,
+  type UnifiedBackendOutput,
   graphqlOutputKey,
 } from '@aws-amplify/backend-output-schemas';
-import { GraphqlClientConfig } from '../client-config-types/graphql_client_config.js';
-import { ModelIntrospectionSchemaAdapter } from './model_introspection_schema_adapater.js';
+import { type GraphqlClientConfig } from '../client-config-types/graphql_client_config.js';
+import { type ModelIntrospectionSchemaAdapter } from './model_introspection_schema_adapater.js';
 
 /**
  * Translator for the Graphql API portion of ClientConfig

--- a/packages/client-config/src/client-config-contributor/model_introspection_schema_adapater.ts
+++ b/packages/client-config/src/client-config-contributor/model_introspection_schema_adapater.ts
@@ -1,5 +1,5 @@
 import { getModelIntrospectionSchemaFromS3Uri } from '@aws-amplify/model-generator';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 
 /**
  * Adapts static getModelIntrospectionSchemaFromS3Uri from @aws-amplify/model-generator call to make it injectable and testable.

--- a/packages/client-config/src/client-config-contributor/platform_client_config_contributor.ts
+++ b/packages/client-config/src/client-config-contributor/platform_client_config_contributor.ts
@@ -1,9 +1,9 @@
-import { ClientConfigContributor } from './client_config_contributor.js';
+import { type ClientConfigContributor } from './client_config_contributor.js';
 import {
-  UnifiedBackendOutput,
+  type UnifiedBackendOutput,
   platformOutputKey,
 } from '@aws-amplify/backend-output-schemas';
-import { PlatformClientConfig } from '../client-config-types/platform_client_config.js';
+import { type PlatformClientConfig } from '../client-config-types/platform_client_config.js';
 
 /**
  * Translator for the Platform portion of ClientConfig

--- a/packages/client-config/src/client-config-contributor/storage_client_config_contributor.ts
+++ b/packages/client-config/src/client-config-contributor/storage_client_config_contributor.ts
@@ -1,9 +1,9 @@
-import { ClientConfigContributor } from './client_config_contributor.js';
+import { type ClientConfigContributor } from './client_config_contributor.js';
 import {
-  UnifiedBackendOutput,
+  type UnifiedBackendOutput,
   storageOutputKey,
 } from '@aws-amplify/backend-output-schemas';
-import { StorageClientConfig } from '../client-config-types/storage_client_config.js';
+import { type StorageClientConfig } from '../client-config-types/storage_client_config.js';
 
 /**
  * Translator for the Storage portion of ClientConfig

--- a/packages/client-config/src/client-config-types/client_config.ts
+++ b/packages/client-config/src/client-config-types/client_config.ts
@@ -1,7 +1,7 @@
-import { AuthClientConfig } from './auth_client_config.js';
-import { GraphqlClientConfig } from './graphql_client_config.js';
-import { PlatformClientConfig } from './platform_client_config.js';
-import { StorageClientConfig } from './storage_client_config.js';
+import { type AuthClientConfig } from './auth_client_config.js';
+import { type GraphqlClientConfig } from './graphql_client_config.js';
+import { type PlatformClientConfig } from './platform_client_config.js';
+import { type StorageClientConfig } from './storage_client_config.js';
 
 /**
  * Merged type of all category client config types

--- a/packages/client-config/src/client-config-writer/client_config_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { ClientConfigConverter } from './client_config_converter.js';
-import { ClientConfigMobile } from '../client-config-types/mobile/client_config_mobile_types.js';
-import { ClientConfig } from '../client-config-types/client_config.js';
+import { type ClientConfigMobile } from '../client-config-types/mobile/client_config_mobile_types.js';
+import { type ClientConfig } from '../client-config-types/client_config.js';
 
 void describe('client config converter', () => {
   const testPackageName = 'test_package_name';

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -1,8 +1,8 @@
-import { ClientConfig } from '../client-config-types/client_config.js';
+import { type ClientConfig } from '../client-config-types/client_config.js';
 import {
-  ClientConfigMobile,
-  ClientConfigMobileApi,
-  ClientConfigMobileAuth,
+  type ClientConfigMobile,
+  type ClientConfigMobileApi,
+  type ClientConfigMobileAuth,
 } from '../client-config-types/mobile/client_config_mobile_types.js';
 
 /**

--- a/packages/client-config/src/client-config-writer/client_config_formatter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import { ClientConfigFormatter } from './client_config_formatter.js';
 import {
-  ClientConfig,
+  type ClientConfig,
   ClientConfigFormat,
 } from '../client-config-types/client_config.js';
 import assert from 'node:assert';
@@ -10,7 +10,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { randomUUID } from 'crypto';
 import { ClientConfigConverter } from './client_config_converter.js';
-import { ClientConfigMobile } from '../client-config-types/mobile/client_config_mobile_types.js';
+import { type ClientConfigMobile } from '../client-config-types/mobile/client_config_mobile_types.js';
 
 void describe('client config formatter', () => {
   const sampleUserPoolId = randomUUID();

--- a/packages/client-config/src/client-config-writer/client_config_formatter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter.ts
@@ -1,9 +1,9 @@
 import {
-  ClientConfig,
+  type ClientConfig,
   ClientConfigFormat,
 } from '../client-config-types/client_config.js';
 import os from 'os';
-import { ClientConfigConverter } from './client_config_converter.js';
+import { type ClientConfigConverter } from './client_config_converter.js';
 
 /**
  * Formats client config to desired format.

--- a/packages/client-config/src/client-config-writer/client_config_writer.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_writer.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import {
-  ClientConfigPathResolver,
+  type ClientConfigPathResolver,
   ClientConfigWriter,
 } from './client_config_writer.js';
 import {
-  ClientConfig,
+  type ClientConfig,
   ClientConfigFormat,
 } from '../client-config-types/client_config.js';
 import { ClientConfigFormatter } from './client_config_formatter.js';

--- a/packages/client-config/src/client-config-writer/client_config_writer.ts
+++ b/packages/client-config/src/client-config-writer/client_config_writer.ts
@@ -1,9 +1,9 @@
 import _fsp from 'fs/promises';
 import {
-  ClientConfig,
+  type ClientConfig,
   ClientConfigFormat,
 } from '../client-config-types/client_config.js';
-import { ClientConfigFormatter } from './client_config_formatter.js';
+import { type ClientConfigFormatter } from './client_config_formatter.js';
 
 export type ClientConfigPathResolver = (
   outDir?: string,

--- a/packages/client-config/src/client_config_generator.ts
+++ b/packages/client-config/src/client_config_generator.ts
@@ -1,4 +1,4 @@
-import { ClientConfig } from './client-config-types/client_config.js';
+import { type ClientConfig } from './client-config-types/client_config.js';
 
 export type ClientConfigGenerator = {
   generateClientConfig: () => Promise<ClientConfig>;

--- a/packages/client-config/src/client_config_generator_factory.ts
+++ b/packages/client-config/src/client_config_generator_factory.ts
@@ -1,10 +1,10 @@
 import { UnifiedClientConfigGenerator } from './unified_client_config_generator.js';
 import { AuthClientConfigContributor } from './client-config-contributor/auth_client_config_contributor.js';
 import { GraphqlClientConfigContributor } from './client-config-contributor/graphql_client_config_contributor.js';
-import { ClientConfigGenerator } from './client_config_generator.js';
+import { type ClientConfigGenerator } from './client_config_generator.js';
 import { StorageClientConfigContributor } from './client-config-contributor/storage_client_config_contributor.js';
-import { BackendOutput } from '@aws-amplify/plugin-types';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type BackendOutput } from '@aws-amplify/plugin-types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { ModelIntrospectionSchemaAdapter } from './client-config-contributor/model_introspection_schema_adapater.js';
 import { PlatformClientConfigContributor } from './client-config-contributor/platform_client_config_contributor.js';
 

--- a/packages/client-config/src/generate_client_config.ts
+++ b/packages/client-config/src/generate_client_config.ts
@@ -1,9 +1,9 @@
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { ClientConfigGeneratorFactory } from './client_config_generator_factory.js';
-import { ClientConfig } from './client-config-types/client_config.js';
+import { type ClientConfig } from './client-config-types/client_config.js';
 import {
   BackendOutputClientFactory,
-  DeployedBackendIdentifier,
+  type DeployedBackendIdentifier,
 } from '@aws-amplify/deployed-backend-client';
 
 // Because this function is acting as the DI container for this functionality, there is no way to test it without

--- a/packages/client-config/src/generate_client_config_to_file.ts
+++ b/packages/client-config/src/generate_client_config_to_file.ts
@@ -1,9 +1,9 @@
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { generateClientConfig } from './generate_client_config.js';
 import { ClientConfigWriter } from './client-config-writer/client_config_writer.js';
-import { ClientConfigFormat } from './client-config-types/client_config.js';
+import { type ClientConfigFormat } from './client-config-types/client_config.js';
 import { getClientConfigPath } from './paths/index.js';
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 import { ClientConfigFormatter } from './client-config-writer/client_config_formatter.js';
 import { ClientConfigConverter } from './client-config-writer/client_config_converter.js';
 import { fileURLToPath } from 'url';

--- a/packages/client-config/src/index.internal.ts
+++ b/packages/client-config/src/index.internal.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/export */
 export * from './index.js';
 
 /*
@@ -5,5 +6,4 @@ export * from './index.js';
  Because this package has a submodule export, we are working around this issue by including that export here and directing api-extract to this entry point instead
  This allows api-extractor to pick up the submodule exports in its analysis
  */
-
 export * from './paths/index.js';

--- a/packages/client-config/src/unified_client_config_generator.test.ts
+++ b/packages/client-config/src/unified_client_config_generator.test.ts
@@ -4,12 +4,12 @@ import assert from 'node:assert';
 import { AuthClientConfigContributor } from './client-config-contributor/auth_client_config_contributor.js';
 import { GraphqlClientConfigContributor } from './client-config-contributor/graphql_client_config_contributor.js';
 import {
-  UnifiedBackendOutput,
+  type UnifiedBackendOutput,
   authOutputKey,
   graphqlOutputKey,
   platformOutputKey,
 } from '@aws-amplify/backend-output-schemas';
-import { ClientConfig } from './client-config-types/client_config.js';
+import { type ClientConfig } from './client-config-types/client_config.js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { ModelIntrospectionSchemaAdapter } from './client-config-contributor/model_introspection_schema_adapater.js';
 import { PlatformClientConfigContributor } from './client-config-contributor/platform_client_config_contributor.js';

--- a/packages/client-config/src/unified_client_config_generator.ts
+++ b/packages/client-config/src/unified_client_config_generator.ts
@@ -1,8 +1,8 @@
-import { BackendOutput } from '@aws-amplify/plugin-types';
+import { type BackendOutput } from '@aws-amplify/plugin-types';
 import { unifiedBackendOutputSchema } from '@aws-amplify/backend-output-schemas';
-import { ClientConfig } from './client-config-types/client_config.js';
-import { ClientConfigContributor } from './client-config-contributor/client_config_contributor.js';
-import { ClientConfigGenerator } from './client_config_generator.js';
+import { type ClientConfig } from './client-config-types/client_config.js';
+import { type ClientConfigContributor } from './client-config-contributor/client_config_contributor.js';
+import { type ClientConfigGenerator } from './client_config_generator.js';
 
 /**
  * Right now this is mostly a stub. This will become a translation layer between backend output and frontend config

--- a/packages/create-amplify/src/amplify_project_creator.ts
+++ b/packages/create-amplify/src/amplify_project_creator.ts
@@ -1,8 +1,8 @@
-import { PackageManagerController } from './package_manager_controller.js';
-import { ProjectRootValidator } from './project_root_validator.js';
-import { InitialProjectFileGenerator } from './initial_project_file_generator.js';
-import { NpmProjectInitializer } from './npm_project_initializer.js';
-import { GitIgnoreInitializer } from './gitignore_initializer.js';
+import { type PackageManagerController } from './package_manager_controller.js';
+import { type ProjectRootValidator } from './project_root_validator.js';
+import { type InitialProjectFileGenerator } from './initial_project_file_generator.js';
+import { type NpmProjectInitializer } from './npm_project_initializer.js';
+import { type GitIgnoreInitializer } from './gitignore_initializer.js';
 import { logger } from './logger.js';
 
 /**

--- a/packages/create-amplify/src/npm_package_manager_controller.ts
+++ b/packages/create-amplify/src/npm_package_manager_controller.ts
@@ -1,7 +1,7 @@
 import { execa as _execa } from 'execa';
 import {
-  DependencyType,
-  PackageManagerController,
+  type DependencyType,
+  type PackageManagerController,
 } from './package_manager_controller.js';
 import { executeWithDebugLogger } from './execute_with_logger.js';
 

--- a/packages/deployed-backend-client/src/backend_output_client.ts
+++ b/packages/deployed-backend-client/src/backend_output_client.ts
@@ -1,9 +1,9 @@
 import { unifiedBackendOutputSchema } from '@aws-amplify/backend-output-schemas';
-import { AmplifyClient } from '@aws-sdk/client-amplify';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { type AmplifyClient } from '@aws-sdk/client-amplify';
+import { type CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { BackendOutputFetcherFactory } from './backend_output_fetcher_factory.js';
-import { DeployedBackendIdentifier } from './index.js';
-import { BackendOutputClient } from './backend_output_client_factory.js';
+import { type DeployedBackendIdentifier } from './index.js';
+import { type BackendOutputClient } from './backend_output_client_factory.js';
 
 /**
  * Simplifies the retrieval of all backend output values

--- a/packages/deployed-backend-client/src/backend_output_client_factory.ts
+++ b/packages/deployed-backend-client/src/backend_output_client_factory.ts
@@ -1,7 +1,7 @@
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
-import { DeployedBackendIdentifier } from './index.js';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type DeployedBackendIdentifier } from './index.js';
 import { DefaultBackendOutputClient } from './backend_output_client.js';
-import { UnifiedBackendOutput } from '@aws-amplify/backend-output-schemas';
+import { type UnifiedBackendOutput } from '@aws-amplify/backend-output-schemas';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 

--- a/packages/deployed-backend-client/src/backend_output_fetcher_factory.test.ts
+++ b/packages/deployed-backend-client/src/backend_output_fetcher_factory.test.ts
@@ -5,7 +5,7 @@ import {
   isBackendIdentifier,
   isStackIdentifier,
 } from './backend_output_fetcher_factory.js';
-import { DeployedBackendIdentifier } from './deployed_backend_identifier.js';
+import { type DeployedBackendIdentifier } from './deployed_backend_identifier.js';
 
 void describe('Backend Identifiers', () => {
   const backendIdentifiers: DeployedBackendIdentifier[] = [

--- a/packages/deployed-backend-client/src/backend_output_fetcher_factory.ts
+++ b/packages/deployed-backend-client/src/backend_output_fetcher_factory.ts
@@ -1,17 +1,17 @@
-import { AmplifyClient } from '@aws-sdk/client-amplify';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
-import { DeployedBackendIdentifier } from './deployed_backend_identifier.js';
+import { type AmplifyClient } from '@aws-sdk/client-amplify';
+import { type CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { type DeployedBackendIdentifier } from './deployed_backend_identifier.js';
 import {
-  AppNameAndBranchBackendIdentifier,
+  type AppNameAndBranchBackendIdentifier,
   AppNameAndBranchMainStackNameResolver,
 } from './stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.js';
 import {
   PassThroughMainStackNameResolver,
-  StackIdentifier,
+  type StackIdentifier,
 } from './stack-name-resolvers/passthrough_main_stack_name_resolver.js';
 import { BackendIdentifierMainStackNameResolver } from './stack-name-resolvers/backend_identifier_main_stack_name_resolver.js';
 import { StackMetadataBackendOutputRetrievalStrategy } from './stack_metadata_output_retrieval_strategy.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 /**
  * Asserts that a BackendIdentifier is a BackendIdentifier

--- a/packages/deployed-backend-client/src/deployed-backend-client/arn_generator.test.ts
+++ b/packages/deployed-backend-client/src/deployed-backend-client/arn_generator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { ArnGenerator } from './arn_generator.js';
-import { ResourceStatus } from '@aws-sdk/client-cloudformation';
+import { type ResourceStatus } from '@aws-sdk/client-cloudformation';
 
 void describe('arn generator', () => {
   const mockResourceSummaryBase = {

--- a/packages/deployed-backend-client/src/deployed-backend-client/arn_generator.ts
+++ b/packages/deployed-backend-client/src/deployed-backend-client/arn_generator.ts
@@ -1,4 +1,4 @@
-import { StackResourceSummary } from '@aws-sdk/client-cloudformation';
+import { type StackResourceSummary } from '@aws-sdk/client-cloudformation';
 
 /**
  * Generates a link to a resource in the AWS Console

--- a/packages/deployed-backend-client/src/deployed-backend-client/deployed_resources_enumerator.test.ts
+++ b/packages/deployed-backend-client/src/deployed-backend-client/deployed_resources_enumerator.test.ts
@@ -2,12 +2,12 @@ import { beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import {
   CloudFormation,
-  ListStackResourcesCommand,
-  StackResourceSummary,
+  type ListStackResourcesCommand,
+  type StackResourceSummary,
 } from '@aws-sdk/client-cloudformation';
 import {
   BackendDeploymentStatus,
-  DeployedBackendResource,
+  type DeployedBackendResource,
 } from '../deployed_backend_client_factory.js';
 import { DeployedResourcesEnumerator } from './deployed_resources_enumerator.js';
 import { StackStatusMapper } from './stack_status_mapper.js';

--- a/packages/deployed-backend-client/src/deployed-backend-client/deployed_resources_enumerator.ts
+++ b/packages/deployed-backend-client/src/deployed-backend-client/deployed_resources_enumerator.ts
@@ -1,13 +1,13 @@
 import {
-  CloudFormationClient,
+  type CloudFormationClient,
   ListStackResourcesCommand,
-  ListStackResourcesCommandOutput,
-  StackResourceSummary,
+  type ListStackResourcesCommandOutput,
+  type StackResourceSummary,
 } from '@aws-sdk/client-cloudformation';
-import { DeployedBackendResource } from '../deployed_backend_client_factory.js';
-import { StackStatusMapper } from './stack_status_mapper.js';
-import { ArnGenerator } from './arn_generator.js';
-import { ArnParser } from './arn_parser.js';
+import { type DeployedBackendResource } from '../deployed_backend_client_factory.js';
+import { type StackStatusMapper } from './stack_status_mapper.js';
+import { type ArnGenerator } from './arn_generator.js';
+import { type ArnParser } from './arn_parser.js';
 
 /**
  * Lists deployed resources

--- a/packages/deployed-backend-client/src/deployed_backend_client.test.ts
+++ b/packages/deployed-backend-client/src/deployed_backend_client.test.ts
@@ -6,7 +6,7 @@ import {
   DescribeStacksCommand,
   ListStackResourcesCommand,
   ListStacksCommand,
-  ListStacksCommandInput,
+  type ListStacksCommandInput,
   StackStatus,
 } from '@aws-sdk/client-cloudformation';
 import { BackendDeploymentStatus } from './deployed_backend_client_factory.js';
@@ -18,9 +18,9 @@ import {
 } from '@aws-amplify/backend-output-schemas';
 import { DefaultBackendOutputClient } from './backend_output_client.js';
 import { DefaultDeployedBackendClient } from './deployed_backend_client.js';
-import { StackIdentifier } from './index.js';
+import { type StackIdentifier } from './index.js';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
-import { GetObjectCommand, S3 } from '@aws-sdk/client-s3';
+import { type GetObjectCommand, S3 } from '@aws-sdk/client-s3';
 import { DeployedResourcesEnumerator } from './deployed-backend-client/deployed_resources_enumerator.js';
 import { StackStatusMapper } from './deployed-backend-client/stack_status_mapper.js';
 import { ArnGenerator } from './deployed-backend-client/arn_generator.js';

--- a/packages/deployed-backend-client/src/deployed_backend_client.ts
+++ b/packages/deployed-backend-client/src/deployed_backend_client.ts
@@ -1,42 +1,42 @@
 import {
-  BackendIdentifier,
-  BackendOutput,
-  DeploymentType,
+  type BackendIdentifier,
+  type BackendOutput,
+  type DeploymentType,
 } from '@aws-amplify/plugin-types';
 import {
-  ApiAuthType,
-  BackendMetadata,
-  ConflictResolutionMode,
-  DeployedBackendClient,
-  ListSandboxesRequest,
-  ListSandboxesResponse,
-  SandboxMetadata,
+  type ApiAuthType,
+  type BackendMetadata,
+  type ConflictResolutionMode,
+  type DeployedBackendClient,
+  type ListSandboxesRequest,
+  type ListSandboxesResponse,
+  type SandboxMetadata,
 } from './deployed_backend_client_factory.js';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
-import { BackendOutputClient } from './backend_output_client_factory.js';
+import { type BackendOutputClient } from './backend_output_client_factory.js';
 import {
-  CloudFormationClient,
+  type CloudFormationClient,
   DeleteStackCommand,
   DescribeStacksCommand,
   ListStackResourcesCommand,
   ListStacksCommand,
-  ListStacksCommandOutput,
-  Stack,
-  StackResourceSummary,
+  type ListStacksCommandOutput,
+  type Stack,
+  type StackResourceSummary,
   StackStatus,
-  StackSummary,
+  type StackSummary,
 } from '@aws-sdk/client-cloudformation';
 
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand, type S3Client } from '@aws-sdk/client-s3';
 import {
   authOutputKey,
   graphqlOutputKey,
   platformOutputKey,
   storageOutputKey,
 } from '@aws-amplify/backend-output-schemas';
-import { DeployedResourcesEnumerator } from './deployed-backend-client/deployed_resources_enumerator.js';
-import { StackStatusMapper } from './deployed-backend-client/stack_status_mapper.js';
-import { ArnParser } from './deployed-backend-client/arn_parser.js';
+import { type DeployedResourcesEnumerator } from './deployed-backend-client/deployed_resources_enumerator.js';
+import { type StackStatusMapper } from './deployed-backend-client/stack_status_mapper.js';
+import { type ArnParser } from './deployed-backend-client/arn_parser.js';
 
 /**
  * Deployment Client

--- a/packages/deployed-backend-client/src/deployed_backend_client_factory.ts
+++ b/packages/deployed-backend-client/src/deployed_backend_client_factory.ts
@@ -1,9 +1,12 @@
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { DefaultDeployedBackendClient } from './deployed_backend_client.js';
-import { BackendIdentifier, DeploymentType } from '@aws-amplify/plugin-types';
+import {
+  type BackendIdentifier,
+  type DeploymentType,
+} from '@aws-amplify/plugin-types';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import {
-  BackendOutputClient,
+  type BackendOutputClient,
   BackendOutputClientFactory,
 } from './backend_output_client_factory.js';
 import { S3Client } from '@aws-sdk/client-s3';

--- a/packages/deployed-backend-client/src/deployed_backend_identifier.ts
+++ b/packages/deployed-backend-client/src/deployed_backend_identifier.ts
@@ -1,6 +1,6 @@
-import { StackIdentifier } from './stack-name-resolvers/passthrough_main_stack_name_resolver.js';
-import { AppNameAndBranchBackendIdentifier } from './stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type StackIdentifier } from './stack-name-resolvers/passthrough_main_stack_name_resolver.js';
+import { type AppNameAndBranchBackendIdentifier } from './stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.js';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 export type DeployedBackendIdentifier =
   | BackendIdentifier

--- a/packages/deployed-backend-client/src/index.ts
+++ b/packages/deployed-backend-client/src/index.ts
@@ -1,5 +1,5 @@
 export * from './deployed_backend_identifier.js';
 export * from './backend_output_client_factory.js';
 export * from './deployed_backend_client_factory.js';
-export { AppNameAndBranchBackendIdentifier } from './stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.js';
-export { StackIdentifier } from './stack-name-resolvers/passthrough_main_stack_name_resolver.js';
+export type { AppNameAndBranchBackendIdentifier } from './stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.js';
+export type { StackIdentifier } from './stack-name-resolvers/passthrough_main_stack_name_resolver.js';

--- a/packages/deployed-backend-client/src/stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.test.ts
+++ b/packages/deployed-backend-client/src/stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import {
-  AppNameAndBranchBackendIdentifier,
+  type AppNameAndBranchBackendIdentifier,
   AppNameAndBranchMainStackNameResolver,
 } from './app_name_and_branch_main_stack_name_resolver.js';
 import assert from 'node:assert';

--- a/packages/deployed-backend-client/src/stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.ts
+++ b/packages/deployed-backend-client/src/stack-name-resolvers/app_name_and_branch_main_stack_name_resolver.ts
@@ -1,5 +1,5 @@
-import { MainStackNameResolver } from '@aws-amplify/plugin-types';
-import { AmplifyClient, ListAppsCommand } from '@aws-sdk/client-amplify';
+import { type MainStackNameResolver } from '@aws-amplify/plugin-types';
+import { type AmplifyClient, ListAppsCommand } from '@aws-sdk/client-amplify';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 
 /**

--- a/packages/deployed-backend-client/src/stack-name-resolvers/backend_identifier_main_stack_name_resolver.test.ts
+++ b/packages/deployed-backend-client/src/stack-name-resolvers/backend_identifier_main_stack_name_resolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { BackendIdentifierMainStackNameResolver } from './backend_identifier_main_stack_name_resolver.js';
 import assert from 'node:assert';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 void describe('BackendIdentifierMainStackNameResolver', () => {
   void describe('resolveMainStackName', () => {

--- a/packages/deployed-backend-client/src/stack-name-resolvers/backend_identifier_main_stack_name_resolver.ts
+++ b/packages/deployed-backend-client/src/stack-name-resolvers/backend_identifier_main_stack_name_resolver.ts
@@ -1,6 +1,6 @@
 import {
-  BackendIdentifier,
-  MainStackNameResolver,
+  type BackendIdentifier,
+  type MainStackNameResolver,
 } from '@aws-amplify/plugin-types';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 

--- a/packages/deployed-backend-client/src/stack-name-resolvers/passthrough_main_stack_name_resolver.ts
+++ b/packages/deployed-backend-client/src/stack-name-resolvers/passthrough_main_stack_name_resolver.ts
@@ -1,4 +1,4 @@
-import { MainStackNameResolver } from '@aws-amplify/plugin-types';
+import { type MainStackNameResolver } from '@aws-amplify/plugin-types';
 
 export type StackIdentifier = {
   stackName: string;

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.test.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, mock } from 'node:test';
 import {
-  CloudFormationClient,
+  type CloudFormationClient,
   DescribeStacksCommand,
   GetTemplateSummaryCommand,
 } from '@aws-sdk/client-cloudformation';
 import { StackMetadataBackendOutputRetrievalStrategy } from './stack_metadata_output_retrieval_strategy.js';
 import assert from 'node:assert';
-import { MainStackNameResolver } from '@aws-amplify/plugin-types';
+import { type MainStackNameResolver } from '@aws-amplify/plugin-types';
 import {
   authOutputKey,
   graphqlOutputKey,

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
@@ -1,12 +1,12 @@
 import {
-  CloudFormationClient,
+  type CloudFormationClient,
   DescribeStacksCommand,
   GetTemplateSummaryCommand,
 } from '@aws-sdk/client-cloudformation';
 import {
-  BackendOutput,
-  BackendOutputRetrievalStrategy,
-  MainStackNameResolver,
+  type BackendOutput,
+  type BackendOutputRetrievalStrategy,
+  type MainStackNameResolver,
 } from '@aws-amplify/plugin-types';
 import { backendOutputStackMetadataSchema } from '@aws-amplify/backend-output-schemas';
 import {

--- a/packages/form-generator/src/codegen_graphql_form_generation_result.ts
+++ b/packages/form-generator/src/codegen_graphql_form_generation_result.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs/promises';
-import { GraphqlGenerationResult } from './graphql_form_generator.js';
+import { type GraphqlGenerationResult } from './graphql_form_generator.js';
 
 /**
  * Encapsulates a result from a call to the codegen form generation service

--- a/packages/form-generator/src/create_form_generator.ts
+++ b/packages/form-generator/src/create_form_generator.ts
@@ -1,6 +1,6 @@
 import { S3Client } from '@aws-sdk/client-s3';
 import { transformIntrospectionSchema } from './transform_appsync_introspection_schema.js';
-import { GraphqlFormGenerator } from './graphql_form_generator.js';
+import { type GraphqlFormGenerator } from './graphql_form_generator.js';
 import { LocalGraphqlFormGenerator } from './local_codegen_graphql_form_generator.js';
 import { S3StringObjectFetcher } from './s3_string_object_fetcher.js';
 import { CodegenGraphqlFormGeneratorResult } from './codegen_graphql_form_generation_result.js';

--- a/packages/form-generator/src/local_codegen_graphql_form_generator.test.ts
+++ b/packages/form-generator/src/local_codegen_graphql_form_generator.test.ts
@@ -1,11 +1,11 @@
-import { GenericDataSchema } from '@aws-amplify/codegen-ui';
+import { type GenericDataSchema } from '@aws-amplify/codegen-ui';
 import assert from 'assert';
 import { describe, it, mock } from 'node:test';
 import fs from 'fs/promises';
 import { CodegenGraphqlFormGeneratorResult } from './codegen_graphql_form_generation_result.js';
 import {
   LocalGraphqlFormGenerator,
-  ResultBuilder,
+  type ResultBuilder,
 } from './local_codegen_graphql_form_generator.js';
 
 type MockDataType = 'String' | 'ID' | 'AWSDateTime';

--- a/packages/form-generator/src/local_codegen_graphql_form_generator.ts
+++ b/packages/form-generator/src/local_codegen_graphql_form_generator.ts
@@ -1,24 +1,24 @@
 import {
-  FormFeatureFlags,
-  GenericDataSchema,
-  StudioForm,
-  StudioSchema,
+  type FormFeatureFlags,
+  type GenericDataSchema,
+  type StudioForm,
+  type StudioSchema,
 } from '@aws-amplify/codegen-ui';
 import {
   AmplifyFormRenderer,
   ModuleKind,
   ReactIndexStudioTemplateRenderer,
-  ReactRenderConfig,
+  type ReactRenderConfig,
   ReactUtilsStudioTemplateRenderer,
   ScriptKind,
   ScriptTarget,
-  UtilTemplateType,
+  type UtilTemplateType,
   getDeclarationFilename,
 } from '@aws-amplify/codegen-ui-react';
 import {
-  FormGenerationOptions,
-  GraphqlFormGenerator,
-  GraphqlGenerationResult,
+  type FormGenerationOptions,
+  type GraphqlFormGenerator,
+  type GraphqlGenerationResult,
 } from './graphql_form_generator.js';
 
 type FormDef = Set<'create' | 'update'>;

--- a/packages/form-generator/src/s3_string_object_fetcher.ts
+++ b/packages/form-generator/src/s3_string_object_fetcher.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand, type S3Client } from '@aws-sdk/client-s3';
 
 /**
  * Handles fetching an object from an s3 bucket and parsing the object contents to a string

--- a/packages/form-generator/src/transform_appsync_introspection_schema.ts
+++ b/packages/form-generator/src/transform_appsync_introspection_schema.ts
@@ -1,5 +1,5 @@
 import {
-  GenericDataSchema,
+  type GenericDataSchema,
   getGenericFromDataStore,
 } from '@aws-amplify/codegen-ui';
 import { parse } from 'graphql';

--- a/packages/function-construct/src/construct.ts
+++ b/packages/function-construct/src/construct.ts
@@ -1,6 +1,9 @@
 import { Construct } from 'constructs';
 import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
-import { AmplifyFunction, FunctionResources } from '@aws-amplify/plugin-types';
+import {
+  type AmplifyFunction,
+  type FunctionResources,
+} from '@aws-amplify/plugin-types';
 import { AttributionMetadataStorage } from '@aws-amplify/backend-output-storage';
 import { Stack } from 'aws-cdk-lib';
 import { fileURLToPath } from 'url';

--- a/packages/integration-tests/src/amplify_app_pool.ts
+++ b/packages/integration-tests/src/amplify_app_pool.ts
@@ -1,15 +1,15 @@
 import {
   AmplifyClient,
-  App,
-  Branch,
+  type App,
+  type Branch,
   CreateAppCommand,
   CreateBranchCommand,
   DeleteBranchCommand,
   GetBranchCommand,
   ListAppsCommand,
-  ListAppsCommandOutput,
+  type ListAppsCommandOutput,
   ListBranchesCommand,
-  ListBranchesCommandOutput,
+  type ListBranchesCommandOutput,
 } from '@aws-sdk/client-amplify';
 import { shortUuid } from './short_uuid.js';
 

--- a/packages/integration-tests/src/cdk_out_dir_validator.ts
+++ b/packages/integration-tests/src/cdk_out_dir_validator.ts
@@ -4,7 +4,11 @@ import assert from 'node:assert';
 import * as fse from 'fs-extra/esm';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
-import { ObjectPath, Predicate, assertCustomMatch } from './object_compare.js';
+import {
+  type ObjectPath,
+  type Predicate,
+  assertCustomMatch,
+} from './object_compare.js';
 
 const UPDATE_SNAPSHOTS = process.env.UPDATE_INTEGRATION_SNAPSHOTS === 'true';
 

--- a/packages/integration-tests/src/cdk_snapshot_test_suite_generator.ts
+++ b/packages/integration-tests/src/cdk_snapshot_test_suite_generator.ts
@@ -1,4 +1,4 @@
-import { CDKSynthSnapshotTestCase } from './cdk_snapshot_test_runner.js';
+import { type CDKSynthSnapshotTestCase } from './cdk_snapshot_test_runner.js';
 import { BackendLocator } from '@aws-amplify/platform-core';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/integration-tests/src/process-controller/execa_process_killer.ts
+++ b/packages/integration-tests/src/process-controller/execa_process_killer.ts
@@ -1,4 +1,4 @@
-import { ExecaChildProcess, execa } from 'execa';
+import { type ExecaChildProcess, execa } from 'execa';
 
 /**
  * Kills the given process (equivalent of sending CTRL-C)

--- a/packages/integration-tests/src/process-controller/predicated_action.ts
+++ b/packages/integration-tests/src/process-controller/predicated_action.ts
@@ -1,4 +1,4 @@
-import { ExecaChildProcess } from 'execa';
+import { type ExecaChildProcess } from 'execa';
 
 /**
  * Type of actions a user can take with their app.

--- a/packages/integration-tests/src/process-controller/predicated_action_queue_builder.ts
+++ b/packages/integration-tests/src/process-controller/predicated_action_queue_builder.ts
@@ -1,13 +1,13 @@
 import {
   ActionType,
   PredicateType,
-  PredicatedAction,
+  type PredicatedAction,
 } from './predicated_action.js';
 import os from 'os';
 import fs from 'fs/promises';
 
 import { killExecaProcess } from './execa_process_killer.js';
-import { ExecaChildProcess } from 'execa';
+import { type ExecaChildProcess } from 'execa';
 
 export const CONTROL_C = '\x03';
 /**

--- a/packages/integration-tests/src/process-controller/process_controller.ts
+++ b/packages/integration-tests/src/process-controller/process_controller.ts
@@ -1,4 +1,4 @@
-import { Options, execa, execaSync } from 'execa';
+import { type Options, execa, execaSync } from 'execa';
 import readline from 'readline';
 import { PredicatedActionBuilder } from './predicated_action_queue_builder.js';
 import { ActionType } from './predicated_action.js';

--- a/packages/integration-tests/src/test-e2e/deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment.test.ts
@@ -7,7 +7,7 @@ import {
 import fs from 'fs/promises';
 import { shortUuid } from '../short_uuid.js';
 import { getTestProjectCreators } from '../test-project-setup/test_project_creator.js';
-import { TestProjectBase } from '../test-project-setup/test_project_base.js';
+import { type TestProjectBase } from '../test-project-setup/test_project_base.js';
 import { userInfo } from 'os';
 import { PredicatedActionBuilder } from '../process-controller/predicated_action_queue_builder.js';
 import { amplifyCli } from '../process-controller/process_controller.js';
@@ -19,8 +19,8 @@ import {
   updateFileContent,
 } from '../process-controller/predicated_action_macros.js';
 import assert from 'node:assert';
-import { TestBranch, amplifyAppPool } from '../amplify_app_pool.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type TestBranch, amplifyAppPool } from '../amplify_app_pool.js';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 import { testConcurrencyLevel } from './test_concurrency.js';
 
 const testProjectCreators = getTestProjectCreators();

--- a/packages/integration-tests/src/test-live-dependency-health-checks/health_checks.test.ts
+++ b/packages/integration-tests/src/test-live-dependency-health-checks/health_checks.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import os from 'os';
 import { execa } from 'execa';
 import { amplifyCli } from '../process-controller/process_controller.js';
-import { TestBranch, amplifyAppPool } from '../amplify_app_pool.js';
+import { type TestBranch, amplifyAppPool } from '../amplify_app_pool.js';
 import assert from 'node:assert';
 import { existsSync } from 'fs';
 import {

--- a/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
+++ b/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
@@ -1,12 +1,15 @@
 import fs from 'fs/promises';
-import { SecretClient } from '@aws-amplify/backend-secret';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type SecretClient } from '@aws-amplify/backend-secret';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 import { createEmptyAmplifyProject } from './create_empty_amplify_project.js';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
-import { TestProjectBase, TestProjectUpdate } from './test_project_base.js';
+import { type CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import {
+  TestProjectBase,
+  type TestProjectUpdate,
+} from './test_project_base.js';
 import { fileURLToPath, pathToFileURL } from 'url';
 import path from 'path';
-import { TestProjectCreator } from './test_project_creator.js';
+import { type TestProjectCreator } from './test_project_creator.js';
 
 type TestConstant = {
   secretNames: {

--- a/packages/integration-tests/src/test-project-setup/minimal_with_typescript_idioms.ts
+++ b/packages/integration-tests/src/test-project-setup/minimal_with_typescript_idioms.ts
@@ -3,8 +3,8 @@ import fs from 'fs/promises';
 import assert from 'node:assert';
 import path from 'path';
 import { createEmptyAmplifyProject } from './create_empty_amplify_project.js';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
-import { TestProjectCreator } from './test_project_creator.js';
+import { type CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { type TestProjectCreator } from './test_project_creator.js';
 
 /**
  * Creates minimal test projects with typescript idioms.

--- a/packages/integration-tests/src/test-project-setup/test_project_base.ts
+++ b/packages/integration-tests/src/test-project-setup/test_project_base.ts
@@ -1,5 +1,5 @@
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 import { amplifyCli } from '../process-controller/process_controller.js';
 import {
   confirmDeleteSandbox,
@@ -9,7 +9,7 @@ import {
 } from '../process-controller/predicated_action_macros.js';
 
 import {
-  CloudFormationClient,
+  type CloudFormationClient,
   DeleteStackCommand,
 } from '@aws-sdk/client-cloudformation';
 

--- a/packages/integration-tests/src/test-project-setup/test_project_creator.ts
+++ b/packages/integration-tests/src/test-project-setup/test_project_creator.ts
@@ -1,4 +1,4 @@
-import { TestProjectBase } from './test_project_base.js';
+import { type TestProjectBase } from './test_project_base.js';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { getSecretClient } from '@aws-amplify/backend-secret';
 import { DataStorageAuthWithTriggerTestProjectCreator } from './data_storage_auth_with_triggers.js';

--- a/packages/integration-tests/test-projects/data-iterative-deploy/amplify/data/resource.ts
+++ b/packages/integration-tests/test-projects/data-iterative-deploy/amplify/data/resource.ts
@@ -1,3 +1,4 @@
+/* eslint-disable-next-line import/no-unresolved */
 import { defineData } from '@aws-amplify/backend';
 
 export const data = defineData({

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/update-1/data/resource.ts
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-cjs/update-1/data/resource.ts
@@ -1,3 +1,4 @@
+/* eslint-disable-next-line import/no-unresolved */
 import { defineData } from '@aws-amplify/backend-graphql';
 
 const schema = `

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/update-1/data/resource.ts
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-js/update-1/data/resource.ts
@@ -1,3 +1,4 @@
+/* eslint-disable-next-line import/no-unresolved */
 import { defineData } from '@aws-amplify/backend-graphql';
 
 const schema = `

--- a/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/update-1/data/resource.ts
+++ b/packages/integration-tests/test-projects/data-storage-auth-with-triggers-ts/update-1/data/resource.ts
@@ -1,4 +1,5 @@
 import { Func, defineData } from '@aws-amplify/backend';
+/* eslint-disable-next-line import/no-unresolved */
 import { myFunc } from '../function.js';
 
 export const data = defineData({

--- a/packages/model-generator/src/appsync_graphql_generation_result.ts
+++ b/packages/model-generator/src/appsync_graphql_generation_result.ts
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { GenerationResult } from './model_generator.js';
+import { type GenerationResult } from './model_generator.js';
 
 type ClientOperations = Record<string, string>;
 /**

--- a/packages/model-generator/src/appsync_schema_fetcher.test.ts
+++ b/packages/model-generator/src/appsync_schema_fetcher.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { describe, it, mock } from 'node:test';
-import { AppSyncClient } from '@aws-sdk/client-appsync';
+import { type AppSyncClient } from '@aws-sdk/client-appsync';
 import { AppSyncIntrospectionSchemaFetcher } from './appsync_schema_fetcher.js';
 
 void describe('AppSyncIntrospectionSchemaFetcher', () => {

--- a/packages/model-generator/src/appsync_schema_fetcher.ts
+++ b/packages/model-generator/src/appsync_schema_fetcher.ts
@@ -1,5 +1,5 @@
 import {
-  AppSyncClient,
+  type AppSyncClient,
   GetIntrospectionSchemaCommand,
 } from '@aws-sdk/client-appsync';
 

--- a/packages/model-generator/src/create_graphql_document_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_document_generator.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { createGraphqlDocumentGenerator } from './create_graphql_document_generator.js';
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 
 void describe('model generator factory', () => {
   void it('throws an error if a null backendIdentifier is passed in', async () => {

--- a/packages/model-generator/src/create_graphql_document_generator.ts
+++ b/packages/model-generator/src/create_graphql_document_generator.ts
@@ -1,14 +1,14 @@
 import { AppSyncClient } from '@aws-sdk/client-appsync';
 import {
   BackendOutputClientFactory,
-  DeployedBackendIdentifier,
+  type DeployedBackendIdentifier,
 } from '@aws-amplify/deployed-backend-client';
 import { graphqlOutputKey } from '@aws-amplify/backend-output-schemas';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { AppsyncGraphqlGenerationResult } from './appsync_graphql_generation_result.js';
 import { AppSyncIntrospectionSchemaFetcher } from './appsync_schema_fetcher.js';
 import { AppSyncGraphqlDocumentGenerator } from './graphql_document_generator.js';
-import { GraphqlDocumentGenerator } from './model_generator.js';
+import { type GraphqlDocumentGenerator } from './model_generator.js';
 
 export type GraphqlDocumentGeneratorFactoryParams = {
   backendIdentifier: DeployedBackendIdentifier;

--- a/packages/model-generator/src/create_graphql_models_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_models_generator.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 import {
   createGraphqlModelsFromS3UriGenerator,
   createGraphqlModelsGenerator,

--- a/packages/model-generator/src/create_graphql_models_generator.ts
+++ b/packages/model-generator/src/create_graphql_models_generator.ts
@@ -1,13 +1,13 @@
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { S3Client } from '@aws-sdk/client-s3';
 import {
   BackendOutputClientFactory,
-  DeployedBackendIdentifier,
+  type DeployedBackendIdentifier,
 } from '@aws-amplify/deployed-backend-client';
 import { graphqlOutputKey } from '@aws-amplify/backend-output-schemas';
 import { AppsyncGraphqlGenerationResult } from './appsync_graphql_generation_result.js';
 import { StackMetadataGraphqlModelsGenerator } from './graphql_models_generator.js';
-import { GraphqlModelsGenerator } from './model_generator.js';
+import { type GraphqlModelsGenerator } from './model_generator.js';
 import { S3StringObjectFetcher } from './s3_string_object_fetcher.js';
 
 export type GraphqlModelsGeneratorFactoryParams = {

--- a/packages/model-generator/src/create_graphql_types_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_types_generator.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { createGraphqlTypesGenerator } from './create_graphql_types_generator.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 void describe('types generator factory', () => {
   void it('throws an error if a null backendIdentifier is passed in', async () => {

--- a/packages/model-generator/src/create_graphql_types_generator.ts
+++ b/packages/model-generator/src/create_graphql_types_generator.ts
@@ -1,14 +1,14 @@
 import { AppSyncClient } from '@aws-sdk/client-appsync';
 import {
   BackendOutputClientFactory,
-  DeployedBackendIdentifier,
+  type DeployedBackendIdentifier,
 } from '@aws-amplify/deployed-backend-client';
 import { graphqlOutputKey } from '@aws-amplify/backend-output-schemas';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { AppsyncGraphqlGenerationResult } from './appsync_graphql_generation_result.js';
 import { AppSyncIntrospectionSchemaFetcher } from './appsync_schema_fetcher.js';
 import { AppSyncGraphqlTypesGenerator } from './graphql_types_generator.js';
-import { GraphqlTypesGenerator } from './model_generator.js';
+import { type GraphqlTypesGenerator } from './model_generator.js';
 
 export type GraphqlTypesGeneratorFactoryParams = {
   backendIdentifier: DeployedBackendIdentifier;

--- a/packages/model-generator/src/generate_api_code.test.ts
+++ b/packages/model-generator/src/generate_api_code.test.ts
@@ -4,14 +4,14 @@ import {
   ApiCodeGenerator,
   GenerateApiCodeFormat,
   GenerateApiCodeModelTarget,
-  GenerateApiCodeProps,
+  type GenerateApiCodeProps,
   GenerateApiCodeStatementTarget,
   GenerateApiCodeTypeTarget,
 } from './generate_api_code.js';
 import {
-  GraphqlDocumentGenerator,
-  GraphqlModelsGenerator,
-  GraphqlTypesGenerator,
+  type GraphqlDocumentGenerator,
+  type GraphqlModelsGenerator,
+  type GraphqlTypesGenerator,
 } from './model_generator.js';
 
 void describe('generateAPICode', () => {

--- a/packages/model-generator/src/generate_api_code.ts
+++ b/packages/model-generator/src/generate_api_code.ts
@@ -1,18 +1,18 @@
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import {
-  DocumentGenerationParameters,
-  GenerationResult,
-  GraphqlDocumentGenerator,
-  GraphqlModelsGenerator,
-  GraphqlTypesGenerator,
+  type DocumentGenerationParameters,
+  type GenerationResult,
+  type GraphqlDocumentGenerator,
+  type GraphqlModelsGenerator,
+  type GraphqlTypesGenerator,
 } from './model_generator.js';
 import { createGraphqlModelsGenerator } from './create_graphql_models_generator.js';
 import { createGraphqlTypesGenerator } from './create_graphql_types_generator.js';
 import { createGraphqlDocumentGenerator } from './create_graphql_document_generator.js';
 import { getOutputFileName } from '@aws-amplify/graphql-types-generator';
 import path from 'path';
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
+import { type DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 
 export enum GenerateApiCodeFormat {
   MODELGEN = 'modelgen',

--- a/packages/model-generator/src/generate_model_introspection_from_schema_uri.ts
+++ b/packages/model-generator/src/generate_model_introspection_from_schema_uri.ts
@@ -1,4 +1,4 @@
-import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { type AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { createGraphqlModelsFromS3UriGenerator } from './create_graphql_models_generator.js';
 
 export type GetModelIntrospectionSchemaParams = {

--- a/packages/model-generator/src/graphql_document_generator.ts
+++ b/packages/model-generator/src/graphql_document_generator.ts
@@ -1,8 +1,8 @@
 import { generateStatements } from '@aws-amplify/graphql-generator';
 import {
-  DocumentGenerationParameters,
-  GenerationResult,
-  GraphqlDocumentGenerator,
+  type DocumentGenerationParameters,
+  type GenerationResult,
+  type GraphqlDocumentGenerator,
 } from './model_generator.js';
 
 /**

--- a/packages/model-generator/src/graphql_models_generator.ts
+++ b/packages/model-generator/src/graphql_models_generator.ts
@@ -1,8 +1,8 @@
 import { generateModels } from '@aws-amplify/graphql-generator';
 import {
-  GenerationResult,
-  GraphqlModelsGenerator,
-  ModelsGenerationParameters,
+  type GenerationResult,
+  type GraphqlModelsGenerator,
+  type ModelsGenerationParameters,
 } from './model_generator.js';
 import { defaultDirectiveDefinitions } from './default_directive_definitions.js';
 

--- a/packages/model-generator/src/graphql_types_generator.ts
+++ b/packages/model-generator/src/graphql_types_generator.ts
@@ -4,9 +4,9 @@ import {
 } from '@aws-amplify/graphql-generator';
 import { Source } from 'graphql';
 import {
-  GenerationResult,
-  GraphqlTypesGenerator,
-  TypesGenerationParameters,
+  type GenerationResult,
+  type GraphqlTypesGenerator,
+  type TypesGenerationParameters,
 } from './model_generator.js';
 
 /**

--- a/packages/model-generator/src/index.ts
+++ b/packages/model-generator/src/index.ts
@@ -1,15 +1,17 @@
 export * from './model_generator.js';
 export * from './create_graphql_document_generator.js';
-export {
-  GenerateApiCodeFormat,
-  GenerateApiCodeModelTarget,
-  GenerateApiCodeStatementTarget,
-  GenerateApiCodeTypeTarget,
+export type {
   GenerateModelsOptions,
   GenerateGraphqlCodegenOptions,
   GenerateIntrospectionOptions,
   GenerateOptions,
   GenerateApiCodeProps,
+} from './generate_api_code.js';
+export {
+  GenerateApiCodeFormat,
+  GenerateApiCodeModelTarget,
+  GenerateApiCodeStatementTarget,
+  GenerateApiCodeTypeTarget,
   generateApiCode,
 } from './generate_api_code.js';
 export * from './generate_model_introspection_from_schema_uri.js';

--- a/packages/model-generator/src/model_generator.ts
+++ b/packages/model-generator/src/model_generator.ts
@@ -1,7 +1,7 @@
 import {
-  ModelsTarget,
-  StatementsTarget,
-  TypesTarget,
+  type ModelsTarget,
+  type StatementsTarget,
+  type TypesTarget,
 } from '@aws-amplify/graphql-generator';
 export type TargetLanguage = StatementsTarget;
 

--- a/packages/model-generator/src/s3_string_object_fetcher.ts
+++ b/packages/model-generator/src/s3_string_object_fetcher.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand, type S3Client } from '@aws-sdk/client-s3';
 
 /**
  * Handles fetching an object from an s3 bucket and parsing the object contents to a string

--- a/packages/platform-core/src/backend_identifier_conversions.test.ts
+++ b/packages/platform-core/src/backend_identifier_conversions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { BackendIdentifierConversions } from './backend_identifier_conversions.js';
 import assert from 'node:assert';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 void describe('toStackName', () => {
   void it('removes non-alphanumeric chars from namespace and instance', () => {

--- a/packages/platform-core/src/backend_identifier_conversions.ts
+++ b/packages/platform-core/src/backend_identifier_conversions.ts
@@ -1,4 +1,4 @@
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 import { createHash } from 'crypto';
 
 const STACK_NAME_LENGTH_LIMIT = 128;

--- a/packages/platform-core/src/package_json_reader.ts
+++ b/packages/platform-core/src/package_json_reader.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import z from 'zod';
+import { z } from 'zod';
 
 /**
  * return the package json

--- a/packages/platform-core/src/usage-data/get_usage_data_url.ts
+++ b/packages/platform-core/src/usage-data/get_usage_data_url.ts
@@ -1,4 +1,4 @@
-import url, { UrlWithStringQuery } from 'url';
+import url, { type UrlWithStringQuery } from 'url';
 import { latestApiVersion } from './constants.js';
 
 let cachedUrl: UrlWithStringQuery;

--- a/packages/platform-core/src/usage-data/usage_data.ts
+++ b/packages/platform-core/src/usage-data/usage_data.ts
@@ -1,4 +1,4 @@
-import { SerializableError } from './serializable_error';
+import { type SerializableError } from './serializable_error';
 
 export type UsageData = {
   sessionUuid: string;

--- a/packages/platform-core/src/usage-data/usage_data_emitter.test.ts
+++ b/packages/platform-core/src/usage-data/usage_data_emitter.test.ts
@@ -4,11 +4,11 @@ import { DefaultUsageDataEmitter } from './usage_data_emitter';
 import { v4, validate } from 'uuid';
 import url from 'url';
 import https from 'https';
-import http from 'http';
+import type http from 'http';
 import fs from 'fs';
 import os from 'os';
-import { AccountIdFetcher } from './account_id_fetcher';
-import { UsageData } from './usage_data';
+import { type AccountIdFetcher } from './account_id_fetcher';
+import { type UsageData } from './usage_data';
 import isCI from 'is-ci';
 
 void describe('UsageDataEmitter', () => {

--- a/packages/platform-core/src/usage-data/usage_data_emitter.ts
+++ b/packages/platform-core/src/usage-data/usage_data_emitter.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { AccountIdFetcher } from './account_id_fetcher.js';
-import { UsageData } from './usage_data.js';
+import { type UsageData } from './usage_data.js';
 import os from 'os';
 import https from 'https';
 import { getInstallationUuid } from './get_installation_id.js';
@@ -8,7 +8,7 @@ import { latestPayloadVersion } from './constants.js';
 import { getUrl } from './get_usage_data_url.js';
 import isCI from 'is-ci';
 import { SerializableError } from './serializable_error.js';
-import { UsageDataEmitter } from './usage_data_emitter_factory.js';
+import { type UsageDataEmitter } from './usage_data_emitter_factory.js';
 
 /**
  * Entry point for sending usage data metrics

--- a/packages/plugin-types/src/amplify_function.ts
+++ b/packages/plugin-types/src/amplify_function.ts
@@ -1,4 +1,4 @@
-import { ResourceProvider } from './resource_provider.js';
-import { FunctionResources } from './function_resources.js';
+import { type ResourceProvider } from './resource_provider.js';
+import { type FunctionResources } from './function_resources.js';
 
 export type AmplifyFunction = ResourceProvider<FunctionResources>;

--- a/packages/plugin-types/src/auth_resources.ts
+++ b/packages/plugin-types/src/auth_resources.ts
@@ -1,11 +1,11 @@
-import { IRole } from 'aws-cdk-lib/aws-iam';
+import { type IRole } from 'aws-cdk-lib/aws-iam';
 import {
-  CfnIdentityPool,
-  CfnIdentityPoolRoleAttachment,
-  CfnUserPool,
-  CfnUserPoolClient,
-  IUserPool,
-  IUserPoolClient,
+  type CfnIdentityPool,
+  type CfnIdentityPoolRoleAttachment,
+  type CfnUserPool,
+  type CfnUserPoolClient,
+  type IUserPool,
+  type IUserPoolClient,
 } from 'aws-cdk-lib/aws-cognito';
 
 /**

--- a/packages/plugin-types/src/backend_identifier.ts
+++ b/packages/plugin-types/src/backend_identifier.ts
@@ -1,4 +1,4 @@
-import { DeploymentType } from './deployment_type';
+import { type DeploymentType } from './deployment_type';
 
 /**
  * These are some utility types to make the BackendIdentifier a bit more self-documenting

--- a/packages/plugin-types/src/backend_secret_resolver.ts
+++ b/packages/plugin-types/src/backend_secret_resolver.ts
@@ -1,6 +1,6 @@
-import { Construct } from 'constructs';
-import { BackendIdentifier } from './backend_identifier.js';
-import { SecretValue } from 'aws-cdk-lib';
+import { type Construct } from 'constructs';
+import { type BackendIdentifier } from './backend_identifier.js';
+import { type SecretValue } from 'aws-cdk-lib';
 
 export type BackendSecret = {
   /**

--- a/packages/plugin-types/src/backend_stack_creator.ts
+++ b/packages/plugin-types/src/backend_stack_creator.ts
@@ -1,4 +1,4 @@
-import { Stack } from 'aws-cdk-lib';
+import { type Stack } from 'aws-cdk-lib';
 
 /**
  * Interface for objects that can create stacks in a given scope

--- a/packages/plugin-types/src/construct_container.ts
+++ b/packages/plugin-types/src/construct_container.ts
@@ -1,6 +1,6 @@
-import { Construct } from 'constructs';
-import { ConstructFactory } from './construct_factory.js';
-import { BackendSecretResolver } from './backend_secret_resolver.js';
+import { type Construct } from 'constructs';
+import { type ConstructFactory } from './construct_factory.js';
+import { type BackendSecretResolver } from './backend_secret_resolver.js';
 
 /**
  * Initializes a CDK Construct in a given scope

--- a/packages/plugin-types/src/construct_factory.ts
+++ b/packages/plugin-types/src/construct_factory.ts
@@ -1,7 +1,7 @@
-import { ConstructContainer } from './construct_container.js';
-import { BackendOutputStorageStrategy } from './output_storage_strategy.js';
-import { BackendOutputEntry } from './backend_output.js';
-import { ImportPathVerifier } from './import_path_verifier.js';
+import { type ConstructContainer } from './construct_container.js';
+import { type BackendOutputStorageStrategy } from './output_storage_strategy.js';
+import { type BackendOutputEntry } from './backend_output.js';
+import { type ImportPathVerifier } from './import_path_verifier.js';
 
 export type ConstructFactoryGetInstanceProps = {
   constructContainer: ConstructContainer;

--- a/packages/plugin-types/src/function_resources.ts
+++ b/packages/plugin-types/src/function_resources.ts
@@ -1,4 +1,4 @@
-import { Function as LambdaFunction } from 'aws-cdk-lib/aws-lambda';
+import { type Function as LambdaFunction } from 'aws-cdk-lib/aws-lambda';
 
 export type FunctionResources = {
   lambda: LambdaFunction;

--- a/packages/plugin-types/src/output_retrieval_strategy.ts
+++ b/packages/plugin-types/src/output_retrieval_strategy.ts
@@ -1,7 +1,7 @@
 /**
  * Interface for classes that can fetch outputs for an Amplify backend
  */
-import { BackendOutput } from './backend_output.js';
+import { type BackendOutput } from './backend_output.js';
 
 export type BackendOutputRetrievalStrategy = {
   /**

--- a/packages/plugin-types/src/output_storage_strategy.ts
+++ b/packages/plugin-types/src/output_storage_strategy.ts
@@ -1,4 +1,4 @@
-import { BackendOutputEntry } from './backend_output.js';
+import { type BackendOutputEntry } from './backend_output.js';
 
 /**
  * Type for an object that collects output data from constructs

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -14,12 +14,15 @@ import fs from 'fs';
 import parseGitIgnore from 'parse-gitignore';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import _open from 'open';
-import { SecretListItem, getSecretClient } from '@aws-amplify/backend-secret';
-import { ClientConfigFormat } from '@aws-amplify/client-config';
-import { Sandbox } from './sandbox.js';
+import {
+  type SecretListItem,
+  getSecretClient,
+} from '@aws-amplify/backend-secret';
+import { type ClientConfigFormat } from '@aws-amplify/client-config';
+import { type Sandbox } from './sandbox.js';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
 import { fileURLToPath } from 'url';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 // Watcher mocks
 const unsubscribeMockFn = mock.fn();

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -1,12 +1,12 @@
 import debounce from 'debounce-promise';
-import parcelWatcher, { subscribe } from '@parcel/watcher';
-import { AmplifySandboxExecutor } from './sandbox_executor.js';
+import parcelWatcher, { type subscribe } from '@parcel/watcher';
+import { type AmplifySandboxExecutor } from './sandbox_executor.js';
 import {
-  BackendIdSandboxResolver,
-  Sandbox,
-  SandboxDeleteOptions,
-  SandboxEvents,
-  SandboxOptions,
+  type BackendIdSandboxResolver,
+  type Sandbox,
+  type SandboxDeleteOptions,
+  type SandboxEvents,
+  type SandboxOptions,
 } from './sandbox.js';
 import parseGitIgnore from 'parse-gitignore';
 import path from 'path';
@@ -14,12 +14,12 @@ import fs from 'fs';
 import _open from 'open';
 import EventEmitter from 'events';
 import {
-  CloudFormationClient,
+  type CloudFormationClient,
   DescribeStacksCommand,
 } from '@aws-sdk/client-cloudformation';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
 import {
-  FilesChangesTracker,
+  type FilesChangesTracker,
   createFilesChangesTracker,
 } from './files_changes_tracker.js';
 

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -1,5 +1,5 @@
 import debounce from 'debounce-promise';
-import parcelWatcher, { type subscribe } from '@parcel/watcher';
+import { subscribe } from '@parcel/watcher';
 import { type AmplifySandboxExecutor } from './sandbox_executor.js';
 import {
   type BackendIdSandboxResolver,
@@ -8,7 +8,7 @@ import {
   type SandboxEvents,
   type SandboxOptions,
 } from './sandbox.js';
-import parseGitIgnore from 'parse-gitignore';
+import { parse as parseGitIgnore } from 'parse-gitignore';
 import path from 'path';
 import fs from 'fs';
 import _open from 'open';
@@ -132,7 +132,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       this.emitWatching();
     });
 
-    this.watcherSubscription = await parcelWatcher.subscribe(
+    this.watcherSubscription = await subscribe(
       options.dir ?? './amplify',
       async (_, events) => {
         // Log and track file changes.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,6 +1,6 @@
-import EventEmitter from 'events';
-import { ClientConfigFormat } from '@aws-amplify/client-config';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import type EventEmitter from 'events';
+import { type ClientConfigFormat } from '@aws-amplify/client-config';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 
 /**
  * Interface for Sandbox.

--- a/packages/sandbox/src/sandbox_executor.test.ts
+++ b/packages/sandbox/src/sandbox_executor.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { AmplifySandboxExecutor } from './sandbox_executor.js';
 import { BackendDeployerFactory } from '@aws-amplify/backend-deployer';
-import { SecretListItem, getSecretClient } from '@aws-amplify/backend-secret';
+import {
+  type SecretListItem,
+  getSecretClient,
+} from '@aws-amplify/backend-secret';
 
 const backendDeployer = BackendDeployerFactory.getInstance();
 const secretClient = getSecretClient();

--- a/packages/sandbox/src/sandbox_executor.ts
+++ b/packages/sandbox/src/sandbox_executor.ts
@@ -1,11 +1,11 @@
 import debounce from 'debounce-promise';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { type BackendIdentifier } from '@aws-amplify/plugin-types';
 import {
-  BackendDeployer,
-  DeployResult,
-  DestroyResult,
+  type BackendDeployer,
+  type DeployResult,
+  type DestroyResult,
 } from '@aws-amplify/backend-deployer';
-import { SecretClient } from '@aws-amplify/backend-secret';
+import { type SecretClient } from '@aws-amplify/backend-secret';
 
 /**
  * Execute CDK commands.

--- a/packages/sandbox/src/sandbox_singleton_factory.ts
+++ b/packages/sandbox/src/sandbox_singleton_factory.ts
@@ -1,5 +1,5 @@
 import { FileWatchingSandbox } from './file_watching_sandbox.js';
-import { BackendIdSandboxResolver, Sandbox } from './sandbox.js';
+import { type BackendIdSandboxResolver, type Sandbox } from './sandbox.js';
 import { BackendDeployerFactory } from '@aws-amplify/backend-deployer';
 import { AmplifySandboxExecutor } from './sandbox_executor.js';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';

--- a/packages/storage-construct/src/construct.test.ts
+++ b/packages/storage-construct/src/construct.test.ts
@@ -3,11 +3,11 @@ import { AmplifyStorage } from './construct.js';
 import { App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import {
-  BackendOutputEntry,
-  BackendOutputStorageStrategy,
+  type BackendOutputEntry,
+  type BackendOutputStorageStrategy,
 } from '@aws-amplify/plugin-types';
 import assert from 'node:assert';
-import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { type Bucket } from 'aws-cdk-lib/aws-s3';
 import { storageOutputKey } from '@aws-amplify/backend-output-schemas';
 
 void describe('AmplifyStorage', () => {

--- a/packages/storage-construct/src/construct.ts
+++ b/packages/storage-construct/src/construct.ts
@@ -1,8 +1,8 @@
 import { Construct } from 'constructs';
-import { Bucket, BucketProps } from 'aws-cdk-lib/aws-s3';
-import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
+import { Bucket, type BucketProps } from 'aws-cdk-lib/aws-s3';
+import { type BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import {
-  StorageOutput,
+  type StorageOutput,
   storageOutputKey,
 } from '@aws-amplify/backend-output-schemas';
 import { Stack } from 'aws-cdk-lib';

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -2,37 +2,37 @@ import {
   CloudFormationClient,
   DeleteStackCommand,
   ListStacksCommand,
-  ListStacksCommandOutput,
+  type ListStacksCommandOutput,
   StackStatus,
-  StackSummary,
+  type StackSummary,
 } from '@aws-sdk/client-cloudformation';
 import {
-  Bucket,
+  type Bucket,
   DeleteBucketCommand,
   DeleteObjectsCommand,
   ListBucketsCommand,
   ListObjectVersionsCommand,
   ListObjectsV2Command,
-  ListObjectsV2CommandOutput,
-  ObjectIdentifier,
+  type ListObjectsV2CommandOutput,
+  type ObjectIdentifier,
   S3Client,
 } from '@aws-sdk/client-s3';
 import {
   CognitoIdentityProviderClient,
   DeleteUserPoolCommand,
   ListUserPoolsCommand,
-  ListUserPoolsCommandOutput,
-  UserPoolDescriptionType,
+  type ListUserPoolsCommandOutput,
+  type UserPoolDescriptionType,
 } from '@aws-sdk/client-cognito-identity-provider';
 import {
   AmplifyClient,
-  App,
-  Branch,
+  type App,
+  type Branch,
   DeleteBranchCommand,
   ListAppsCommand,
-  ListAppsCommandOutput,
+  type ListAppsCommandOutput,
   ListBranchesCommand,
-  ListBranchesCommandOutput,
+  type ListBranchesCommandOutput,
 } from '@aws-sdk/client-amplify';
 
 const amplifyClient = new AmplifyClient({

--- a/scripts/components/dependencies_validator.test.ts
+++ b/scripts/components/dependencies_validator.test.ts
@@ -1,7 +1,7 @@
 import { before, describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { DependenciesValidator } from './dependencies_validator.js';
-import { ExecaChildProcess } from 'execa';
+import { type ExecaChildProcess } from 'execa';
 import fsp from 'fs/promises';
 import { fileURLToPath } from 'url';
 

--- a/scripts/publish_runner.ts
+++ b/scripts/publish_runner.ts
@@ -1,4 +1,4 @@
-import { Options, execa } from 'execa';
+import { type Options, execa } from 'execa';
 
 const publishDefaults = {
   /**

--- a/scripts/update_tsconfig_refs.ts
+++ b/scripts/update_tsconfig_refs.ts
@@ -1,7 +1,7 @@
 import { globSync } from 'glob';
 import * as fs from 'fs';
 import * as path from 'path';
-import prettier from 'prettier';
+import * as prettier from 'prettier';
 
 /*
  * In a monorepo where packages depend on each other, TS needs to know what order to build those packages.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enforces consistent type imports and exports. This can help prevent errors such as https://typescript.tv/errors/#ts2742 when consuming the libraries with pnpm or npm's "linked" install strategy.

- enables https://typescript-eslint.io/rules/consistent-type-imports
- enables https://typescript-eslint.io/rules/consistent-type-exports
- enables https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/consistent-type-specifier-style.md
- extends https://github.com/import-js/eslint-plugin-import/blob/main/config/recommended.js
- extends https://github.com/import-js/eslint-plugin-import/blob/main/config/typescript.js

Enabling this emits 504 errors from ESLint 
```
✖ 504 problems (504 errors, 0 warnings)
  504 errors and 0 warnings potentially fixable with the `--fix` option.
```

*Questions:*
- how do we feel about the inline type imports? This adheres to "no duplicate imports", but can be rough to sort properly with ESLint (it's easier to sort `import type`)
- any thoughts on enforcing import order? https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#options


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
