### PR TITLE
fix: keep original attribute mappings when adding email for login with email

### DIFF
--- a/.changeset/fuzzy-pets-wonder.md
+++ b/.changeset/fuzzy-pets-wonder.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': minor
+---
+
+fix external providers attribute mappings

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -42,6 +42,7 @@
   "formatter",
   "frontend",
   "frontends",
+  "fullname",
   "func",
   "gitignore",
   "gitignored",

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -1735,7 +1735,7 @@ void describe('Auth construct', () => {
         },
       });
     });
-    
+
     void it('automatically maps email attributes for external providers and keeps existing configuration', () => {
       const app = new App();
       const stack = new Stack(app);

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -623,7 +623,7 @@ export class AmplifyAuth
                   email: { attributeName: 'email' },
                 }
               : googleProps.attributeMapping?.email),
-          };
+          },
           scopes: googleProps.scopes,
         }
       );

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -609,6 +609,14 @@ export class AmplifyAuth
     }
     if (external.google) {
       const googleProps = external.google;
+      const attributeMapping = {
+        ...googleProps.attributeMapping,
+        ...(shouldMapEmailAttributes
+          ? googleProps.attributeMapping?.email || {
+              email: { attributeName: 'email' },
+            }
+          : googleProps.attributeMapping?.email),
+      };
       result.google = new cognito.UserPoolIdentityProviderGoogle(
         this,
         `${this.name}GoogleIdP`,
@@ -616,14 +624,7 @@ export class AmplifyAuth
           userPool,
           clientId: googleProps.clientId,
           clientSecretValue: googleProps.clientSecret,
-          attributeMapping:
-            googleProps.attributeMapping ?? shouldMapEmailAttributes
-              ? {
-                  email: {
-                    attributeName: 'email',
-                  },
-                }
-              : undefined,
+          attributeMapping,
           scopes: googleProps.scopes,
         }
       );
@@ -637,14 +638,14 @@ export class AmplifyAuth
         {
           userPool,
           ...external.facebook,
-          attributeMapping:
-            external.facebook.attributeMapping ?? shouldMapEmailAttributes
-              ? {
-                  email: {
-                    attributeName: 'email',
-                  },
+          attributeMapping: {
+            ...external.facebook.attributeMapping,
+            ...(shouldMapEmailAttributes
+              ? external.facebook.attributeMapping?.email || {
+                  email: { attributeName: 'email' },
                 }
-              : undefined,
+              : external.facebook.attributeMapping?.email),
+          },
         }
       );
       result.oauthMappings[authProvidersList.facebook] =
@@ -658,15 +659,14 @@ export class AmplifyAuth
         {
           userPool,
           ...external.loginWithAmazon,
-          attributeMapping:
-            external.loginWithAmazon.attributeMapping ??
-            shouldMapEmailAttributes
-              ? {
-                  email: {
-                    attributeName: 'email',
-                  },
+          attributeMapping: {
+            ...external.loginWithAmazon.attributeMapping,
+            ...(shouldMapEmailAttributes
+              ? external.loginWithAmazon.attributeMapping?.email || {
+                  email: { attributeName: 'email' },
                 }
-              : undefined,
+              : external.loginWithAmazon.attributeMapping?.email),
+          },
         }
       );
       result.oauthMappings[authProvidersList.amazon] =
@@ -680,15 +680,14 @@ export class AmplifyAuth
         {
           userPool,
           ...external.signInWithApple,
-          attributeMapping:
-            external.signInWithApple.attributeMapping ??
-            shouldMapEmailAttributes
-              ? {
-                  email: {
-                    attributeName: 'email',
-                  },
+          attributeMapping: {
+            ...external.signInWithApple.attributeMapping,
+            ...(shouldMapEmailAttributes
+              ? external.signInWithApple.attributeMapping?.email || {
+                  email: { attributeName: 'email' },
                 }
-              : undefined,
+              : external.signInWithApple.attributeMapping?.email),
+          },
         }
       );
       result.oauthMappings[authProvidersList.apple] =
@@ -702,14 +701,14 @@ export class AmplifyAuth
         {
           userPool,
           ...external.oidc,
-          attributeMapping:
-            external.oidc.attributeMapping ?? shouldMapEmailAttributes
-              ? {
-                  email: {
-                    attributeName: 'email',
-                  },
+          attributeMapping: {
+            ...external.oidc.attributeMapping,
+            ...(shouldMapEmailAttributes
+              ? external.oidc.attributeMapping?.email || {
+                  email: { attributeName: 'email' },
                 }
-              : undefined,
+              : external.oidc.attributeMapping?.email),
+          },
         }
       );
       result.providersList.push('OIDC');

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -609,14 +609,6 @@ export class AmplifyAuth
     }
     if (external.google) {
       const googleProps = external.google;
-      const attributeMapping = {
-        ...googleProps.attributeMapping,
-        ...(shouldMapEmailAttributes
-          ? googleProps.attributeMapping?.email || {
-              email: { attributeName: 'email' },
-            }
-          : googleProps.attributeMapping?.email),
-      };
       result.google = new cognito.UserPoolIdentityProviderGoogle(
         this,
         `${this.name}GoogleIdP`,
@@ -624,7 +616,14 @@ export class AmplifyAuth
           userPool,
           clientId: googleProps.clientId,
           clientSecretValue: googleProps.clientSecret,
-          attributeMapping,
+          attributeMapping: {
+            ...googleProps.attributeMapping,
+            ...(shouldMapEmailAttributes
+              ? googleProps.attributeMapping?.email || {
+                  email: { attributeName: 'email' },
+                }
+              : googleProps.attributeMapping?.email),
+          };
           scopes: googleProps.scopes,
         }
       );


### PR DESCRIPTION
## Problem
Fixes the issue when defined attribute mappings are getting ignored if the login with email is true

Issue: https://github.com/aws-amplify/amplify-backend/issues/963

## Changes
Keeps the original attribute mapping when adding email mapping if missing instead of a full replace

## Validation
Unit Test added

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
