### PR TITLE
chore: validate create event before validating user existence

### DIFF
--- a/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.test.ts
+++ b/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.test.ts
@@ -233,7 +233,6 @@ void describe('createAuthChallenge', () => {
       [CognitoMetadataKeys.SIGN_IN_METHOD]: 'OTP',
       [CognitoMetadataKeys.ACTION]: 'REQUEST',
       [CognitoMetadataKeys.DELIVERY_MEDIUM]: 'SMS',
-      requiredMetadata: 'foo',
     };
     const userAttributes = {
       phone_number: '+5555557890',
@@ -252,10 +251,8 @@ void describe('createAuthChallenge', () => {
     void it('throws an error if validateCreateAuthChallengeEvent throws', async () => {
       const challengeService: ChallengeService = {
         ...mockChallengeService,
-        validateCreateAuthChallengeEvent: (event) => {
-          if (!event.request.clientMetadata?.requiredMetadata) {
-            throw new Error('missing required metadata.');
-          }
+        validateCreateAuthChallengeEvent: () => {
+          throw new Error('missing required metadata.');
         },
       };
       const customAuthService = new CustomAuthService({

--- a/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.test.ts
+++ b/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.test.ts
@@ -259,9 +259,9 @@ void describe('createAuthChallenge', () => {
         getService: () => challengeService,
       });
       const metadata = {
-        signInMethod: 'OTP',
-        action: 'REQUEST',
-        deliveryMedium: 'SMS',
+        [CognitoMetadataKeys.SIGN_IN_METHOD]: 'OTP',
+        [CognitoMetadataKeys.ACTION]: 'REQUEST',
+        [CognitoMetadataKeys.DELIVERY_MEDIUM]: 'SMS',
       };
       const event = buildCreateAuthChallengeEvent(
         [initialSession],

--- a/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.ts
+++ b/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.ts
@@ -139,6 +139,14 @@ export class CustomAuthService {
       event
     );
 
+    const challengeService = this.challengeServiceFactory.getService(method);
+
+    // ensure event is valid before checking for user existence to prevent
+    // returning an error that would reveal user existence.
+    if (challengeService.validateCreateAuthChallengeEvent) {
+      challengeService.validateCreateAuthChallengeEvent(event);
+    }
+
     // If the user is not found or if the attribute requested for challenge
     // delivery is not verified, return a fake successful response to prevent
     // user enumeration
@@ -161,9 +169,11 @@ export class CustomAuthService {
       return response;
     }
 
-    return this.challengeServiceFactory
-      .getService(method)
-      .createChallenge({ deliveryMedium, attributeName }, destination, event);
+    return challengeService.createChallenge(
+      { deliveryMedium, attributeName },
+      destination,
+      event
+    );
   };
 
   /**

--- a/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.ts
+++ b/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.ts
@@ -9,6 +9,7 @@ import {
   CodeDeliveryDetails,
   DeliveryMedium,
   PasswordlessAuthChallengeParams,
+  RespondToAutChallengeParams,
   SignInMethod,
 } from '../types.js';
 import { CognitoMetadataKeys } from '../constants.js';
@@ -154,15 +155,17 @@ export class CustomAuthService {
       logger.info(
         'User not found or user does not have a verified phone/email.'
       );
+      const publicChallengeParameters: RespondToAutChallengeParams = {
+        nextStep: 'PROVIDE_CHALLENGE_RESPONSE',
+        ...event.response.publicChallengeParameters,
+        attributeName,
+        deliveryMedium,
+      };
       const response: CreateAuthChallengeTriggerEvent = {
         ...event,
         response: {
           ...event.response,
-          publicChallengeParameters: {
-            ...event.response.publicChallengeParameters,
-            attributeName,
-            deliveryMedium,
-          },
+          publicChallengeParameters,
         },
       };
       logger.debug(JSON.stringify(response, null, 2));

--- a/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.test.ts
+++ b/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.test.ts
@@ -81,7 +81,7 @@ void describe('MagicLinkChallengeService', () => {
       const event: CreateAuthChallengeTriggerEvent =
         buildCreateAuthChallengeEvent([], {
           ...requestMagicLinkMetaData,
-          redirectUri: '',
+          [CognitoMetadataKeys.REDIRECT_URI]: '',
         });
       await rejects(
         async () => service.validateCreateAuthChallengeEvent(event),
@@ -93,7 +93,7 @@ void describe('MagicLinkChallengeService', () => {
       const event: CreateAuthChallengeTriggerEvent =
         buildCreateAuthChallengeEvent([], {
           ...requestMagicLinkMetaData,
-          redirectUri: 'https://foo.com/',
+          [CognitoMetadataKeys.REDIRECT_URI]: 'https://foo.com/',
         });
       await rejects(
         async () => service.validateCreateAuthChallengeEvent(event),

--- a/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.test.ts
+++ b/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.test.ts
@@ -76,6 +76,34 @@ void describe('MagicLinkChallengeService', () => {
     );
   });
 
+  void describe('validateCreateAuthChallengeEvent()', () => {
+    void it('should throw if no redirect URI is provided', async () => {
+      const event: CreateAuthChallengeTriggerEvent =
+        buildCreateAuthChallengeEvent([], {
+          ...requestMagicLinkMetaData,
+          redirectUri: '',
+        });
+      await rejects(
+        async () => service.validateCreateAuthChallengeEvent(event),
+        Error('No redirect URI provided.')
+      );
+    });
+
+    void it('should throw if the redirect URI is not in the allow list', async () => {
+      const event: CreateAuthChallengeTriggerEvent =
+        buildCreateAuthChallengeEvent([], {
+          ...requestMagicLinkMetaData,
+          redirectUri: 'https://foo.com/',
+        });
+      await rejects(
+        async () => service.validateCreateAuthChallengeEvent(event),
+        Error(
+          'Invalid redirectUri: https://foo.com not in allowed origins list.'
+        )
+      );
+    });
+  });
+
   void describe('createChallenge()', () => {
     void it('should send a message, store the link, and return and event with correct params', async () => {
       const mockSend = mock.method(deliveryService, 'send');

--- a/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.ts
+++ b/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.ts
@@ -9,6 +9,7 @@ import {
   ChallengeService,
   CodeDeliveryDetails,
   MagicLinkConfig,
+  RespondToAutChallengeParams,
   SigningService,
   StorageService,
 } from '../types.js';
@@ -93,15 +94,17 @@ export class MagicLinkChallengeService implements ChallengeService {
       .getService(deliveryMedium)
       .send(fullRedirectUri, destination, this.signInMethod);
 
+    const publicChallengeParameters: RespondToAutChallengeParams = {
+      nextStep: 'PROVIDE_CHALLENGE_RESPONSE',
+      ...event.response.publicChallengeParameters,
+      ...deliveryDetails,
+    };
+
     const response: CreateAuthChallengeTriggerEvent = {
       ...event,
       response: {
         ...event.response,
-        publicChallengeParameters: {
-          nextStep: 'PROVIDE_CHALLENGE_RESPONSE',
-          ...event.response.publicChallengeParameters,
-          ...deliveryDetails,
-        },
+        publicChallengeParameters,
       },
     };
 

--- a/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.ts
+++ b/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.ts
@@ -36,6 +36,17 @@ export class MagicLinkChallengeService implements ChallengeService {
   public readonly maxAttempts = 1;
 
   /**
+   * Validates that the event has any Magic Link specific data. An exception is
+   * thrown if the event is not valid.
+   * @param event - The Create Auth Challenge event.
+   */
+  public validateCreateAuthChallengeEvent = (
+    event: CreateAuthChallengeTriggerEvent
+  ): void => {
+    this.validateRedirectUri(event.request);
+  };
+
+  /**
    * Create Magic Link challenge
    * Steps:
    * 1. Validate redirect URI

--- a/packages/passwordless-auth-construct/src/types.ts
+++ b/packages/passwordless-auth-construct/src/types.ts
@@ -140,12 +140,12 @@ type InitiateAuthChallengeParams = {
   nextStep: 'PROVIDE_AUTH_PARAMETERS';
 };
 
-type RespondToAutChallengeParams = Pick<
+export type RespondToAutChallengeParams = Pick<
   CodeDeliveryDetails,
   'attributeName' | 'deliveryMedium'
 > & {
   nextStep: 'PROVIDE_CHALLENGE_RESPONSE';
-  errorCode: PasswordlessErrorCodes;
+  errorCode?: PasswordlessErrorCodes;
 };
 
 export type CodeDeliveryDetails = {

--- a/packages/passwordless-auth-construct/src/types.ts
+++ b/packages/passwordless-auth-construct/src/types.ts
@@ -53,6 +53,9 @@ export type SignInMethod =
 export type ChallengeService = {
   signInMethod: SignInMethod;
   maxAttempts: number;
+  validateCreateAuthChallengeEvent?: (
+    event: CreateAuthChallengeTriggerEvent
+  ) => void;
   createChallenge: (
     deliveryDetails: CodeDeliveryDetails,
     destination: string,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- validate the event including required metadata before checking for the existence of a user.

Prior to this change, an attacker could discover the existence of a user by making certain bad requests. For certain bad requests an error would be thrown only when the user existed. With the update the request validation happens first which ensures the same response is returned when the user does not exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
