### PR TITLE
set user read/write only permissions when creating aws cred files

### DIFF
--- a/.changeset/angry-guests-notice.md
+++ b/.changeset/angry-guests-notice.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Create ~/.aws/config and ~/.aws/credentials files using owner read/write only. This is consistent with how the AWS CLI configures these files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21310,12 +21310,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-output-storage": "^0.2.6",
-        "@aws-amplify/plugin-types": "^0.6.0",
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/backend-output-storage": "^0.2.7",
+        "@aws-amplify/plugin-types": "^0.7.0",
         "@aws-sdk/util-arn-parser": "^3.465.0"
       },
       "peerDependencies": {
@@ -21336,19 +21336,19 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.3.7",
-        "@aws-amplify/backend-data": "^0.9.0",
-        "@aws-amplify/backend-function": "^0.4.0",
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-output-storage": "^0.2.6",
-        "@aws-amplify/backend-secret": "^0.3.3",
-        "@aws-amplify/backend-storage": "^0.4.0",
+        "@aws-amplify/backend-auth": "^0.4.0",
+        "@aws-amplify/backend-data": "^0.9.1",
+        "@aws-amplify/backend-function": "^0.5.0",
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/backend-output-storage": "^0.2.7",
+        "@aws-amplify/backend-secret": "^0.3.4",
+        "@aws-amplify/backend-storage": "^0.4.1",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.3.3",
-        "@aws-amplify/plugin-types": "^0.6.0",
+        "@aws-amplify/platform-core": "^0.3.4",
+        "@aws-amplify/plugin-types": "^0.7.0",
         "@aws-sdk/client-amplify": "^3.440.0"
       },
       "devDependencies": {
@@ -21362,16 +21362,16 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.4.4",
-        "@aws-amplify/backend-output-storage": "0.2.6",
-        "@aws-amplify/plugin-types": "^0.6.0"
+        "@aws-amplify/auth-construct-alpha": "^0.5.0",
+        "@aws-amplify/backend-output-storage": "0.2.7",
+        "@aws-amplify/plugin-types": "^0.7.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.1",
-        "@aws-amplify/platform-core": "^0.3.3"
+        "@aws-amplify/platform-core": "^0.3.4"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21380,19 +21380,19 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-output-storage": "0.2.6",
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/backend-output-storage": "0.2.7",
         "@aws-amplify/data-construct": "^1.4.1",
         "@aws-amplify/data-schema-types": "^0.6.6",
-        "@aws-amplify/plugin-types": "^0.6.0"
+        "@aws-amplify/plugin-types": "^0.7.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.1",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.3.3"
+        "@aws-amplify/platform-core": "^0.3.4"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21401,11 +21401,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.3.3",
-        "@aws-amplify/plugin-types": "^0.6.0",
+        "@aws-amplify/platform-core": "^0.3.4",
+        "@aws-amplify/plugin-types": "^0.7.0",
         "execa": "^7.2.0",
         "tsx": "^4.6.1"
       },
@@ -21416,16 +21416,16 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "0.2.6",
-        "@aws-amplify/plugin-types": "^0.6.0",
+        "@aws-amplify/backend-output-storage": "0.2.7",
+        "@aws-amplify/plugin-types": "^0.7.0",
         "execa": "^7.1.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.1",
-        "@aws-amplify/platform-core": "^0.3.3",
+        "@aws-amplify/platform-core": "^0.3.4",
         "@aws-sdk/client-ssm": "^3.398.0",
         "uuid": "^9.0.1"
       },
@@ -21449,10 +21449,10 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "0.6.0"
+        "@aws-amplify/plugin-types": "0.7.0"
       },
       "peerDependencies": {
         "zod": "^3.21.4"
@@ -21460,11 +21460,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/platform-core": "^0.3.1"
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/platform-core": "^0.3.4"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1"
@@ -21481,11 +21481,11 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.3.3",
-        "@aws-amplify/plugin-types": "^0.6.0",
+        "@aws-amplify/platform-core": "^0.3.4",
+        "@aws-amplify/plugin-types": "^0.7.0",
         "@aws-sdk/client-ssm": "^3.398.0"
       },
       "devDependencies": {
@@ -21494,16 +21494,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-output-storage": "^0.2.6",
-        "@aws-amplify/plugin-types": "^0.6.0"
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/backend-output-storage": "^0.2.7",
+        "@aws-amplify/plugin-types": "^0.7.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.1",
-        "@aws-amplify/platform-core": "^0.3.3"
+        "@aws-amplify/platform-core": "^0.3.4"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21512,18 +21512,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-secret": "^0.3.2",
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/backend-secret": "^0.3.4",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.4.2",
-        "@aws-amplify/deployed-backend-client": "^0.3.4",
+        "@aws-amplify/client-config": "^0.5.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.5",
         "@aws-amplify/form-generator": "^0.6.0",
-        "@aws-amplify/model-generator": "^0.2.3",
-        "@aws-amplify/platform-core": "^0.3.2",
-        "@aws-amplify/sandbox": "^0.3.7",
+        "@aws-amplify/model-generator": "^0.2.4",
+        "@aws-amplify/platform-core": "^0.3.4",
+        "@aws-amplify/sandbox": "^0.3.10",
         "@aws-sdk/credential-provider-ini": "^3.360.0",
         "@aws-sdk/credential-providers": "^3.360.0",
         "@aws-sdk/region-config-resolver": "^3.433.0",
@@ -21693,12 +21693,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.3",
-        "@aws-amplify/model-generator": "^0.2.3",
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.5",
+        "@aws-amplify/model-generator": "^0.2.4",
         "@aws-sdk/client-amplify": "^3.376.0",
         "@aws-sdk/client-cloudformation": "^3.376.0",
         "@aws-sdk/client-ssm": "^3.398.0",
@@ -21706,16 +21706,16 @@
         "zod": "^3.21.4"
       },
       "devDependencies": {
-        "@aws-amplify/platform-core": "^0.3.0",
+        "@aws-amplify/platform-core": "^0.3.4",
         "@aws-sdk/types": "^3.370.0"
       }
     },
     "packages/create-amplify": {
-      "version": "0.3.10",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/platform-core": "0.3.3",
+        "@aws-amplify/platform-core": "0.3.4",
         "execa": "^7.2.0",
         "yargs": "^17.7.2"
       },
@@ -21828,11 +21828,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/platform-core": "^0.3.2",
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/platform-core": "^0.3.4",
         "@aws-sdk/client-amplify": "^3.329.0",
         "@aws-sdk/client-cloudformation": "^3.329.0",
         "@aws-sdk/client-s3": "^3.329.0",
@@ -21874,15 +21874,15 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.3.8",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.4.4",
-        "@aws-amplify/backend": "^0.7.0",
-        "@aws-amplify/backend-secret": "^0.3.3",
-        "@aws-amplify/client-config": "^0.4.0",
+        "@aws-amplify/auth-construct-alpha": "^0.5.0",
+        "@aws-amplify/backend": "^0.8.0",
+        "@aws-amplify/backend-secret": "^0.3.4",
+        "@aws-amplify/client-config": "^0.5.0",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.3.3",
+        "@aws-amplify/platform-core": "^0.3.4",
         "@aws-sdk/client-amplify": "^3.440.0",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/client-lambda": "^3.460.0",
@@ -22338,11 +22338,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.3",
+        "@aws-amplify/backend-output-schemas": "^0.5.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.5",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.398.0",
@@ -22358,10 +22358,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^0.6.0",
+        "@aws-amplify/plugin-types": "^0.7.0",
         "@aws-sdk/client-sts": "3.445.0",
         "is-ci": "^3.0.1",
         "uuid": "9.0.1",
@@ -22782,7 +22782,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -22791,15 +22791,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "0.4.2",
-        "@aws-amplify/backend-secret": "^0.3.3",
+        "@aws-amplify/backend-deployer": "0.4.3",
+        "@aws-amplify/backend-secret": "^0.3.4",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "0.4.2",
-        "@aws-amplify/deployed-backend-client": "^0.3.4",
-        "@aws-amplify/platform-core": "^0.3.3",
+        "@aws-amplify/client-config": "0.5.0",
+        "@aws-amplify/deployed-backend-client": "^0.3.5",
+        "@aws-amplify/platform-core": "^0.3.4",
         "@aws-sdk/client-cloudformation": "^3.421.0",
         "@aws-sdk/credential-providers": "^3.382.0",
         "@aws-sdk/types": "^3.378.0",

--- a/packages/cli/src/commands/configure/configure_profile_command.test.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.test.ts
@@ -16,7 +16,7 @@ void describe('configure command', () => {
   const profileController = new ProfileController();
   const mockAppendAWSFiles = mock.method(
     profileController,
-    'appendAWSFiles',
+    'createOrAppendAWSFiles',
     () => Promise.resolve()
   );
 

--- a/packages/cli/src/commands/configure/configure_profile_command.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.ts
@@ -73,7 +73,7 @@ export class ConfigureProfileCommand
       message: `Enter the AWS region to use with the '${profileName}' profile (eg us-east-1, us-west-2, etc):`,
     });
 
-    await this.profileController.appendAWSFiles({
+    await this.profileController.createOrAppendAWSFiles({
       profile: profileName,
       region,
       accessKeyId,

--- a/packages/cli/src/commands/configure/profile_controller.test.ts
+++ b/packages/cli/src/commands/configure/profile_controller.test.ts
@@ -301,6 +301,7 @@ const assertFilePermissionsAreOwnerReadWriteOnly = async (filePath: string) => {
   assert.ok(
     // bit-wise mask that tests for owner RW of the file
     // unfortunately there does not appear to be a better way to test this using node built-ins
-    credentialFileStats.mode & (fs.constants.S_IRUSR | fs.constants.S_IWUSR)
+    credentialFileStats.mode ===
+      (fs.constants.S_IFREG | fs.constants.S_IRUSR | fs.constants.S_IWUSR)
   );
 };

--- a/packages/cli/src/commands/configure/profile_controller.test.ts
+++ b/packages/cli/src/commands/configure/profile_controller.test.ts
@@ -57,14 +57,14 @@ void describe('profile controller', () => {
     delete process.env.AWS_SHARED_CREDENTIALS_FILE;
   });
 
-  void describe('appendAWSFiles', () => {
+  void describe('createOrAppendAWSFiles', () => {
     before(async () => {
       await fs.rm(configFilePath, { force: true });
       await fs.rm(credFilePath, { force: true });
     });
 
     void it('creates new files', async () => {
-      await profileController.appendAWSFiles({
+      await profileController.createOrAppendAWSFiles({
         profile: testProfile,
         region: testRegion,
         accessKeyId: testAccessKeyId,
@@ -100,10 +100,13 @@ void describe('profile controller', () => {
         'utf-8'
       );
       assert.equal(credentialText, expectedCredentialText);
+
+      await assertFilePermissionsAreOwnerReadWriteOnly(configFilePath);
+      await assertFilePermissionsAreOwnerReadWriteOnly(credFilePath);
     });
 
     void it('appends to files which ends with EOL', async () => {
-      await profileController.appendAWSFiles({
+      await profileController.createOrAppendAWSFiles({
         profile: testProfile2,
         region: testRegion2,
         accessKeyId: testAccessKeyId2,
@@ -157,7 +160,7 @@ void describe('profile controller', () => {
         process.env.AWS_SHARED_CREDENTIALS_FILE as string
       );
 
-      await profileController.appendAWSFiles({
+      await profileController.createOrAppendAWSFiles({
         profile: testProfile3,
         region: testRegion3,
         accessKeyId: testAccessKeyId3,
@@ -220,7 +223,7 @@ void describe('profile controller', () => {
       await fs.rm(testDir, { recursive: true, force: true });
 
       // assert that this doesn't throw
-      await profileController.appendAWSFiles({
+      await profileController.createOrAppendAWSFiles({
         profile: testProfile,
         region: testRegion,
         accessKeyId: testAccessKeyId,
@@ -292,3 +295,12 @@ void describe('profile controller', () => {
     });
   });
 });
+
+const assertFilePermissionsAreOwnerReadWriteOnly = async (filePath: string) => {
+  const credentialFileStats = await fs.stat(filePath);
+  assert.ok(
+    // bit-wise mask that tests for owner RW of the file
+    // unfortunately there does not appear to be a better way to test this using node built-ins
+    credentialFileStats.mode & (fs.constants.S_IRUSR | fs.constants.S_IWUSR)
+  );
+};

--- a/packages/cli/src/commands/configure/profile_controller.test.ts
+++ b/packages/cli/src/commands/configure/profile_controller.test.ts
@@ -297,6 +297,11 @@ void describe('profile controller', () => {
 });
 
 const assertFilePermissionsAreOwnerReadWriteOnly = async (filePath: string) => {
+  if (process.platform.startsWith('win')) {
+    // no good way to check for these permissions on windows.
+    // We check on unix systems and trust node to duplicate the behavior on Windows
+    return;
+  }
   const credentialFileStats = await fs.stat(filePath);
   assert.ok(
     // bit-wise mask that tests for owner RW of the file

--- a/packages/cli/src/commands/configure/profile_controller.ts
+++ b/packages/cli/src/commands/configure/profile_controller.ts
@@ -77,7 +77,7 @@ export class ProfileController {
         : `[profile ${options.profile}]${EOL}`;
     configData += `region = ${options.region}${EOL}`;
 
-    await fs.appendFile(filePath, configData, { mode: '666' });
+    await fs.appendFile(filePath, configData, { mode: '600' });
 
     // validate after write. It is to ensure this function is compatible with the current AWS format.
     const profileData = await loadSharedConfigFiles({

--- a/packages/cli/src/commands/configure/profile_controller.ts
+++ b/packages/cli/src/commands/configure/profile_controller.ts
@@ -52,12 +52,14 @@ export class ProfileController {
   /**
    * Appends a profile to AWS config and credential files.
    */
-  appendAWSFiles = async (options: ProfileOptions) => {
-    await this.appendAWSConfigFile(options);
-    await this.appendAWSCredentialFile(options);
+  createOrAppendAWSFiles = async (options: ProfileOptions) => {
+    await this.createOrAppendAWSConfigFile(options);
+    await this.createOrAppendAWSCredentialFile(options);
   };
 
-  private appendAWSConfigFile = async (options: ConfigProfileOptions) => {
+  private createOrAppendAWSConfigFile = async (
+    options: ConfigProfileOptions
+  ) => {
     const filePath =
       process.env.AWS_CONFIG_FILE ?? path.join(getHomeDir(), '.aws', 'config');
 
@@ -75,7 +77,7 @@ export class ProfileController {
         : `[profile ${options.profile}]${EOL}`;
     configData += `region = ${options.region}${EOL}`;
 
-    await fs.appendFile(filePath, configData);
+    await fs.appendFile(filePath, configData, { mode: '666' });
 
     // validate after write. It is to ensure this function is compatible with the current AWS format.
     const profileData = await loadSharedConfigFiles({
@@ -87,7 +89,7 @@ export class ProfileController {
     }
   };
 
-  private appendAWSCredentialFile = async (
+  private createOrAppendAWSCredentialFile = async (
     options: CredentialProfileOptions
   ) => {
     const filePath =
@@ -106,7 +108,7 @@ export class ProfileController {
     credentialData += `aws_access_key_id = ${options.accessKeyId}${EOL}`;
     credentialData += `aws_secret_access_key = ${options.secretAccessKey}${EOL}`;
 
-    await fs.appendFile(filePath, credentialData);
+    await fs.appendFile(filePath, credentialData, { mode: '600' });
 
     // validate after write. It is to ensure this function is compatible with the current AWS format.
     const provider = fromIni({


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
When `npx amplify configure profile` creates `~/.aws/config` and `~/.aws/credentials` files, they were created with the default mode of "666" (read/write for owner/group/other). This is different than the permissions created when configuring these files using the AWS CLI which is "600" (read/write for owner only).

**Issue number, if available:**
Fixes https://github.com/aws-amplify/amplify-backend/issues/884 although that is just a naming concern that is colocated with this change.
## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Sets the file mode to 600 when creating new config and credential files
**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Tested locally and added coverage to existing unit test
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
