### PR TITLE
match aws-cdk-lib versions

### DIFF
--- a/.changeset/cuddly-ears-move.md
+++ b/.changeset/cuddly-ears-move.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/integration-tests': patch
+---
+
+match aws-cdk-lib versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -21018,7 +21018,7 @@
         "@aws-sdk/client-amplify": "^3.440.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/client-lambda": "^3.460.0",
-        "aws-cdk-lib": "^2.112.0",
+        "aws-cdk-lib": "^2.110.1",
         "constructs": "^10.3.0",
         "execa": "^8.0.1",
         "fs-extra": "^11.1.1",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/client-amplify": "^3.440.0",
     "@aws-sdk/client-cloudformation": "^3.421.0",
     "@aws-sdk/client-lambda": "^3.460.0",
-    "aws-cdk-lib": "^2.112.0",
+    "aws-cdk-lib": "^2.110.1",
     "constructs": "^10.3.0",
     "execa": "^8.0.1",
     "fs-extra": "^11.1.1",

--- a/templates/construct/package.json
+++ b/templates/construct/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.80.0",
+    "aws-cdk-lib": "^2.110.1",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fresh npm install without package-lock.json should succeed. 

*Description of changes:*
Match aws-cdk-lib versions in sub-packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
