### PR TITLE
fix: sanitize branch linker logs

### DIFF
--- a/.changeset/friendly-jokes-roll.md
+++ b/.changeset/friendly-jokes-roll.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': patch
+---
+
+Remove excessive logging from branch linker.

--- a/packages/backend/src/engine/branch-linker/lambda/branch_linker.ts
+++ b/packages/backend/src/engine/branch-linker/lambda/branch_linker.ts
@@ -87,7 +87,9 @@ export class AmplifyBranchLinkerCustomResourceEventHandler {
     }
 
     const branch: Branch = await this.getBranch(appId, branchName);
-    console.info(`Received branch details ${JSON.stringify(branch)}`);
+    console.info(
+      `Received details of branchName=${branchName} of appId=${appId}`
+    );
     // Populate update command input with existing values, so we don't lose them.
     const updateBranchCommandInput: UpdateBranchCommandInput = {
       appId,
@@ -114,7 +116,7 @@ export class AmplifyBranchLinkerCustomResourceEventHandler {
     }
 
     console.info(
-      `Sending branch update ${JSON.stringify(updateBranchCommandInput)}`
+      `Sending update of branchName=${branchName} of appId=${appId}`
     );
     await this.amplifyClient.send(
       new UpdateBranchCommand(updateBranchCommandInput)


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

This PR removes excessive logging from branch linker. Logging dumps of rest requests and responses poses a risk of logging of sensitive data.

## Changes

This removes request and response dumps from logging messages.

I keep sanitized log messages instead of just removing them so that there's a trace of how logic flow executed.

## Validation

PR checks. The log messages are not used in any logic.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
