### PR TITLE
fix: hide tsc --showConfig output since its used for validation only

### DIFF
--- a/.changeset/moody-pugs-drive.md
+++ b/.changeset/moody-pugs-drive.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+fix: hide tsc --showConfig output since its used for validation only


### PR DESCRIPTION
*Description of changes:* fix: hide tsc --showConfig output since its used for validation only


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
