### PR TITLE
fix: Expose name prop to allow controlling resource naming

### DIFF
--- a/.changeset/many-lobsters-move.md
+++ b/.changeset/many-lobsters-move.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Allow users to customize the resource names for auth.

--- a/packages/auth-construct/API.md
+++ b/packages/auth-construct/API.md
@@ -31,6 +31,7 @@ export type AppleProviderProps = Omit<aws_cognito.UserPoolIdentityProviderAppleP
 
 // @public
 export type AuthProps = {
+    name?: string;
     loginWith: {
         email?: EmailLogin;
         phone?: PhoneNumberLogin;

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -103,6 +103,8 @@ export class AmplifyAuth
 
   private readonly oAuthSettings: cognito.OAuthSettings | undefined;
 
+  private readonly name: string;
+
   /**
    * Create a new Auth construct with AuthProps.
    * If no props are provided, email login and defaults will be used.
@@ -114,11 +116,13 @@ export class AmplifyAuth
   ) {
     super(scope, id);
 
+    this.name = props.name ?? '';
+
     // UserPool
     this.computedUserPoolProps = this.getUserPoolProps(props);
     this.userPool = new cognito.UserPool(
       this,
-      'UserPool',
+      `${this.name ?? ''}UserPool`,
       this.computedUserPoolProps
     );
 
@@ -133,7 +137,7 @@ export class AmplifyAuth
       this.domainPrefix &&
       this.providerSetupResult.providersList.length > 0
     ) {
-      this.userPool.addDomain('UserPoolDomain', {
+      this.userPool.addDomain(`${this.name ?? ''}UserPoolDomain`, {
         cognitoDomain: { domainPrefix: this.domainPrefix },
       });
     } else if (
@@ -174,7 +178,7 @@ export class AmplifyAuth
     // UserPool Client
     const userPoolClient = new cognito.UserPoolClient(
       this,
-      'UserPoolAppClient',
+      `${this.name ?? ''}UserPoolAppClient`,
       {
         userPool: this.userPool,
         authFlows: DEFAULTS.AUTH_FLOWS,
@@ -244,7 +248,7 @@ export class AmplifyAuth
    */
   private setupAuthAndUnAuthRoles = (identityPoolId: string): DefaultRoles => {
     const result: DefaultRoles = {
-      auth: new Role(this, 'authenticatedUserRole', {
+      auth: new Role(this, `${this.name ?? ''}authenticatedUserRole`, {
         assumedBy: new FederatedPrincipal(
           'cognito-identity.amazonaws.com',
           {
@@ -258,7 +262,7 @@ export class AmplifyAuth
           'sts:AssumeRoleWithWebIdentity'
         ),
       }),
-      unAuth: new Role(this, 'unauthenticatedUserRole', {
+      unAuth: new Role(this, `${this.name ?? ''}unauthenticatedUserRole`, {
         assumedBy: new FederatedPrincipal(
           'cognito-identity.amazonaws.com',
           {
@@ -286,14 +290,19 @@ export class AmplifyAuth
   ) => {
     // setup identity pool
     const region = Stack.of(this).region;
-    const identityPool = new cognito.CfnIdentityPool(this, 'IdentityPool', {
-      allowUnauthenticatedIdentities: DEFAULTS.ALLOW_UNAUTHENTICATED_IDENTITIES,
-    });
+    const identityPool = new cognito.CfnIdentityPool(
+      this,
+      `${this.name ?? ''}IdentityPool`,
+      {
+        allowUnauthenticatedIdentities:
+          DEFAULTS.ALLOW_UNAUTHENTICATED_IDENTITIES,
+      }
+    );
     const roles = this.setupAuthAndUnAuthRoles(identityPool.ref);
     const identityPoolRoleAttachment =
       new cognito.CfnIdentityPoolRoleAttachment(
         this,
-        'IdentityPoolRoleAttachment',
+        `${this.name ?? ''}IdentityPoolRoleAttachment`,
         {
           identityPoolId: identityPool.ref,
           roles: {
@@ -602,7 +611,7 @@ export class AmplifyAuth
       const googleProps = external.google;
       result.google = new cognito.UserPoolIdentityProviderGoogle(
         this,
-        'GoogleIdP',
+        `${this.name ?? ''}GoogleIdP`,
         {
           userPool,
           clientId: googleProps.clientId,
@@ -624,7 +633,7 @@ export class AmplifyAuth
     if (external.facebook) {
       result.facebook = new cognito.UserPoolIdentityProviderFacebook(
         this,
-        'FacebookIDP',
+        `${this.name ?? ''}FacebookIDP`,
         {
           userPool,
           ...external.facebook,
@@ -645,7 +654,7 @@ export class AmplifyAuth
     if (external.loginWithAmazon) {
       result.amazon = new cognito.UserPoolIdentityProviderAmazon(
         this,
-        'AmazonIDP',
+        `${this.name ?? ''}AmazonIDP`,
         {
           userPool,
           ...external.loginWithAmazon,
@@ -667,7 +676,7 @@ export class AmplifyAuth
     if (external.signInWithApple) {
       result.apple = new cognito.UserPoolIdentityProviderApple(
         this,
-        'AppleIDP',
+        `${this.name ?? ''}AppleIDP`,
         {
           userPool,
           ...external.signInWithApple,
@@ -687,36 +696,44 @@ export class AmplifyAuth
       result.providersList.push('APPLE');
     }
     if (external.oidc) {
-      result.oidc = new cognito.UserPoolIdentityProviderOidc(this, 'OidcIDP', {
-        userPool,
-        ...external.oidc,
-        attributeMapping:
-          external.oidc.attributeMapping ?? shouldMapEmailAttributes
-            ? {
-                email: {
-                  attributeName: 'email',
-                },
-              }
-            : undefined,
-      });
+      result.oidc = new cognito.UserPoolIdentityProviderOidc(
+        this,
+        `${this.name ?? ''}OidcIDP`,
+        {
+          userPool,
+          ...external.oidc,
+          attributeMapping:
+            external.oidc.attributeMapping ?? shouldMapEmailAttributes
+              ? {
+                  email: {
+                    attributeName: 'email',
+                  },
+                }
+              : undefined,
+        }
+      );
       result.providersList.push('OIDC');
     }
     if (external.saml) {
       const saml = external.saml;
-      result.saml = new cognito.UserPoolIdentityProviderSaml(this, 'SamlIDP', {
-        userPool,
-        attributeMapping: saml.attributeMapping,
-        identifiers: saml.identifiers,
-        idpSignout: saml.idpSignout,
-        metadata: {
-          metadataContent: saml.metadata.metadataContent,
-          metadataType:
-            saml.metadata.metadataType === 'FILE'
-              ? UserPoolIdentityProviderSamlMetadataType.FILE
-              : UserPoolIdentityProviderSamlMetadataType.URL,
-        },
-        name: saml.name,
-      });
+      result.saml = new cognito.UserPoolIdentityProviderSaml(
+        this,
+        `${this.name ?? ''}SamlIDP`,
+        {
+          userPool,
+          attributeMapping: saml.attributeMapping,
+          identifiers: saml.identifiers,
+          idpSignout: saml.idpSignout,
+          metadata: {
+            metadataContent: saml.metadata.metadataContent,
+            metadataType:
+              saml.metadata.metadataType === 'FILE'
+                ? UserPoolIdentityProviderSamlMetadataType.FILE
+                : UserPoolIdentityProviderSamlMetadataType.URL,
+          },
+          name: saml.name,
+        }
+      );
       result.providersList.push('SAML');
     }
     return result;

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -122,7 +122,7 @@ export class AmplifyAuth
     this.computedUserPoolProps = this.getUserPoolProps(props);
     this.userPool = new cognito.UserPool(
       this,
-      `${this.name ?? ''}UserPool`,
+      `${this.name}UserPool`,
       this.computedUserPoolProps
     );
 
@@ -137,7 +137,7 @@ export class AmplifyAuth
       this.domainPrefix &&
       this.providerSetupResult.providersList.length > 0
     ) {
-      this.userPool.addDomain(`${this.name ?? ''}UserPoolDomain`, {
+      this.userPool.addDomain(`${this.name}UserPoolDomain`, {
         cognitoDomain: { domainPrefix: this.domainPrefix },
       });
     } else if (
@@ -178,7 +178,7 @@ export class AmplifyAuth
     // UserPool Client
     const userPoolClient = new cognito.UserPoolClient(
       this,
-      `${this.name ?? ''}UserPoolAppClient`,
+      `${this.name}UserPoolAppClient`,
       {
         userPool: this.userPool,
         authFlows: DEFAULTS.AUTH_FLOWS,
@@ -248,7 +248,7 @@ export class AmplifyAuth
    */
   private setupAuthAndUnAuthRoles = (identityPoolId: string): DefaultRoles => {
     const result: DefaultRoles = {
-      auth: new Role(this, `${this.name ?? ''}authenticatedUserRole`, {
+      auth: new Role(this, `${this.name}authenticatedUserRole`, {
         assumedBy: new FederatedPrincipal(
           'cognito-identity.amazonaws.com',
           {
@@ -262,7 +262,7 @@ export class AmplifyAuth
           'sts:AssumeRoleWithWebIdentity'
         ),
       }),
-      unAuth: new Role(this, `${this.name ?? ''}unauthenticatedUserRole`, {
+      unAuth: new Role(this, `${this.name}unauthenticatedUserRole`, {
         assumedBy: new FederatedPrincipal(
           'cognito-identity.amazonaws.com',
           {
@@ -292,7 +292,7 @@ export class AmplifyAuth
     const region = Stack.of(this).region;
     const identityPool = new cognito.CfnIdentityPool(
       this,
-      `${this.name ?? ''}IdentityPool`,
+      `${this.name}IdentityPool`,
       {
         allowUnauthenticatedIdentities:
           DEFAULTS.ALLOW_UNAUTHENTICATED_IDENTITIES,
@@ -302,7 +302,7 @@ export class AmplifyAuth
     const identityPoolRoleAttachment =
       new cognito.CfnIdentityPoolRoleAttachment(
         this,
-        `${this.name ?? ''}IdentityPoolRoleAttachment`,
+        `${this.name}IdentityPoolRoleAttachment`,
         {
           identityPoolId: identityPool.ref,
           roles: {
@@ -611,7 +611,7 @@ export class AmplifyAuth
       const googleProps = external.google;
       result.google = new cognito.UserPoolIdentityProviderGoogle(
         this,
-        `${this.name ?? ''}GoogleIdP`,
+        `${this.name}GoogleIdP`,
         {
           userPool,
           clientId: googleProps.clientId,
@@ -633,7 +633,7 @@ export class AmplifyAuth
     if (external.facebook) {
       result.facebook = new cognito.UserPoolIdentityProviderFacebook(
         this,
-        `${this.name ?? ''}FacebookIDP`,
+        `${this.name}FacebookIDP`,
         {
           userPool,
           ...external.facebook,
@@ -654,7 +654,7 @@ export class AmplifyAuth
     if (external.loginWithAmazon) {
       result.amazon = new cognito.UserPoolIdentityProviderAmazon(
         this,
-        `${this.name ?? ''}AmazonIDP`,
+        `${this.name}AmazonIDP`,
         {
           userPool,
           ...external.loginWithAmazon,
@@ -676,7 +676,7 @@ export class AmplifyAuth
     if (external.signInWithApple) {
       result.apple = new cognito.UserPoolIdentityProviderApple(
         this,
-        `${this.name ?? ''}AppleIDP`,
+        `${this.name}AppleIDP`,
         {
           userPool,
           ...external.signInWithApple,
@@ -698,7 +698,7 @@ export class AmplifyAuth
     if (external.oidc) {
       result.oidc = new cognito.UserPoolIdentityProviderOidc(
         this,
-        `${this.name ?? ''}OidcIDP`,
+        `${this.name}OidcIDP`,
         {
           userPool,
           ...external.oidc,
@@ -718,7 +718,7 @@ export class AmplifyAuth
       const saml = external.saml;
       result.saml = new cognito.UserPoolIdentityProviderSaml(
         this,
-        `${this.name ?? ''}SamlIDP`,
+        `${this.name}SamlIDP`,
         {
           userPool,
           attributeMapping: saml.attributeMapping,

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -243,6 +243,10 @@ export type TriggerEvent = (typeof triggerEvents)[number];
  */
 export type AuthProps = {
   /**
+   * Specify a name which will aid in generating resource names.
+   */
+  name?: string;
+  /**
    * Specify how you would like users to log in. You can choose from email, phone, and even external providers such as LoginWithAmazon.
    */
   loginWith: {


### PR DESCRIPTION

## Problem

Resource names were not configurable. This is not aligned with the way things are handled in the Data construct.

**Issue number, if available:**

## Changes

This adds a 'name' property that is optional. If specified, the name prop is used to prefix resource names.
Users can customize name based on things like process.env.AWS_BRANCH as well.

**Corresponding docs PR, if applicable:**

## Validation
Unit test added.

<img width="644" alt="image" src="https://github.com/aws-amplify/amplify-backend/assets/110861985/7de967a7-de30-4218-95ab-8fc94e846403">

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
