### PR TITLE
bug(796): Replaces arn construction logic with SDK parser

### DIFF
--- a/.changeset/nice-socks-complain.md
+++ b/.changeset/nice-socks-complain.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Fixes bug with ARN construction when configuring SAML/OIDC

--- a/package-lock.json
+++ b/package-lock.json
@@ -21319,11 +21319,23 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.6",
-        "@aws-amplify/plugin-types": "^0.5.0"
+        "@aws-amplify/plugin-types": "^0.5.0",
+        "@aws-sdk/util-arn-parser": "^3.465.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
         "constructs": "^10.0.0"
+      }
+    },
+    "packages/auth-construct/node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.465.0.tgz",
+      "integrity": "sha512-zOJ82vzDJFqBX9yZBlNeHHrul/kpx/DCoxzW5UBbZeb26kfV53QhMSoEmY8/lEbBqlqargJ/sgRC845GFhHNQw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "packages/backend": {

--- a/packages/auth-construct/package.json
+++ b/packages/auth-construct/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@aws-amplify/backend-output-schemas": "^0.4.0",
     "@aws-amplify/backend-output-storage": "^0.2.6",
-    "@aws-amplify/plugin-types": "^0.5.0"
+    "@aws-amplify/plugin-types": "^0.5.0",
+    "@aws-sdk/util-arn-parser": "^3.465.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.110.1",

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import { AmplifyAuth } from './construct.js';
 import { App, SecretValue, Stack } from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import assert from 'node:assert';
 import {
   AmplifyFunction,
@@ -1164,6 +1164,25 @@ void describe('Auth construct', () => {
         'AWS::Cognito::UserPoolIdentityProvider',
         ExpectedOidcIDPProperties
       );
+      template.hasResourceProperties('AWS::Cognito::IdentityPool', {
+        OpenIdConnectProviderARNs: [
+          Match.objectEquals({
+            'Fn::Join': [
+              '',
+              [
+                'arn:aws:iam:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':oidc-provider/cognito-idp.',
+                { Ref: 'AWS::Region' },
+                '.amazonaws.com/',
+                { Ref: 'testOidcIDP12B3582F' },
+              ],
+            ],
+          }),
+        ],
+      });
     });
     void it('supports oidc and phone', () => {
       const app = new App();
@@ -1190,6 +1209,25 @@ void describe('Auth construct', () => {
         'AWS::Cognito::UserPoolIdentityProvider',
         ExpectedOidcIDPProperties
       );
+      template.hasResourceProperties('AWS::Cognito::IdentityPool', {
+        OpenIdConnectProviderARNs: [
+          Match.objectEquals({
+            'Fn::Join': [
+              '',
+              [
+                'arn:aws:iam:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':oidc-provider/cognito-idp.',
+                { Ref: 'AWS::Region' },
+                '.amazonaws.com/',
+                { Ref: 'testOidcIDP12B3582F' },
+              ],
+            ],
+          }),
+        ],
+      });
     });
     void it('supports saml and email', () => {
       const app = new App();
@@ -1217,6 +1255,23 @@ void describe('Auth construct', () => {
         'AWS::Cognito::UserPoolIdentityProvider',
         ExpectedSAMLIDPProperties
       );
+      template.hasResourceProperties('AWS::Cognito::IdentityPool', {
+        SamlProviderARNs: [
+          Match.objectEquals({
+            'Fn::Join': [
+              '',
+              [
+                'arn:aws:iam:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':saml-provider/',
+                { Ref: 'testSamlIDP7B98F3F4' },
+              ],
+            ],
+          }),
+        ],
+      });
     });
     void it('supports saml and phone', () => {
       const app = new App();
@@ -1244,6 +1299,23 @@ void describe('Auth construct', () => {
         'AWS::Cognito::UserPoolIdentityProvider',
         ExpectedSAMLIDPProperties
       );
+      template.hasResourceProperties('AWS::Cognito::IdentityPool', {
+        SamlProviderARNs: [
+          Match.objectEquals({
+            'Fn::Join': [
+              '',
+              [
+                'arn:aws:iam:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':saml-provider/',
+                { Ref: 'testSamlIDP7B98F3F4' },
+              ],
+            ],
+          }),
+        ],
+      });
     });
 
     void it('supports additional oauth settings', () => {

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -37,6 +37,7 @@ import {
 } from '@aws-amplify/backend-output-storage';
 import * as path from 'path';
 import { coreAttributeNameMap } from './string_maps.js';
+import { build as arnBuilder } from '@aws-sdk/util-arn-parser';
 
 type DefaultRoles = { auth: Role; unAuth: Role };
 type IdentityProviderSetupResult = {
@@ -256,18 +257,22 @@ export class AmplifyAuth
     identityPool.supportedLoginProviders = providerSetupResult.oauthMappings;
     if (providerSetupResult.oidc) {
       identityPool.openIdConnectProviderArns = [
-        `arn:${region}:iam::${
-          Stack.of(this).account
-        }:oidc-provider/cognito-idp.${region}.amazonaws.com/${
-          providerSetupResult.oidc.providerName
-        }`,
+        arnBuilder({
+          service: 'iam',
+          region,
+          accountId: Stack.of(this).account,
+          resource: `oidc-provider/cognito-idp.${region}.amazonaws.com/${providerSetupResult.oidc.providerName}`,
+        }),
       ];
     }
     if (providerSetupResult.saml) {
       identityPool.samlProviderArns = [
-        `arn:${region}:iam::${Stack.of(this).account}:saml-provider/${
-          providerSetupResult.saml.providerName
-        }`,
+        arnBuilder({
+          service: 'iam',
+          region,
+          accountId: Stack.of(this).account,
+          resource: `saml-provider/${providerSetupResult.saml.providerName}`,
+        }),
       ];
     }
     return {


### PR DESCRIPTION
*Issue 796*
https://github.com/aws-amplify/amplify-backend/issues/796

*Description of changes:*
Replaces manual creation of ARN strings with official builder from AWS SDK


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
