### PR TITLE
fix: Flatten OIDC props to eliminate importing OidcAttributeRequestMethod

### DIFF
--- a/.changeset/proud-brooms-live.md
+++ b/.changeset/proud-brooms-live.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+OIDC attributeRequestMethod no longer requires importing OidcAttributeRequestMethod.

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -61,6 +61,7 @@
   "javascript",
   "jsdoc",
   "jsons",
+  "jwks",
   "keyof",
   "lang",
   "linux",

--- a/packages/auth-construct/API.md
+++ b/packages/auth-construct/API.md
@@ -89,7 +89,9 @@ export type MFASettings = {
 };
 
 // @public
-export type OidcProviderProps = Omit<aws_cognito.UserPoolIdentityProviderOidcProps, 'userPool'>;
+export type OidcProviderProps = Omit<aws_cognito.UserPoolIdentityProviderOidcProps, 'userPool' | 'attributeRequestMethod'> & {
+    readonly attributeRequestMethod?: 'GET' | 'POST';
+};
 
 // @public
 export type PhoneNumberLogin = true | {

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -1231,7 +1231,7 @@ void describe('Auth construct', () => {
       const app = new App();
       const stack = new Stack(app);
       const authorizationURL = 'http://localhost:3000/authorization';
-      const jwksURL = 'https://localhost:3000/jwksuri';
+      const jwksURI = 'https://localhost:3000/jwksuri';
       const tokensURL = 'http://localhost:3000/token';
       const userInfoURL = 'http://localhost:3000/userinfo';
       const mockIdentifiers = ['one', 'two'];
@@ -1254,7 +1254,7 @@ void describe('Auth construct', () => {
               attributeRequestMethod: attributeRequestMethod,
               endpoints: {
                 authorization: authorizationURL,
-                jwksUri: jwksURL,
+                jwksUri: jwksURI,
                 token: tokensURL,
                 userInfo: userInfoURL,
               },
@@ -1283,7 +1283,7 @@ void describe('Auth construct', () => {
           authorize_url: authorizationURL,
           client_id: oidcClientId,
           client_secret: oidcClientSecret,
-          jwks_url: jwksURL,
+          jwks_uri: jwksURI,
           oidc_issuer: oidcIssuerUrl,
           token_url: tokensURL,
         },

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -1239,6 +1239,20 @@ void describe('Auth construct', () => {
               clientSecret: oidcClientSecret,
               issuerUrl: oidcIssuerUrl,
               name: oidcProviderName,
+              attributeMapping: {
+                email: {
+                  attributeName: 'email',
+                },
+              },
+              attributeRequestMethod: 'POST',
+              endpoints: {
+                authorization: 'http://localhost:3000/authorization',
+                jwksUri: 'https://localhost:3000/jwksuri',
+                token: 'http://localhost:3000/token',
+                userInfo: 'http://localhost:3000/userinfo',
+              },
+              identifiers: ['one', 'two'],
+              scopes: ['scope1', 'scope2'],
             },
             callbackUrls: ['https://redirect.com'],
             logoutUrls: ['https://logout.com'],

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -1310,6 +1310,87 @@ void describe('Auth construct', () => {
         ],
       });
     });
+    void it('oidc defaults to GET for oidc method', () => {
+      const app = new App();
+      const stack = new Stack(app);
+      const authorizationURL = 'http://localhost:3000/authorization';
+      const jwksURI = 'https://localhost:3000/jwksuri';
+      const tokensURL = 'http://localhost:3000/token';
+      const userInfoURL = 'http://localhost:3000/userinfo';
+      const mockIdentifiers = ['one', 'two'];
+      const mockScopes = ['scope1', 'scope2'];
+      new AmplifyAuth(stack, 'test', {
+        loginWith: {
+          email: true,
+          externalProviders: {
+            oidc: {
+              clientId: oidcClientId,
+              clientSecret: oidcClientSecret,
+              issuerUrl: oidcIssuerUrl,
+              name: oidcProviderName,
+              attributeMapping: {
+                email: {
+                  attributeName: 'email',
+                },
+              },
+              endpoints: {
+                authorization: authorizationURL,
+                jwksUri: jwksURI,
+                token: tokensURL,
+                userInfo: userInfoURL,
+              },
+              identifiers: mockIdentifiers,
+              scopes: mockScopes,
+            },
+            callbackUrls: ['https://redirect.com'],
+            logoutUrls: ['https://logout.com'],
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::Cognito::UserPool', {
+        UsernameAttributes: ['email'],
+        AutoVerifiedAttributes: ['email'],
+      });
+      template.hasResourceProperties('AWS::Cognito::UserPoolIdentityProvider', {
+        AttributeMapping: {
+          email: 'email',
+        },
+        IdpIdentifiers: mockIdentifiers,
+        ProviderDetails: {
+          attributes_request_method: 'GET',
+          attributes_url: userInfoURL,
+          authorize_scopes: mockScopes.join(' '),
+          authorize_url: authorizationURL,
+          client_id: oidcClientId,
+          client_secret: oidcClientSecret,
+          jwks_uri: jwksURI,
+          oidc_issuer: oidcIssuerUrl,
+          token_url: tokensURL,
+        },
+        ProviderName: oidcProviderName,
+        ProviderType: 'OIDC',
+      });
+      template.hasResourceProperties('AWS::Cognito::IdentityPool', {
+        OpenIdConnectProviderARNs: [
+          Match.objectEquals({
+            'Fn::Join': [
+              '',
+              [
+                'arn:aws:iam:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':oidc-provider/cognito-idp.',
+                { Ref: 'AWS::Region' },
+                '.amazonaws.com/',
+                { Ref: 'testOidcIDP12B3582F' },
+              ],
+            ],
+          }),
+        ],
+      });
+    });
     void it('supports oidc and phone', () => {
       const app = new App();
       const stack = new Stack(app);

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -11,6 +11,7 @@ import {
   CfnUserPoolClient,
   Mfa,
   OAuthScope,
+  OidcAttributeRequestMethod,
   UserPool,
   UserPoolClient,
   UserPoolIdentityProviderAmazon,
@@ -696,14 +697,29 @@ export class AmplifyAuth
       result.providersList.push('APPLE');
     }
     if (external.oidc) {
+      const oidc = external.oidc;
+      const requestMethod =
+        oidc.attributeRequestMethod === undefined
+          ? 'GET' // default if not defined
+          : oidc.attributeRequestMethod;
       result.oidc = new cognito.UserPoolIdentityProviderOidc(
         this,
         `${this.name}OidcIDP`,
         {
           userPool,
-          ...external.oidc,
+          attributeRequestMethod:
+            requestMethod === 'GET'
+              ? OidcAttributeRequestMethod.GET
+              : OidcAttributeRequestMethod.POST,
+          clientId: oidc.clientId,
+          clientSecret: oidc.clientSecret,
+          endpoints: oidc.endpoints,
+          identifiers: oidc.identifiers,
+          issuerUrl: oidc.issuerUrl,
+          name: oidc.name,
+          scopes: oidc.scopes,
           attributeMapping:
-            external.oidc.attributeMapping ?? shouldMapEmailAttributes
+            oidc.attributeMapping ?? shouldMapEmailAttributes
               ? {
                   email: {
                     attributeName: 'email',

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -139,8 +139,19 @@ export type FacebookProviderProps = Omit<
  */
 export type OidcProviderProps = Omit<
   cognito.UserPoolIdentityProviderOidcProps,
-  'userPool'
->;
+  'userPool' | 'attributeRequestMethod'
+> & {
+  /**
+   * The method to use to request attributes
+   * @default 'GET'
+   *
+   * For details about each option, see below.
+   *
+   * 'GET' - use GET
+   * 'POST' - use POST
+   */
+  readonly attributeRequestMethod?: 'GET' | 'POST';
+};
 
 /**
  * SAML provider.


### PR DESCRIPTION


## Problem
Users would need to import OidcAttributeRequestMethod to specify values for attributeRequestMethod.

**Issue number, if available:**

## Changes
The attributeRequestMethod type has been converted to a string union in order to eliminate the need to import OidcAttributeRequestMethod.

**Corresponding docs PR, if applicable:**

## Validation
Tests updated to ensure that mapping accounts for all properties and translates string union back to OidcAttributeRequestMethod under the hood.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
