### PR TITLE
fix tsconfig resolution

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,7 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
     project: ['**/tsconfig.json'],
+    tsconfigRootDir: __dirname,
   },
   plugins: [
     '@typescript-eslint',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This fixes IDE issues where it's not able to correctly resolve the tsconfig that corresponds to a particular file if there was a nested eslint config in the directory hierarchy of that file.

AFAICT, this config was not affecting eslint when running as a script; it was only affecting IDE lint error highlighting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
