### PR TITLE
test: fix api check - retain version information after local publish

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -64,16 +64,17 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
+      - name: Publish packages locally
+        run: npm run vend
       - name: Checkout base branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
         with:
-          path: ../base-branch-content
+          path: base-branch-content
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Check API changes
         run: |
-          npm run vend
           mkdir api-validation-projects
-          npx tsx scripts/check_api_changes.ts ../base-branch-content api-validation-projects
+          npx tsx scripts/check_api_changes.ts base-branch-content api-validation-projects
   do_include_e2e:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -65,6 +65,10 @@ jobs:
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
       - name: Publish packages locally
+        # We have to publish before checking out base branch because that makes local git repo 'dirty'.
+        # On the other hand if we separate both checkouts, i.e. put them in separate directories,
+        # then we wouldn't benefit from build cache, as we would have to change location of where pull request
+        # content is (GitHub won't let us checkout to ../base-branch-content).
         run: npm run vend
       - name: Checkout base branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
@@ -73,6 +77,8 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Check API changes
         run: |
+          # We have to start proxy again in new shell session
+          npm run start:npm-proxy
           mkdir api-validation-projects
           npx tsx scripts/check_api_changes.ts base-branch-content api-validation-projects
   do_include_e2e:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -65,10 +65,6 @@ jobs:
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
       - name: Publish packages locally
-        # We have to publish before checking out base branch because that makes local git repo 'dirty'.
-        # On the other hand if we separate both checkouts, i.e. put them in separate directories,
-        # then we wouldn't benefit from build cache, as we would have to change location of where pull request
-        # content is (GitHub won't let us checkout to ../base-branch-content).
         run: npm run vend
       - name: Checkout base branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
@@ -77,8 +73,6 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Check API changes
         run: |
-          # We have to start proxy again in new shell session
-          npm run start:npm-proxy
           mkdir api-validation-projects
           npx tsx scripts/check_api_changes.ts base-branch-content api-validation-projects
   do_include_e2e:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -64,8 +64,6 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
-      - name: Publish packages locally
-        run: npm run vend
       - name: Checkout base branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
         with:
@@ -73,6 +71,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Check API changes
         run: |
+          npm run vend
           mkdir api-validation-projects
           npx tsx scripts/check_api_changes.ts base-branch-content api-validation-projects
   do_include_e2e:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -67,13 +67,13 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
         with:
-          path: base-branch-content
+          path: ../base-branch-content
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Check API changes
         run: |
           npm run vend
           mkdir api-validation-projects
-          npx tsx scripts/check_api_changes.ts base-branch-content api-validation-projects
+          npx tsx scripts/check_api_changes.ts ../base-branch-content api-validation-projects
   do_include_e2e:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -65,7 +65,10 @@ jobs:
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
       - name: Publish packages locally
-        run: npm run vend
+        run: |
+          npm run start:npm-proxy
+          # keep git diff with version increment to make sure test projects resolve right version
+          npm run publish:local -- --keepGitDiff
       - name: Checkout base branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
         with:

--- a/scripts/check_api_changes.ts
+++ b/scripts/check_api_changes.ts
@@ -10,10 +10,11 @@ import { fileURLToPath } from 'url';
  *
  * In order to debug this check locally:
  * 1. Checkout content of your PR
- * 2. Build and publish packages locally, i.e. 'npm run build && npm run vend'
+ * 2. Build and publish packages locally, i.e. 'npm run build && npm run start:npm-proxy && npm run publish:local -- --keepGitDiff'
  * 3. Checkout content of your PR's base branch to different directory
  * 4. Create a directory where test projects are going to be generated
  * 5. Run 'tsx scripts/check_api_changes.ts <baselineBranchPath> <workingDirectory>'
+ * 6. Remember to reset changes from step 2. i.e. version increments and changelogs
  */
 
 // extract the command args that should be run in each package

--- a/scripts/publish_local.ts
+++ b/scripts/publish_local.ts
@@ -2,15 +2,21 @@ import { execa } from 'execa';
 import { runPublish } from './publish_runner.js';
 import * as path from 'path';
 
-const isCleanWorkingTree = async (): Promise<boolean> => {
-  const buffer = await execa('git', ['status', '--porcelain']);
-  return !buffer.stdout.trim();
-};
-const isCleanTree = await isCleanWorkingTree();
-if (!isCleanTree) {
-  throw new Error(
-    `Detected a dirty working tree. Commit or stash changes before publishing a snapshot`
-  );
+const runArgs = process.argv.slice(2);
+
+const keepGitDiff = runArgs.find((arg) => arg === '--keepGitDiff');
+
+if (!keepGitDiff) {
+  const isCleanWorkingTree = async (): Promise<boolean> => {
+    const buffer = await execa('git', ['status', '--porcelain']);
+    return !buffer.stdout.trim();
+  };
+  const isCleanTree = await isCleanWorkingTree();
+  if (!isCleanTree) {
+    throw new Error(
+      `Detected a dirty working tree. Commit or stash changes before publishing a snapshot`
+    );
+  }
 }
 
 // this command will write staged changesets into changelog files and update versions
@@ -24,15 +30,17 @@ await runPublish({
   useLocalRegistry: true,
 });
 
-// this is safe because the script ensures the working tree is clean before starting
-await execa('git', ['reset', '--hard']);
+if (!keepGitDiff) {
+  // this is safe because the script ensures the working tree is clean before starting
+  await execa('git', ['reset', '--hard']);
 
-// if any packages have not been published yet, this script will produce a new changelog file
-// this is not cleaned up by git reset because the file is not tracked by git yet
-// this command cleans up those changelog files
-await execa('git', [
-  'clean',
-  '-f',
-  '--',
-  path.join('packages', '**', 'CHANGELOG.md'),
-]);
+  // if any packages have not been published yet, this script will produce a new changelog file
+  // this is not cleaned up by git reset because the file is not tracked by git yet
+  // this command cleans up those changelog files
+  await execa('git', [
+    'clean',
+    '-f',
+    '--',
+    path.join('packages', '**', 'CHANGELOG.md'),
+  ]);
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes https://github.com/aws-amplify/amplify-backend/actions/runs/7177124185/job/19543184647?pr=810 .

Add option to retain git diff after local publish. I.e. retain information about versions that got published to verdaccio.
Test projects in api check use pinned versions to resolve package under test to make sure they don't accidentally pull wrong version.

I was debating if we should use `latest` in test project's package json but I figured using precise version is going to remove some doubts about what exactly is resolved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
