### PR TITLE
feat(passwordless): Add missing public challenge parameter `nextStep` when creating a challenge

### DIFF
--- a/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.test.ts
+++ b/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.test.ts
@@ -99,6 +99,10 @@ void describe('MagicLinkChallengeService', () => {
         newEvent.response.publicChallengeParameters['deliveryMedium'],
         'EMAIL'
       );
+      strictEqual(
+        newEvent.response.publicChallengeParameters['nextStep'],
+        'PROVIDE_CHALLENGE_RESPONSE'
+      );
     });
 
     void it('should throw if no redirect URI is provided', async () => {

--- a/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.ts
+++ b/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.ts
@@ -86,6 +86,7 @@ export class MagicLinkChallengeService implements ChallengeService {
       response: {
         ...event.response,
         publicChallengeParameters: {
+          nextStep: 'PROVIDE_CHALLENGE_RESPONSE',
           ...event.response.publicChallengeParameters,
           ...deliveryDetails,
         },

--- a/packages/passwordless-auth-construct/src/otp/otp_challenge_service.test.ts
+++ b/packages/passwordless-auth-construct/src/otp/otp_challenge_service.test.ts
@@ -98,6 +98,10 @@ void describe('OTP Challenge', () => {
         result.response.publicChallengeParameters.deliveryMedium,
         'SMS'
       );
+      strictEqual(
+        result.response.publicChallengeParameters['nextStep'],
+        'PROVIDE_CHALLENGE_RESPONSE'
+      );
       const actualCode = result.response.privateChallengeParameters.otpCode;
       strictEqual(actualCode.length, expectedOtpLength);
       // code is string of numbers

--- a/packages/passwordless-auth-construct/src/otp/otp_challenge_service.ts
+++ b/packages/passwordless-auth-construct/src/otp/otp_challenge_service.ts
@@ -55,6 +55,7 @@ export class OtpChallengeService implements ChallengeService {
           otpCode: otpCode,
         },
         publicChallengeParameters: {
+          nextStep: 'PROVIDE_CHALLENGE_RESPONSE',
           ...event.response.publicChallengeParameters,
           ...deliveryDetails,
         },


### PR DESCRIPTION
*Description of changes:*

Adding missing next step public challenge parameter that the client is expecting. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
