### PR TITLE
build: add timeouts in api check

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -78,12 +78,14 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout pull request ref
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
       - name: Publish packages locally
+        timeout-minutes: 2
         run: |
           npm run start:npm-proxy
           # keep git diff with version increment to make sure test projects resolve right version


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Sometimes API check hangs on publish local packages step (which usually happens around release if branch is not synchronized with main).


<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

While this doesn't solve the root cause, it makes these jobs fail faster. Otherwise they'd hang until default limit (60 min?) is hit.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

This PR checks.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
