### PR TITLE
feat(passwordless): Allow OTP Retry

### DIFF
--- a/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.test.ts
+++ b/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.test.ts
@@ -251,18 +251,6 @@ void describe('createAuthChallenge', () => {
   });
 
   void describe('bad requests', () => {
-    void it('throws an error for an unsupported confirm action when using MAGIC_LINK', async () => {
-      const event = buildCreateAuthChallengeEvent([initialSession], {
-        [CognitoMetadataKeys.SIGN_IN_METHOD]: 'MAGIC_LINK',
-        [CognitoMetadataKeys.ACTION]: 'CONFIRM', // confirm is not supported for Magic link Create Auth Challenge
-      });
-      await rejects(
-        async () => customAuthService.createAuthChallenge(event),
-        Error(
-          'Unsupported signInMethod: MAGIC_LINK with action CONFIRM for Create Auth'
-        )
-      );
-    });
     void it('throws an error for an unsupported action', async () => {
       const event = buildCreateAuthChallengeEvent([initialSession], {
         [CognitoMetadataKeys.SIGN_IN_METHOD]: 'OTP',

--- a/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.test.ts
+++ b/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.test.ts
@@ -28,6 +28,7 @@ const initialSession: ChallengeResult = {
 
 const mockChallengeService: ChallengeService = {
   signInMethod: 'OTP',
+  maxAttempts: 1,
   createChallenge: async (
     deliveryDetails: CodeDeliveryDetails,
     destination: string,
@@ -130,21 +131,45 @@ void describe('defineAuthChallenge', () => {
       [CognitoMetadataKeys.SIGN_IN_METHOD]: 'OTP',
       [CognitoMetadataKeys.ACTION]: 'CONFIRM',
     };
+    const successResult: ChallengeResult = {
+      challengeName: 'CUSTOM_CHALLENGE',
+      challengeResult: true,
+    };
+    const failedResult: ChallengeResult = {
+      challengeName: 'CUSTOM_CHALLENGE',
+      challengeResult: false,
+    };
     void it('returns tokens when the previous challengeResult == true', async () => {
-      const successResult: ChallengeResult = {
-        challengeName: 'CUSTOM_CHALLENGE',
-        challengeResult: true,
-      };
       const event = buildDefineAuthChallengeEvent([successResult], metadata);
       const { response } = await customAuthService.defineAuthChallenge(event);
       strictEqual(isSuccessfulAuthentication(response), true);
     });
-    void it('fails authentication when the previous challengeResult == false', async () => {
+    void it('it returns tokens up to three attempts', async () => {
       const failedResult: ChallengeResult = {
         challengeName: 'CUSTOM_CHALLENGE',
         challengeResult: false,
       };
-      const event = buildDefineAuthChallengeEvent([failedResult], metadata);
+      const twoAttemptsEvent = buildDefineAuthChallengeEvent(
+        [failedResult, successResult],
+        metadata
+      );
+      const { response: twoAttemptsResponse } =
+        await customAuthService.defineAuthChallenge(twoAttemptsEvent);
+      strictEqual(isSuccessfulAuthentication(twoAttemptsResponse), true);
+
+      const threeAttemptsEvent = buildDefineAuthChallengeEvent(
+        [failedResult, failedResult, successResult],
+        metadata
+      );
+      const { response: threeAttemptsResponse } =
+        await customAuthService.defineAuthChallenge(threeAttemptsEvent);
+      strictEqual(isSuccessfulAuthentication(threeAttemptsResponse), true);
+    });
+    void it('fails authentication after three challengeResult == false results', async () => {
+      const event = buildDefineAuthChallengeEvent(
+        [failedResult, failedResult, failedResult],
+        metadata
+      );
       const { response } = await customAuthService.defineAuthChallenge(event);
       strictEqual(isFailedAuthentication(response), true);
     });
@@ -226,14 +251,26 @@ void describe('createAuthChallenge', () => {
   });
 
   void describe('bad requests', () => {
-    void it('throws an error for an unsupported action', async () => {
+    void it('throws an error for an unsupported confirm action when using MAGIC_LINK', async () => {
       const event = buildCreateAuthChallengeEvent([initialSession], {
-        [CognitoMetadataKeys.SIGN_IN_METHOD]: 'OTP',
-        [CognitoMetadataKeys.ACTION]: 'CONFIRM', // confirm is not supported for Create Auth Challenge
+        [CognitoMetadataKeys.SIGN_IN_METHOD]: 'MAGIC_LINK',
+        [CognitoMetadataKeys.ACTION]: 'CONFIRM', // confirm is not supported for Magic link Create Auth Challenge
       });
       await rejects(
         async () => customAuthService.createAuthChallenge(event),
-        Error('Unsupported action for Create Auth: CONFIRM')
+        Error(
+          'Unsupported signInMethod: MAGIC_LINK with action CONFIRM for Create Auth'
+        )
+      );
+    });
+    void it('throws an error for an unsupported action', async () => {
+      const event = buildCreateAuthChallengeEvent([initialSession], {
+        [CognitoMetadataKeys.SIGN_IN_METHOD]: 'OTP',
+        [CognitoMetadataKeys.ACTION]: 'FOO',
+      });
+      await rejects(
+        async () => customAuthService.createAuthChallenge(event),
+        Error('Unsupported action for Create Auth: FOO')
       );
     });
     void it('throws an error for an unsupported sign in method', async () => {
@@ -248,15 +285,18 @@ void describe('createAuthChallenge', () => {
       );
     });
     void it('should throw an error if deliveryMedium is not SMS or EMAIL', async () => {
+      const fakeDeliveryMedium = 'PHONE';
       const event: CreateAuthChallengeTriggerEvent =
         buildCreateAuthChallengeEvent([initialSession], {
           ...requestOtpSmsMetaData,
-          [CognitoMetadataKeys.DELIVERY_MEDIUM]: 'PHONE',
+          [CognitoMetadataKeys.DELIVERY_MEDIUM]: fakeDeliveryMedium,
         });
 
       await rejects(
         async () => customAuthService.createAuthChallenge(event),
-        Error('Invalid delivery medium. Only SMS and email are supported.')
+        Error(
+          `Invalid delivery medium: ${fakeDeliveryMedium}. Only SMS and email are supported.`
+        )
       );
     });
   });

--- a/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.ts
+++ b/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.ts
@@ -126,11 +126,9 @@ export class CustomAuthService {
 
     const clientMetadata = event.request.clientMetadata || {};
     const signInMethod = clientMetadata[CognitoMetadataKeys.SIGN_IN_METHOD];
+    const signInAction = clientMetadata[CognitoMetadataKeys.ACTION];
     const method = this.validateSignInMethod(signInMethod);
-    const action = this.validateAction(
-      signInMethod,
-      clientMetadata[CognitoMetadataKeys.ACTION]
-    );
+    const action = this.validateAction(signInAction);
     logger.info(`Requested signInMethod: ${signInMethod} and action ${action}`);
 
     const { deliveryMedium, attributeName } =
@@ -218,24 +216,13 @@ export class CustomAuthService {
 
   /**
    * Validates that the action from the client is supported.
-   * @param signInMethod - The sign in method provided by the client.
    * @param action - The action provided by the client.
    * @returns A valid action.
    */
-  private validateAction(
-    signInMethod: string,
-    action?: string
-  ): 'REQUEST' | 'CONFIRM' {
+  private validateAction(action?: string): 'REQUEST' | 'CONFIRM' {
     if (action !== 'REQUEST' && action !== 'CONFIRM') {
       throw new Error(
         `Unsupported action for Create Auth: ${action || 'Null'}`
-      );
-    }
-
-    // If the action is CONFIRM, the sign in method must be OTP.
-    if (action === 'CONFIRM' && signInMethod !== 'OTP') {
-      throw new Error(
-        `Unsupported signInMethod: ${signInMethod} with action CONFIRM for Create Auth`
       );
     }
 

--- a/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.ts
+++ b/packages/passwordless-auth-construct/src/custom-auth/custom_auth_service.ts
@@ -55,7 +55,10 @@ export class CustomAuthService {
     const clientMetadata = event.request.clientMetadata || {};
     const action = clientMetadata[CognitoMetadataKeys.ACTION];
     const signInMethod = clientMetadata[CognitoMetadataKeys.SIGN_IN_METHOD];
-    logger.info(`Requested signInMethod: ${signInMethod} and action ${action}`);
+    const attempts = this.countAttempts(event);
+    logger.info(
+      `Requested signInMethod: ${signInMethod},  action: ${action}, attempt: ${attempts}`
+    );
 
     if (signInMethod !== 'MAGIC_LINK' && signInMethod !== 'OTP') {
       return this.failAuthentication(
@@ -69,17 +72,28 @@ export class CustomAuthService {
       return this.customChallenge(event);
     }
 
-    // If the client is confirming a challenge, issue tokens or fail auth based on
+    // If the client is confirming a challenge, issue tokens, allow retry, or fail auth based on
     // the last response, which is from Verify Auth Challenge.
     if (action === 'CONFIRM') {
       const lastResponse = previousSessions.slice(-1)[0];
       if (lastResponse.challengeResult === true) {
         return this.issueTokens(event);
       }
-      // TODO: Implement retry attempts for OTP.
+
+      // Check the number of failed attempts allowed.
+      if (
+        attempts <
+        this.challengeServiceFactory.getService(signInMethod).maxAttempts
+      ) {
+        // If the number of attempts is less than 3, return a custom challenge (restart sign in flow).
+        logger.info('Challenge failed, retrying ...');
+        return this.customChallenge(event);
+      }
+
+      // If the number of attempts is 3 or more, fail authentication.
       return this.failAuthentication(
         event,
-        'The previous challenge result was false. See Verify Auth Challenge for more details.'
+        'Reached the maximum number of incorrect challenge attempts.'
       );
     }
 
@@ -111,15 +125,13 @@ export class CustomAuthService {
     }
 
     const clientMetadata = event.request.clientMetadata || {};
-    const action = clientMetadata[CognitoMetadataKeys.ACTION];
     const signInMethod = clientMetadata[CognitoMetadataKeys.SIGN_IN_METHOD];
-    logger.info(`Requested signInMethod: ${signInMethod} and action ${action}`);
-
-    if (action != 'REQUEST') {
-      throw new Error(`Unsupported action for Create Auth: ${action}`);
-    }
-
     const method = this.validateSignInMethod(signInMethod);
+    const action = this.validateAction(
+      signInMethod,
+      clientMetadata[CognitoMetadataKeys.ACTION]
+    );
+    logger.info(`Requested signInMethod: ${signInMethod} and action ${action}`);
 
     const { deliveryMedium, attributeName } =
       this.validateDeliveryCodeDetails(event);
@@ -205,6 +217,32 @@ export class CustomAuthService {
   }
 
   /**
+   * Validates that the action from the client is supported.
+   * @param signInMethod - The sign in method provided by the client.
+   * @param action - The action provided by the client.
+   * @returns A valid action.
+   */
+  private validateAction(
+    signInMethod: string,
+    action?: string
+  ): 'REQUEST' | 'CONFIRM' {
+    if (action !== 'REQUEST' && action !== 'CONFIRM') {
+      throw new Error(
+        `Unsupported action for Create Auth: ${action || 'Null'}`
+      );
+    }
+
+    // If the action is CONFIRM, the sign in method must be OTP.
+    if (action === 'CONFIRM' && signInMethod !== 'OTP') {
+      throw new Error(
+        `Unsupported signInMethod: ${signInMethod} with action CONFIRM for Create Auth`
+      );
+    }
+
+    return action;
+  }
+
+  /**
    * Parses and validates the CodeDeliveryDetails out of the CreateAuthChallengeTriggerEvent.
    * Verifies that the user, delivery medium, and destination are valid.
    * @param event - The Create Auth Challenge event provided by Cognito.
@@ -213,11 +251,20 @@ export class CustomAuthService {
   private validateDeliveryCodeDetails = (
     event: CreateAuthChallengeTriggerEvent
   ): CodeDeliveryDetails => {
+    const previousChallenge = event.request.session.slice(-1)[0];
+    const previousDeliveryMedium: string | undefined =
+      previousChallenge.challengeMetadata?.includes('deliveryMedium')
+        ? JSON.parse(previousChallenge.challengeMetadata).deliveryMedium
+        : undefined;
     const clientMetadata = event.request.clientMetadata || {};
-    const deliveryMedium = clientMetadata[CognitoMetadataKeys.DELIVERY_MEDIUM];
+    const deliveryMedium =
+      clientMetadata[CognitoMetadataKeys.DELIVERY_MEDIUM] ??
+      previousDeliveryMedium;
 
     if (deliveryMedium !== 'SMS' && deliveryMedium !== 'EMAIL') {
-      throw Error('Invalid delivery medium. Only SMS and email are supported.');
+      throw Error(
+        `Invalid delivery medium: ${deliveryMedium}. Only SMS and email are supported.`
+      );
     }
 
     const attributeName = deliveryMedium === 'SMS' ? 'phone_number' : 'email';
@@ -339,4 +386,15 @@ export class CustomAuthService {
       },
     };
   };
+
+  /**
+   * Counts the number of submission attempts in the event.
+   * @param event - The lambda event.
+   * @returns the number of attempts.
+   */
+  private countAttempts(event: DefineAuthChallengeTriggerEvent) {
+    return event.request.session.filter(
+      (entry) => !entry.challengeMetadata?.includes('PROVIDE_AUTH_PARAMETERS')
+    ).length;
+  }
 }

--- a/packages/passwordless-auth-construct/src/factories/challenge_service_factory.test.ts
+++ b/packages/passwordless-auth-construct/src/factories/challenge_service_factory.test.ts
@@ -7,11 +7,13 @@ void describe('ChallengeServiceFactory', () => {
   void it('getService returns the correct service', () => {
     const otpChallengeService: ChallengeService = {
       signInMethod: 'OTP',
+      maxAttempts: 1,
       createChallenge: async (_, __, event) => event,
       verifyChallenge: async (event) => event,
     };
     const magicLinkChallengeService: ChallengeService = {
       signInMethod: 'MAGIC_LINK',
+      maxAttempts: 1,
       createChallenge: async (_, __, event) => event,
       verifyChallenge: async (event) => event,
     };

--- a/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.ts
+++ b/packages/passwordless-auth-construct/src/magic-link/magic_link_challenge_service.ts
@@ -33,6 +33,7 @@ export class MagicLinkChallengeService implements ChallengeService {
     private storageService: StorageService<SignedMagicLink>
   ) {}
   public readonly signInMethod = 'MAGIC_LINK';
+  public readonly maxAttempts = 1;
 
   /**
    * Create Magic Link challenge

--- a/packages/passwordless-auth-construct/src/otp/otp_challenge_service.test.ts
+++ b/packages/passwordless-auth-construct/src/otp/otp_challenge_service.test.ts
@@ -2,7 +2,7 @@ import { VerifyAuthChallengeResponseTriggerEvent } from 'aws-lambda';
 import { match, notStrictEqual, rejects, strictEqual } from 'node:assert';
 import { beforeEach, describe, it, mock } from 'node:test';
 import { DeliveryServiceFactory } from '../factories/delivery_service_factory.js';
-
+import { CustomChallengeResult } from 'aws-lambda/trigger/cognito-user-pool-trigger/_common.js';
 import {
   buildCreateAuthChallengeEvent,
   buildVerifyAuthChallengeResponseEvent,
@@ -10,7 +10,12 @@ import {
   phoneUserAttributes,
   requestOtpSmsMetaData,
 } from '../mocks/challenge_events.mock.js';
-import { DeliveryMedium, DeliveryService, OtpConfig } from '../types.js';
+import {
+  DeliveryMedium,
+  DeliveryService,
+  OtpConfig,
+  PasswordlessErrorCodes,
+} from '../types.js';
 import { OtpChallengeService } from './otp_challenge_service.js';
 
 /**
@@ -20,6 +25,12 @@ class MockDeliveryService implements DeliveryService {
   constructor(public deliveryMedium: DeliveryMedium) {}
   send = async (): Promise<void> => Promise.resolve();
 }
+
+const initialSession: CustomChallengeResult = {
+  challengeName: 'CUSTOM_CHALLENGE',
+  challengeResult: false,
+  challengeMetadata: 'PROVIDE_AUTH_PARAMETERS',
+};
 
 void describe('OTP Challenge', () => {
   const mockOtpCode = '123456';
@@ -58,7 +69,7 @@ void describe('OTP Challenge', () => {
   void describe('createChallenge()', () => {
     void it('should send and attach sms delivery details', async () => {
       const smsRequestCreateChallengeEvent = buildCreateAuthChallengeEvent(
-        [],
+        [initialSession],
         requestOtpSmsMetaData,
         phoneUserAttributes
       );
@@ -106,6 +117,64 @@ void describe('OTP Challenge', () => {
       strictEqual(actualCode.length, expectedOtpLength);
       // code is string of numbers
       notStrictEqual(actualCode.match(/^\d+$/), null);
+      strictEqual(
+        result.response.privateChallengeParameters.errorCode,
+        undefined
+      );
+    });
+    void it('should retrieve previous code when present in event', async () => {
+      const previousOtpCode = '123456';
+      const previousDeliveryMedium = 'SMS';
+      const previousChallengeMetadata = JSON.stringify({
+        OTP_CODE: previousOtpCode,
+        deliveryMedium: previousDeliveryMedium,
+      });
+      const previousSessions: CustomChallengeResult[] = [
+        initialSession,
+        {
+          challengeName: 'CUSTOM_CHALLENGE',
+          challengeResult: false,
+          challengeMetadata: previousChallengeMetadata,
+        },
+      ];
+      const retrySmsRequestCreateChallengeEvent = buildCreateAuthChallengeEvent(
+        previousSessions,
+        requestOtpSmsMetaData,
+        phoneUserAttributes
+      );
+      const expectedPhoneNumber = '+15555555555';
+
+      const sendMock = mock.method(mockSmsService, 'send', () => {
+        return;
+      });
+
+      strictEqual(sendMock.mock.callCount(), 0);
+
+      const result = await otpChallenge.createChallenge(
+        { deliveryMedium: 'SMS', attributeName: 'phone_number' },
+        expectedPhoneNumber,
+        retrySmsRequestCreateChallengeEvent
+      );
+
+      // Assert that a message was not sent
+      strictEqual(sendMock.mock.callCount(), 0);
+
+      strictEqual(
+        result.response.challengeMetadata.includes(previousChallengeMetadata),
+        true
+      );
+      strictEqual(
+        result.response.publicChallengeParameters.deliveryMedium,
+        previousDeliveryMedium
+      );
+      strictEqual(
+        result.response.privateChallengeParameters.otpCode,
+        previousOtpCode
+      );
+      strictEqual(
+        result.response.publicChallengeParameters.errorCode,
+        PasswordlessErrorCodes.CODE_MISMATCH_EXCEPTION
+      );
     });
   });
 

--- a/packages/passwordless-auth-construct/src/types.ts
+++ b/packages/passwordless-auth-construct/src/types.ts
@@ -52,6 +52,7 @@ export type SignInMethod =
  */
 export type ChallengeService = {
   signInMethod: SignInMethod;
+  maxAttempts: number;
   createChallenge: (
     deliveryDetails: CodeDeliveryDetails,
     destination: string,
@@ -141,6 +142,7 @@ type RespondToAutChallengeParams = Pick<
   'attributeName' | 'deliveryMedium'
 > & {
   nextStep: 'PROVIDE_CHALLENGE_RESPONSE';
+  errorCode: PasswordlessErrorCodes;
 };
 
 export type CodeDeliveryDetails = {
@@ -333,3 +335,7 @@ export type KmsConfig = {
   /** KMS Key ID to use for generating Magic Links (signatures) */
   keyId?: string;
 };
+
+export enum PasswordlessErrorCodes {
+  CODE_MISMATCH_EXCEPTION = 'CodeMismatchException',
+}


### PR DESCRIPTION
*Description of changes:*
Allow users to make up to 3 attempts when trying to confirm their OTP code before the auth session fails. This is accomplished by: 

1. Saving the OTP and delivery method under the `challengeMetadata` key in the response.
2. On failed attempts, restart the flow and reuse the saved OTP code and delivery method.
3. Fail auth session after 3 attempts 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
