### PR TITLE
switch role name

### DIFF
--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Configure test execution credentials
         uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # version 3.0.1
         with:
-          role-to-assume: ${{ secrets.E2E_RUNNER_ROLE_ARN_NEW }}
+          role-to-assume: ${{ secrets.E2E_RUNNER_ROLE_ARN }}
           aws-region: us-west-2
       - name: Run live dependency health checks
         shell: bash

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -104,9 +104,7 @@ jobs:
       - name: Configure test execution credentials
         uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # version 3.0.1
         with:
-          # TODO follow up PR to switch this back after merge
-          # (can't do it before merge without impacting other e2e runs)
-          role-to-assume: ${{ secrets.E2E_RUNNER_ROLE_ARN_NEW }}
+          role-to-assume: ${{ secrets.E2E_RUNNER_ROLE_ARN }}
           aws-region: us-west-2
       - name: Run E2E tests
         run: npm run e2e


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Follow up to https://github.com/aws-amplify/amplify-backend/pull/768 to switch the e2e runner role arn name back to the original

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
