### PR TITLE
fix: eliminate SAML type import by flattening MetadataType to string union

### DIFF
--- a/.changeset/three-shrimps-shave.md
+++ b/.changeset/three-shrimps-shave.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Updated SAML metadata types to simplify imports.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21091,12 +21091,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.9",
-        "@aws-amplify/plugin-types": "^0.7.0",
+        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/plugin-types": "^0.7.1",
         "@aws-sdk/util-arn-parser": "^3.465.0"
       },
       "peerDependencies": {
@@ -21106,19 +21106,19 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.4.2",
-        "@aws-amplify/backend-data": "^0.9.3",
-        "@aws-amplify/backend-function": "^0.6.1",
+        "@aws-amplify/backend-auth": "^0.4.3",
+        "@aws-amplify/backend-data": "^0.9.4",
+        "@aws-amplify/backend-function": "^0.6.2",
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.9",
-        "@aws-amplify/backend-secret": "^0.4.1",
-        "@aws-amplify/backend-storage": "^0.4.2",
+        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/backend-secret": "^0.4.2",
+        "@aws-amplify/backend-storage": "^0.4.3",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.4.1",
-        "@aws-amplify/plugin-types": "^0.7.0",
+        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/plugin-types": "^0.7.1",
         "@aws-sdk/client-amplify": "^3.465.0"
       },
       "devDependencies": {
@@ -21132,16 +21132,16 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.9",
-        "@aws-amplify/plugin-types": "^0.7.0"
+        "@aws-amplify/auth-construct-alpha": "^0.5.2",
+        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/plugin-types": "^0.7.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.1",
-        "@aws-amplify/platform-core": "^0.4.1"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
+        "@aws-amplify/platform-core": "^0.4.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21150,19 +21150,19 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.9",
+        "@aws-amplify/backend-output-storage": "^0.2.10",
         "@aws-amplify/data-construct": "^1.4.1",
         "@aws-amplify/data-schema-types": "^0.6.6",
-        "@aws-amplify/plugin-types": "^0.7.0"
+        "@aws-amplify/plugin-types": "^0.7.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.1",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.4.1"
+        "@aws-amplify/platform-core": "^0.4.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21171,11 +21171,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.4.1",
-        "@aws-amplify/plugin-types": "^0.7.0",
+        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/plugin-types": "^0.7.1",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -21186,16 +21186,16 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "^0.2.9",
-        "@aws-amplify/plugin-types": "^0.7.0",
+        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/plugin-types": "^0.7.1",
         "execa": "^8.0.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.1",
-        "@aws-amplify/platform-core": "^0.4.1",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
+        "@aws-amplify/platform-core": "^0.4.2",
         "@aws-sdk/client-ssm": "^3.465.0",
         "uuid": "^9.0.1"
       },
@@ -21222,7 +21222,7 @@
       "version": "0.5.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.7.0"
+        "@aws-amplify/plugin-types": "^0.7.1"
       },
       "peerDependencies": {
         "zod": "^3.22.2"
@@ -21230,11 +21230,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/platform-core": "^0.4.1"
+        "@aws-amplify/platform-core": "^0.4.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1"
@@ -21242,7 +21242,7 @@
     },
     "packages/backend-platform-test-stubs": {
       "name": "@aws-amplify/backend-platform-test-stubs",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21251,11 +21251,11 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.4.1",
-        "@aws-amplify/plugin-types": "^0.7.0",
+        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/plugin-types": "^0.7.1",
         "@aws-sdk/client-ssm": "^3.465.0"
       },
       "devDependencies": {
@@ -21264,16 +21264,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.9",
-        "@aws-amplify/plugin-types": "^0.7.0"
+        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/plugin-types": "^0.7.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.1",
-        "@aws-amplify/platform-core": "^0.4.1"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
+        "@aws-amplify/platform-core": "^0.4.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21282,19 +21282,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^0.4.5",
+        "@aws-amplify/backend-deployer": "^0.4.6",
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-secret": "^0.4.1",
+        "@aws-amplify/backend-secret": "^0.4.2",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.5.1",
-        "@aws-amplify/deployed-backend-client": "^0.3.7",
+        "@aws-amplify/client-config": "^0.5.2",
+        "@aws-amplify/deployed-backend-client": "^0.3.8",
         "@aws-amplify/form-generator": "^0.6.1",
-        "@aws-amplify/model-generator": "^0.2.5",
-        "@aws-amplify/platform-core": "^0.4.1",
-        "@aws-amplify/sandbox": "^0.3.12",
+        "@aws-amplify/model-generator": "^0.2.6",
+        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/sandbox": "^0.3.13",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -21429,12 +21429,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/deployed-backend-client": "^0.3.7",
-        "@aws-amplify/model-generator": "^0.2.5",
+        "@aws-amplify/deployed-backend-client": "^0.3.8",
+        "@aws-amplify/model-generator": "^0.2.6",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",
@@ -21442,16 +21442,16 @@
         "zod": "^3.22.2"
       },
       "devDependencies": {
-        "@aws-amplify/platform-core": "^0.4.1",
+        "@aws-amplify/platform-core": "^0.4.2",
         "@aws-sdk/types": "^3.465.0"
       }
     },
     "packages/create-amplify": {
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.4.1",
+        "@aws-amplify/platform-core": "^0.4.2",
         "execa": "^8.0.1",
         "yargs": "^17.7.2"
       },
@@ -21564,11 +21564,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/platform-core": "^0.4.1",
+        "@aws-amplify/platform-core": "^0.4.2",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
@@ -21749,15 +21749,15 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.5.1",
-        "@aws-amplify/backend": "^0.10.0",
-        "@aws-amplify/backend-secret": "^0.4.1",
-        "@aws-amplify/client-config": "^0.5.1",
+        "@aws-amplify/auth-construct-alpha": "^0.5.2",
+        "@aws-amplify/backend": "^0.10.1",
+        "@aws-amplify/backend-secret": "^0.4.2",
+        "@aws-amplify/client-config": "^0.5.2",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.4.1",
+        "@aws-amplify/platform-core": "^0.4.2",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-lambda": "^3.465.0",
@@ -22162,11 +22162,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/deployed-backend-client": "^0.3.7",
+        "@aws-amplify/deployed-backend-client": "^0.3.8",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.465.0",
@@ -22182,10 +22182,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^0.7.0",
+        "@aws-amplify/plugin-types": "^0.7.1",
         "@aws-sdk/client-sts": "3.445.0",
         "is-ci": "^3.0.1",
         "uuid": "^9.0.1",
@@ -22606,7 +22606,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -22615,15 +22615,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^0.4.5",
-        "@aws-amplify/backend-secret": "^0.4.1",
+        "@aws-amplify/backend-deployer": "^0.4.6",
+        "@aws-amplify/backend-secret": "^0.4.2",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.5.1",
-        "@aws-amplify/deployed-backend-client": "^0.3.7",
-        "@aws-amplify/platform-core": "^0.4.1",
+        "@aws-amplify/client-config": "^0.5.2",
+        "@aws-amplify/deployed-backend-client": "^0.3.8",
+        "@aws-amplify/platform-core": "^0.4.2",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/types": "^3.465.0",

--- a/packages/auth-construct/API.md
+++ b/packages/auth-construct/API.md
@@ -14,6 +14,7 @@ import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { SecretValue } from 'aws-cdk-lib';
 import { StandardAttributes } from 'aws-cdk-lib/aws-cognito';
+import { UserPoolIdentityProviderSamlMetadata } from 'aws-cdk-lib/aws-cognito';
 
 // @public
 export type AmazonProviderProps = Omit<aws_cognito.UserPoolIdentityProviderAmazonProps, 'userPool'>;
@@ -95,7 +96,11 @@ export type PhoneNumberLogin = true | {
 };
 
 // @public
-export type SamlProviderProps = Omit<aws_cognito.UserPoolIdentityProviderSamlProps, 'userPool'>;
+export type SamlProviderProps = Omit<aws_cognito.UserPoolIdentityProviderSamlProps, 'userPool' | 'metadata'> & {
+    metadata: Omit<UserPoolIdentityProviderSamlMetadata, 'metadataType'> & {
+        metadataType: 'URL' | 'FILE';
+    };
+};
 
 // @public
 export type TriggerEvent = (typeof triggerEvents)[number];

--- a/packages/auth-construct/README.md
+++ b/packages/auth-construct/README.md
@@ -54,7 +54,6 @@ In this example, you will create a stack with email, phone, and external login p
 ```ts
 import { App, Stack, SecretValue } from 'aws-cdk-lib';
 import { AmplifyAuth } from '@aws-amplify/auth-construct-alpha';
-import { UserPoolIdentityProviderSamlMetadataType } from 'aws-cdk-lib/aws-cognito';
 
 const app = new App();
 const stack = new Stack(app, 'AuthStack');
@@ -101,7 +100,7 @@ new AmplifyAuth(stack, 'Auth', {
         name: 'samlProviderName',
         metadata: {
           metadataContent: 'samlMetadataContent',
-          metadataType: UserPoolIdentityProviderSamlMetadataType.FILE,
+          metadataType: 'FILE',
         },
       },
     },

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -19,6 +19,7 @@ import {
   UserPoolIdentityProviderGoogle,
   UserPoolIdentityProviderOidc,
   UserPoolIdentityProviderSaml,
+  UserPoolIdentityProviderSamlMetadataType,
   UserPoolOperation,
   UserPoolProps,
 } from 'aws-cdk-lib/aws-cognito';
@@ -655,9 +656,20 @@ export class AmplifyAuth
       result.providersList.push('OIDC');
     }
     if (external.saml) {
+      const saml = external.saml;
       result.saml = new cognito.UserPoolIdentityProviderSaml(this, 'SamlIDP', {
         userPool,
-        ...external.saml,
+        attributeMapping: saml.attributeMapping,
+        identifiers: saml.identifiers,
+        idpSignout: saml.idpSignout,
+        metadata: {
+          metadataContent: saml.metadata.metadataContent,
+          metadataType:
+            saml.metadata.metadataType === 'FILE'
+              ? UserPoolIdentityProviderSamlMetadataType.FILE
+              : UserPoolIdentityProviderSamlMetadataType.URL,
+        },
+        name: saml.name,
       });
       result.providersList.push('SAML');
     }

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -2,7 +2,10 @@ import { SecretValue, aws_cognito as cognito } from 'aws-cdk-lib';
 import { triggerEvents } from './trigger_events.js';
 import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { AuthOutput } from '@aws-amplify/backend-output-schemas';
-import { StandardAttributes } from 'aws-cdk-lib/aws-cognito';
+import {
+  StandardAttributes,
+  UserPoolIdentityProviderSamlMetadata,
+} from 'aws-cdk-lib/aws-cognito';
 
 /**
  * Email login settings object
@@ -144,8 +147,24 @@ export type OidcProviderProps = Omit<
  */
 export type SamlProviderProps = Omit<
   cognito.UserPoolIdentityProviderSamlProps,
-  'userPool'
->;
+  'userPool' | 'metadata'
+> & {
+  /**
+   * The SAML metadata.
+   */
+  metadata: Omit<UserPoolIdentityProviderSamlMetadata, 'metadataType'> & {
+    /**
+     * Metadata types that can be used for a SAML user pool identity provider.
+     * @example 'URL'
+     *
+     * For details about each option, see below.
+     *
+     * 'URL' - Metadata provided via a URL.
+     * 'FILE' - Metadata provided via the contents of a file.
+     */
+    metadataType: 'URL' | 'FILE';
+  };
+};
 
 /**
  * External provider options.


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Previously, users would need to import types to specify the saml MetadataType, like this:

> `import { UserPoolIdentityProviderSamlMetadataType } from 'aws-cdk-lib/aws-cognito';`

> metadata: {
                metadataContent: samlMetadataContent,
                metadataType: UserPoolIdentityProviderSamlMetadataType.FILE,
              },

**Issue number, if available:**

## Changes

Now, customers can simply specify "FILE" or "URL" without importing any types.

> metadata: {
                metadataContent: samlMetadataContent,
                metadataType: 'FILE',
              },
              
 DX:
 
![image](https://github.com/aws-amplify/amplify-backend/assets/110861985/24ec9b3d-b5a2-45e2-9971-08395eff26a5)


**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
