### PR TITLE
classify package.json errors as user errors

### DIFF
--- a/.changeset/brown-taxis-allow.md
+++ b/.changeset/brown-taxis-allow.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/platform-core': patch
+'@aws-amplify/backend-cli': patch
+---
+
+Classify package json parsing errors as user errors

--- a/packages/cli/src/backend-identifier/local_namespace_resolver.ts
+++ b/packages/cli/src/backend-identifier/local_namespace_resolver.ts
@@ -1,4 +1,7 @@
-import { PackageJsonReader } from '@aws-amplify/platform-core';
+import {
+  AmplifyUserError,
+  PackageJsonReader,
+} from '@aws-amplify/platform-core';
 
 export type NamespaceResolver = {
   resolve: () => Promise<string>;
@@ -20,6 +23,10 @@ export class LocalNamespaceResolver implements NamespaceResolver {
   resolve = async () => {
     const name = this.packageJsonReader.readFromCwd().name;
     if (name) return name;
-    throw new Error('Cannot load name from the package.json');
+    throw new AmplifyUserError('InvalidPackageJsonError', {
+      message: 'Cannot load name from the package.json',
+      resolution:
+        'In order to resolve this error check if your are running command in root of your project (i.e. not in amplify directory) and if package.json has name property',
+    });
   };
 }

--- a/packages/cli/src/backend-identifier/local_namespace_resolver.ts
+++ b/packages/cli/src/backend-identifier/local_namespace_resolver.ts
@@ -26,7 +26,7 @@ export class LocalNamespaceResolver implements NamespaceResolver {
     throw new AmplifyUserError('InvalidPackageJsonError', {
       message: 'Cannot load name from the package.json',
       resolution:
-        'In order to resolve this error check if your are running command in root of your project (i.e. not in amplify directory) and if package.json has name property',
+        'Ensure you are running amplify commands in root of your project (i.e. in the parent of the `amplify` directory). Also ensure that your root package.json file has a "name" field.',
     });
   };
 }

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -64,7 +64,7 @@ export class AmplifyUserError extends AmplifyError {
 }
 
 // @public
-export type AmplifyUserErrorType = 'InvalidSchemaAuthError' | 'InvalidSchemaError' | 'ExpiredTokenError' | 'CloudFormationDeploymentError' | 'CFNUpdateNotSupportedError' | 'SyntaxError' | 'BackendBuildError' | 'BootstrapNotDetectedError' | 'AccessDeniedError' | 'FileConventionError';
+export type AmplifyUserErrorType = 'InvalidPackageJsonError' | 'InvalidSchemaAuthError' | 'InvalidSchemaError' | 'ExpiredTokenError' | 'CloudFormationDeploymentError' | 'CFNUpdateNotSupportedError' | 'SyntaxError' | 'BackendBuildError' | 'BootstrapNotDetectedError' | 'AccessDeniedError' | 'FileConventionError';
 
 // @public
 export class BackendIdentifierConversions {

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -116,6 +116,7 @@ export type AmplifyErrorType = AmplifyUserErrorType | AmplifyLibraryFaultType;
  * Amplify error types
  */
 export type AmplifyUserErrorType =
+  | 'InvalidPackageJsonError'
   | 'InvalidSchemaAuthError'
   | 'InvalidSchemaError'
   | 'ExpiredTokenError'

--- a/packages/platform-core/src/package_json_reader.test.ts
+++ b/packages/platform-core/src/package_json_reader.test.ts
@@ -51,7 +51,7 @@ void describe('Package JSON reader', () => {
   void it('throws when package json is not parse-able', async () => {
     fsReadFileSync.mock.mockImplementationOnce(() => 'not json content');
     assert.throws(() => packageJsonReader.read(testPath), {
-      message: 'Could not JSON.parse the contents of /test_path',
+      message: 'Could not parse the contents of /test_path',
     });
   });
 });

--- a/packages/platform-core/src/package_json_reader.ts
+++ b/packages/platform-core/src/package_json_reader.ts
@@ -24,7 +24,7 @@ export class PackageJsonReader {
         'InvalidPackageJsonError',
         {
           message: `Could not parse the contents of ${absolutePackageJsonPath}`,
-          resolution: `Check if ${absolutePackageJsonPath} exists and is a valid JSON file`,
+          resolution: `Ensure that ${absolutePackageJsonPath} exists and is a valid JSON file`,
         },
         err as Error
       );

--- a/packages/platform-core/src/package_json_reader.ts
+++ b/packages/platform-core/src/package_json_reader.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import z from 'zod';
+import { AmplifyUserError } from './errors';
 
 /**
  * return the package json
@@ -19,8 +20,13 @@ export class PackageJsonReader {
         fs.readFileSync(absolutePackageJsonPath, 'utf-8')
       );
     } catch (err) {
-      throw new Error(
-        `Could not JSON.parse the contents of ${absolutePackageJsonPath}`
+      throw new AmplifyUserError(
+        'InvalidPackageJsonError',
+        {
+          message: `Could not parse the contents of ${absolutePackageJsonPath}`,
+          resolution: `Check if ${absolutePackageJsonPath} exists and is a valid JSON file`,
+        },
+        err as Error
       );
     }
     return packageJsonSchema.parse(jsonParsedValue);


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Errors thrown due to invalid package json file are thrown as faults.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Throw user errors instead with remedy steps.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

Unit tests amended.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
