### PR TITLE
enforce consistent type imports and exports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,6 +10,8 @@ module.exports = {
     'plugin:amplify-backend-rules/recommended',
     'plugin:jsdoc/recommended-typescript-error',
     'plugin:promise/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
     'prettier',
   ],
   overrides: [
@@ -41,6 +43,11 @@ module.exports = {
     '@shopify',
   ],
   rules: {
+    '@typescript-eslint/consistent-type-exports': 'error',
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { fixStyle: 'inline-type-imports' },
+    ],
     '@typescript-eslint/naming-convention': [
       'error',
       {
@@ -157,6 +164,7 @@ module.exports = {
     ],
     'jsdoc/require-param': 'off',
     'jsdoc/require-returns': 'off',
+    'import/consistent-type-specifier-style': ['error', 'prefer-inline'],
     'spellcheck/spell-checker': [
       'warn',
       {
@@ -169,5 +177,11 @@ module.exports = {
         minLength: 4,
       },
     ],
+  },
+  settings: {
+    'import/resolver': {
+      typescript: true,
+      node: true,
+    },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-config-xo-typescript": "^0.57.0",
+        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-amplify-backend-rules": "^0.0.1",
         "eslint-plugin-check-file": "^2.6.2",
         "eslint-plugin-import": "^2.27.5",
@@ -12896,6 +12897,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -13201,6 +13215,31 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -19590,6 +19629,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/term-size": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint-plugin-jsdoc": "^43.0.6",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-promise": "^6.1.1",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-spellcheck": "^0.0.20",
     "eslint-plugin-unicorn": "^46.0.0",
     "execa": "^8.0.1",


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

follow-up to https://github.com/aws-amplify/amplify-backend/pull/709

Enforces consistent type imports and exports. This can help prevent errors such as https://typescript.tv/errors/#ts2742 when consuming the libraries with pnpm or npm's "linked" install strategy.

- enables https://typescript-eslint.io/rules/consistent-type-imports
- enables https://typescript-eslint.io/rules/consistent-type-exports
- enables https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/consistent-type-specifier-style.md
- extends https://github.com/import-js/eslint-plugin-import/blob/main/config/recommended.js
- extends https://github.com/import-js/eslint-plugin-import/blob/main/config/typescript.js

Enabling this emits 504 errors from ESLint 
```
✖ 504 problems (504 errors, 0 warnings)
  504 errors and 0 warnings potentially fixable with the `--fix` option.
```

*Questions:*
- how do we feel about the inline type imports? This adheres to "no duplicate imports", but can be rough to sort properly with ESLint (it's easier to sort `import type`)
- any thoughts on enforcing import order? https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#options

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
