### PR TITLE
feat: added tags to the stack resources

### DIFF
--- a/.changeset/tricky-socks-wash.md
+++ b/.changeset/tricky-socks-wash.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': minor
+---
+
+Added tags to CFN resources

--- a/packages/backend/src/project_environment_main_stack_creator.ts
+++ b/packages/backend/src/project_environment_main_stack_creator.ts
@@ -1,6 +1,6 @@
 import { BackendIdentifier, MainStackCreator } from '@aws-amplify/plugin-types';
 import { Construct } from 'constructs';
-import { Stack } from 'aws-cdk-lib';
+import { Stack, Tags } from 'aws-cdk-lib';
 import { AmplifyStack } from './engine/amplify_stack.js';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 
@@ -26,6 +26,16 @@ export class ProjectEnvironmentMainStackCreator implements MainStackCreator {
         this.scope,
         BackendIdentifierConversions.toStackName(this.backendId)
       );
+    }
+
+    const deploymentType = this.backendId.type;
+    Tags.of(this.mainStack).add('created-by', 'amplify');
+    if (deploymentType === 'branch') {
+      Tags.of(this.mainStack).add('amplify:app-id', this.backendId.namespace);
+      Tags.of(this.mainStack).add('amplify:branch-name', this.backendId.name);
+      Tags.of(this.mainStack).add('amplify:deployment-type', 'branch');
+    } else if (deploymentType === 'sandbox') {
+      Tags.of(this.mainStack).add('amplify:deployment-type', 'sandbox');
     }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this.mainStack!;


### PR DESCRIPTION
## Problem
Currently we don't have tags added to any of the Gen2 stacks

## Changes
Added below mentioned tags:
**For branch deployments:**
  created-by = "amplify"
  app-id = <backend namespace>
  branch-name = <backend name>
  deployment-type = "branch"

**For sandbox deployments:**
  created-by = "amplify"
  deployment-type = "sandbox"

## Validation

- Added unit tests
- Tested on my local setup 
<img width="771" alt="Screenshot 2024-02-02 at 9 52 18 AM" src="https://github.com/aws-amplify/amplify-backend/assets/115104450/0f3ccc4c-dcb0-40f9-a1c2-77b9b9a8a73b">


## Checklist

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
