### PR TITLE
fix: Output OAuth settings to config without requiring domain prefix

### DIFF
--- a/.changeset/metal-radios-pay.md
+++ b/.changeset/metal-radios-pay.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+'@aws-amplify/client-config': patch
+---
+
+Fix bug in frontend config where oauth would not be output if domain prefix was not defined.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21091,7 +21091,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.2",
@@ -21106,12 +21106,12 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.4.4",
+        "@aws-amplify/backend-auth": "^0.4.5",
         "@aws-amplify/backend-data": "^0.9.5",
-        "@aws-amplify/backend-function": "^0.6.3",
+        "@aws-amplify/backend-function": "^0.6.4",
         "@aws-amplify/backend-output-schemas": "^0.5.2",
         "@aws-amplify/backend-output-storage": "^0.2.11",
         "@aws-amplify/backend-secret": "^0.4.3",
@@ -21132,10 +21132,10 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.5.3",
+        "@aws-amplify/auth-construct-alpha": "^0.5.4",
         "@aws-amplify/backend-output-storage": "^0.2.11",
         "@aws-amplify/plugin-types": "^0.7.1"
       },
@@ -21186,7 +21186,7 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-storage": "^0.2.11",
@@ -21282,19 +21282,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.9.7",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.4.7",
         "@aws-amplify/backend-output-schemas": "^0.5.2",
         "@aws-amplify/backend-secret": "^0.4.3",
-        "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.5.3",
+        "@aws-amplify/cli-core": "^0.3.0",
+        "@aws-amplify/client-config": "^0.6.0",
         "@aws-amplify/deployed-backend-client": "^0.3.9",
-        "@aws-amplify/form-generator": "^0.6.1",
-        "@aws-amplify/model-generator": "^0.2.7",
+        "@aws-amplify/form-generator": "^0.7.0",
+        "@aws-amplify/model-generator": "^0.3.0",
         "@aws-amplify/platform-core": "^0.4.3",
-        "@aws-amplify/sandbox": "^0.3.14",
+        "@aws-amplify/sandbox": "^0.4.0",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -21321,7 +21321,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^3.0.0"
@@ -21429,12 +21429,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.2",
         "@aws-amplify/deployed-backend-client": "^0.3.9",
-        "@aws-amplify/model-generator": "^0.2.7",
+        "@aws-amplify/model-generator": "^0.3.0",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",
@@ -21447,10 +21447,10 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.2.0",
+        "@aws-amplify/cli-core": "^0.3.0",
         "@aws-amplify/platform-core": "^0.4.3",
         "execa": "^8.0.1",
         "yargs": "^17.7.2"
@@ -21717,7 +21717,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
@@ -21752,10 +21752,10 @@
       "version": "0.4.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.5.3",
-        "@aws-amplify/backend": "^0.10.2",
+        "@aws-amplify/auth-construct-alpha": "^0.5.4",
+        "@aws-amplify/backend": "^0.10.3",
         "@aws-amplify/backend-secret": "^0.4.3",
-        "@aws-amplify/client-config": "^0.5.3",
+        "@aws-amplify/client-config": "^0.6.0",
         "@aws-amplify/data-schema": "^0.12.9",
         "@aws-amplify/platform-core": "^0.4.3",
         "@aws-sdk/client-amplify": "^3.465.0",
@@ -22162,7 +22162,7 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.2.7",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.2",
@@ -22615,13 +22615,13 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.3.14",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.4.7",
         "@aws-amplify/backend-secret": "^0.4.3",
-        "@aws-amplify/cli-core": "^0.2.0",
-        "@aws-amplify/client-config": "^0.5.3",
+        "@aws-amplify/cli-core": "^0.3.0",
+        "@aws-amplify/client-config": "^0.6.0",
         "@aws-amplify/deployed-backend-client": "^0.3.9",
         "@aws-amplify/platform-core": "^0.4.3",
         "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -556,6 +556,7 @@ void describe('Auth construct', () => {
             verificationMechanisms: '["EMAIL"]',
             usernameAttributes: '["EMAIL"]',
             googleClientId: 'googleClientId',
+            oauthClientId: expectedWebClientId, // same thing
             oauthDomain: `test-prefix.auth.${expectedRegion}.amazoncognito.com`,
             oauthScope: '["email","profile"]',
             oauthRedirectSignIn: 'http://callback.com',

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -885,7 +885,7 @@ export class AmplifyAuth
         output.oauthRedirectSignOut = this.oAuthSettings.logoutUrls
           ? this.oAuthSettings.logoutUrls.join(',')
           : '';
-        output.webClientId = this.resources.userPoolClient.userPoolClientId;
+        output.oauthClientId = this.resources.userPoolClient.userPoolClientId;
         output.oauthResponseType = 'code';
       }
     }

--- a/packages/client-config/src/client-config-contributor/auth_client_config_contributor.ts
+++ b/packages/client-config/src/client-config-contributor/auth_client_config_contributor.ts
@@ -87,21 +87,24 @@ export class AuthClientConfigContributor implements ClientConfigContributor {
       );
     }
 
-    authClientConfig.oauth = {};
-    if (authOutput.payload.oauthDomain) {
-      authClientConfig.oauth.domain = authOutput.payload.oauthDomain;
+    if (authOutput.payload.oauthClientId) {
+      authClientConfig.oauth = {};
+      if (authOutput.payload.oauthDomain) {
+        authClientConfig.oauth.domain = authOutput.payload.oauthDomain;
+      }
+      parseAndAssignObject(
+        authClientConfig.oauth,
+        'scope',
+        authOutput.payload.oauthScope
+      );
+      authClientConfig.oauth.redirectSignIn =
+        authOutput.payload.oauthRedirectSignIn;
+      authClientConfig.oauth.redirectSignOut =
+        authOutput.payload.oauthRedirectSignOut;
+      authClientConfig.oauth.clientId = authOutput.payload.oauthClientId;
+      authClientConfig.oauth.responseType =
+        authOutput.payload.oauthResponseType;
     }
-    parseAndAssignObject(
-      authClientConfig.oauth,
-      'scope',
-      authOutput.payload.oauthScope
-    );
-    authClientConfig.oauth.redirectSignIn =
-      authOutput.payload.oauthRedirectSignIn;
-    authClientConfig.oauth.redirectSignOut =
-      authOutput.payload.oauthRedirectSignOut;
-    authClientConfig.oauth.clientId = authOutput.payload.oauthClientId;
-    authClientConfig.oauth.responseType = authOutput.payload.oauthResponseType;
     return authClientConfig;
   };
 }

--- a/packages/client-config/src/client-config-contributor/auth_client_config_contributor.ts
+++ b/packages/client-config/src/client-config-contributor/auth_client_config_contributor.ts
@@ -87,22 +87,21 @@ export class AuthClientConfigContributor implements ClientConfigContributor {
       );
     }
 
+    authClientConfig.oauth = {};
     if (authOutput.payload.oauthDomain) {
-      authClientConfig.oauth = {};
       authClientConfig.oauth.domain = authOutput.payload.oauthDomain;
-      parseAndAssignObject(
-        authClientConfig.oauth,
-        'scope',
-        authOutput.payload.oauthScope
-      );
-      authClientConfig.oauth.redirectSignIn =
-        authOutput.payload.oauthRedirectSignIn;
-      authClientConfig.oauth.redirectSignOut =
-        authOutput.payload.oauthRedirectSignOut;
-      authClientConfig.oauth.clientId = authOutput.payload.oauthClientId;
-      authClientConfig.oauth.responseType =
-        authOutput.payload.oauthResponseType;
     }
+    parseAndAssignObject(
+      authClientConfig.oauth,
+      'scope',
+      authOutput.payload.oauthScope
+    );
+    authClientConfig.oauth.redirectSignIn =
+      authOutput.payload.oauthRedirectSignIn;
+    authClientConfig.oauth.redirectSignOut =
+      authOutput.payload.oauthRedirectSignOut;
+    authClientConfig.oauth.clientId = authOutput.payload.oauthClientId;
+    authClientConfig.oauth.responseType = authOutput.payload.oauthResponseType;
     return authClientConfig;
   };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
OAuth settings were not being output to the frontend config if domainPrefix was missing.

**Issue number, if available:**

## Changes
OAuth settings will now be output to the frontend config even if domainPrefix is missing.
domainPrefix (as oauthDomain) will only be output if it is set.

**Corresponding docs PR, if applicable:**

## Validation
Tests updated

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
