### PR TITLE
functions fallback to resolve shared secrets

### DIFF
--- a/.changeset/gorgeous-lies-change.md
+++ b/.changeset/gorgeous-lies-change.md
@@ -6,4 +6,4 @@
 '@aws-amplify/backend': patch
 ---
 
-Enhance functions to resolve shared secrets
+Enhance functions to fallback to resolve shared secrets

--- a/.changeset/gorgeous-lies-change.md
+++ b/.changeset/gorgeous-lies-change.md
@@ -1,0 +1,9 @@
+---
+'@aws-amplify/backend-platform-test-stubs': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/plugin-types': patch
+'@aws-amplify/backend': patch
+---
+
+Enhance functions to resolve shared secrets

--- a/packages/backend-auth/src/translate_auth_props.test.ts
+++ b/packages/backend-auth/src/translate_auth_props.test.ts
@@ -50,6 +50,9 @@ class TestBackendSecret implements BackendSecret {
       this.secretName
     );
   };
+  getSecretName = (): string => {
+    return this.secretName;
+  };
 }
 
 class TestBackendSecretResolver implements BackendSecretResolver {

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -286,6 +286,9 @@ void describe('AmplifyFunctionFactory', () => {
               TEST_SECRET:
                 '/amplify/testBackendId/testBranchName-branch-e482a1c36f/secretValue',
             }),
+            AMPLIFY_SHARED_SECRET_PATHS: JSON.stringify({
+              TEST_SECRET: '/amplify/shared/testBackendId/secretValue',
+            }),
           },
         },
       });
@@ -301,7 +304,7 @@ void describe('AmplifyFunctionFactory', () => {
             },
           }).getInstance(getInstanceProps),
         new Error(
-          'AMPLIFY_SECRET_PATHS is a reserved environment variable name'
+          'AMPLIFY_SECRET_PATHS and AMPLIFY_SHARED_SECRET_PATHS are reserved environment variable names'
         )
       );
     });

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -44,6 +44,9 @@ class TestBackendSecret implements BackendSecret {
       this.secretName
     );
   };
+  getSecretName = (): string => {
+    return this.secretName;
+  };
 }
 
 void describe('AmplifyFunctionFactory', () => {

--- a/packages/backend-function/src/resolve_secret_banner.ts
+++ b/packages/backend-function/src/resolve_secret_banner.ts
@@ -7,31 +7,58 @@ import { SSM } from '@aws-sdk/client-ssm';
 export const internalAmplifyFunctionBannerResolveSecrets = async (
   client?: SSM
 ) => {
-  if (!client) {
-    client = new SSM();
-  }
-
   const envPathObj: Record<string, string> = JSON.parse(
     process.env.AMPLIFY_SECRET_PATHS ?? '{}'
   );
+  const sharedEnvPathObj: Record<string, string> = JSON.parse(
+    process.env.AMPLIFY_SHARED_SECRET_PATHS ?? '{}'
+  );
   const paths = Object.values(envPathObj);
+  const sharedPaths = Object.values(sharedEnvPathObj);
 
-  if (paths.length === 0) {
+  if (paths.length === 0 && sharedPaths.length === 0) {
     return;
   }
 
-  const response = await client.getParameters({
-    Names: paths,
-    WithDecryption: true,
-  });
-  if (response.Parameters && response.Parameters?.length > 0) {
-    for (const parameter of response.Parameters) {
-      for (const [env, path] of Object.entries(envPathObj)) {
-        if (parameter.Name === path) {
-          process.env[env] = parameter.Value;
+  const resolveSecrets = async (
+    paths: string[],
+    envPathObject: Record<string, string>
+  ) => {
+    if (!client) {
+      client = new SSM();
+    }
+
+    const response = await client.getParameters({
+      Names: paths,
+      WithDecryption: true,
+    });
+
+    if (response.Parameters && response.Parameters.length > 0) {
+      for (const parameter of response.Parameters) {
+        for (const [env, path] of Object.entries(envPathObject)) {
+          if (parameter.Name === path) {
+            process.env[env] = parameter.Value;
+          }
         }
       }
     }
+
+    return response;
+  };
+
+  const response = await resolveSecrets(paths, envPathObj);
+
+  if (response.InvalidParameters && response.InvalidParameters.length > 0) {
+    const pathsToResolve: string[] = [];
+    for (const invalidParameter of response.InvalidParameters) {
+      const env = Object.keys(envPathObj).find(
+        (env) => envPathObj[env] === invalidParameter
+      );
+      if (env) {
+        pathsToResolve.push(sharedEnvPathObj[env]);
+      }
+    }
+    await resolveSecrets(pathsToResolve, sharedEnvPathObj);
   }
 };
 

--- a/packages/backend/src/engine/backend-secret/backend_secret.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret.ts
@@ -41,4 +41,11 @@ export class CfnTokenBackendSecret implements BackendSecret {
       this.name
     );
   };
+
+  /**
+   * Get the name of the secret
+   */
+  getSecretName = (): string => {
+    return this.name;
+  };
 }

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -75,6 +75,7 @@ export type BackendOutputStorageStrategy<T extends BackendOutputEntry> = {
 export type BackendSecret = {
     resolve: (scope: Construct, backendIdentifier: BackendIdentifier) => SecretValue;
     resolvePath: (backendIdentifier: BackendIdentifier) => string;
+    getSecretName: () => string;
 };
 
 // @public (undocumented)

--- a/packages/plugin-types/src/backend_secret_resolver.ts
+++ b/packages/plugin-types/src/backend_secret_resolver.ts
@@ -15,6 +15,11 @@ export type BackendSecret = {
    * Resolves the given secret to its path
    */
   resolvePath: (backendIdentifier: BackendIdentifier) => string;
+
+  /**
+   * Get the name of the secret
+   */
+  getSecretName: () => string;
 };
 
 export type BackendSecretResolver = {


### PR DESCRIPTION
## Problem

If defining an environment variable with a shared secret (app level secret), the code snippet that resolves secrets does not have logic to fallback to getting parameters with a shared secret path.

**Issue number, if available:** Resolves #846 

## Changes

- Add shared secret paths to lambda IAM policy
- Update code snippet to fallback to trying to resolve secrets with shared secret paths if they fail with branch secret paths

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Updated unit testing to ensure shared secret paths are defined.

Manually verified secret with a shared secret path is properly resolved still.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
