### PR TITLE
build: refactor package json access

### DIFF
--- a/scripts/check_package_versions.ts
+++ b/scripts/check_package_versions.ts
@@ -1,6 +1,5 @@
 import { glob } from 'glob';
-import path from 'path';
-import * as fs from 'fs/promises';
+import { readPackageJson } from './components/package-json/package_json.js';
 
 const expectedVersionPrefix = '0.';
 
@@ -14,13 +13,10 @@ const expectedVersionPrefix = '0.';
 const packagePaths = await glob('./packages/*');
 
 for (const packagePath of packagePaths) {
-  const packageJsonPath = path.resolve(packagePath, 'package.json');
-  const { version } = JSON.parse(
-    await fs.readFile(packageJsonPath, 'utf-8')
-  ) as { version: string };
+  const { version } = await readPackageJson(packagePath);
   if (!version.startsWith(expectedVersionPrefix)) {
     throw new Error(
-      `Expected package version to start with "${expectedVersionPrefix}" but found version ${version} in ${packageJsonPath}.`
+      `Expected package version to start with "${expectedVersionPrefix}" but found version ${version} in ${packagePath}.`
     );
   }
 }

--- a/scripts/components/dependencies_validator.ts
+++ b/scripts/components/dependencies_validator.ts
@@ -1,7 +1,6 @@
-import fsp from 'fs/promises';
-import path from 'path';
 import { execa as _execa } from 'execa';
 import { EOL } from 'os';
+import { readPackageJson } from './package-json/package_json.js';
 
 export type DependencyRule =
   | {
@@ -21,13 +20,6 @@ type NpmListOutputItem = {
 type DependencyViolation = {
   packageName: string;
   dependencyName: string;
-};
-
-type PackageJson = {
-  name: string;
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
 };
 
 /**
@@ -60,7 +52,7 @@ export class DependenciesValidator {
   private async validateDependencyVersionsConsistency(): Promise<void> {
     console.log('Checking dependency versions consistency');
     const packageJsons = await Promise.all(
-      this.packagePaths.map((packagePath) => this.getPackageJson(packagePath))
+      this.packagePaths.map((packagePath) => readPackageJson(packagePath))
     );
 
     type DependencyVersionsUsage = {
@@ -143,22 +135,13 @@ export class DependenciesValidator {
   }
 
   /**
-   * Reads a name from package.json located at package path.
-   */
-  private async getPackageJson(packagePath: string): Promise<PackageJson> {
-    return JSON.parse(
-      (await fsp.readFile(path.join(packagePath, 'package.json'))).toString()
-    ) as PackageJson;
-  }
-
-  /**
    * Checks dependencies of a package located at packagePath against
    * provided rules.
    */
   private async checkPackageDependencies(
     packagePath: string
   ): Promise<Array<DependencyViolation>> {
-    const packageName = (await this.getPackageJson(packagePath)).name;
+    const packageName = (await readPackageJson(packagePath)).name;
     console.log(`Checking ${packageName} dependencies.`);
     const npmListResult = JSON.parse(
       // We're using 'npm ls' to reveal dependencies because it reveals

--- a/scripts/components/package-json/package_json.ts
+++ b/scripts/components/package-json/package_json.ts
@@ -1,0 +1,35 @@
+import fsp from 'fs/promises';
+import path from 'path';
+
+export type PackageJson = {
+  name: string;
+  version: string;
+  private?: boolean;
+  type?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+} & Record<string, unknown>;
+
+/**
+ * Reads content of package.json file.
+ */
+export const readPackageJson = async (
+  packageDirectoryPath: string
+): Promise<PackageJson> => {
+  const packageJsonPath = path.join(packageDirectoryPath, 'package.json');
+  return JSON.parse(
+    await fsp.readFile(packageJsonPath, 'utf-8')
+  ) as PackageJson;
+};
+
+/**
+ * Writes package json content to file.
+ */
+export const writePackageJson = async (
+  packageDirectoryPath: string,
+  packageJson: PackageJson
+): Promise<void> => {
+  const packageJsonPath = path.join(packageDirectoryPath, 'package.json');
+  await fsp.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+};

--- a/scripts/setup_test_project.ts
+++ b/scripts/setup_test_project.ts
@@ -1,6 +1,10 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import {
+  PackageJson,
+  writePackageJson,
+} from './components/package-json/package_json.js';
 
 const projectName = process.argv[2];
 if (!projectName) {
@@ -27,17 +31,13 @@ await fsp.cp(createAmplifyTemplateLocation, testProjectDir, {
 
 // create minimal package.json
 // if you want to test out changes in a commonjs package, change the "type" field in the package.json of the test project after it is created
-const packageJson = {
+const packageJson: PackageJson = {
   name: projectName,
+  version: '1.0.0',
   type: 'module',
 };
 
-const packageJsonPath = path.join(
-  fileURLToPath(testProjectDir),
-  'package.json'
-);
-
-await fsp.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+await writePackageJson(fileURLToPath(testProjectDir), packageJson);
 
 // create minimal tsconfig.json
 const tsConfig = {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

We have couple of places in `scripts` that read and write package json and we keep re-defining types for it.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

This PR removes that redundancy by introducing a component to define, read and write package json.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Alternatives considered

I was looking into packages like https://www.npmjs.com/package/type-fest that could provide typings, but I found that their typings lead to increased need for non-null assertions, so I chose to just centralize existing solution given it's simplicity.
Using 3rd party types later is still an option and should be easier to implement if this change goes in.

## Validation

This PR checks.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
