### PR TITLE
build: health checks tweaks - remove schedule, run manually, narrow d…

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -59,7 +59,7 @@ jobs:
       # if the workflow is running on a pull request, we perform an additional check for the run-e2e label
       # this is not a security measure (that is already handled by the pull_request event behavior) but rather a way for PR authors to easily check e2e test results if they wish
       # the reason it doesn't run all the time is because it will always fail for external contributor PRs (they don't have access to repo secrets) and we don't want to waste resources running e2e on every PR commit
-      - name: Check event is push or pull request has run-e2e label
+      - name: Check event is push to main or pull request has run-e2e label
         id: check
         run: |
           if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]] || gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r '.labels[].name' | grep run-e2e --quiet; then

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -7,8 +7,7 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: '0 12 * * *' # every day 12:00 UTC
+  workflow_dispatch:
 
 jobs:
   install:
@@ -56,13 +55,14 @@ jobs:
       run_e2e: ${{ steps.check.outputs.run_e2e }}
     steps:
       # if this workflow is running on a push (ie merge to main), then e2e tests always run
+      # if this workflow is triggered manually, then e2e tests always run
       # if the workflow is running on a pull request, we perform an additional check for the run-e2e label
       # this is not a security measure (that is already handled by the pull_request event behavior) but rather a way for PR authors to easily check e2e test results if they wish
       # the reason it doesn't run all the time is because it will always fail for external contributor PRs (they don't have access to repo secrets) and we don't want to waste resources running e2e on every PR commit
       - name: Check event is push or pull request has run-e2e label
         id: check
         run: |
-          if [[ ${{ github.event_name }} == 'push' ]] || gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r '.labels[].name' | grep run-e2e --quiet; then
+          if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]] || gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r '.labels[].name' | grep run-e2e --quiet; then
             echo setting run_e2e to true;
             echo "run_e2e=true" >> "$GITHUB_OUTPUT";
           else
@@ -147,7 +147,7 @@ jobs:
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
       - run: npm run docs
-      - if: github.event_name == 'push'
+      - if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # version 3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -188,7 +188,7 @@ jobs:
       - uses: ./.github/actions/restore_install_cache
       - run: npm run check:package-versions
   update_or_publish_versions:
-    if: github.event_name == 'push'
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
     needs:
       - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
…own branch for publish steps

**Description of changes:**

This PR:
1. Removes scheduled run of health checks (since we have separate canaries now).
2. Adds ability to trigger health checks manually (e.g. from feature branch), this includes e2e tests by default.
3. Narrows down publish steps condition to make sure we're triggering them on `main` only (in case feature branches allow list `push` like [here](https://github.com/aws-amplify/amplify-backend/blob/3b20cc3da080246305e6a3b64ad0c725b4b2aa0c/.github/workflows/health_checks.yml#L7) ).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
