### PR TITLE
fix: typedoc version for conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "prettier": "^2.8.7",
         "rimraf": "^5.0.0",
         "tsx": "^3.12.6",
-        "typedoc": "^0.25.0",
+        "typedoc": "^0.25.3",
         "typescript": "^5.0.4",
         "verdaccio": "^5.24.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "rimraf": "^5.0.0",
         "tsx": "^3.12.6",
         "typedoc": "^0.25.3",
-        "typescript": "^5.0.4",
+        "typescript": "~5.2.0",
         "verdaccio": "^5.24.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "rimraf": "^5.0.0",
     "tsx": "^3.12.6",
     "typedoc": "^0.25.3",
-    "typescript": "^5.0.4",
+    "typescript": "~5.2.0",
     "verdaccio": "^5.24.1"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "prettier": "^2.8.7",
     "rimraf": "^5.0.0",
     "tsx": "^3.12.6",
-    "typedoc": "^0.25.0",
+    "typedoc": "^0.25.3",
     "typescript": "^5.0.4",
     "verdaccio": "^5.24.1"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Canary [build586](https://github.com/aws-amplify/amplify-backend/actions/runs/6934039976/job/18861438228) faiiled for error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: amplify-vnext@0.0.1
npm ERR! Found: typescript@5.3.2
npm ERR! node_modules/typescript
npm ERR!   dev typescript@"^5.0.4" from the root project
npm ERR!   peer typescript@">=4.4" from eslint-config-xo-typescript@0.5[7](https://github.com/aws-amplify/amplify-backend/actions/runs/6934039976/job/18861438228#step:4:8).0
npm ERR!   node_modules/eslint-config-xo-typescript
npm ERR!     dev eslint-config-xo-typescript@"^0.57.0" from the root project
npm ERR!   1 more (@aws-amplify/backend-deployer)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! dev typedoc@"^0.25.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: typescript@5.2.2
npm ERR! node_modules/typescript
npm ERR!   peer typescript@"4.6.x || 4.7.x || 4.[8](https://github.com/aws-amplify/amplify-backend/actions/runs/6934039976/job/18861438228#step:4:9).x || 4.9.x || 5.0.x || 5.1.x || 5.2.x" from typedoc@0.25.3
npm ERR!   node_modules/typedoc
npm ERR!     dev typedoc@"^0.25.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! 
npm ERR! For a full report see:
npm ERR! /home/runner/.npm/_logs/2023-11-20T18_06_3[9](https://github.com/aws-amplify/amplify-backend/actions/runs/6934039976/job/18861438228#step:4:10)_680Z-eresolve-report.txt
```

The reason was because [typescript](https://www.npmjs.com/package/typescript) just released v5.3.2 (there was no 5.3.0 or 5.3.1), so it conflicts with typedoc's peer's dep as the error above.

![image](https://github.com/aws-amplify/amplify-backend/assets/11983489/ecd3ea5e-0473-483c-9dd8-0db2393f13cc)


Tested on local. The error would be changed to warning...

```
❯ npm install
npm WARN deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated @babel/plugin-proposal-object-rest-spread@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
npm WARN deprecated @aws-sdk/util-stream-node@3.374.0: This package has moved to @smithy/util-stream
npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated sinon@14.0.2: 16.1.1
npm WARN deprecated core-js@2.6.12: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.

> amplify-vnext@0.0.1 prepare
> husky install

husky - Git hooks installed

added 1569 packages, and audited 1708 packages in 37s

240 packages are looking for funding
  run `npm fund` for details

3 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

Test on personal fork: https://github.com/0618/amplify-backend/actions/runs/6935180667/job/18864824925

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
