### PR TITLE
feat: add support for allowDestructiveSchemaUpdates in defineData

### DIFF
--- a/.changeset/calm-beers-drive.md
+++ b/.changeset/calm-beers-drive.md
@@ -2,4 +2,4 @@
 '@aws-amplify/backend-data': minor
 ---
 
-Add support for allowDestructiveGraphqlSchemaUpdates in defineData
+Add support for allowDestructiveSchemaUpdates in defineData

--- a/.changeset/calm-beers-drive.md
+++ b/.changeset/calm-beers-drive.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': minor
+---
+
+Add support for allowDestructiveGraphqlSchemaUpdates in defineData

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "amplify-vnext",
+  "name": "amplify-backend",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "amplify-vnext",
+      "name": "amplify-backend",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "workspaces": [
@@ -20014,18 +20014,18 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.3.2",
-        "@aws-amplify/backend-data": "^0.8.0",
-        "@aws-amplify/backend-function": "^0.2.2",
+        "@aws-amplify/backend-auth": "^0.3.4",
+        "@aws-amplify/backend-data": "^0.8.1",
+        "@aws-amplify/backend-function": "^0.2.4",
         "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-output-storage": "^0.2.3",
-        "@aws-amplify/backend-secret": "^0.3.0",
+        "@aws-amplify/backend-output-storage": "^0.2.5",
+        "@aws-amplify/backend-secret": "^0.3.1",
         "@aws-amplify/backend-storage": "^0.3.0",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.2.1",
+        "@aws-amplify/platform-core": "^0.3.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "@aws-sdk/client-amplify": "^3.440.0"
       },
@@ -20040,16 +20040,16 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/auth-construct-alpha": "^0.4.1",
-        "@aws-amplify/backend-output-storage": "0.2.4",
+        "@aws-amplify/backend-output-storage": "0.2.5",
         "@aws-amplify/plugin-types": "^0.4.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
-        "@aws-amplify/platform-core": "^0.2.2"
+        "@aws-amplify/platform-core": "^0.3.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20058,11 +20058,11 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-output-storage": "0.2.4",
+        "@aws-amplify/backend-output-storage": "0.2.5",
         "@aws-amplify/data-construct": "^1.4.1",
         "@aws-amplify/data-schema-types": "^0.6.6",
         "@aws-amplify/plugin-types": "^0.4.1"
@@ -20070,7 +20070,7 @@
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.2.2"
+        "@aws-amplify/platform-core": "^0.3.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20079,10 +20079,10 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.2.2",
+        "@aws-amplify/platform-core": "^0.3.0",
         "@aws-amplify/plugin-types": "^0.4.0",
         "execa": "^7.2.0",
         "tsx": "^3.12.6"
@@ -20094,17 +20094,17 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "0.2.4",
+        "@aws-amplify/backend-output-storage": "0.2.5",
         "@aws-amplify/function-construct-alpha": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "execa": "^7.1.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
-        "@aws-amplify/platform-core": "^0.2.2"
+        "@aws-amplify/platform-core": "^0.3.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20124,11 +20124,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/platform-core": "^0.2.2"
+        "@aws-amplify/platform-core": "^0.3.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0"
@@ -20145,10 +20145,10 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.2.0",
+        "@aws-amplify/platform-core": "^0.3.0",
         "@aws-amplify/plugin-types": "^0.4.0",
         "@aws-sdk/client-ssm": "^3.398.0"
       },
@@ -20161,13 +20161,13 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "^0.2.1",
+        "@aws-amplify/backend-output-storage": "^0.2.5",
         "@aws-amplify/plugin-types": "^0.4.0",
         "@aws-amplify/storage-construct-alpha": "^0.2.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.0",
-        "@aws-amplify/platform-core": "^0.2.0"
+        "@aws-amplify/platform-core": "^0.3.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.103.0",
@@ -20176,18 +20176,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-secret": "^0.3.0",
+        "@aws-amplify/backend-secret": "^0.3.1",
         "@aws-amplify/cli-core": "^0.2.0",
         "@aws-amplify/client-config": "^0.4.2",
-        "@aws-amplify/deployed-backend-client": "^0.3.2",
+        "@aws-amplify/deployed-backend-client": "^0.3.3",
         "@aws-amplify/form-generator": "^0.5.0",
-        "@aws-amplify/model-generator": "^0.2.2",
-        "@aws-amplify/platform-core": "^0.2.2",
-        "@aws-amplify/sandbox": "^0.3.4",
+        "@aws-amplify/model-generator": "^0.2.3",
+        "@aws-amplify/platform-core": "^0.3.0",
+        "@aws-amplify/sandbox": "^0.3.5",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@aws-sdk/region-config-resolver": "^3.433.0",
@@ -20206,7 +20206,7 @@
         "@types/yargs": "^17.0.24"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.16.0"
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.347.0"
@@ -20364,8 +20364,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.1",
-        "@aws-amplify/model-generator": "^0.2.2",
+        "@aws-amplify/deployed-backend-client": "^0.3.3",
+        "@aws-amplify/model-generator": "^0.2.3",
         "@aws-sdk/client-amplify": "^3.376.0",
         "@aws-sdk/client-cloudformation": "^3.376.0",
         "@aws-sdk/client-ssm": "^3.398.0",
@@ -20373,16 +20373,16 @@
         "zod": "^3.21.4"
       },
       "devDependencies": {
-        "@aws-amplify/platform-core": "^0.2.1",
+        "@aws-amplify/platform-core": "^0.3.0",
         "@aws-sdk/types": "^3.370.0"
       }
     },
     "packages/create-amplify": {
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/platform-core": "0.2.2",
+        "@aws-amplify/platform-core": "0.3.0",
         "execa": "^7.2.0",
         "yargs": "^17.7.2"
       },
@@ -20495,11 +20495,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/platform-core": "^0.2.2",
+        "@aws-amplify/platform-core": "^0.3.0",
         "@aws-sdk/client-amplify": "^3.329.0",
         "@aws-sdk/client-cloudformation": "^3.329.0",
         "@aws-sdk/client-s3": "^3.329.0",
@@ -20540,16 +20540,16 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/backend": "0.5.3",
-        "@aws-amplify/backend-auth": "0.3.3",
-        "@aws-amplify/backend-secret": "^0.3.0",
+        "@aws-amplify/backend": "0.5.4",
+        "@aws-amplify/backend-auth": "0.3.4",
+        "@aws-amplify/backend-secret": "^0.3.1",
         "@aws-amplify/backend-storage": "0.3.0",
         "@aws-amplify/client-config": "^0.4.0",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.2.2",
+        "@aws-amplify/platform-core": "^0.3.0",
         "@aws-sdk/client-amplify": "^3.440.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "execa": "^8.0.1",
@@ -20627,11 +20627,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.1",
+        "@aws-amplify/deployed-backend-client": "^0.3.3",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -20647,7 +20647,7 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^0.4.0",
@@ -21066,15 +21066,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "0.3.2",
-        "@aws-amplify/backend-secret": "^0.3.0",
+        "@aws-amplify/backend-deployer": "0.3.3",
+        "@aws-amplify/backend-secret": "^0.3.1",
         "@aws-amplify/cli-core": "^0.2.0",
         "@aws-amplify/client-config": "0.4.2",
-        "@aws-amplify/deployed-backend-client": "^0.3.2",
-        "@aws-amplify/platform-core": "^0.2.2",
+        "@aws-amplify/deployed-backend-client": "^0.3.3",
+        "@aws-amplify/platform-core": "^0.3.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
         "@aws-sdk/types": "^3.378.0",

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -30,7 +30,7 @@ export type DataProps = {
     name?: string;
     authorizationModes?: AuthorizationModes;
     functions?: Record<string, ConstructFactory<AmplifyFunction>>;
-    allowDestructiveGraphqlSchemaUpdates?: boolean;
+    allowDestructiveSchemaUpdates?: boolean;
 };
 
 // @public

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -30,6 +30,7 @@ export type DataProps = {
     name?: string;
     authorizationModes?: AuthorizationModes;
     functions?: Record<string, ConstructFactory<AmplifyFunction>>;
+    allowDestructiveGraphqlSchemaUpdates?: boolean;
 };
 
 // @public

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -232,4 +232,66 @@ void describe('DataFactory', () => {
       }
     );
   });
+
+  void it('defaults allowDestructiveGraphqlSchemaUpdates to false', () => {
+    const dataConstruct = defineData({
+      schema:
+        'type Todo @model @auth(rules: [{ allow: public }]) { content: String! }',
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+    }).getInstance(getInstanceProps);
+
+    // Validate that the api resources are created for the function
+    assert('Todo' in dataConstruct.resources.nestedStacks);
+    const todoStack = Template.fromStack(
+      dataConstruct.resources.nestedStacks.Todo
+    );
+    todoStack.hasResourceProperties('Custom::AmplifyDynamoDBTable', {
+      allowDestructiveGraphqlSchemaUpdates: false,
+    });
+  });
+
+  void it('passes down false allowDestructiveGraphqlSchemaUpdates option', () => {
+    const dataConstruct = defineData({
+      schema:
+        'type Todo @model @auth(rules: [{ allow: public }]) { content: String! }',
+      allowDestructiveGraphqlSchemaUpdates: false,
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+    }).getInstance(getInstanceProps);
+
+    // Validate that the api resources are created for the function
+    assert('Todo' in dataConstruct.resources.nestedStacks);
+    const todoStack = Template.fromStack(
+      dataConstruct.resources.nestedStacks.Todo
+    );
+    todoStack.hasResourceProperties('Custom::AmplifyDynamoDBTable', {
+      allowDestructiveGraphqlSchemaUpdates: false,
+    });
+  });
+
+  void it('passes down true allowDestructiveGraphqlSchemaUpdates option', () => {
+    const dataConstruct = defineData({
+      schema:
+        'type Todo @model @auth(rules: [{ allow: public }]) { content: String! }',
+      allowDestructiveGraphqlSchemaUpdates: true,
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+    }).getInstance(getInstanceProps);
+
+    // Validate that the api resources are created for the function
+    assert('Todo' in dataConstruct.resources.nestedStacks);
+    const todoStack = Template.fromStack(
+      dataConstruct.resources.nestedStacks.Todo
+    );
+    todoStack.hasResourceProperties('Custom::AmplifyDynamoDBTable', {
+      allowDestructiveGraphqlSchemaUpdates: true,
+    });
+  });
 });

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -233,7 +233,7 @@ void describe('DataFactory', () => {
     );
   });
 
-  void it('defaults allowDestructiveGraphqlSchemaUpdates to false', () => {
+  void it('defaults allowDestructiveSchemaUpdates to false', () => {
     const dataConstruct = defineData({
       schema:
         'type Todo @model @auth(rules: [{ allow: public }]) { content: String! }',
@@ -253,11 +253,11 @@ void describe('DataFactory', () => {
     });
   });
 
-  void it('passes down false allowDestructiveGraphqlSchemaUpdates option', () => {
+  void it('passes down false allowDestructiveSchemaUpdates option', () => {
     const dataConstruct = defineData({
       schema:
         'type Todo @model @auth(rules: [{ allow: public }]) { content: String! }',
-      allowDestructiveGraphqlSchemaUpdates: false,
+      allowDestructiveSchemaUpdates: false,
       authorizationModes: {
         defaultAuthorizationMode: 'apiKey',
         apiKeyAuthorizationMode: { expiresInDays: 7 },
@@ -274,11 +274,11 @@ void describe('DataFactory', () => {
     });
   });
 
-  void it('passes down true allowDestructiveGraphqlSchemaUpdates option', () => {
+  void it('passes down true allowDestructiveSchemaUpdates option', () => {
     const dataConstruct = defineData({
       schema:
         'type Todo @model @auth(rules: [{ allow: public }]) { content: String! }',
-      allowDestructiveGraphqlSchemaUpdates: true,
+      allowDestructiveSchemaUpdates: true,
       authorizationModes: {
         defaultAuthorizationMode: 'apiKey',
         apiKeyAuthorizationMode: { expiresInDays: 7 },

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -107,7 +107,11 @@ class DataGenerator implements ConstructContainerEntryGenerator {
       authorizationModes,
       outputStorageStrategy: this.outputStorageStrategy,
       functionNameMap,
-      translationBehavior: { sandboxModeEnabled },
+      translationBehavior: {
+        sandboxModeEnabled,
+        allowDestructiveGraphqlSchemaUpdates:
+          this.props.allowDestructiveGraphqlSchemaUpdates,
+      },
     });
   };
 }

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -110,7 +110,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
       translationBehavior: {
         sandboxModeEnabled,
         allowDestructiveGraphqlSchemaUpdates:
-          this.props.allowDestructiveGraphqlSchemaUpdates,
+          this.props.allowDestructiveSchemaUpdates,
       },
     });
   };

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -135,7 +135,7 @@ export type DataProps = {
 
   /**
    * When enabled, will allow for destructive updates to the schema (e.g. replace on primary key or identifier updates).
-   * It is recommended to only enable this if you plan on making a destructive change, and re-enable in a subsequent deployment.
+   * It is recommended to only enable this if you plan on making a destructive change, and disable it again in a subsequent deployment.
    * @default false
    */
   allowDestructiveSchemaUpdates?: boolean;

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -135,8 +135,8 @@ export type DataProps = {
 
   /**
    * When enabled, will allow for destructive updates to the schema (e.g. replace on primary key or identifier updates).
-   * It is recommended to only enable this, if you plan on making a destructive change, and re-enable in a subsequent deployment.
+   * It is recommended to only enable this if you plan on making a destructive change, and re-enable in a subsequent deployment.
    * @default false
    */
-  allowDestructiveGraphqlSchemaUpdates?: boolean;
+  allowDestructiveSchemaUpdates?: boolean;
 };

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -132,4 +132,11 @@ export type DataProps = {
    * Functions invokable by the API. The specific input type of the function is subject to change or removal.
    */
   functions?: Record<string, ConstructFactory<AmplifyFunction>>;
+
+  /**
+   * When enabled, will allow for destructive updates to the schema (e.g. replace on primary key or identifier updates).
+   * It is recommended to only enable this, if you plan on making a destructive change, and re-enable in a subsequent deployment.
+   * @default false
+   */
+  allowDestructiveGraphqlSchemaUpdates?: boolean;
 };


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When AMPLIFY_TABLE deployment strategy was enabled, we didn't add the requisite override flag to enable deploying destructive updates (e.g. key changes). This PR wires that through, and adds test for default, positive, and negative cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
