### PR TITLE
feat: add initial e2e integ test setup for passwordless auth

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -12,6 +12,7 @@
     "@aws-sdk/client-amplify": "^3.440.0",
     "@aws-sdk/client-cloudformation": "^3.421.0",
     "@aws-sdk/client-lambda": "^3.460.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.421.0",
     "aws-cdk-lib": "^2.110.1",
     "constructs": "^10.3.0",
     "execa": "^8.0.1",

--- a/packages/integration-tests/src/test-project-setup/passwordless_auth.ts
+++ b/packages/integration-tests/src/test-project-setup/passwordless_auth.ts
@@ -1,0 +1,92 @@
+import fs from 'fs/promises';
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { TestProjectBase } from './test_project_base.js';
+import { TestProjectCreator } from './test_project_creator.js';
+import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
+import { createEmptyAmplifyProject } from './create_empty_amplify_project.js';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { DeployedResourcesFinder } from '../find_deployed_resource.js';
+import assert from 'node:assert';
+
+/**
+ * Creates test projects with passwordless auth.
+ */
+export class PasswordlessAuthTestProjectCreator implements TestProjectCreator {
+  readonly name = 'passwordless-auth';
+
+  /**
+   * Creates project creator.
+   */
+  constructor(
+    private readonly cfnClient: CloudFormationClient,
+    private readonly cognitoIdentityProviderClient: CognitoIdentityProviderClient,
+    private readonly resourceFinder: DeployedResourcesFinder
+  ) {}
+
+  createProject = async (e2eProjectDir: string): Promise<TestProjectBase> => {
+    const { projectName, projectRoot, projectAmplifyDir } =
+      await createEmptyAmplifyProject(this.name, e2eProjectDir);
+
+    const project = new PasswordlessAuthTestProject(
+      projectName,
+      projectRoot,
+      projectAmplifyDir,
+      this.cfnClient,
+      this.cognitoIdentityProviderClient,
+      this.resourceFinder
+    );
+    await fs.cp(
+      project.sourceProjectAmplifyDirPath,
+      project.projectAmplifyDirPath,
+      {
+        recursive: true,
+      }
+    );
+    return project;
+  };
+}
+
+/**
+ * Test project with passwordless auth.
+ */
+class PasswordlessAuthTestProject extends TestProjectBase {
+  readonly sourceProjectDirPath = '../../src/test-projects/passwordless-auth';
+
+  readonly sourceProjectAmplifyDirSuffix = `${this.sourceProjectDirPath}/amplify`;
+
+  readonly sourceProjectAmplifyDirPath: URL = new URL(
+    this.sourceProjectAmplifyDirSuffix,
+    import.meta.url
+  );
+
+  /**
+   * Create a test project instance.
+   */
+  constructor(
+    name: string,
+    projectDirPath: string,
+    projectAmplifyDirPath: string,
+    cfnClient: CloudFormationClient,
+    private readonly cognitoIdentityProviderClient: CognitoIdentityProviderClient,
+    private readonly resourceFinder: DeployedResourcesFinder
+  ) {
+    super(name, projectDirPath, projectAmplifyDirPath, cfnClient);
+  }
+
+  override async assertPostDeployment(
+    backendId: BackendIdentifier
+  ): Promise<void> {
+    await super.assertPostDeployment(backendId);
+    const userPoolClientId = (
+      await this.resourceFinder.find(backendId, 'AWS::Cognito::UserPoolClient')
+    )[0];
+    const userPoolId = (
+      await this.resourceFinder.find(backendId, 'AWS::Cognito::UserPool')
+    )[0];
+
+    assert.notEqual(userPoolClientId, NaN);
+    assert.notEqual(userPoolId, NaN);
+
+    // TODO: define tests assertions bellow
+  }
+}

--- a/packages/integration-tests/src/test-project-setup/test_project_creator.ts
+++ b/packages/integration-tests/src/test-project-setup/test_project_creator.ts
@@ -5,6 +5,8 @@ import { DataStorageAuthWithTriggerTestProjectCreator } from './data_storage_aut
 import { MinimalWithTypescriptIdiomTestProjectCreator } from './minimal_with_typescript_idioms.js';
 import { LambdaClient } from '@aws-sdk/client-lambda';
 import { DeployedResourcesFinder } from '../find_deployed_resource.js';
+import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
+import { PasswordlessAuthTestProjectCreator } from './passwordless_auth.js';
 
 export type TestProjectCreator = {
   readonly name: string;
@@ -20,6 +22,7 @@ export const getTestProjectCreators = (): TestProjectCreator[] => {
   const lambdaClient = new LambdaClient();
   const resourceFinder = new DeployedResourcesFinder(cfnClient);
   const secretClient = getSecretClient();
+  const cognitoIdentityProviderClient = new CognitoIdentityProviderClient();
   testProjectCreators.push(
     new DataStorageAuthWithTriggerTestProjectCreator(
       cfnClient,
@@ -27,7 +30,12 @@ export const getTestProjectCreators = (): TestProjectCreator[] => {
       lambdaClient,
       resourceFinder
     ),
-    new MinimalWithTypescriptIdiomTestProjectCreator(cfnClient)
+    new MinimalWithTypescriptIdiomTestProjectCreator(cfnClient),
+    new PasswordlessAuthTestProjectCreator(
+      cfnClient,
+      cognitoIdentityProviderClient,
+      resourceFinder
+    )
   );
   return testProjectCreators;
 };

--- a/packages/integration-tests/src/test-projects/passwordless-auth/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/passwordless-auth/amplify/auth/resource.ts
@@ -8,7 +8,7 @@ export const auth = defineAuth({
     // originationNumber and fromAddress values are placeholders
     // until we find a solution to add them to work with CI.
     otp: {
-      sms: { originationNumber: '+18888747169' },
+      sms: { originationNumber: '+18888888888' },
       email: {
         fromAddress: 'dummy@email.com',
       },

--- a/packages/integration-tests/src/test-projects/passwordless-auth/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/passwordless-auth/amplify/auth/resource.ts
@@ -1,0 +1,21 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+  },
+  passwordlessAuth: {
+    // originationNumber and fromAddress values are placeholders
+    // until we find a solution to add them to work with CI.
+    otp: {
+      sms: { originationNumber: '+18888747169' },
+      email: {
+        fromAddress: 'dummy@email.com',
+      },
+    },
+    magicLink: {
+      allowedOrigins: ['http://localhost:3000/'],
+      email: { fromAddress: 'dummy@email.com' },
+    },
+  },
+});

--- a/packages/integration-tests/src/test-projects/passwordless-auth/amplify/backend.ts
+++ b/packages/integration-tests/src/test-projects/passwordless-auth/amplify/backend.ts
@@ -1,0 +1,6 @@
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource.js';
+
+defineBackend({
+  auth,
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 
add initial integ test setup for `passwordless-auth`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
