### PR TITLE
test: handle var args in api check

### DIFF
--- a/scripts/components/api-changes-validator/api_changes_validator.test.ts
+++ b/scripts/components/api-changes-validator/api_changes_validator.test.ts
@@ -37,7 +37,7 @@ void describe('Api changes validator', { concurrency: true }, () => {
   });
 
   after(async () => {
-    await fsp.rm(workingDirectory, { recursive: true, force: true });
+    // await fsp.rm(workingDirectory, { recursive: true, force: true });
   });
 
   for (const testProject of testProjectsWithBreaks) {

--- a/scripts/components/api-changes-validator/api_changes_validator.test.ts
+++ b/scripts/components/api-changes-validator/api_changes_validator.test.ts
@@ -37,7 +37,7 @@ void describe('Api changes validator', { concurrency: true }, () => {
   });
 
   after(async () => {
-    // await fsp.rm(workingDirectory, { recursive: true, force: true });
+    await fsp.rm(workingDirectory, { recursive: true, force: true });
   });
 
   for (const testProject of testProjectsWithBreaks) {

--- a/scripts/components/api-changes-validator/api_usage_generator.test.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.test.ts
@@ -81,12 +81,14 @@ export const someFunction1: () => void;
 export const someFunction2: (param1: string, param2?: number) => string;
 export const someFunction3: (param1: string, param2: number = 1) => string;
 export const someFunction4: <T1, T2, T3>(param1: T1, param2?: T2) => Promise<T3>;
+export const someFunction5: (param1: string, ...param2: number) => string;
     `,
     expectedApiUsage: `
 import { someFunction1 } from 'samplePackageName';
 import { someFunction2 } from 'samplePackageName';
 import { someFunction3 } from 'samplePackageName';
 import { someFunction4 } from 'samplePackageName';
+import { someFunction5 } from 'samplePackageName';
 
 const someFunction1UsageFunction = () => {
   someFunction1();
@@ -106,6 +108,11 @@ const someFunction3UsageFunction = (param1: string, param2: number = 1) => {
 const someFunction4UsageFunction = <T1, T2, T3>(param1: T1, param2?: T2) => {
   const returnValue: Promise<T3> = someFunction4(param1);
   someFunction4(param1, param2);
+}
+
+const someFunction5UsageFunction = (param1: string, ...param2: number) => {
+  const returnValue: string = someFunction5(param1, ...param2);
+  someFunction5(param1, ...param2);
 }
     `,
   },
@@ -135,6 +142,9 @@ export class SomeClass7<T1 extends SomeClass1, T2, T3, T4, T5, T6> {
   someMethod: (param1: T3, param2?: T4) => T5;
   someProperty: T6;
 }
+export class SomeClass8 {
+  someMethod: (param1: string, ...param2: string) => string;
+}
 export abstract class SomeAbstractClass1 {
   constructor(param1: string, param2?: string);
   someMethod: (param1: string, param2?: string) => string;
@@ -154,6 +164,7 @@ import { SomeClass4 } from 'samplePackageName';
 import { SomeClass5 } from 'samplePackageName';
 import { SomeClass6 } from 'samplePackageName';
 import { SomeClass7 } from 'samplePackageName';
+import { SomeClass8 } from 'samplePackageName';
 import { SomeAbstractClass1 } from 'samplePackageName';
 import { SomeAbstractClass2 } from 'samplePackageName';
 
@@ -204,6 +215,14 @@ const someClass7SomeMethodUsageOuterFunction = <T1 extends SomeClass1, T2, T3, T
 }
 const someClass7SomePropertyUsageOuterFunction = <T1 extends SomeClass1, T2, T3, T4, T5, T6>(someClass7SomePropertyUsageOuterFunctionParameter: SomeClass7<T1, T2, T3, T4, T5, T6>) => {
   const propertyValue: T6 = someClass7SomePropertyUsageOuterFunctionParameter.someProperty;
+}
+
+
+const someClass8SomeMethodUsageOuterFunction = (someClass8SomeMethodUsageOuterFunctionParameter: SomeClass8) => {
+  const SomeClass8SomeMethodUsageInnerFunction = (param1: string, ...param2: string) => {
+    const returnValue: string = someClass8SomeMethodUsageOuterFunctionParameter.someMethod(param1, ...param2);
+    someClass8SomeMethodUsageOuterFunctionParameter.someMethod(param1, ...param2);
+  }
 }
 
 

--- a/scripts/components/api-changes-validator/api_usage_statements_generators.ts
+++ b/scripts/components/api-changes-validator/api_usage_statements_generators.ts
@@ -628,7 +628,13 @@ export class CallableParameterUsageStatementsGenerator
             return true;
         }
       })
-      .map((parameter) => parameter.name.getText())
+      .map((parameter) => {
+        if (parameter.dotDotDotToken) {
+          // expand var arg
+          return `...${parameter.name.getText()}`;
+        }
+        return parameter.name.getText();
+      })
       .join(', ');
     return {
       usageStatement,

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/API.md
@@ -59,6 +59,10 @@ export class SomeDerivedClass2<T1, T2 extends SampleType, T3, T4, T5, T6>
   someProperty: T1;
 }
 
+export class SomeClassWithTemplateMethodAndVarArg {
+  someTemplateMethodWithVarArg: <T extends Record<string | number, string>>(...objects: T[]) => void;
+}
+
 export const someFunction1: () => void;
 export const someFunction2: (param1: string, param2?: number) => string;
 export const someFunction3: (param1: string, param2: number = 1) => string;

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/API.md
@@ -70,6 +70,7 @@ export const someFunction4: <T1, T2, T3>(
   param1: T1,
   param2?: T2
 ) => Promise<T3>;
+export const someFunction5: (param1: string, ...param2: number[]) => string;
 
 export type SampleTypeUsingClass = {
   sampleMethod: (param: SampleClass1) => void;

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/src/index.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/src/index.ts
@@ -99,6 +99,9 @@ export const someFunction4 = <T1, T2, T3>(
 ): Promise<T3> => {
   throw new Error();
 };
+export const someFunction5 = (param1: string, ...param2: number[]): string => {
+  throw new Error();
+};
 
 export type SampleTypeUsingClass = {
   sampleMethod: (param: SampleClass1) => void;

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/src/index.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/src/index.ts
@@ -76,6 +76,14 @@ export class SomeDerivedClass2<T1, T2 extends SampleType, T3, T4, T5, T6>
   someProperty: T1;
 }
 
+export class SomeClassWithTemplateMethodAndVarArg {
+  someTemplateMethodWithVarArg = <T extends Record<string | number, string>>(
+    ...objects: T[]
+  ): void => {
+    throw new Error();
+  };
+}
+
 export const someFunction1 = (): void => {
   throw new Error();
 };


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-backend/actions/runs/7628068742/job/20778342823?pr=942 .

```
Validation of model-generator completed successfully
Validation of client-config completed successfully
Validation of sandbox completed successfully
/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:87
  throw new AggregateError(errors, 'There are validation failures');
        ^


AggregateError: There are validation failures
    at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:87:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  [errors]: [
    Error: Validation of @aws-amplify/cli-core failed, compiler output:
    index.ts(59,65): error TS2345: Argument of type 'T[]' is not assignable to parameter of type 'Record<string | number, RecordValue>'.
      Index signature for type 'string' is missing in type 'T[]'.
    index.ts(60,65): error TS2345: Argument of type 'T[]' is not assignable to parameter of type 'Record<string | number, RecordValue>'.
        at ApiChangesValidator.validate (/home/runner/work/amplify-backend/amplify-backend/scripts/components/api-changes-validator/api_changes_validator.ts:[61](https://github.com/aws-amplify/amplify-backend/actions/runs/7628068742/job/20778342823?pr=942#step:7:62):13)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:[70](https://github.com/aws-amplify/amplify-backend/actions/runs/7628068742/job/20778342823?pr=942#step:7:71):5)
        at async Promise.allSettled (index 10)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:50:27)
  ]
}

Node.js v18.19.0
Error: Process completed with exit code 1.
```