### PR TITLE
cover geo in client config

### DIFF
--- a/.changeset/angry-zebras-tease.md
+++ b/.changeset/angry-zebras-tease.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': minor
+---
+
+Add typings for geo category in client config

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -43,6 +43,7 @@
   "frontend",
   "frontends",
   "func",
+  "geofence",
   "gitignore",
   "gitignored",
   "globals",

--- a/packages/client-config/API.md
+++ b/packages/client-config/API.md
@@ -36,7 +36,7 @@ export type AuthClientConfig = {
 };
 
 // @public
-export type ClientConfig = Partial<AuthClientConfig & GraphqlClientConfig & StorageClientConfig & PlatformClientConfig & CustomClientConfig>;
+export type ClientConfig = Partial<AuthClientConfig & GeoClientConfig & GraphqlClientConfig & StorageClientConfig & PlatformClientConfig & CustomClientConfig>;
 
 // @public (undocumented)
 export enum ClientConfigFormat {
@@ -62,6 +62,29 @@ export const generateClientConfig: (credentialProvider: AwsCredentialIdentityPro
 
 // @public
 export const generateClientConfigToFile: (credentialProvider: AwsCredentialIdentityProvider, backendIdentifier: DeployedBackendIdentifier, outDir?: string, format?: ClientConfigFormat, log?: ((message: string) => void) | undefined) => Promise<void>;
+
+// @public (undocumented)
+export type GeoClientConfig = {
+    geo?: {
+        amazon_location_service: {
+            region: string;
+            maps?: {
+                items: Record<string, {
+                    style: string;
+                }>;
+                default: string;
+            };
+            search_indices?: {
+                items: Array<string>;
+                default: string;
+            };
+            geofenceCollections?: {
+                items: Array<string>;
+                default: string;
+            };
+        };
+    };
+};
 
 // @public
 export const getClientConfigPath: (outDir?: string, format?: ClientConfigFormat) => Promise<string>;

--- a/packages/client-config/src/client-config-types/client_config.ts
+++ b/packages/client-config/src/client-config-types/client_config.ts
@@ -3,12 +3,14 @@ import { GraphqlClientConfig } from './graphql_client_config.js';
 import { PlatformClientConfig } from './platform_client_config.js';
 import { StorageClientConfig } from './storage_client_config.js';
 import { CustomClientConfig } from './custom_client_config.js';
+import { GeoClientConfig } from './geo_client_config.js';
 
 /**
  * Merged type of all category client config types
  */
 export type ClientConfig = Partial<
   AuthClientConfig &
+    GeoClientConfig &
     GraphqlClientConfig &
     StorageClientConfig &
     PlatformClientConfig &

--- a/packages/client-config/src/client-config-types/geo_client_config.ts
+++ b/packages/client-config/src/client-config-types/geo_client_config.ts
@@ -1,0 +1,24 @@
+export type GeoClientConfig = {
+  geo?: {
+    amazon_location_service: {
+      region: string;
+      maps?: {
+        items: Record<
+          string,
+          {
+            style: string;
+          }
+        >;
+        default: string;
+      };
+      search_indices?: {
+        items: Array<string>;
+        default: string;
+      };
+      geofenceCollections?: {
+        items: Array<string>;
+        default: string;
+      };
+    };
+  };
+};

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -3,6 +3,7 @@ export type ClientConfigMobile = {
   Version: '1.0';
   api?: ClientConfigMobileApi;
   auth?: ClientConfigMobileAuth;
+  geo?: ClientConfigMobileGeo;
 };
 
 export type ClientConfigMobileApi = {
@@ -65,6 +66,28 @@ export type ClientConfigMobileAuth = {
       AppSync?: {
         Default: ClientConfigMobileAppsyncAuth;
       } & Record<string, ClientConfigMobileAppsyncAuth>;
+    };
+  };
+};
+
+export type ClientConfigMobileGeo = {
+  plugins: {
+    awsLocationGeoPlugin: {
+      region: string;
+      maps?: {
+        items: Record<
+          string,
+          {
+            style: string;
+          }
+        >;
+
+        default: string;
+      };
+      searchIndices?: {
+        items: Array<string>;
+        default: string;
+      };
     };
   };
 };

--- a/packages/client-config/src/client-config-writer/client_config_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.test.ts
@@ -219,4 +219,64 @@ void describe('client config converter', () => {
 
     assert.deepStrictEqual(expectedMobileConfig, actualMobileConfig);
   });
+
+  void it('converts geo config', () => {
+    const clientConfig: ClientConfig = {
+      geo: {
+        amazon_location_service: {
+          region: 'us-west-2',
+          maps: {
+            items: {
+              map1: {
+                style: 'style1',
+              },
+              map2: {
+                style: 'style2',
+              },
+            },
+            default: 'map1',
+          },
+          search_indices: {
+            items: ['index1', 'index2'],
+            default: 'index1',
+          },
+          // these are not in mobile schema, making sure this doesn't derail converter
+          geofenceCollections: {
+            items: ['geoFence1', 'geoFence2'],
+            default: 'geoFence1',
+          },
+        },
+      },
+    };
+
+    const expectedMobileConfig: ClientConfigMobile = {
+      UserAgent: 'test_package_name/test_package_version;',
+      Version: '1.0',
+      geo: {
+        plugins: {
+          awsLocationGeoPlugin: {
+            maps: {
+              default: 'map1',
+              items: {
+                map1: {
+                  style: 'style1',
+                },
+                map2: {
+                  style: 'style2',
+                },
+              },
+            },
+            region: 'us-west-2',
+            searchIndices: {
+              default: 'index1',
+              items: ['index1', 'index2'],
+            },
+          },
+        },
+      },
+    };
+    const actualMobileConfig = converter.convertToMobileConfig(clientConfig);
+
+    assert.deepStrictEqual(expectedMobileConfig, actualMobileConfig);
+  });
 });

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -3,6 +3,7 @@ import {
   ClientConfigMobile,
   ClientConfigMobileApi,
   ClientConfigMobileAuth,
+  ClientConfigMobileGeo,
 } from '../client-config-types/mobile/client_config_mobile_types.js';
 
 /**
@@ -120,6 +121,28 @@ export class ClientConfigConverter {
           }
         }
       }
+    }
+
+    if (clientConfig.geo) {
+      const geoConfig: ClientConfigMobileGeo = {
+        plugins: {
+          awsLocationGeoPlugin: {
+            region: clientConfig.geo.amazon_location_service.region,
+          },
+        },
+      };
+
+      const maps = clientConfig.geo.amazon_location_service.maps;
+      if (maps) {
+        geoConfig.plugins.awsLocationGeoPlugin.maps = maps;
+      }
+      const searchIndices =
+        clientConfig.geo.amazon_location_service.search_indices;
+      if (searchIndices) {
+        geoConfig.plugins.awsLocationGeoPlugin.searchIndices = searchIndices;
+      }
+
+      mobileConfig.geo = geoConfig;
     }
     return mobileConfig;
   };

--- a/packages/client-config/src/index.ts
+++ b/packages/client-config/src/index.ts
@@ -2,6 +2,7 @@ export * from './generate_client_config.js';
 export * from './generate_client_config_to_file.js';
 export * from './client-config-types/client_config.js';
 export * from './client-config-types/auth_client_config.js';
+export * from './client-config-types/geo_client_config.js';
 export * from './client-config-types/custom_client_config.js';
 export * from './client-config-types/graphql_client_config.js';
 export * from './client-config-types/storage_client_config.js';


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

This PR adds typings for geo category in client config.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Added:
- typings in ClientConfig for geo
- added mapping to mobile format
- added unit test

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

Unit test

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
