### PR TITLE
Enable CORS on S3 Bucket

### DIFF
--- a/.changeset/loud-sheep-occur.md
+++ b/.changeset/loud-sheep-occur.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': patch
+---
+
+Enable CORS on the S3 Bucket

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -20,6 +20,7 @@
   "codegen",
   "cognito",
   "commonjs",
+  "cors",
   "ctor",
   "darwin",
   "datastore",

--- a/packages/backend-storage/src/construct.test.ts
+++ b/packages/backend-storage/src/construct.test.ts
@@ -42,6 +42,32 @@ void describe('AmplifyStorage', () => {
     );
   });
 
+  void it('enables cors on the bucket', () => {
+    const app = new App();
+    const stack = new Stack(app);
+    new AmplifyStorage(stack, 'testAuth', { name: 'testName' });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      CorsConfiguration: {
+        CorsRules: [
+          {
+            AllowedHeaders: ['*'],
+            AllowedMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE'],
+            AllowedOrigins: ['*'],
+            ExposedHeaders: [
+              'x-amz-server-side-encryption',
+              'x-amz-request-id',
+              'x-amz-id-2',
+              'ETag',
+            ],
+            MaxAge: 3000,
+          },
+        ],
+      },
+    });
+  });
+
   void describe('storeOutput', () => {
     void it('stores output using the provided strategy', () => {
       const app = new App();

--- a/packages/backend-storage/src/construct.ts
+++ b/packages/backend-storage/src/construct.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { Bucket, BucketProps, IBucket } from 'aws-cdk-lib/aws-s3';
+import { Bucket, BucketProps, HttpMethods, IBucket } from 'aws-cdk-lib/aws-s3';
 import {
   BackendOutputStorageStrategy,
   ResourceProvider,
@@ -46,6 +46,26 @@ export class AmplifyStorage
 
     const bucketProps: BucketProps = {
       versioned: props.versioned || false,
+      cors: [
+        {
+          maxAge: 3000,
+          exposedHeaders: [
+            'x-amz-server-side-encryption',
+            'x-amz-request-id',
+            'x-amz-id-2',
+            'ETag',
+          ],
+          allowedHeaders: ['*'],
+          allowedOrigins: ['*'],
+          allowedMethods: [
+            HttpMethods.GET,
+            HttpMethods.HEAD,
+            HttpMethods.PUT,
+            HttpMethods.POST,
+            HttpMethods.DELETE,
+          ],
+        },
+      ],
     };
 
     this.resources = {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Accessing files in S3 from the browser requires CORS rules on the bucket
**Issue number, if available:**
fixes https://github.com/aws-amplify/amplify-backend/issues/992
## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Add CORS rules to the S3 Bucket configuration in defineStorage. These rules are copied from the Gen1 CORS rules.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Manually tested and added a unit test
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
