### PR TITLE
add --config-out-dir arg to pipeline-deploy

### DIFF
--- a/.changeset/moody-grapes-move.md
+++ b/.changeset/moody-grapes-move.md
@@ -2,4 +2,4 @@
 '@aws-amplify/backend-cli': patch
 ---
 
-add --out-dir to pipeline-deploy command
+add --config-out-dir to pipeline-deploy command

--- a/.changeset/moody-grapes-move.md
+++ b/.changeset/moody-grapes-move.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+add --out-dir to pipeline-deploy command

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -92,7 +92,7 @@ void describe('deploy command', () => {
       () => Promise.resolve()
     );
     await getCommandRunner(true).runCommand(
-      'pipeline-deploy --app-id abc --branch test-branch --out-dir src'
+      'pipeline-deploy --app-id abc --branch test-branch --config-out-dir src'
     );
     assert.strictEqual(mockDeploy.mock.callCount(), 1);
     assert.deepStrictEqual(mockDeploy.mock.calls[0].arguments, [

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -84,4 +84,35 @@ void describe('deploy command', () => {
     ]);
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
   });
+
+  void it('allows --out-dir argument', async () => {
+    const mockDeploy = mock.method(
+      BackendDeployerFactory.getInstance(),
+      'deploy',
+      () => Promise.resolve()
+    );
+    await getCommandRunner(true).runCommand(
+      'pipeline-deploy --app-id abc --branch test-branch --out-dir src'
+    );
+    assert.strictEqual(mockDeploy.mock.callCount(), 1);
+    assert.deepStrictEqual(mockDeploy.mock.calls[0].arguments, [
+      {
+        name: 'test-branch',
+        namespace: 'abc',
+        type: 'branch',
+      },
+      {
+        validateAppSources: true,
+      },
+    ]);
+    assert.equal(generateClientConfigMock.mock.callCount(), 1);
+    assert.deepStrictEqual(generateClientConfigMock.mock.calls[0].arguments, [
+      {
+        name: 'test-branch',
+        namespace: 'abc',
+        type: 'branch',
+      },
+      'src',
+    ]);
+  });
 });

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -85,7 +85,7 @@ void describe('deploy command', () => {
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
   });
 
-  void it('allows --out-dir argument', async () => {
+  void it('allows --config-out-dir argument', async () => {
     const mockDeploy = mock.method(
       BackendDeployerFactory.getInstance(),
       'deploy',

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -12,7 +12,7 @@ export type PipelineDeployCommandOptions =
 type PipelineDeployCommandOptionsCamelCase = {
   branch: string;
   appId: string;
-  outDir?: string;
+  configOutDir?: string;
 };
 
 /**
@@ -64,7 +64,7 @@ export class PipelineDeployCommand
     });
     await this.clientConfigGenerator.generateClientConfigToFile(
       backendId,
-      args['out-dir']
+      args['config-out-dir']
     );
   };
 
@@ -83,7 +83,7 @@ export class PipelineDeployCommand
         type: 'string',
         array: false,
       })
-      .option('out-dir', {
+      .option('config-out-dir', {
         describe:
           'A path to directory where config is written. If not provided defaults to current process working directory.',
         type: 'string',

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -19,7 +19,8 @@ type PipelineDeployCommandOptionsCamelCase = {
  * An entry point for deploy command.
  */
 export class PipelineDeployCommand
-  implements CommandModule<object, PipelineDeployCommandOptions> {
+  implements CommandModule<object, PipelineDeployCommandOptions>
+{
   /**
    * @inheritDoc
    */
@@ -61,7 +62,10 @@ export class PipelineDeployCommand
     await this.backendDeployer.deploy(backendId, {
       validateAppSources: true,
     });
-    await this.clientConfigGenerator.generateClientConfigToFile(backendId, args['out-dir']);
+    await this.clientConfigGenerator.generateClientConfigToFile(
+      backendId,
+      args['out-dir']
+    );
   };
 
   builder = (yargs: Argv): Argv<PipelineDeployCommandOptions> => {
@@ -80,7 +84,8 @@ export class PipelineDeployCommand
         array: false,
       })
       .option('out-dir', {
-        describe: 'A path to directory where config is written. If not provided defaults to current process working directory.',
+        describe:
+          'A path to directory where config is written. If not provided defaults to current process working directory.',
         type: 'string',
         array: false,
       })

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -12,14 +12,14 @@ export type PipelineDeployCommandOptions =
 type PipelineDeployCommandOptionsCamelCase = {
   branch: string;
   appId: string;
+  outDir?: string;
 };
 
 /**
  * An entry point for deploy command.
  */
 export class PipelineDeployCommand
-  implements CommandModule<object, PipelineDeployCommandOptions>
-{
+  implements CommandModule<object, PipelineDeployCommandOptions> {
   /**
    * @inheritDoc
    */
@@ -61,7 +61,7 @@ export class PipelineDeployCommand
     await this.backendDeployer.deploy(backendId, {
       validateAppSources: true,
     });
-    await this.clientConfigGenerator.generateClientConfigToFile(backendId);
+    await this.clientConfigGenerator.generateClientConfigToFile(backendId, args['out-dir']);
   };
 
   builder = (yargs: Argv): Argv<PipelineDeployCommandOptions> => {
@@ -76,6 +76,11 @@ export class PipelineDeployCommand
       .option('app-id', {
         describe: 'The app id of the target Amplify app',
         demandOption: true,
+        type: 'string',
+        array: false,
+      })
+      .option('out-dir', {
+        describe: 'A path to directory where config is written. If not provided defaults to current process working directory.',
         type: 'string',
         array: false,
       })


### PR DESCRIPTION
## Problem

`amplify pipeline-deploy` deploys cdk resources in CI/CD environments and runs `amplify generate config` automatically. However, `pipeline-deploy` does not currently allow an `--out-dir` to be specified, so the config is always written to the root of the project which is not always desired.

**Issue number, if available:**

N/A

## Changes

This pr adds the `--out-dir` argument to the `pipeline-deploy` command.

**Corresponding docs PR, if applicable:**

## Validation

* unit tests
* performed deployment with `--out-dir` set
* performed deployment without `--out-dir` set

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
