### PR TITLE
fix: create dir if not exists when configuring profile

### DIFF
--- a/.changeset/angry-avocados-teach.md
+++ b/.changeset/angry-avocados-teach.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Create directory if does not exists when configuring profile

--- a/packages/cli/src/commands/configure/profile_controller.test.ts
+++ b/packages/cli/src/commands/configure/profile_controller.test.ts
@@ -214,6 +214,25 @@ void describe('profile controller', () => {
         `${expectedCredentialText}${expectedCredentialText2}${expectedCredentialText3}`
       );
     });
+
+    void it('creates directory if does not exist', async () => {
+      // delete directory
+      await fs.rm(testDir, { recursive: true, force: true });
+
+      // assert that this doesn't throw
+      await profileController.appendAWSFiles({
+        profile: testProfile,
+        region: testRegion,
+        accessKeyId: testAccessKeyId,
+        secretAccessKey: testSecretAccessKey,
+      });
+
+      const data = await loadSharedConfigFiles({
+        ignoreCache: true,
+      });
+
+      assert.ok(data);
+    });
   });
 
   void describe('profile exists', () => {

--- a/packages/cli/src/commands/configure/profile_controller.ts
+++ b/packages/cli/src/commands/configure/profile_controller.ts
@@ -6,7 +6,8 @@ import {
 import { fromIni } from '@aws-sdk/credential-providers';
 import { EOL } from 'os';
 import fs from 'fs/promises';
-import { join } from 'path';
+import path from 'path';
+import { existsSync } from 'fs';
 
 /**
  * Options for the profile configuration.
@@ -58,7 +59,12 @@ export class ProfileController {
 
   private appendAWSConfigFile = async (options: ConfigProfileOptions) => {
     const filePath =
-      process.env.AWS_CONFIG_FILE ?? join(getHomeDir(), '.aws', 'config');
+      process.env.AWS_CONFIG_FILE ?? path.join(getHomeDir(), '.aws', 'config');
+
+    const dirName = path.dirname(filePath);
+    if (!existsSync(dirName)) {
+      await fs.mkdir(dirName, { recursive: true });
+    }
 
     const fileEndsWithEOL = await this.isFileEndsWithEOL(filePath);
     let configData = fileEndsWithEOL ? '' : EOL;
@@ -86,7 +92,12 @@ export class ProfileController {
   ) => {
     const filePath =
       process.env.AWS_SHARED_CREDENTIALS_FILE ??
-      join(getHomeDir(), '.aws', 'credentials');
+      path.join(getHomeDir(), '.aws', 'credentials');
+
+    const dirName = path.dirname(filePath);
+    if (!existsSync(dirName)) {
+      await fs.mkdir(dirName, { recursive: true });
+    }
 
     const fileEndsWithEOL = await this.isFileEndsWithEOL(filePath);
     let credentialData = fileEndsWithEOL ? '' : EOL;


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Fixes https://github.com/aws-amplify/amplify-backend/issues/881 .

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Add logic to create directory if it doesn't exist yet when creating profile.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

Added unit test.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
