### PR TITLE
Improve construct access ergonomics

### DIFF
--- a/.changeset/tender-ligers-cross.md
+++ b/.changeset/tender-ligers-cross.md
@@ -1,0 +1,8 @@
+---
+'@aws-amplify/storage-construct-alpha': minor
+'@aws-amplify/backend-data': minor
+'@aws-amplify/plugin-types': minor
+'@aws-amplify/backend': minor
+---
+
+Rework Backend platform type to allow accessing CDK constructs using backend.<name>.<constructName> rather than backend.resources.<name>.resources.<constructName>

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -4,10 +4,11 @@
 
 ```ts
 
-import { AmplifyData } from '@aws-amplify/data-construct';
+import { AmplifyDataResources } from '@aws-amplify/data-construct';
 import { AmplifyFunction } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
+import { ResourceProvider } from '@aws-amplify/plugin-types';
 
 // @public
 export type ApiKeyAuthorizationModeProps = {
@@ -39,7 +40,7 @@ export type DataSchema = string | DerivedModelSchema;
 export type DefaultAuthorizationMode = 'iam' | 'userPool' | 'oidc' | 'apiKey' | 'lambda';
 
 // @public
-export const defineData: (props: DataProps) => ConstructFactory<AmplifyData>;
+export const defineData: (props: DataProps) => ConstructFactory<ResourceProvider<AmplifyDataResources>>;
 
 // @public
 export type LambdaAuthorizationModeProps = {

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -25,12 +25,12 @@ import {
 } from 'aws-cdk-lib/aws-cognito';
 import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
-import { AmplifyData } from '@aws-amplify/data-construct';
 import {
   ConstructContainerStub,
   ImportPathVerifierStub,
   StackResolverStub,
 } from '@aws-amplify/backend-platform-test-stubs';
+import { AmplifyDataResources } from '@aws-amplify/data-construct';
 
 const testSchema = /* GraphQL */ `
   type Todo @model {
@@ -54,7 +54,7 @@ void describe('DataFactory', () => {
   let constructContainer: ConstructContainer;
   let outputStorageStrategy: BackendOutputStorageStrategy<BackendOutputEntry>;
   let importPathVerifier: ImportPathVerifier;
-  let dataFactory: ConstructFactory<AmplifyData>;
+  let dataFactory: ConstructFactory<ResourceProvider<AmplifyDataResources>>;
   let getInstanceProps: ConstructFactoryGetInstanceProps;
 
   beforeEach(() => {
@@ -121,7 +121,9 @@ void describe('DataFactory', () => {
 
   void it('adds construct to stack', () => {
     const dataConstruct = dataFactory.getInstance(getInstanceProps);
-    const template = Template.fromStack(Stack.of(dataConstruct));
+    const template = Template.fromStack(
+      Stack.of(dataConstruct.resources.graphqlApi)
+    );
     template.resourceCountIs('AWS::AppSync::GraphQLApi', 1);
   });
 
@@ -151,7 +153,9 @@ void describe('DataFactory', () => {
 
   void it('sets a default api name if none is specified', () => {
     const dataConstruct = dataFactory.getInstance(getInstanceProps);
-    const template = Template.fromStack(Stack.of(dataConstruct));
+    const template = Template.fromStack(
+      Stack.of(dataConstruct.resources.graphqlApi)
+    );
     template.resourceCountIs('AWS::AppSync::GraphQLApi', 1);
     template.hasResourceProperties('AWS::AppSync::GraphQLApi', {
       Name: 'amplifyData',
@@ -164,7 +168,9 @@ void describe('DataFactory', () => {
       name: 'MyTestApiName',
     });
     const dataConstruct = dataFactory.getInstance(getInstanceProps);
-    const template = Template.fromStack(Stack.of(dataConstruct));
+    const template = Template.fromStack(
+      Stack.of(dataConstruct.resources.graphqlApi)
+    );
     template.resourceCountIs('AWS::AppSync::GraphQLApi', 1);
     template.hasResourceProperties('AWS::AppSync::GraphQLApi', {
       Name: 'MyTestApiName',

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -7,7 +7,7 @@ import {
   ConstructFactoryGetInstanceProps,
   ResourceProvider,
 } from '@aws-amplify/plugin-types';
-import { AmplifyData } from '@aws-amplify/data-construct';
+import { AmplifyData, AmplifyDataResources } from '@aws-amplify/data-construct';
 import { GraphqlOutput } from '@aws-amplify/backend-output-schemas';
 import * as path from 'path';
 import { DataProps } from './types.js';
@@ -29,7 +29,9 @@ import { AmplifyUserError } from '@aws-amplify/platform-core';
 /**
  * Singleton factory for AmplifyGraphqlApi constructs that can be used in Amplify project files
  */
-class DataFactory implements ConstructFactory<AmplifyData> {
+class DataFactory
+  implements ConstructFactory<ResourceProvider<AmplifyDataResources>>
+{
   private generator: ConstructContainerEntryGenerator;
 
   /**
@@ -160,5 +162,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
 /**
  * Creates a factory that implements ConstructFactory<AmplifyGraphqlApi>
  */
-export const defineData = (props: DataProps): ConstructFactory<AmplifyData> =>
+export const defineData = (
+  props: DataProps
+): ConstructFactory<ResourceProvider<AmplifyDataResources>> =>
   new DataFactory(props, new Error().stack);

--- a/packages/backend-platform-test-stubs/API.md
+++ b/packages/backend-platform-test-stubs/API.md
@@ -5,11 +5,11 @@
 ```ts
 
 import { CfnElement } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
 import { ConstructContainer } from '@aws-amplify/plugin-types';
 import { ConstructContainerEntryGenerator } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { ImportPathVerifier } from '@aws-amplify/plugin-types';
+import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { Stack } from 'aws-cdk-lib';
 
 // @public
@@ -20,8 +20,8 @@ export class AmplifyStackStub extends Stack {
 // @public
 export class ConstructContainerStub implements ConstructContainer {
     constructor(stackResolver: StackResolver);
-    getConstructFactory: <T>(token: string) => ConstructFactory<T> | undefined;
-    getOrCompute: (generator: ConstructContainerEntryGenerator) => Construct;
+    getConstructFactory: <T extends ResourceProvider>(token: string) => ConstructFactory<T> | undefined;
+    getOrCompute: (generator: ConstructContainerEntryGenerator) => ResourceProvider;
     registerConstructFactory: (token: string, provider: ConstructFactory) => void;
 }
 

--- a/packages/backend-platform-test-stubs/src/construct_container_stub.ts
+++ b/packages/backend-platform-test-stubs/src/construct_container_stub.ts
@@ -1,10 +1,10 @@
-import { Construct } from 'constructs';
 import { StackResolver } from './stack_resolver_stub.js';
 import {
   BackendIdentifier,
   ConstructContainer,
   ConstructContainerEntryGenerator,
   ConstructFactory,
+  ResourceProvider,
 } from '@aws-amplify/plugin-types';
 import { BackendSecretResolverStub } from './backend_secret_resolver_stub.js';
 
@@ -13,9 +13,9 @@ import { BackendSecretResolverStub } from './backend_secret_resolver_stub.js';
  */
 export class ConstructContainerStub implements ConstructContainer {
   // uses the CacheEntryGenerator as the map key. The value is what the generator returned the first time it was seen
-  private readonly constructCache: Map<
+  private readonly providerCache: Map<
     ConstructContainerEntryGenerator,
-    Construct
+    ResourceProvider
   > = new Map();
 
   private readonly providerFactoryTokenMap: Record<string, ConstructFactory> =
@@ -30,20 +30,24 @@ export class ConstructContainerStub implements ConstructContainer {
    * If generator has been seen before, the cached Construct instance is returned
    * Otherwise, the generator is called and the value is cached and returned
    */
-  getOrCompute = (generator: ConstructContainerEntryGenerator): Construct => {
-    if (!this.constructCache.has(generator)) {
+  getOrCompute = (
+    generator: ConstructContainerEntryGenerator
+  ): ResourceProvider => {
+    if (!this.providerCache.has(generator)) {
       const scope = this.stackResolver.getStackFor(generator.resourceGroupName);
       const backendId = getBackendIdentifierStub();
       const backendSecretResolver = new BackendSecretResolverStub(
         scope,
         backendId
       );
-      this.constructCache.set(
+      this.providerCache.set(
         generator,
         generator.generateContainerEntry(scope, backendSecretResolver)
       );
     }
-    return this.constructCache.get(generator) as Construct;
+    // safe because we checked for existence above
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.providerCache.get(generator)!;
   };
 
   /**
@@ -55,7 +59,9 @@ export class ConstructContainerStub implements ConstructContainer {
    *
    * By convention, tokens should be the name of type T
    */
-  getConstructFactory = <T>(token: string): ConstructFactory<T> | undefined => {
+  getConstructFactory = <T extends ResourceProvider>(
+    token: string
+  ): ConstructFactory<T> | undefined => {
     if (token in this.providerFactoryTokenMap) {
       return this.providerFactoryTokenMap[token] as ConstructFactory<T>;
     }

--- a/packages/backend/API.md
+++ b/packages/backend/API.md
@@ -7,22 +7,21 @@
 import { a } from '@aws-amplify/data-schema';
 import { BackendSecret } from '@aws-amplify/plugin-types';
 import { ClientSchema } from '@aws-amplify/data-schema';
-import { Construct } from 'constructs';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { defineAuth } from '@aws-amplify/backend-auth';
 import { defineData } from '@aws-amplify/backend-data';
 import { defineFunction } from '@aws-amplify/backend-function';
 import { defineStorage } from '@aws-amplify/backend-storage';
+import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { Stack } from 'aws-cdk-lib';
 
 export { a }
 
 // @public
-export type Backend<T extends Record<string, ConstructFactory<Construct>>> = {
+export type Backend<T extends Record<string, ConstructFactory<ResourceProvider>>> = {
     createStack: (name: string) => Stack;
-    readonly resources: {
-        [K in keyof T]: ReturnType<T[K]['getInstance']>;
-    };
+} & {
+    [K in keyof T]: ReturnType<T[K]['getInstance']>['resources'];
 };
 
 export { ClientSchema }
@@ -30,7 +29,7 @@ export { ClientSchema }
 export { defineAuth }
 
 // @public
-export const defineBackend: <T extends Record<string, ConstructFactory<Construct>>>(constructFactories: T) => Backend<T>;
+export const defineBackend: <T extends Record<string, ConstructFactory<ResourceProvider>>>(constructFactories: T) => Backend<T>;
 
 export { defineData }
 

--- a/packages/backend/src/backend.ts
+++ b/packages/backend/src/backend.ts
@@ -1,14 +1,14 @@
-import { ConstructFactory } from '@aws-amplify/plugin-types';
-import { Construct } from 'constructs';
+import { ConstructFactory, ResourceProvider } from '@aws-amplify/plugin-types';
 import { Stack } from 'aws-cdk-lib';
 
 /**
  * Top level type for instance returned from `defineBackend`. Contains property `resources` for overriding
  * Amplify generated resources and `getStack()` for adding custom resources.
  */
-export type Backend<T extends Record<string, ConstructFactory<Construct>>> = {
+export type Backend<
+  T extends Record<string, ConstructFactory<ResourceProvider>>
+> = {
   createStack: (name: string) => Stack;
-  readonly resources: {
-    [K in keyof T]: ReturnType<T[K]['getInstance']>;
-  };
+} & {
+  [K in keyof T]: ReturnType<T[K]['getInstance']>['resources'];
 };

--- a/packages/integration-tests/src/define_backend_template_harness.ts
+++ b/packages/integration-tests/src/define_backend_template_harness.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { CDKContextKey } from '@aws-amplify/platform-core';
 import { defineBackend } from '@aws-amplify/backend';
 import { Stack } from 'aws-cdk-lib';
-import { ConstructFactory } from '@aws-amplify/plugin-types';
+import { ConstructFactory, ResourceProvider } from '@aws-amplify/plugin-types';
 import { Construct } from 'constructs';
 
 /**
@@ -27,7 +27,7 @@ export const assertExpectedLogicalIds = (
  * Supplies stable CDK context values to the synth process for deterministic synth output
  */
 export const synthesizeBackendTemplates: SynthesizeBackendTemplates = <
-  T extends Record<string, ConstructFactory<Construct>>
+  T extends Record<string, ConstructFactory<ResourceProvider>>
 >(
   constructFactories: T
 ) => {
@@ -45,7 +45,7 @@ export const synthesizeBackendTemplates: SynthesizeBackendTemplates = <
 };
 
 const backendTemplatesCollector: SynthesizeBackendTemplates = <
-  T extends Record<string, ConstructFactory<Construct>>
+  T extends Record<string, ConstructFactory<ResourceProvider>>
 >(
   constructFactories: T
 ) => {
@@ -53,22 +53,32 @@ const backendTemplatesCollector: SynthesizeBackendTemplates = <
     throw new Error('constructFactories must have at least one entry');
   }
   const backend = defineBackend(constructFactories);
+  const firstResourceProvider = backend[Object.keys(constructFactories)[0]];
+  const firstConstruct = Object.values(firstResourceProvider).find(
+    (value) => value instanceof Construct
+  );
   const result = {
     // need to go up two levels to get the root stack
-    root: Template.fromStack(
-      Stack.of(backend.resources[Object.keys(constructFactories)[0]]).node
-        .scope as Stack
-    ),
+    root: Template.fromStack(Stack.of(firstConstruct).node.scope as Stack),
   } as Partial<{ [K in keyof T]: Template }> & { root: Template };
 
-  for (const [name, construct] of Object.entries(backend.resources)) {
-    result[name as keyof T] = Template.fromStack(Stack.of(construct)) as never; // TS can't figure out which "K in keyof T" "name" corresponds to here but this assignment is safe
+  for (const [key, resourceRecord] of Object.entries(backend)) {
+    if (key === 'createStack') {
+      continue;
+    }
+    // find some construct in the resources exposed by the resourceRecord
+    const firstConstruct = Object.values(resourceRecord).find(
+      (value) => value instanceof Construct
+    );
+    result[key as keyof T] = Template.fromStack(
+      Stack.of(firstConstruct)
+    ) as never; // TS can't figure out which "K in keyof T" "name" corresponds to here but this assignment is safe
   }
   return result as { [K in keyof T]: Template } & { root: Template };
 };
 
 type SynthesizeBackendTemplates = <
-  T extends Record<string, ConstructFactory<Construct>>
+  T extends Record<string, ConstructFactory<ResourceProvider>>
 >(
   constructFactories: T
 ) => { [K in keyof T]: Template } & { root: Template };

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -86,19 +86,19 @@ export type BranchName = string;
 
 // @public
 export type ConstructContainer = {
-    getOrCompute: (generator: ConstructContainerEntryGenerator) => Construct;
+    getOrCompute: (generator: ConstructContainerEntryGenerator) => ResourceProvider;
     registerConstructFactory: (token: string, provider: ConstructFactory) => void;
-    getConstructFactory: <T>(token: string) => ConstructFactory<T> | undefined;
+    getConstructFactory: <T extends ResourceProvider>(token: string) => ConstructFactory<T> | undefined;
 };
 
 // @public
-export type ConstructContainerEntryGenerator = {
+export type ConstructContainerEntryGenerator<T extends object = object> = {
     resourceGroupName: string;
-    generateContainerEntry: (scope: Construct, backendSecretResolver: BackendSecretResolver) => Construct;
+    generateContainerEntry: (scope: Construct, backendSecretResolver: BackendSecretResolver) => ResourceProvider<T>;
 };
 
 // @public
-export type ConstructFactory<T = unknown> = {
+export type ConstructFactory<T extends ResourceProvider = ResourceProvider> = {
     readonly provides?: string;
     getInstance: (props: ConstructFactoryGetInstanceProps) => T;
 };
@@ -137,7 +137,7 @@ export type MainStackNameResolver = {
 export type ProjectName = string;
 
 // @public
-export type ResourceProvider<T> = {
+export type ResourceProvider<T extends object = object> = {
     resources: T;
 };
 

--- a/packages/plugin-types/src/construct_container.ts
+++ b/packages/plugin-types/src/construct_container.ts
@@ -1,11 +1,12 @@
 import { Construct } from 'constructs';
 import { ConstructFactory } from './construct_factory.js';
 import { BackendSecretResolver } from './backend_secret_resolver.js';
+import { ResourceProvider } from './resource_provider.js';
 
 /**
  * Initializes a CDK Construct in a given scope
  */
-export type ConstructContainerEntryGenerator = {
+export type ConstructContainerEntryGenerator<T extends object = object> = {
   /**
    * A group name for this generator.
    * This is used by the cache to determine which stack to place the generated construct in
@@ -18,14 +19,18 @@ export type ConstructContainerEntryGenerator = {
   generateContainerEntry: (
     scope: Construct,
     backendSecretResolver: BackendSecretResolver
-  ) => Construct;
+  ) => ResourceProvider<T>;
 };
 
 /**
  * Vends Constructs based on an initializer function
  */
 export type ConstructContainer = {
-  getOrCompute: (generator: ConstructContainerEntryGenerator) => Construct;
+  getOrCompute: (
+    generator: ConstructContainerEntryGenerator
+  ) => ResourceProvider;
   registerConstructFactory: (token: string, provider: ConstructFactory) => void;
-  getConstructFactory: <T>(token: string) => ConstructFactory<T> | undefined;
+  getConstructFactory: <T extends ResourceProvider>(
+    token: string
+  ) => ConstructFactory<T> | undefined;
 };

--- a/packages/plugin-types/src/construct_factory.ts
+++ b/packages/plugin-types/src/construct_factory.ts
@@ -2,6 +2,7 @@ import { ConstructContainer } from './construct_container.js';
 import { BackendOutputStorageStrategy } from './output_storage_strategy.js';
 import { BackendOutputEntry } from './backend_output.js';
 import { ImportPathVerifier } from './import_path_verifier.js';
+import { ResourceProvider } from './resource_provider.js';
 
 export type ConstructFactoryGetInstanceProps = {
   constructContainer: ConstructContainer;
@@ -12,7 +13,7 @@ export type ConstructFactoryGetInstanceProps = {
 /**
  * Functional interface for construct factories. All objects in the backend-engine definition must implement this interface.
  */
-export type ConstructFactory<T = unknown> = {
+export type ConstructFactory<T extends ResourceProvider = ResourceProvider> = {
   /**
    * A construct factory can register that the return value implements additional interfaces
    * Registering as a provider allows other construct factories to fetch this one based on the provides token

--- a/packages/plugin-types/src/resource_provider.ts
+++ b/packages/plugin-types/src/resource_provider.ts
@@ -1,6 +1,9 @@
 /**
  * Provides reference to underlying CDK resources.
+ *
+ * Note: we have to use object as the generic construct rather than Record<string, unknown> so that interfaces will also satisfy the constraint
+ * See: https://stackoverflow.com/questions/63617344/how-to-satisfy-the-constraint-of-recordstring-unknown-with-interface
  */
-export type ResourceProvider<T> = {
+export type ResourceProvider<T extends object = object> = {
   resources: T;
 };

--- a/packages/storage-construct/API.md
+++ b/packages/storage-construct/API.md
@@ -6,17 +6,26 @@
 
 import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { Construct } from 'constructs';
+import { IBucket } from 'aws-cdk-lib/aws-s3';
+import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { StorageOutput } from '@aws-amplify/backend-output-schemas';
 
 // @public
-export class AmplifyStorage extends Construct {
+export class AmplifyStorage extends Construct implements ResourceProvider<StorageResources> {
     constructor(scope: Construct, id: string, props: AmplifyStorageProps);
+    // (undocumented)
+    readonly resources: StorageResources;
 }
 
 // @public (undocumented)
 export type AmplifyStorageProps = {
     versioned?: boolean;
     outputStorageStrategy?: BackendOutputStorageStrategy<StorageOutput>;
+};
+
+// @public (undocumented)
+export type StorageResources = {
+    bucket: IBucket;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/packages/storage-construct/src/construct.ts
+++ b/packages/storage-construct/src/construct.ts
@@ -1,6 +1,9 @@
 import { Construct } from 'constructs';
-import { Bucket, BucketProps } from 'aws-cdk-lib/aws-s3';
-import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
+import { Bucket, BucketProps, IBucket } from 'aws-cdk-lib/aws-s3';
+import {
+  BackendOutputStorageStrategy,
+  ResourceProvider,
+} from '@aws-amplify/plugin-types';
 import {
   StorageOutput,
   storageOutputKey,
@@ -20,13 +23,20 @@ export type AmplifyStorageProps = {
   outputStorageStrategy?: BackendOutputStorageStrategy<StorageOutput>;
 };
 
+export type StorageResources = {
+  bucket: IBucket;
+};
+
 /**
  * Amplify Storage CDK Construct
  *
  * Currently just a thin wrapper around an S3 bucket
  */
-export class AmplifyStorage extends Construct {
-  private readonly bucket: Bucket;
+export class AmplifyStorage
+  extends Construct
+  implements ResourceProvider<StorageResources>
+{
+  readonly resources: StorageResources;
   /**
    * Create a new AmplifyStorage instance
    */
@@ -37,7 +47,9 @@ export class AmplifyStorage extends Construct {
       versioned: props.versioned || false,
     };
 
-    this.bucket = new Bucket(this, `${id}Bucket`, bucketProps);
+    this.resources = {
+      bucket: new Bucket(this, `${id}Bucket`, bucketProps),
+    };
 
     this.storeOutput(props.outputStorageStrategy);
 
@@ -60,7 +72,7 @@ export class AmplifyStorage extends Construct {
       version: '1',
       payload: {
         storageRegion: Stack.of(this).region,
-        bucketName: this.bucket.bucketName,
+        bucketName: this.resources.bucket.bucketName,
       },
     });
   };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reworks the Backend type and BackendFactory to allow accessing CDK constructs using a pattern like `backend.auth.userPool` instead of `backend.resources.auth.resources.userPool`. The functional change is essentially just the change in the `backend_factory.ts` file. Everything else is type updates and test updates to match the new shape.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
