### PR TITLE
inject shim for cjs dependencies

### DIFF
--- a/.changeset/lucky-lizards-tan.md
+++ b/.changeset/lucky-lizards-tan.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+Inject shim for cjs require for functions

--- a/packages/backend-function/src/cjs_shim.ts
+++ b/packages/backend-function/src/cjs_shim.ts
@@ -1,0 +1,2 @@
+import { createRequire } from 'node:module';
+global.require = createRequire(import.meta.url);

--- a/packages/backend-function/src/cjs_shim.ts
+++ b/packages/backend-function/src/cjs_shim.ts
@@ -1,2 +1,6 @@
 import { createRequire } from 'node:module';
+import path from 'node:path';
+import url from 'node:url';
 global.require = createRequire(import.meta.url);
+global.__filename = url.fileURLToPath(import.meta.url);
+global.__dirname = path.dirname(__filename);

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -13,7 +13,6 @@ import * as path from 'path';
 import { getCallerDirectory } from './get_caller_directory.js';
 import { Duration } from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-
 import fs from 'fs';
 import { createRequire } from 'module';
 import { FunctionEnvironmentTranslator } from './function_env_translator.js';
@@ -246,6 +245,8 @@ class AmplifyFunction
       .replaceAll('\r', '')
       .split('//#')[0]; // remove source map
 
+    const cjsShimRequire = require.resolve('./cjs_shim');
+
     const functionLambda = new NodejsFunction(scope, `${id}-lambda`, {
       entry: props.entry,
       environment: environmentRecord as { [key: string]: string }, // for some reason TS can't figure out that this is the same as Record<string, string>
@@ -255,6 +256,7 @@ class AmplifyFunction
       bundling: {
         banner: bannerCode,
         format: OutputFormat.ESM,
+        inject: [cjsShimRequire], // replace require to fix dynamic require errors with cjs
       },
     });
 


### PR DESCRIPTION
## Problem

Error when executing functions with a 3p import:
```
Error: "Dynamic require of ___ is not supported"
```
This happens when the 3p import statement ends up with `require` syntax instead of `import` syntax while the function is formatted as ESM for top level await support for resolving secrets.

**Issue number, if available:**

## Changes

Add shim for cjs require that is injected into the function. Shim replaces `require`, `__filename`, and `__dirname`.

**Corresponding docs PR, if applicable:**

## Validation

With a local project where the handler has `const { Buffer } = require('node:buffer');`:

Before change:
When executing function got the `Dynamic require` error mentioned above

After change:
Function execution is successful and secrets are resolved.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
