### PR TITLE
Migrate to module resolution bundler 2

### DIFF
--- a/packages/create-amplify/src/initial_project_file_generator.test.ts
+++ b/packages/create-amplify/src/initial_project_file_generator.test.ts
@@ -31,14 +31,6 @@ void describe('InitialProjectFileGenerator', () => {
       path.join(process.cwd(), 'testDir', 'amplify'),
       { recursive: true },
     ]);
-    assert.equal(
-      fsMock.writeFile.mock.calls[0].arguments[0],
-      path.join(process.cwd(), 'testDir', 'amplify', 'package.json')
-    );
-    assert.deepStrictEqual(
-      JSON.parse(fsMock.writeFile.mock.calls[0].arguments[1]),
-      { type: 'module' }
-    );
   });
 
   void it('creates default tsconfig file', async () => {
@@ -60,9 +52,9 @@ void describe('InitialProjectFileGenerator', () => {
           '--resolveJsonModule',
           'true',
           '--module',
-          'node16',
+          'es2022',
           '--moduleResolution',
-          'node16',
+          'bundler',
           '--target',
           'es2022',
         ],

--- a/packages/create-amplify/src/initial_project_file_generator.ts
+++ b/packages/create-amplify/src/initial_project_file_generator.ts
@@ -29,12 +29,6 @@ export class InitialProjectFileGenerator {
       { recursive: true }
     );
 
-    const packageJsonContent = { type: 'module' };
-    await this.fs.writeFile(
-      path.resolve(targetDir, 'package.json'),
-      JSON.stringify(packageJsonContent, null, 2)
-    );
-
     await this.initializeTsConfig(targetDir);
   };
 
@@ -45,9 +39,9 @@ export class InitialProjectFileGenerator {
       '--resolveJsonModule',
       'true',
       '--module',
-      'node16',
+      'es2022',
       '--moduleResolution',
-      'node16',
+      'bundler',
       '--target',
       'es2022',
     ];

--- a/packages/create-amplify/templates/basic-auth-data/amplify/backend.ts
+++ b/packages/create-amplify/templates/basic-auth-data/amplify/backend.ts
@@ -1,6 +1,6 @@
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 defineBackend({
   auth,

--- a/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/amplify/backend.ts
+++ b/packages/integration-tests/test-projects/minimalist-project-with-typescript-idioms/amplify/backend.ts
@@ -1,5 +1,6 @@
 import { defineBackend } from '@aws-amplify/backend';
-import { storage } from './storage/resource.js';
+// we do not need to use explicit file extensions when using `"moduleResolution": "bundler"`
+import { storage } from './storage/resource';
 
 defineBackend({
   storage,


### PR DESCRIPTION
*Issue #, if available:*

follow-up to #634, #708

*Description of changes:*

- migrates `tsc init` to initialize with `"module": "es2022"` and `"moduleResolution": "bundler"`
- updates associated tests
- updates integration test typescript template, removes explicit file extension from relative import


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
