### PR TITLE
Initial implementation for function secret access

### DIFF
--- a/.changeset/grumpy-trainers-repeat.md
+++ b/.changeset/grumpy-trainers-repeat.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-function': minor
+'@aws-amplify/plugin-types': minor
+'@aws-amplify/backend': minor
+---
+
+Implement function secret access

--- a/.changeset/young-rings-do.md
+++ b/.changeset/young-rings-do.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-secret': patch
+'@aws-amplify/platform-core': patch
+---
+
+Move parameter path methods to BackendIdentifierConversions

--- a/.changeset/young-rings-do.md
+++ b/.changeset/young-rings-do.md
@@ -3,4 +3,4 @@
 '@aws-amplify/platform-core': patch
 ---
 
-Move parameter path methods to BackendIdentifierConversions
+Move parameter path methods to ParameterPathConversions

--- a/package-lock.json
+++ b/package-lock.json
@@ -21421,6 +21421,7 @@
       "dependencies": {
         "@aws-amplify/backend-output-storage": "0.2.6",
         "@aws-amplify/plugin-types": "^0.5.0",
+        "@aws-sdk/client-ssm": "^3.398.0",
         "execa": "^7.1.1"
       },
       "devDependencies": {

--- a/packages/backend-auth/src/translate_auth_props.test.ts
+++ b/packages/backend-auth/src/translate_auth_props.test.ts
@@ -10,6 +10,7 @@ import { AuthProps, PhoneNumberLogin } from '@aws-amplify/auth-construct-alpha';
 import { SecretValue } from 'aws-cdk-lib';
 import assert from 'node:assert';
 import { translateToAuthConstructLoginWith } from './translate_auth_props.js';
+import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 
 const phone: PhoneNumberLogin = {
   verificationMessage: (code: string) => `text${code}text2`,
@@ -42,11 +43,20 @@ class TestBackendSecret implements BackendSecret {
   resolve = (): SecretValue => {
     return SecretValue.unsafePlainText(this.secretName);
   };
+  resolveToPath = (): string => {
+    return BackendIdentifierConversions.toParameterFullPath(
+      testBackendIdentifier,
+      this.secretName
+    );
+  };
 }
 
 class TestBackendSecretResolver implements BackendSecretResolver {
   resolveSecret = (backendSecret: BackendSecret): SecretValue => {
     return backendSecret.resolve(testStack, testBackendIdentifier);
+  };
+  resolveToPath = (backendSecret: BackendSecret): string => {
+    return backendSecret.resolveToPath(testBackendIdentifier);
   };
 }
 

--- a/packages/backend-auth/src/translate_auth_props.test.ts
+++ b/packages/backend-auth/src/translate_auth_props.test.ts
@@ -10,7 +10,7 @@ import { AuthProps, PhoneNumberLogin } from '@aws-amplify/auth-construct-alpha';
 import { SecretValue } from 'aws-cdk-lib';
 import assert from 'node:assert';
 import { translateToAuthConstructLoginWith } from './translate_auth_props.js';
-import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import { ParameterPathConversions } from '@aws-amplify/platform-core';
 
 const phone: PhoneNumberLogin = {
   verificationMessage: (code: string) => `text${code}text2`,
@@ -44,7 +44,7 @@ class TestBackendSecret implements BackendSecret {
     return SecretValue.unsafePlainText(this.secretName);
   };
   resolveToPath = (): string => {
-    return BackendIdentifierConversions.toParameterFullPath(
+    return ParameterPathConversions.toParameterFullPath(
       testBackendIdentifier,
       this.secretName
     );

--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { BackendSecret } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
@@ -17,7 +18,7 @@ export type FunctionProps = {
     entry?: string;
     timeoutSeconds?: number;
     memoryMB?: number;
-    environment?: Record<string, string>;
+    environment?: Record<string, string | BackendSecret>;
     runtime?: NodeVersion;
 };
 

--- a/packages/backend-function/package.json
+++ b/packages/backend-function/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "0.2.6",
     "@aws-amplify/plugin-types": "^0.5.0",
+    "@aws-sdk/client-ssm": "^3.398.0",
     "execa": "^7.1.1"
   },
   "devDependencies": {

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -3,7 +3,6 @@ import { App, SecretValue, Stack } from 'aws-cdk-lib';
 import {
   BackendIdentifier,
   BackendSecret,
-  BackendSecretResolver,
   ConstructFactoryGetInstanceProps,
 } from '@aws-amplify/plugin-types';
 import assert from 'node:assert';
@@ -18,7 +17,6 @@ import { NodeVersion, defineFunction } from './factory.js';
 import { lambdaWithDependencies } from './test-assets/lambda-with-dependencies/resource.js';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
-import { Construct } from 'constructs';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -45,17 +43,6 @@ class TestBackendSecret implements BackendSecret {
       testBackendIdentifier,
       this.secretName
     );
-  };
-}
-
-const testStack = {} as Construct;
-
-class TestBackendSecretResolver implements BackendSecretResolver {
-  resolveSecret = (backendSecret: BackendSecret): SecretValue => {
-    return backendSecret.resolve(testStack, testBackendIdentifier);
-  };
-  resolveToPath = (backendSecret: BackendSecret): string => {
-    return backendSecret.resolveToPath(testBackendIdentifier);
   };
 }
 
@@ -278,7 +265,6 @@ void describe('AmplifyFunctionFactory', () => {
 
     void it('sets environment variables with secret path and placeholder text', () => {
       const testSecret = new TestBackendSecret('secretValue');
-      const backendResolver = new TestBackendSecretResolver();
       const lambda = defineFunction({
         entry: './test-assets/default-lambda/handler.ts',
         environment: {
@@ -293,7 +279,8 @@ void describe('AmplifyFunctionFactory', () => {
           Variables: {
             TEST_VAR: 'testValue',
             TEST_SECRET: '<value will be resolved during runtime>',
-            TEST_SECRET_PATH: backendResolver.resolveToPath(testSecret),
+            TEST_SECRET_PATH:
+              '/amplify/testBackendId/testBranchName/secretValue',
           },
         },
       });

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -16,7 +16,7 @@ import { Template } from 'aws-cdk-lib/assertions';
 import { NodeVersion, defineFunction } from './factory.js';
 import { lambdaWithDependencies } from './test-assets/lambda-with-dependencies/resource.js';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import { ParameterPathConversions } from '@aws-amplify/platform-core';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -39,7 +39,7 @@ class TestBackendSecret implements BackendSecret {
     return SecretValue.unsafePlainText(this.secretName);
   };
   resolveToPath = (): string => {
-    return BackendIdentifierConversions.toParameterFullPath(
+    return ParameterPathConversions.toParameterFullPath(
       testBackendIdentifier,
       this.secretName
     );

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -255,8 +255,7 @@ const translateToEnvironmentSecretPath = (
 
   for (const [key, value] of Object.entries(result)) {
     if (typeof value !== 'string') {
-      result[`${key}_PATH`] =
-        backendSecretResolver.resolveToPath?.(value) ?? '';
+      result[`${key}_PATH`] = backendSecretResolver.resolveToPath(value);
       result[key] = '<value will be resolved during runtime>';
     }
   }

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -206,7 +206,7 @@ class FunctionGenerator implements ConstructContainerEntryGenerator {
   ) => {
     const functionProps: HydratedFunctionProps = {
       ...this.props,
-      environment: translateToEnvironmentSecretPath(
+      environment: translateEnvironmentProp(
         this.props.environment,
         backendSecretResolver
       ),
@@ -280,17 +280,19 @@ const nodeVersionMap: Record<NodeVersion, Runtime> = {
 const secretPathSuffix = '_PATH';
 const secretPlaceholderText = '<value will be resolved during runtime>';
 
-const translateToEnvironmentSecretPath = (
+const translateEnvironmentProp = (
   functionEnvironmentProp: HydratedFunctionProps['environment'],
   backendSecretResolver: BackendSecretResolver
-): HydratedFunctionProps['environment'] => {
-  const result = functionEnvironmentProp;
+): Record<string, string> => {
+  const result: Record<string, string> = {};
 
-  for (const [key, value] of Object.entries(result)) {
+  for (const [key, value] of Object.entries(functionEnvironmentProp)) {
     if (typeof value !== 'string') {
       result[key + secretPathSuffix] =
         backendSecretResolver.resolveToPath(value);
       result[key] = secretPlaceholderText;
+    } else {
+      result[key] = value;
     }
   }
 

--- a/packages/backend-function/src/resolve_secret_banner.ts
+++ b/packages/backend-function/src/resolve_secret_banner.ts
@@ -1,0 +1,28 @@
+import { SSM } from '@aws-sdk/client-ssm';
+
+const ssmClient = new SSM();
+
+/**
+ * The body of this function will be used to resolve secrets for Lambda functions
+ */
+export const resolveSecretBanner = async (client: SSM = ssmClient) => {
+  const envArray = process.env.SECRET_PATH_ENV_VARS?.split(',');
+  if (envArray) {
+    const response = await client.getParameters({
+      Names: envArray.map((a) => process.env[a] ?? ''),
+      WithDecryption: true,
+    });
+
+    if (response.Parameters && response.Parameters?.length > 0) {
+      for (const parameter of response.Parameters) {
+        for (const envName of envArray) {
+          if (parameter.Name === process.env[envName]) {
+            process.env[envName.replace('_PATH', '')] = parameter.Value;
+          }
+        }
+      }
+    }
+  }
+};
+
+await resolveSecretBanner();

--- a/packages/backend-platform-test-stubs/src/backend_secret_resolver_stub.ts
+++ b/packages/backend-platform-test-stubs/src/backend_secret_resolver_stub.ts
@@ -21,4 +21,8 @@ export class BackendSecretResolverStub implements BackendSecretResolver {
   resolveSecret = (backendSecret: BackendSecret): SecretValue => {
     return backendSecret.resolve(this.scope, this.backendId);
   };
+
+  resolveToPath = (backendSecret: BackendSecret): string => {
+    return backendSecret.resolveToPath(this.backendId);
+  };
 }

--- a/packages/backend-secret/src/ssm_secret.ts
+++ b/packages/backend-secret/src/ssm_secret.ts
@@ -7,7 +7,7 @@ import {
   SecretListItem,
 } from './secret.js';
 import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
-import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import { ParameterPathConversions } from '@aws-amplify/platform-core';
 
 /**
  * This class implements Amplify Secret using SSM parameter store.
@@ -26,7 +26,7 @@ export class SSMSecretClient implements SecretClient {
     secretIdentifier: SecretIdentifier
   ): Promise<Secret> => {
     let secret: Secret | undefined;
-    const name: string = BackendIdentifierConversions.toParameterFullPath(
+    const name: string = ParameterPathConversions.toParameterFullPath(
       backendIdentifier,
       secretIdentifier.name
     );
@@ -64,8 +64,7 @@ export class SSMSecretClient implements SecretClient {
   public listSecrets = async (
     backendIdentifier: BackendIdentifier | AppId
   ): Promise<SecretListItem[]> => {
-    const path =
-      BackendIdentifierConversions.toParameterPrefix(backendIdentifier);
+    const path = ParameterPathConversions.toParameterPrefix(backendIdentifier);
     const result: SecretListItem[] = [];
 
     try {
@@ -101,7 +100,7 @@ export class SSMSecretClient implements SecretClient {
     secretName: string,
     secretValue: string
   ): Promise<SecretIdentifier> => {
-    const name = BackendIdentifierConversions.toParameterFullPath(
+    const name = ParameterPathConversions.toParameterFullPath(
       backendIdentifier,
       secretName
     );
@@ -129,7 +128,7 @@ export class SSMSecretClient implements SecretClient {
     backendIdentifier: BackendIdentifier | AppId,
     secretName: string
   ) => {
-    const name = BackendIdentifierConversions.toParameterFullPath(
+    const name = ParameterPathConversions.toParameterFullPath(
       backendIdentifier,
       secretName
     );

--- a/packages/backend-secret/src/ssm_secret.ts
+++ b/packages/backend-secret/src/ssm_secret.ts
@@ -7,8 +7,7 @@ import {
   SecretListItem,
 } from './secret.js';
 import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
-
-const SHARED_SECRET = 'shared';
+import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 
 /**
  * This class implements Amplify Secret using SSM parameter store.
@@ -20,65 +19,6 @@ export class SSMSecretClient implements SecretClient {
   constructor(private readonly ssmClient: SSM) {}
 
   /**
-   * Get a branch-specific parameter prefix.
-   */
-  private getBranchParameterPrefix = (parts: BackendIdentifier): string => {
-    return `/amplify/${parts.namespace}/${parts.name}`;
-  };
-
-  /**
-   * Get a branch-specific parameter full path.
-   */
-  private getBranchParameterFullPath = (
-    backendIdentifier: BackendIdentifier,
-    secretName: string
-  ): string => {
-    return `${this.getBranchParameterPrefix(backendIdentifier)}/${secretName}`;
-  };
-
-  /**
-   * Get a shared parameter prefix.
-   */
-  private getSharedParameterPrefix = (appId: AppId): string => {
-    return `/amplify/${SHARED_SECRET}/${appId}`;
-  };
-
-  /**
-   * Get a shared parameter full path.
-   */
-  private getSharedParameterFullPath = (
-    appId: AppId,
-    secretName: string
-  ): string => {
-    return `${this.getSharedParameterPrefix(appId)}/${secretName}`;
-  };
-
-  /**
-   * Get a parameter full path.
-   */
-  private getParameterFullPath = (
-    backendIdentifier: BackendIdentifier | AppId,
-    secretName: string
-  ): string => {
-    if (typeof backendIdentifier === 'object') {
-      return this.getBranchParameterFullPath(backendIdentifier, secretName);
-    }
-    return this.getSharedParameterFullPath(backendIdentifier, secretName);
-  };
-
-  /**
-   * Get a parameter prefix.
-   */
-  private getParameterPrefix = (
-    backendIdentifier: BackendIdentifier | AppId
-  ): string => {
-    if (typeof backendIdentifier === 'object') {
-      return this.getBranchParameterPrefix(backendIdentifier);
-    }
-    return this.getSharedParameterPrefix(backendIdentifier);
-  };
-
-  /**
    * Get a secret from SSM parameter store.
    */
   public getSecret = async (
@@ -86,7 +26,7 @@ export class SSMSecretClient implements SecretClient {
     secretIdentifier: SecretIdentifier
   ): Promise<Secret> => {
     let secret: Secret | undefined;
-    const name = this.getParameterFullPath(
+    const name: string = BackendIdentifierConversions.toParameterFullPath(
       backendIdentifier,
       secretIdentifier.name
     );
@@ -124,7 +64,8 @@ export class SSMSecretClient implements SecretClient {
   public listSecrets = async (
     backendIdentifier: BackendIdentifier | AppId
   ): Promise<SecretListItem[]> => {
-    const path = this.getParameterPrefix(backendIdentifier);
+    const path =
+      BackendIdentifierConversions.toParameterPrefix(backendIdentifier);
     const result: SecretListItem[] = [];
 
     try {
@@ -160,7 +101,10 @@ export class SSMSecretClient implements SecretClient {
     secretName: string,
     secretValue: string
   ): Promise<SecretIdentifier> => {
-    const name = this.getParameterFullPath(backendIdentifier, secretName);
+    const name = BackendIdentifierConversions.toParameterFullPath(
+      backendIdentifier,
+      secretName
+    );
     try {
       const resp = await this.ssmClient.putParameter({
         Name: name,
@@ -185,7 +129,10 @@ export class SSMSecretClient implements SecretClient {
     backendIdentifier: BackendIdentifier | AppId,
     secretName: string
   ) => {
-    const name = this.getParameterFullPath(backendIdentifier, secretName);
+    const name = BackendIdentifierConversions.toParameterFullPath(
+      backendIdentifier,
+      secretName
+    );
     try {
       await this.ssmClient.deleteParameter({
         Name: name,

--- a/packages/backend/src/engine/backend-secret/backend_secret.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret.ts
@@ -2,7 +2,7 @@ import { BackendIdentifier, BackendSecret } from '@aws-amplify/plugin-types';
 import { Construct } from 'constructs';
 import { BackendSecretFetcherFactory } from './backend_secret_fetcher_factory.js';
 import { SecretValue } from 'aws-cdk-lib';
-import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import { ParameterPathConversions } from '@aws-amplify/platform-core';
 
 /**
  * Resolves a backend secret to a CFN token via a lambda-backed CFN custom resource.
@@ -36,7 +36,7 @@ export class CfnTokenBackendSecret implements BackendSecret {
    * Resolve to the secret path
    */
   resolveToPath = (backendIdentifier: BackendIdentifier): string => {
-    return BackendIdentifierConversions.toParameterFullPath(
+    return ParameterPathConversions.toParameterFullPath(
       backendIdentifier,
       this.name
     );

--- a/packages/backend/src/engine/backend-secret/backend_secret.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret.ts
@@ -2,6 +2,7 @@ import { BackendIdentifier, BackendSecret } from '@aws-amplify/plugin-types';
 import { Construct } from 'constructs';
 import { BackendSecretFetcherFactory } from './backend_secret_fetcher_factory.js';
 import { SecretValue } from 'aws-cdk-lib';
+import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 
 /**
  * Resolves a backend secret to a CFN token via a lambda-backed CFN custom resource.
@@ -29,5 +30,15 @@ export class CfnTokenBackendSecret implements BackendSecret {
 
     const val = secretResource.getAttString('secretValue');
     return SecretValue.unsafePlainText(val); // safe since 'val' is a cdk token.
+  };
+
+  /**
+   * Resolve to the secret path
+   */
+  resolveToPath = (backendIdentifier: BackendIdentifier): string => {
+    return BackendIdentifierConversions.toParameterFullPath(
+      backendIdentifier,
+      this.name
+    );
   };
 }

--- a/packages/backend/src/engine/backend-secret/backend_secret_resolver.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_resolver.ts
@@ -21,4 +21,8 @@ export class DefaultBackendSecretResolver implements BackendSecretResolver {
   resolveSecret = (backendSecret: BackendSecret): SecretValue => {
     return backendSecret.resolve(this.scope, this.backendId);
   };
+
+  resolveToPath = (backendSecret: BackendSecret): string => {
+    return backendSecret.resolveToPath(this.backendId);
+  };
 }

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -69,8 +69,6 @@ export type AmplifyUserErrorType = 'InvalidSchemaAuthError' | 'InvalidSchemaErro
 // @public
 export class BackendIdentifierConversions {
     static fromStackName(stackName?: string): BackendIdentifier | undefined;
-    static toParameterFullPath(backendId: BackendIdentifier | AppId, secretName: string): string;
-    static toParameterPrefix(backendId: BackendIdentifier | AppId): string;
     static toStackName(backendId: BackendIdentifier): string;
 }
 
@@ -142,6 +140,12 @@ export const packageJsonSchema: z.ZodObject<{
     version?: string | undefined;
     type?: "module" | "commonjs" | undefined;
 }>;
+
+// @public
+export class ParameterPathConversions {
+    static toParameterFullPath(backendId: BackendIdentifier | AppId, secretName: string): string;
+    static toParameterPrefix(backendId: BackendIdentifier | AppId): string;
+}
 
 // @public
 export const USAGE_DATA_TRACKING_ENABLED = "telemetry.enabled";

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AppId } from '@aws-amplify/plugin-types';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import z from 'zod';
 
@@ -68,6 +69,8 @@ export type AmplifyUserErrorType = 'InvalidSchemaAuthError' | 'InvalidSchemaErro
 // @public
 export class BackendIdentifierConversions {
     static fromStackName(stackName?: string): BackendIdentifier | undefined;
+    static toParameterFullPath(backendId: BackendIdentifier | AppId, secretName: string): string;
+    static toParameterPrefix(backendId: BackendIdentifier | AppId): string;
     static toStackName(backendId: BackendIdentifier): string;
 }
 

--- a/packages/platform-core/src/backend_identifier_conversions.ts
+++ b/packages/platform-core/src/backend_identifier_conversions.ts
@@ -1,14 +1,13 @@
-import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { createHash } from 'crypto';
 
 const STACK_NAME_LENGTH_LIMIT = 128;
 const AMPLIFY_PREFIX = 'amplify';
 const HASH_LENGTH = 10;
 const NUM_DASHES = 4;
-const SHARED_SECRET = 'shared';
 
 /**
- * Provides static methods for converting BackendIdentifier to/from a stack name or parameter path string
+ * Provides static methods for converting BackendIdentifier to/from a stack name string
  */
 export class BackendIdentifierConversions {
   /**
@@ -69,29 +68,6 @@ export class BackendIdentifierConversions {
 
     return ['amplify', namespace, name, backendId.type, hash].join('-');
   }
-
-  /**
-   * Convert a BackendIdentifier to a parameter prefix.
-   */
-  static toParameterPrefix(backendId: BackendIdentifier | AppId): string {
-    if (typeof backendId === 'object') {
-      return getBranchParameterPrefix(backendId);
-    }
-    return getSharedParameterPrefix(backendId);
-  }
-
-  /**
-   * Convert a BackendIdentifier to a parameter full path
-   */
-  static toParameterFullPath(
-    backendId: BackendIdentifier | AppId,
-    secretName: string
-  ): string {
-    if (typeof backendId === 'object') {
-      return getBranchParameterFullPath(backendId, secretName);
-    }
-    return getSharedParameterFullPath(backendId, secretName);
-  }
 }
 
 /**
@@ -118,38 +94,4 @@ const getHash = (backendId: BackendIdentifier): string =>
  */
 const sanitizeChars = (str: string): string => {
   return str.replace(/[^A-Za-z0-9]/g, '');
-};
-
-/**
- * Get a branch-specific parameter prefix.
- */
-const getBranchParameterPrefix = (parts: BackendIdentifier): string => {
-  return `/amplify/${parts.namespace}/${parts.name}`;
-};
-
-/**
- * Get a branch-specific parameter full path.
- */
-const getBranchParameterFullPath = (
-  backendIdentifier: BackendIdentifier,
-  secretName: string
-): string => {
-  return `${getBranchParameterPrefix(backendIdentifier)}/${secretName}`;
-};
-
-/**
- * Get a shared parameter prefix.
- */
-const getSharedParameterPrefix = (appId: AppId): string => {
-  return `/amplify/${SHARED_SECRET}/${appId}`;
-};
-
-/**
- * Get a shared parameter full path.
- */
-const getSharedParameterFullPath = (
-  appId: AppId,
-  secretName: string
-): string => {
-  return `${getSharedParameterPrefix(appId)}/${secretName}`;
 };

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -7,3 +7,4 @@ export * from './config/local_configuration_controller_factory.js';
 export * from './errors';
 export { USAGE_DATA_TRACKING_ENABLED } from './usage-data/constants.js';
 export { CDKContextKey } from './cdk_context_key.js';
+export * from './parameter_path_conversions.js';

--- a/packages/platform-core/src/parameter_path_conversions.test.ts
+++ b/packages/platform-core/src/parameter_path_conversions.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import { ParameterPathConversions } from './parameter_path_conversions';
+import assert from 'node:assert';
+
+void describe('toParameterPrefix', () => {
+  void it('passes through values for type sandbox', () => {
+    const actual = ParameterPathConversions.toParameterPrefix({
+      namespace: 'reasonableName',
+      name: 'userName',
+      type: 'sandbox',
+    });
+    assert.equal(actual, '/amplify/reasonableName/userName');
+  });
+
+  void it('passes through values for shared parameter', () => {
+    const actual = ParameterPathConversions.toParameterPrefix('someAppId');
+    assert.equal(actual, '/amplify/shared/someAppId');
+  });
+});
+
+void describe('toParameterFullPath', () => {
+  void it('passes through values for type sandbox', () => {
+    const actual = ParameterPathConversions.toParameterFullPath(
+      {
+        namespace: 'reasonableName',
+        name: 'userName',
+        type: 'sandbox',
+      },
+      'secretName'
+    );
+    assert.equal(actual, '/amplify/reasonableName/userName/secretName');
+  });
+
+  void it('passes through values for shared parameter', () => {
+    const actual = ParameterPathConversions.toParameterFullPath(
+      'someAppId',
+      'secretName'
+    );
+    assert.equal(actual, '/amplify/shared/someAppId/secretName');
+  });
+});

--- a/packages/platform-core/src/parameter_path_conversions.ts
+++ b/packages/platform-core/src/parameter_path_conversions.ts
@@ -1,0 +1,65 @@
+import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
+
+const SHARED_SECRET = 'shared';
+
+/**
+ * Provides static methods for converting BackendIdentifier to parameter path strings
+ */
+export class ParameterPathConversions {
+  /**
+   * Convert a BackendIdentifier to a parameter prefix.
+   */
+  static toParameterPrefix(backendId: BackendIdentifier | AppId): string {
+    if (typeof backendId === 'object') {
+      return getBranchParameterPrefix(backendId);
+    }
+    return getSharedParameterPrefix(backendId);
+  }
+
+  /**
+   * Convert a BackendIdentifier to a parameter full path.
+   */
+  static toParameterFullPath(
+    backendId: BackendIdentifier | AppId,
+    secretName: string
+  ): string {
+    if (typeof backendId === 'object') {
+      return getBranchParameterFullPath(backendId, secretName);
+    }
+    return getSharedParameterFullPath(backendId, secretName);
+  }
+}
+
+/**
+ * Get a branch-specific parameter prefix.
+ */
+const getBranchParameterPrefix = (parts: BackendIdentifier): string => {
+  return `/amplify/${parts.namespace}/${parts.name}`;
+};
+
+/**
+ * Get a branch-specific parameter full path.
+ */
+const getBranchParameterFullPath = (
+  backendIdentifier: BackendIdentifier,
+  secretName: string
+): string => {
+  return `${getBranchParameterPrefix(backendIdentifier)}/${secretName}`;
+};
+
+/**
+ * Get a shared parameter prefix.
+ */
+const getSharedParameterPrefix = (appId: AppId): string => {
+  return `/amplify/${SHARED_SECRET}/${appId}`;
+};
+
+/**
+ * Get a shared parameter full path.
+ */
+const getSharedParameterFullPath = (
+  appId: AppId,
+  secretName: string
+): string => {
+  return `${getSharedParameterPrefix(appId)}/${secretName}`;
+};

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -74,11 +74,13 @@ export type BackendOutputStorageStrategy<T extends BackendOutputEntry> = {
 // @public (undocumented)
 export type BackendSecret = {
     resolve: (scope: Construct, backendIdentifier: BackendIdentifier) => SecretValue;
+    resolveToPath?: (backendIdentifier: BackendIdentifier) => string;
 };
 
 // @public (undocumented)
 export type BackendSecretResolver = {
     resolveSecret: (backendSecret: BackendSecret) => SecretValue;
+    resolveToPath?: (backendSecret: BackendSecret) => string;
 };
 
 // @public (undocumented)

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -74,13 +74,13 @@ export type BackendOutputStorageStrategy<T extends BackendOutputEntry> = {
 // @public (undocumented)
 export type BackendSecret = {
     resolve: (scope: Construct, backendIdentifier: BackendIdentifier) => SecretValue;
-    resolveToPath?: (backendIdentifier: BackendIdentifier) => string;
+    resolveToPath: (backendIdentifier: BackendIdentifier) => string;
 };
 
 // @public (undocumented)
 export type BackendSecretResolver = {
     resolveSecret: (backendSecret: BackendSecret) => SecretValue;
-    resolveToPath?: (backendSecret: BackendSecret) => string;
+    resolveToPath: (backendSecret: BackendSecret) => string;
 };
 
 // @public (undocumented)

--- a/packages/plugin-types/src/backend_secret_resolver.ts
+++ b/packages/plugin-types/src/backend_secret_resolver.ts
@@ -10,8 +10,14 @@ export type BackendSecret = {
     scope: Construct,
     backendIdentifier: BackendIdentifier
   ) => SecretValue;
+
+  /**
+   * Resolves the given secret to its path
+   */
+  resolveToPath?: (backendIdentifier: BackendIdentifier) => string;
 };
 
 export type BackendSecretResolver = {
   resolveSecret: (backendSecret: BackendSecret) => SecretValue;
+  resolveToPath?: (backendSecret: BackendSecret) => string;
 };

--- a/packages/plugin-types/src/backend_secret_resolver.ts
+++ b/packages/plugin-types/src/backend_secret_resolver.ts
@@ -14,10 +14,10 @@ export type BackendSecret = {
   /**
    * Resolves the given secret to its path
    */
-  resolveToPath?: (backendIdentifier: BackendIdentifier) => string;
+  resolveToPath: (backendIdentifier: BackendIdentifier) => string;
 };
 
 export type BackendSecretResolver = {
   resolveSecret: (backendSecret: BackendSecret) => SecretValue;
-  resolveToPath?: (backendSecret: BackendSecret) => string;
+  resolveToPath: (backendSecret: BackendSecret) => string;
 };


### PR DESCRIPTION
## Problem

`defineFunction` does not have access to secrets created with `npx amplify sandbox secret`.

**Issue number, if available:**

## Changes

- Add support for passing in secrets through the `environment` parameter of `defineFunction`.
- Move parameter path methods from `backend-secret` to `platform-core` to be used across multiple packages.
- Add bundling options for function to add a code snippet to resolve secrets for users.

**Corresponding docs PR, if applicable:**

## Validation

Used a test project with local changes to deploy a function with secrets using `defineFunction` and verified the following:
- Environment variables for the placeholder text and secret path are populating in the Lambda console as expected.
- Test executing the function to verify secrets are resolved to their expected values as seen in the Parameter Store.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
