### PR TITLE
fix: automatically map email attributes for social providers and OIDC

### DIFF
--- a/.changeset/weak-geese-allow.md
+++ b/.changeset/weak-geese-allow.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Automatically map email attributes for social providers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21091,11 +21091,11 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/backend-output-storage": "^0.2.11",
         "@aws-amplify/plugin-types": "^0.7.1",
         "@aws-sdk/util-arn-parser": "^3.465.0"
       },
@@ -21106,18 +21106,18 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.4.3",
-        "@aws-amplify/backend-data": "^0.9.4",
-        "@aws-amplify/backend-function": "^0.6.2",
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.10",
-        "@aws-amplify/backend-secret": "^0.4.2",
-        "@aws-amplify/backend-storage": "^0.4.3",
+        "@aws-amplify/backend-auth": "^0.4.4",
+        "@aws-amplify/backend-data": "^0.9.5",
+        "@aws-amplify/backend-function": "^0.6.3",
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/backend-output-storage": "^0.2.11",
+        "@aws-amplify/backend-secret": "^0.4.3",
+        "@aws-amplify/backend-storage": "^0.4.4",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/platform-core": "^0.4.3",
         "@aws-amplify/plugin-types": "^0.7.1",
         "@aws-sdk/client-amplify": "^3.465.0"
       },
@@ -21132,16 +21132,16 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.5.2",
-        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/auth-construct-alpha": "^0.5.3",
+        "@aws-amplify/backend-output-storage": "^0.2.11",
         "@aws-amplify/plugin-types": "^0.7.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
-        "@aws-amplify/platform-core": "^0.4.2"
+        "@aws-amplify/platform-core": "^0.4.3"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21150,11 +21150,11 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/backend-output-storage": "^0.2.11",
         "@aws-amplify/data-construct": "^1.4.1",
         "@aws-amplify/data-schema-types": "^0.6.6",
         "@aws-amplify/plugin-types": "^0.7.1"
@@ -21162,7 +21162,7 @@
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.4.2"
+        "@aws-amplify/platform-core": "^0.4.3"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21171,10 +21171,10 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/platform-core": "^0.4.3",
         "@aws-amplify/plugin-types": "^0.7.1",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
@@ -21186,16 +21186,16 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/backend-output-storage": "^0.2.11",
         "@aws-amplify/plugin-types": "^0.7.1",
         "execa": "^8.0.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/platform-core": "^0.4.3",
         "@aws-sdk/client-ssm": "^3.465.0",
         "uuid": "^9.0.1"
       },
@@ -21219,7 +21219,7 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/plugin-types": "^0.7.1"
@@ -21230,11 +21230,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/platform-core": "^0.4.2"
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/platform-core": "^0.4.3"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1"
@@ -21251,10 +21251,10 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/platform-core": "^0.4.3",
         "@aws-amplify/plugin-types": "^0.7.1",
         "@aws-sdk/client-ssm": "^3.465.0"
       },
@@ -21264,16 +21264,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-output-storage": "^0.2.10",
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/backend-output-storage": "^0.2.11",
         "@aws-amplify/plugin-types": "^0.7.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
-        "@aws-amplify/platform-core": "^0.4.2"
+        "@aws-amplify/platform-core": "^0.4.3"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.110.1",
@@ -21282,19 +21282,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^0.4.6",
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/backend-secret": "^0.4.2",
+        "@aws-amplify/backend-deployer": "^0.4.7",
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/backend-secret": "^0.4.3",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.5.2",
-        "@aws-amplify/deployed-backend-client": "^0.3.8",
+        "@aws-amplify/client-config": "^0.5.3",
+        "@aws-amplify/deployed-backend-client": "^0.3.9",
         "@aws-amplify/form-generator": "^0.6.1",
-        "@aws-amplify/model-generator": "^0.2.6",
-        "@aws-amplify/platform-core": "^0.4.2",
-        "@aws-amplify/sandbox": "^0.3.13",
+        "@aws-amplify/model-generator": "^0.2.7",
+        "@aws-amplify/platform-core": "^0.4.3",
+        "@aws-amplify/sandbox": "^0.3.14",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -21429,12 +21429,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/deployed-backend-client": "^0.3.8",
-        "@aws-amplify/model-generator": "^0.2.6",
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/deployed-backend-client": "^0.3.9",
+        "@aws-amplify/model-generator": "^0.2.7",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",
@@ -21442,16 +21442,16 @@
         "zod": "^3.22.2"
       },
       "devDependencies": {
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/platform-core": "^0.4.3",
         "@aws-sdk/types": "^3.465.0"
       }
     },
     "packages/create-amplify": {
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/platform-core": "^0.4.3",
         "execa": "^8.0.1",
         "yargs": "^17.7.2"
       },
@@ -21564,11 +21564,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/platform-core": "^0.4.3",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
@@ -21749,15 +21749,15 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.5.2",
-        "@aws-amplify/backend": "^0.10.1",
-        "@aws-amplify/backend-secret": "^0.4.2",
-        "@aws-amplify/client-config": "^0.5.2",
+        "@aws-amplify/auth-construct-alpha": "^0.5.3",
+        "@aws-amplify/backend": "^0.10.2",
+        "@aws-amplify/backend-secret": "^0.4.3",
+        "@aws-amplify/client-config": "^0.5.3",
         "@aws-amplify/data-schema": "^0.12.9",
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/platform-core": "^0.4.3",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-lambda": "^3.465.0",
@@ -22162,11 +22162,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.5.1",
-        "@aws-amplify/deployed-backend-client": "^0.3.8",
+        "@aws-amplify/backend-output-schemas": "^0.5.2",
+        "@aws-amplify/deployed-backend-client": "^0.3.9",
         "@aws-amplify/graphql-generator": "^0.1.3",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.465.0",
@@ -22182,7 +22182,7 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^0.7.1",
@@ -22615,15 +22615,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^0.4.6",
-        "@aws-amplify/backend-secret": "^0.4.2",
+        "@aws-amplify/backend-deployer": "^0.4.7",
+        "@aws-amplify/backend-secret": "^0.4.3",
         "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.5.2",
-        "@aws-amplify/deployed-backend-client": "^0.3.8",
-        "@aws-amplify/platform-core": "^0.4.2",
+        "@aws-amplify/client-config": "^0.5.3",
+        "@aws-amplify/deployed-backend-client": "^0.3.9",
+        "@aws-amplify/platform-core": "^0.4.3",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/types": "^3.465.0",

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -602,7 +602,11 @@ export class AmplifyAuth
           userPool,
           clientId: googleProps.clientId,
           clientSecretValue: googleProps.clientSecret,
-          attributeMapping: googleProps.attributeMapping,
+          attributeMapping: googleProps.attributeMapping ?? {
+            email: {
+              attributeName: 'email',
+            },
+          },
           scopes: googleProps.scopes,
         }
       );
@@ -616,6 +620,11 @@ export class AmplifyAuth
         {
           userPool,
           ...external.facebook,
+          attributeMapping: external.facebook.attributeMapping ?? {
+            email: {
+              attributeName: 'email',
+            },
+          },
         }
       );
       result.oauthMappings[authProvidersList.facebook] =
@@ -629,6 +638,11 @@ export class AmplifyAuth
         {
           userPool,
           ...external.loginWithAmazon,
+          attributeMapping: external.loginWithAmazon.attributeMapping ?? {
+            email: {
+              attributeName: 'email',
+            },
+          },
         }
       );
       result.oauthMappings[authProvidersList.amazon] =
@@ -642,6 +656,11 @@ export class AmplifyAuth
         {
           userPool,
           ...external.signInWithApple,
+          attributeMapping: external.signInWithApple.attributeMapping ?? {
+            email: {
+              attributeName: 'email',
+            },
+          },
         }
       );
       result.oauthMappings[authProvidersList.apple] =
@@ -652,6 +671,11 @@ export class AmplifyAuth
       result.oidc = new cognito.UserPoolIdentityProviderOidc(this, 'OidcIDP', {
         userPool,
         ...external.oidc,
+        attributeMapping: external.oidc.attributeMapping ?? {
+          email: {
+            attributeName: 'email',
+          },
+        },
       });
       result.providersList.push('OIDC');
     }

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -584,6 +584,11 @@ export class AmplifyAuth
     userPool: UserPool,
     loginOptions: AuthProps['loginWith']
   ): IdentityProviderSetupResult => {
+    /**
+     * If email is enabled, and is the only required attribute, we are able to
+     * automatically map the email attribute from external providers, excluding SAML.
+     */
+    const shouldMapEmailAttributes = loginOptions.email && !loginOptions.phone;
     const result: IdentityProviderSetupResult = {
       oauthMappings: {},
       providersList: [],
@@ -602,11 +607,14 @@ export class AmplifyAuth
           userPool,
           clientId: googleProps.clientId,
           clientSecretValue: googleProps.clientSecret,
-          attributeMapping: googleProps.attributeMapping ?? {
-            email: {
-              attributeName: 'email',
-            },
-          },
+          attributeMapping:
+            googleProps.attributeMapping ?? shouldMapEmailAttributes
+              ? {
+                  email: {
+                    attributeName: 'email',
+                  },
+                }
+              : undefined,
           scopes: googleProps.scopes,
         }
       );
@@ -620,11 +628,14 @@ export class AmplifyAuth
         {
           userPool,
           ...external.facebook,
-          attributeMapping: external.facebook.attributeMapping ?? {
-            email: {
-              attributeName: 'email',
-            },
-          },
+          attributeMapping:
+            external.facebook.attributeMapping ?? shouldMapEmailAttributes
+              ? {
+                  email: {
+                    attributeName: 'email',
+                  },
+                }
+              : undefined,
         }
       );
       result.oauthMappings[authProvidersList.facebook] =
@@ -638,11 +649,15 @@ export class AmplifyAuth
         {
           userPool,
           ...external.loginWithAmazon,
-          attributeMapping: external.loginWithAmazon.attributeMapping ?? {
-            email: {
-              attributeName: 'email',
-            },
-          },
+          attributeMapping:
+            external.loginWithAmazon.attributeMapping ??
+            shouldMapEmailAttributes
+              ? {
+                  email: {
+                    attributeName: 'email',
+                  },
+                }
+              : undefined,
         }
       );
       result.oauthMappings[authProvidersList.amazon] =
@@ -656,11 +671,15 @@ export class AmplifyAuth
         {
           userPool,
           ...external.signInWithApple,
-          attributeMapping: external.signInWithApple.attributeMapping ?? {
-            email: {
-              attributeName: 'email',
-            },
-          },
+          attributeMapping:
+            external.signInWithApple.attributeMapping ??
+            shouldMapEmailAttributes
+              ? {
+                  email: {
+                    attributeName: 'email',
+                  },
+                }
+              : undefined,
         }
       );
       result.oauthMappings[authProvidersList.apple] =
@@ -671,11 +690,14 @@ export class AmplifyAuth
       result.oidc = new cognito.UserPoolIdentityProviderOidc(this, 'OidcIDP', {
         userPool,
         ...external.oidc,
-        attributeMapping: external.oidc.attributeMapping ?? {
-          email: {
-            attributeName: 'email',
-          },
-        },
+        attributeMapping:
+          external.oidc.attributeMapping ?? shouldMapEmailAttributes
+            ? {
+                email: {
+                  attributeName: 'email',
+                },
+              }
+            : undefined,
       });
       result.providersList.push('OIDC');
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
Users currently need to map the email attributes manually when using social providers.

For example: https://github.com/josefaidt/amplify-gen2-workaround-cognito-domain/blob/main/amplify/auth/resource.ts#L21-L25

**Issue number, if available:**

## Changes

The email attribute will be automatically mapped for social providers and for OIDC.
SAML is not automatically mapped.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
