### PR TITLE
Add unit test to know when oldest node lts changes

### DIFF
--- a/.changeset/calm-books-refuse.md
+++ b/.changeset/calm-books-refuse.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+Add unit test to know when oldest Node LTS changes to update default function runtime

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -339,10 +339,10 @@ void describe('AmplifyFunctionFactory', () => {
     });
 
     void it('throws when the oldest maintained Node LTS reaches end of life', () => {
-      // Date when the oldest Node LTS maintenance ends according to https://github.com/nodejs/release#release-schedule.
-      // Once this test fails, update endDate to the end date of the next Node LTS version.
-      // After updating the date, next would be updating the default function runtime in factory.ts
-      const endDate = new Date('2025-04-30');
+      // A month before the date when the oldest Node LTS maintenance ends according to https://github.com/nodejs/release#release-schedule.
+      // Once this test fails, update endDate to a month before the end date of the next Node LTS version.
+      // After updating the date, next would be updating the default function runtime in factory.ts.
+      const endDate = new Date('2025-03-30');
       const currentDate = new Date();
 
       assert.equal(endDate > currentDate, true);

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -337,5 +337,15 @@ void describe('AmplifyFunctionFactory', () => {
         new Error('runtime must be one of the following: 16, 18, 20')
       );
     });
+
+    void it('throws when the oldest maintained Node LTS reaches end of life', () => {
+      // Date when the oldest Node LTS maintenance ends according to https://github.com/nodejs/release#release-schedule.
+      // Once this test fails, update endDate to the end date of the next Node LTS version.
+      // After updating the date, next would be updating the default function runtime in factory.ts
+      const endDate = new Date('2025-04-30');
+      const currentDate = new Date();
+
+      assert.equal(endDate > currentDate, true);
+    });
   });
 });

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -345,7 +345,7 @@ void describe('AmplifyFunctionFactory', () => {
       const endDate = new Date('2025-03-30');
       const currentDate = new Date();
 
-      assert.equal(endDate > currentDate, true);
+      assert.ok(endDate > currentDate);
     });
   });
 });


### PR DESCRIPTION
## Problem

Currently for `defineFunction` we default to the oldest maintained Node LTS for runtime. We would need to know when the oldest maintained Node LTS changes in order to update the default as well.

**Issue number, if available:**
Resolves #813

## Changes

Add unit test that will start to fail once the current day's date reaches a specified date. This unit test includes comments to describe what it is there for and first steps to fix the unit test.

**Corresponding docs PR, if applicable:**

## Validation

Manually ran the unit test with different `endDate` values:
- `endDate` is today = FAIL
- `endDate` is in the past = FAIL
- `endDate` is in the future = PASS

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
