### PR TITLE
fix: enable desctructive schema updates when sandbox is enabled

### DIFF
--- a/.changeset/great-geese-change.md
+++ b/.changeset/great-geese-change.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': patch
+---
+
+enable desctructive schema updates when sanbox is enabled

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -152,7 +152,10 @@ class DataGenerator implements ConstructContainerEntryGenerator {
       authorizationModes,
       outputStorageStrategy: this.outputStorageStrategy,
       functionNameMap,
-      translationBehavior: { sandboxModeEnabled },
+      translationBehavior: {
+        sandboxModeEnabled,
+        allowDestructiveGraphqlSchemaUpdates: sandboxModeEnabled,
+      },
     });
   };
 }

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -154,7 +154,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
       functionNameMap,
       translationBehavior: {
         sandboxModeEnabled,
-        allowDestructiveGraphqlSchemaUpdates: sandboxModeEnabled,
+        allowDestructiveGraphqlSchemaUpdates: true,
       },
     });
   };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

https://github.com/aws-amplify/amplify-backend/issues/894

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Enable `allowDestructiveGraphqlSchemaUpdates` when `sandboxModeEnabled` is true. This allows destructive graphql schema updates by default when in sandbox mode.

This is likely not the final form this will take for GA, but the API design for exposing `translationBehavior` configuration is not finalized. However, `allowDestructiveGraphqlSchemaUpdates` enabled by default when in sandbox mode is the intended behavior.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

1. Create a `Todo` and `Foo` model
2. `npx amplify sandbox`
3. remove `Foo` model to trigger destructive update.

```typescript
const schema = a.schema({
  Todo: a
    .model({
      content: a.string(),
    })
    .authorization([a.allow.owner(), a.allow.public().to(['read'])]),
  Foo: a
    .model({
      content: a.string(),
    })
    .authorization([a.allow.owner(), a.allow.public().to(['read'])]),
});

export type Schema = ClientSchema<typeof schema>;

export const data = defineData({
  schema,
  authorizationModes: {
    defaultAuthorizationMode: 'apiKey',
    // API Key is used for a.allow.public() rules
    apiKeyAuthorizationMode: {
      expiresInDays: 30,
    },
  },
});
```


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
