### PR TITLE
require backend identifier in deployer, remove redundant deploymentTy…

### DIFF
--- a/.changeset/mighty-bottles-leave.md
+++ b/.changeset/mighty-bottles-leave.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-deployer': minor
+'@aws-amplify/sandbox': patch
+'@aws-amplify/backend-cli': patch
+---
+
+require backend identifier in deployer, remove redundant deploymentType parameter

--- a/packages/backend-deployer/API.md
+++ b/packages/backend-deployer/API.md
@@ -5,12 +5,11 @@
 ```ts
 
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
-import { DeploymentType } from '@aws-amplify/plugin-types';
 
 // @public
 export type BackendDeployer = {
-    deploy: (backendId?: BackendIdentifier, deployProps?: DeployProps) => Promise<DeployResult>;
-    destroy: (backendId?: BackendIdentifier, destroyProps?: DestroyProps) => Promise<DestroyResult>;
+    deploy: (backendId: BackendIdentifier, deployProps?: DeployProps) => Promise<DeployResult>;
+    destroy: (backendId: BackendIdentifier) => Promise<DestroyResult>;
 };
 
 // @public
@@ -26,7 +25,6 @@ export type DeploymentTimes = {
 
 // @public (undocumented)
 export type DeployProps = {
-    deploymentType?: DeploymentType;
     secretLastUpdated?: Date;
     validateAppSources?: boolean;
 };
@@ -34,11 +32,6 @@ export type DeployProps = {
 // @public (undocumented)
 export type DeployResult = {
     deploymentTimes: DeploymentTimes;
-};
-
-// @public (undocumented)
-export type DestroyProps = {
-    deploymentType?: DeploymentType;
 };
 
 // @public (undocumented)

--- a/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
+++ b/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
@@ -1,20 +1,15 @@
-import { BackendIdentifier, DeploymentType } from '@aws-amplify/plugin-types';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { CDKDeployer } from './cdk_deployer.js';
 import { CdkErrorMapper } from './cdk_error_mapper.js';
 import { BackendLocator } from '@aws-amplify/platform-core';
 
 export type DeployProps = {
-  deploymentType?: DeploymentType;
   secretLastUpdated?: Date;
   validateAppSources?: boolean;
 };
 
 export type DeployResult = {
   deploymentTimes: DeploymentTimes;
-};
-
-export type DestroyProps = {
-  deploymentType?: DeploymentType;
 };
 
 export type DestroyResult = {
@@ -31,13 +26,10 @@ export type DeploymentTimes = {
  */
 export type BackendDeployer = {
   deploy: (
-    backendId?: BackendIdentifier,
+    backendId: BackendIdentifier,
     deployProps?: DeployProps
   ) => Promise<DeployResult>;
-  destroy: (
-    backendId?: BackendIdentifier,
-    destroyProps?: DestroyProps
-  ) => Promise<DestroyResult>;
+  destroy: (backendId: BackendIdentifier) => Promise<DestroyResult>;
 };
 
 /**

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -79,7 +79,6 @@ void describe('deploy command', () => {
         type: 'branch',
       },
       {
-        deploymentType: 'branch',
         validateAppSources: true,
       },
     ]);

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -59,7 +59,6 @@ export class PipelineDeployCommand
       type: 'branch',
     };
     await this.backendDeployer.deploy(backendId, {
-      deploymentType: 'branch',
       validateAppSources: true,
     });
     await this.clientConfigGenerator.generateClientConfigToFile(backendId);

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -229,7 +229,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: false,
       },
@@ -257,7 +256,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -289,7 +287,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -324,7 +321,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -345,7 +341,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: false,
       },
@@ -372,7 +367,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -395,7 +389,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -404,7 +397,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[1].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -442,7 +434,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -451,7 +442,6 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[1].arguments, [
       testSandboxBackendId,
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -471,9 +461,6 @@ void describe('Sandbox using local project name resolver', () => {
     // BackendDeployer should be called with the right params
     assert.deepEqual(backendDeployerDestroyMock.mock.calls[0].arguments, [
       testSandboxBackendId,
-      {
-        deploymentType: 'sandbox',
-      },
     ]);
   });
 
@@ -642,7 +629,6 @@ void describe('Sandbox using local project name resolver', () => {
         type: 'sandbox',
       },
       {
-        deploymentType: 'sandbox',
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -666,9 +652,6 @@ void describe('Sandbox using local project name resolver', () => {
         namespace: 'testSandboxId',
         name: 'customSandboxName',
         type: 'sandbox',
-      },
-      {
-        deploymentType: 'sandbox',
       },
     ]);
   });

--- a/packages/sandbox/src/sandbox_executor.test.ts
+++ b/packages/sandbox/src/sandbox_executor.test.ts
@@ -94,7 +94,6 @@ void describe('Sandbox executor', () => {
             type: 'sandbox',
           },
           {
-            deploymentType: 'sandbox',
             secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
             validateAppSources: shouldValidateSources,
           },

--- a/packages/sandbox/src/sandbox_executor.ts
+++ b/packages/sandbox/src/sandbox_executor.ts
@@ -55,7 +55,6 @@ export class AmplifySandboxExecutor {
       // doesn't get lost while debouncing
       const validateAppSources = validateAppSourcesProvider();
       return this.backendDeployer.deploy(backendId, {
-        deploymentType: 'sandbox',
         secretLastUpdated,
         validateAppSources,
       });
@@ -65,13 +64,9 @@ export class AmplifySandboxExecutor {
   /**
    * Destroy sandbox. Do not swallow errors
    */
-  destroy = (backendId?: BackendIdentifier): Promise<DestroyResult> => {
+  destroy = (backendId: BackendIdentifier): Promise<DestroyResult> => {
     console.debug('[Sandbox] Executing command `destroy`');
-    return this.invoke(() =>
-      this.backendDeployer.destroy(backendId, {
-        deploymentType: 'sandbox',
-      })
-    );
+    return this.invoke(() => this.backendDeployer.destroy(backendId));
   };
 
   /**


### PR DESCRIPTION
…pe parameter

*Issue #, if available:*

Addresses https://github.com/aws-amplify/amplify-backend/issues/358 .

*Description of changes:*

This PR:
1. Makes `backendId` mandatory parameter in deployer methods. (and makes deployment type mandatory since id now includes it).
2. Removes now redundant `deploymentType` from deployer options.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
