### PR TITLE
Require name in defineStorage props

### DIFF
--- a/.changeset/selfish-eels-jam.md
+++ b/.changeset/selfish-eels-jam.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': minor
+---
+
+Require name in defineStorage props

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -15,6 +15,7 @@ export type AmplifyStorageFactoryProps = Omit<AmplifyStorageProps, 'outputStorag
 
 // @public (undocumented)
 export type AmplifyStorageProps = {
+    name: string;
     versioned?: boolean;
     outputStorageStrategy?: BackendOutputStorageStrategy<StorageOutput>;
 };

--- a/packages/backend-storage/src/construct.test.ts
+++ b/packages/backend-storage/src/construct.test.ts
@@ -14,7 +14,7 @@ void describe('AmplifyStorage', () => {
   void it('creates a bucket', () => {
     const app = new App();
     const stack = new Stack(app);
-    new AmplifyStorage(stack, 'test', {});
+    new AmplifyStorage(stack, 'test', { name: 'testName' });
     const template = Template.fromStack(stack);
     template.resourceCountIs('AWS::S3::Bucket', 1);
   });
@@ -22,7 +22,7 @@ void describe('AmplifyStorage', () => {
   void it('turns versioning on if specified', () => {
     const app = new App();
     const stack = new Stack(app);
-    new AmplifyStorage(stack, 'test', { versioned: true });
+    new AmplifyStorage(stack, 'test', { versioned: true, name: 'testName' });
     const template = Template.fromStack(stack);
     template.resourceCountIs('AWS::S3::Bucket', 1);
     template.hasResourceProperties('AWS::S3::Bucket', {
@@ -33,7 +33,7 @@ void describe('AmplifyStorage', () => {
   void it('stores attribution data in stack', () => {
     const app = new App();
     const stack = new Stack(app);
-    new AmplifyStorage(stack, 'testAuth', {});
+    new AmplifyStorage(stack, 'testAuth', { name: 'testName' });
 
     const template = Template.fromStack(stack);
     assert.equal(
@@ -54,6 +54,7 @@ void describe('AmplifyStorage', () => {
         };
 
       const storageConstruct = new AmplifyStorage(stack, 'test', {
+        name: 'testName',
         outputStorageStrategy: storageStrategy,
       });
 
@@ -80,7 +81,7 @@ void describe('AmplifyStorage', () => {
       const app = new App();
       const stack = new Stack(app);
 
-      new AmplifyStorage(stack, 'test', {});
+      new AmplifyStorage(stack, 'test', { name: 'testName' });
       const template = Template.fromStack(stack);
       template.templateMatches({
         Metadata: {

--- a/packages/backend-storage/src/construct.test.ts
+++ b/packages/backend-storage/src/construct.test.ts
@@ -59,7 +59,7 @@ void describe('AmplifyStorage', () => {
       });
 
       const expectedBucketName = (
-        storageConstruct.node.findChild('testBucket') as Bucket
+        storageConstruct.node.findChild('Bucket') as Bucket
       ).bucketName;
       const expectedRegion = Stack.of(storageConstruct).region;
 

--- a/packages/backend-storage/src/construct.ts
+++ b/packages/backend-storage/src/construct.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'url';
 const storageStackType = 'storage-S3';
 
 export type AmplifyStorageProps = {
+  name: string;
   versioned?: boolean;
   outputStorageStrategy?: BackendOutputStorageStrategy<StorageOutput>;
 };

--- a/packages/backend-storage/src/construct.ts
+++ b/packages/backend-storage/src/construct.ts
@@ -49,7 +49,7 @@ export class AmplifyStorage
     };
 
     this.resources = {
-      bucket: new Bucket(this, `${id}Bucket`, bucketProps),
+      bucket: new Bucket(this, 'Bucket', bucketProps),
     };
 
     this.storeOutput(props.outputStorageStrategy);

--- a/packages/backend-storage/src/factory.test.ts
+++ b/packages/backend-storage/src/factory.test.ts
@@ -37,7 +37,7 @@ void describe('AmplifyStorageFactory', () => {
   let getInstanceProps: ConstructFactoryGetInstanceProps;
 
   beforeEach(() => {
-    storageFactory = defineStorage({});
+    storageFactory = defineStorage({ name: 'testName' });
     const stack = createStackAndSetContext();
 
     constructContainer = new ConstructContainerStub(

--- a/packages/backend-storage/src/factory.test.ts
+++ b/packages/backend-storage/src/factory.test.ts
@@ -110,4 +110,12 @@ void describe('AmplifyStorageFactory', () => {
       )
     );
   });
+
+  void it('throws on invalid name', () => {
+    const storageFactory = defineStorage({ name: '!$87++|' });
+    assert.throws(() => storageFactory.getInstance(getInstanceProps), {
+      message:
+        'defineStorage name can only contain alphanumeric characters, found !$87++|',
+    });
+  });
 });

--- a/packages/backend-storage/src/factory.ts
+++ b/packages/backend-storage/src/factory.ts
@@ -60,7 +60,6 @@ class AmplifyStorageFactory
 
 class AmplifyStorageGenerator implements ConstructContainerEntryGenerator {
   readonly resourceGroupName = 'storage';
-  private readonly defaultName = 'amplifyStorage';
 
   constructor(
     private readonly props: AmplifyStorageProps,
@@ -68,7 +67,7 @@ class AmplifyStorageGenerator implements ConstructContainerEntryGenerator {
   ) {}
 
   generateContainerEntry = (scope: Construct) => {
-    return new AmplifyStorage(scope, this.defaultName, {
+    return new AmplifyStorage(scope, `${this.props.name}`, {
       ...this.props,
       outputStorageStrategy: this.outputStorageStrategy,
     });

--- a/packages/backend-storage/src/factory.ts
+++ b/packages/backend-storage/src/factory.ts
@@ -13,6 +13,7 @@ import {
   AmplifyStorageProps,
   StorageResources,
 } from './construct.js';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 export type AmplifyStorageFactoryProps = Omit<
   AmplifyStorageProps,
@@ -48,6 +49,7 @@ class AmplifyStorageFactory
       path.join('amplify', 'storage', 'resource'),
       'Amplify Storage must be defined in amplify/storage/resource.ts'
     );
+    this.validateName(this.props.name);
     if (!this.generator) {
       this.generator = new AmplifyStorageGenerator(
         this.props,
@@ -55,6 +57,17 @@ class AmplifyStorageFactory
       );
     }
     return constructContainer.getOrCompute(this.generator) as AmplifyStorage;
+  };
+
+  private validateName = (name: string): void => {
+    const nameIsAlphanumeric = /^[a-zA-Z0-9]+$/.test(name);
+    if (!nameIsAlphanumeric) {
+      throw new AmplifyUserError('InvalidResourceNameError', {
+        message: `defineStorage name can only contain alphanumeric characters, found ${name}`,
+        resolution:
+          'Change the name parameter of defineStorage to only use alphanumeric characters',
+      });
+    }
   };
 }
 

--- a/packages/integration-tests/src/test-in-memory/integration_tests.test.ts
+++ b/packages/integration-tests/src/test-in-memory/integration_tests.test.ts
@@ -39,7 +39,7 @@ void it('data storage auth with triggers', () => {
 
   assertExpectedLogicalIds(templates.storage, 'AWS::S3::Bucket', [
     // eslint-disable-next-line spellcheck/spell-checker
-    'testNametestNameBucketABFD5AA0',
+    'testNameBucketB4152AD5',
   ]);
 });
 

--- a/packages/integration-tests/src/test-in-memory/integration_tests.test.ts
+++ b/packages/integration-tests/src/test-in-memory/integration_tests.test.ts
@@ -39,7 +39,7 @@ void it('data storage auth with triggers', () => {
 
   assertExpectedLogicalIds(templates.storage, 'AWS::S3::Bucket', [
     // eslint-disable-next-line spellcheck/spell-checker
-    'amplifyStorageamplifyStorageBucketC2F702CD',
+    'testNametestNameBucketABFD5AA0',
   ]);
 });
 

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/storage/resource.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/storage/resource.ts
@@ -1,3 +1,3 @@
 import { defineStorage } from '@aws-amplify/backend';
 
-export const storage = defineStorage({});
+export const storage = defineStorage({name: 'testName'});

--- a/packages/integration-tests/src/test-projects/minimalist-project-with-typescript-idioms/amplify/storage/resource.ts
+++ b/packages/integration-tests/src/test-projects/minimalist-project-with-typescript-idioms/amplify/storage/resource.ts
@@ -1,3 +1,3 @@
 import { defineStorage } from '@aws-amplify/backend';
 
-export const storage = defineStorage({});
+export const storage = defineStorage({name: 'testName'});

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -64,7 +64,7 @@ export class AmplifyUserError extends AmplifyError {
 }
 
 // @public
-export type AmplifyUserErrorType = 'InvalidPackageJsonError' | 'InvalidSchemaAuthError' | 'InvalidSchemaError' | 'ExpiredTokenError' | 'CloudFormationDeploymentError' | 'CFNUpdateNotSupportedError' | 'SyntaxError' | 'BackendBuildError' | 'BootstrapNotDetectedError' | 'AccessDeniedError' | 'FileConventionError';
+export type AmplifyUserErrorType = 'InvalidPackageJsonError' | 'InvalidSchemaAuthError' | 'InvalidSchemaError' | 'ExpiredTokenError' | 'CloudFormationDeploymentError' | 'CFNUpdateNotSupportedError' | 'SyntaxError' | 'BackendBuildError' | 'BootstrapNotDetectedError' | 'AccessDeniedError' | 'FileConventionError' | 'InvalidResourceNameError';
 
 // @public
 export class BackendIdentifierConversions {

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -127,7 +127,8 @@ export type AmplifyUserErrorType =
   | 'BackendBuildError'
   | 'BootstrapNotDetectedError'
   | 'AccessDeniedError'
-  | 'FileConventionError';
+  | 'FileConventionError'
+  | 'InvalidResourceNameError';
 
 /**
  * Amplify library fault types


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
We want to support multiple buckets at some point in the future which will require unique names for each `defineStorage` call.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Requires a name prop in `defineStorage`

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Manually tested, added unit test coverage and updated existing tests.
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
