### PR TITLE
chore: bump graphql-generator version for custom GQL operations

### DIFF
--- a/.changeset/perfect-crabs-grab.md
+++ b/.changeset/perfect-crabs-grab.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/model-generator': minor
+---
+
+Bumped graphql-generator to generate model introspection schema with custom queries/mutations/subscriptions

--- a/package-lock.json
+++ b/package-lock.json
@@ -320,9 +320,9 @@
       }
     },
     "node_modules/@aws-amplify/appsync-modelgen-plugin": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.8.0.tgz",
-      "integrity": "sha512-RfHKzsx/2xjNDyzl2k2d0y509yTJN88DX8x7QfAvzyFp2rClGuBc0fVYHZAf8F1E+9GqKVcbsu7rmnARdWLNBA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.9.0.tgz",
+      "integrity": "sha512-RKrJTnE4P/WVs27mLodBngVHT8W+Jxnyp1x7Dw4vALZS+ihBYzUmLaIfcZbkrVa8jkgjeJaG2ZIWSFlXcqb2iw==",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^1.18.8",
         "@graphql-codegen/visitor-plugin-common": "^1.22.0",
@@ -1637,9 +1637,9 @@
       }
     },
     "node_modules/@aws-amplify/graphql-docs-generator": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-4.2.0.tgz",
-      "integrity": "sha512-V9UXceZlYkumgvcHGp7kivTgvhxYcAdc5C+JCJPyDGvowktExdsnEap6WWn0JHmUK2+5ceBIi4BjcEubn+pXVA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-4.2.1.tgz",
+      "integrity": "sha512-ReBlY5//mWOmO0FL2ndswB9ku+vpg/JTY9Wwemjm/ibyoLHU1ojtGkPBkKH0CzbpOkIuEkIBLIg9EZ2yca/6oA==",
       "dependencies": {
         "graphql": "^15.5.0",
         "handlebars": "4.7.7",
@@ -1790,87 +1790,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-generator": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.1.5.tgz",
-      "integrity": "sha512-QlllwIYYTDASQ0HCTfr1/wUgbJYgquJkPVKCXRvzokh4uSnN2YMSCdJeVbJn96lOoxbHLF5J3DYdv86G/5b9vQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.2.4.tgz",
+      "integrity": "sha512-Wuez+sbba1wJXvBXYAaimHQiC4Kziuq4TDGrEAItxrvcvEr0jRM1skmQjI/DXAEPDMKmWDPjoMusGtPpyPYG9A==",
       "dependencies": {
-        "@aws-amplify/appsync-modelgen-plugin": "2.7.5",
-        "@aws-amplify/graphql-docs-generator": "4.2.0",
-        "@aws-amplify/graphql-types-generator": "3.4.3",
+        "@aws-amplify/appsync-modelgen-plugin": "2.9.0",
+        "@aws-amplify/graphql-docs-generator": "4.2.1",
+        "@aws-amplify/graphql-types-generator": "3.4.6",
         "@graphql-codegen/core": "^2.6.6",
         "@graphql-tools/apollo-engine-loader": "^8.0.0",
-        "graphql": "^15.5.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/@aws-amplify/appsync-modelgen-plugin": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.7.5.tgz",
-      "integrity": "sha512-LUbnjLqTUf7DeMlcvjNh8Br/HgrUIAkm+oL+5aL5aWXEoSFtvGl5xi7XmBw4/tAoN5H2yuhe23fViFCuw6Ti/g==",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^1.18.8",
-        "@graphql-codegen/visitor-plugin-common": "^1.22.0",
-        "@graphql-tools/utils": "^6.0.18",
-        "ajv": "^6.10.0",
-        "chalk": "^3.0.0",
-        "change-case": "^4.1.1",
-        "graphql-transformer-common": "^4.25.1",
-        "lower-case-first": "^2.0.1",
-        "pluralize": "^8.0.0",
-        "strip-indent": "^3.0.0",
-        "ts-dedent": "^1.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.5.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/@aws-amplify/graphql-types-generator": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.4.3.tgz",
-      "integrity": "sha512-w2a2FZ84Z5URWIzwJFsM8Si/3eXcU5jPUdf0v9gW7ZLKOBJ/6Rmuelj+a29EVd0FxfCBH/zgJU1dIFpXnPrmBg==",
-      "dependencies": {
-        "@babel/generator": "7.0.0-beta.4",
-        "@babel/types": "7.0.0-beta.4",
-        "babel-generator": "^6.26.1",
-        "babel-types": "^6.26.0",
-        "change-case": "^4.1.1",
-        "common-tags": "^1.8.0",
-        "core-js": "^3.6.4",
-        "fs-extra": "^8.1.0",
-        "glob": "^7.1.6",
         "graphql": "^15.5.0",
-        "inflected": "^2.0.4",
-        "prettier": "^1.19.1",
-        "rimraf": "^3.0.0",
-        "source-map-support": "^0.5.16",
-        "yargs": "^15.1.0"
-      },
-      "bin": {
-        "graphql-types-generator": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/@babel/generator": {
-      "version": "7.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.4.tgz",
-      "integrity": "sha512-aLpZzf79oGT1bxnsadapfUWErDTcxVKrhvR5F8G27JFgH37+/ATrODMJ0/1D2CgQ/WStDX5B5znnWRv0NzW2JQ==",
-      "dependencies": {
-        "@babel/types": "7.0.0-beta.4",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.2.0",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/@babel/types": {
-      "version": "7.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.4.tgz",
-      "integrity": "sha512-yLvBW5TTAgJwURAUAdZa1vrFTkwXXvk0Kw48LYvgxpyT/IaV8W4OIhxdVztAt5ruDQ/OFUwHpzWqk6TN3EfmWA==",
-      "dependencies": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
-        "to-fast-properties": "^2.0.0"
+        "prettier": "^1.19.1"
       }
     },
     "node_modules/@aws-amplify/graphql-generator/node_modules/@graphql-codegen/core": {
@@ -1941,32 +1871,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@aws-amplify/graphql-generator/node_modules/change-case-all": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
@@ -1984,93 +1888,6 @@
         "upper-case-first": "^2.0.2"
       }
     },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/@aws-amplify/graphql-generator/node_modules/prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -2082,120 +1899,15 @@
         "node": ">=4"
       }
     },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@aws-amplify/graphql-generator/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-generator/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@aws-amplify/graphql-types-generator": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.4.5.tgz",
-      "integrity": "sha512-hzTzNE5UD2rsn4AvynLutcje7DpWUwBV79jle1UK+XvQGAvM0obvXwoyl1AZ60igJmLg6vZWK6FTtozxKXsgCA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.4.6.tgz",
+      "integrity": "sha512-ZyVU5EV7uF/h7JFg0vKlF/DkYDKJYW+U+tB3QMoRjqq4rWWt1DENq22FYARfNgV3Cl8FPHxaxozzTCw2bS7JyA==",
       "dependencies": {
         "@babel/generator": "7.0.0-beta.4",
         "@babel/types": "7.0.0-beta.4",
@@ -2205,7 +1917,7 @@
         "common-tags": "^1.8.0",
         "core-js": "^3.6.4",
         "fs-extra": "^8.1.0",
-        "glob": "^7.1.6",
+        "globby": "^11.1.0",
         "graphql": "^15.5.0",
         "inflected": "^2.0.4",
         "prettier": "^1.19.1",
@@ -22188,7 +21900,7 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.5.2",
         "@aws-amplify/deployed-backend-client": "^0.3.9",
-        "@aws-amplify/graphql-generator": "^0.1.3",
+        "@aws-amplify/graphql-generator": "^0.2.4",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",

--- a/packages/model-generator/package.json
+++ b/packages/model-generator/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-schemas": "^0.5.2",
     "@aws-amplify/deployed-backend-client": "^0.3.9",
-    "@aws-amplify/graphql-generator": "^0.1.3",
+    "@aws-amplify/graphql-generator": "^0.2.4",
     "@aws-amplify/graphql-types-generator": "^3.4.4",
     "@aws-sdk/client-appsync": "^3.465.0",
     "@aws-sdk/client-s3": "^3.465.0",


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Bumped `@aws-amplify/graphql-generator` package from `0.1` to `0.2`. 
The model introspection schema generated by `npx amplify generate config` now includes meta data for custom queries, mutations and subscriptions.
The feature PR from codegen: https://github.com/aws-amplify/amplify-codegen/pull/771
<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
