### PR TITLE
feat: limit calling defineData multiple times

### DIFF
--- a/.changeset/cyan-steaks-repeat.md
+++ b/.changeset/cyan-steaks-repeat.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/backend-data': patch
+---
+
+limit defineData call to one

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -251,9 +251,10 @@ void describe('DataFactory', () => {
         dataFactory = defineData({ schema: testSchema });
         dataFactory = defineData({ schema: testSchema });
       },
-      new AmplifyUserError('TooManyDataFactoryError', {
-        message: 'You cannot instantiate multiple DataFactory',
-        resolution: 'You can only call defineData once',
+      new AmplifyUserError('MultipleSingletonResourcesError', {
+        message:
+          'Multiple `defineData` calls are not allowed within an Amplify backend',
+        resolution: 'Remove all but one `defineData` call',
       })
     );
   });

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -27,10 +27,14 @@ import { validateAuthorizationModes } from './validate_authorization_modes.js';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 /**
- * Singleton factory for AmplifyGraphqlApi constructs that can be used in Amplify project files
+ * Singleton factory for AmplifyGraphqlApi constructs that can be used in Amplify project files.
+ *
+ * Exported for testing purpose only & should NOT be exported out of the package.
  */
 export class DataFactory implements ConstructFactory<AmplifyData> {
+  // publicly accessible for testing purpose only.
   static factoryCount = 0;
+
   private generator: ConstructContainerEntryGenerator;
 
   /**
@@ -41,9 +45,10 @@ export class DataFactory implements ConstructFactory<AmplifyData> {
     private readonly importStack = new Error().stack
   ) {
     if (DataFactory.factoryCount > 0) {
-      throw new AmplifyUserError<AmplifyDataError>('TooManyDataFactoryError', {
-        message: 'You cannot instantiate multiple DataFactory',
-        resolution: 'You can only call defineData once',
+      throw new AmplifyUserError('MultipleSingletonResourcesError', {
+        message:
+          'Multiple `defineData` calls are not allowed within an Amplify backend',
+        resolution: 'Remove all but one `defineData` call',
       });
     }
     DataFactory.factoryCount++;

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -29,7 +29,8 @@ import { AmplifyUserError } from '@aws-amplify/platform-core';
 /**
  * Singleton factory for AmplifyGraphqlApi constructs that can be used in Amplify project files
  */
-class DataFactory implements ConstructFactory<AmplifyData> {
+export class DataFactory implements ConstructFactory<AmplifyData> {
+  static factoryCount = 0;
   private generator: ConstructContainerEntryGenerator;
 
   /**
@@ -38,7 +39,15 @@ class DataFactory implements ConstructFactory<AmplifyData> {
   constructor(
     private readonly props: DataProps,
     private readonly importStack = new Error().stack
-  ) {}
+  ) {
+    if (DataFactory.factoryCount > 0) {
+      throw new AmplifyUserError<AmplifyDataError>('TooManyDataFactoryError', {
+        message: 'You cannot instantiate multiple DataFactory',
+        resolution: 'You can only call defineData once',
+      });
+    }
+    DataFactory.factoryCount++;
+  }
 
   /**
    * Gets an instance of the Data construct

--- a/packages/backend-data/src/index.ts
+++ b/packages/backend-data/src/index.ts
@@ -1,4 +1,4 @@
-export * from './factory.js';
+export { defineData } from './factory.js';
 export {
   ApiKeyAuthorizationModeProps,
   LambdaAuthorizationModeProps,

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -134,4 +134,7 @@ export type DataProps = {
   functions?: Record<string, ConstructFactory<AmplifyFunction>>;
 };
 
-export type AmplifyDataError = 'InvalidSchemaAuthError' | 'InvalidSchemaError';
+export type AmplifyDataError =
+  | 'InvalidSchemaAuthError'
+  | 'InvalidSchemaError'
+  | 'TooManyDataFactoryError';

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -137,4 +137,4 @@ export type DataProps = {
 export type AmplifyDataError =
   | 'InvalidSchemaAuthError'
   | 'InvalidSchemaError'
-  | 'TooManyDataFactoryError';
+  | 'MultipleSingletonResourcesError';

--- a/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
+++ b/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
@@ -1,11 +1,9 @@
-import { dataStorageAuthWithTriggers } from '../test-projects/data-storage-auth-with-triggers-ts/amplify/test_factories.js';
+import { it } from 'node:test';
 import {
   assertExpectedLogicalIds,
   synthesizeBackendTemplates,
 } from '../define_backend_template_harness.js';
-import { it } from 'node:test';
-import { dataWithoutAuth } from '../test-projects/standalone-data-auth-modes/amplify/test_factories.js';
-import { dataWithoutAuthNoAuthMode } from '../test-projects/standalone-data-sandbox-mode/amplify/test_factories.js';
+import { dataStorageAuthWithTriggers } from '../test-projects/data-storage-auth-with-triggers-ts/amplify/test_factories.js';
 
 /**
  * This test suite is meant to provide a fast feedback loop to sanity check that different feature verticals are working properly together.
@@ -59,35 +57,4 @@ void it('data storage auth with triggers', () => {
     'onDeletelambda96BB6F15',
   ]);
   /* eslint-enable spellcheck/spell-checker */
-});
-
-void it('data without auth with lambda auth mode', () => {
-  const templates = synthesizeBackendTemplates(dataWithoutAuth);
-
-  assertExpectedLogicalIds(templates.root, 'AWS::CloudFormation::Stack', [
-    'data7552DF31',
-    'function1351588B',
-  ]);
-  assertExpectedLogicalIds(templates.data, 'AWS::AppSync::GraphQLApi', [
-    'amplifyDataGraphQLAPI42A6FA33',
-  ]);
-  assertExpectedLogicalIds(templates.data, 'AWS::CloudFormation::Stack', [
-    'amplifyDataAmplifyTableManagerNestedStackAmplifyTableManagerNestedStackResource86290833',
-    'amplifyDataTodoNestedStackTodoNestedStackResource551CEA56',
-  ]);
-});
-
-void it('data without auth with default auth mode', () => {
-  const templates = synthesizeBackendTemplates(dataWithoutAuthNoAuthMode);
-
-  assertExpectedLogicalIds(templates.root, 'AWS::CloudFormation::Stack', [
-    'data7552DF31',
-  ]);
-  assertExpectedLogicalIds(templates.data, 'AWS::AppSync::GraphQLApi', [
-    'amplifyDataGraphQLAPI42A6FA33',
-  ]);
-  assertExpectedLogicalIds(templates.data, 'AWS::CloudFormation::Stack', [
-    'amplifyDataAmplifyTableManagerNestedStackAmplifyTableManagerNestedStackResource86290833',
-    'amplifyDataTodoNestedStackTodoNestedStackResource551CEA56',
-  ]);
 });

--- a/packages/integration-tests/src/test-in-memory/data_without_auth.test.ts
+++ b/packages/integration-tests/src/test-in-memory/data_without_auth.test.ts
@@ -1,0 +1,29 @@
+import { it } from 'node:test';
+import {
+  assertExpectedLogicalIds,
+  synthesizeBackendTemplates,
+} from '../define_backend_template_harness.js';
+import { dataWithoutAuth } from '../test-projects/standalone-data-auth-modes/amplify/test_factories.js';
+
+/**
+ * This test suite is meant to provide a fast feedback loop to sanity check that different feature verticals are working properly together.
+ * Specific feature configurations should be checked at the unit test level.
+ * Some assertions about how feature verticals interact could be appropriate here.
+ * Critical path interactions should be exercised in a full e2e test.
+ */
+
+void it('data without auth with lambda auth mode', () => {
+  const templates = synthesizeBackendTemplates(dataWithoutAuth);
+
+  assertExpectedLogicalIds(templates.root, 'AWS::CloudFormation::Stack', [
+    'data7552DF31',
+    'function1351588B',
+  ]);
+  assertExpectedLogicalIds(templates.data, 'AWS::AppSync::GraphQLApi', [
+    'amplifyDataGraphQLAPI42A6FA33',
+  ]);
+  assertExpectedLogicalIds(templates.data, 'AWS::CloudFormation::Stack', [
+    'amplifyDataAmplifyTableManagerNestedStackAmplifyTableManagerNestedStackResource86290833',
+    'amplifyDataTodoNestedStackTodoNestedStackResource551CEA56',
+  ]);
+});

--- a/packages/integration-tests/src/test-in-memory/data_without_auth_no_auth_mode.test.ts
+++ b/packages/integration-tests/src/test-in-memory/data_without_auth_no_auth_mode.test.ts
@@ -1,0 +1,28 @@
+import { it } from 'node:test';
+import {
+  assertExpectedLogicalIds,
+  synthesizeBackendTemplates,
+} from '../define_backend_template_harness.js';
+import { dataWithoutAuthNoAuthMode } from '../test-projects/standalone-data-sandbox-mode/amplify/test_factories.js';
+
+/**
+ * This test suite is meant to provide a fast feedback loop to sanity check that different feature verticals are working properly together.
+ * Specific feature configurations should be checked at the unit test level.
+ * Some assertions about how feature verticals interact could be appropriate here.
+ * Critical path interactions should be exercised in a full e2e test.
+ */
+
+void it('data without auth with default auth mode', () => {
+  const templates = synthesizeBackendTemplates(dataWithoutAuthNoAuthMode);
+
+  assertExpectedLogicalIds(templates.root, 'AWS::CloudFormation::Stack', [
+    'data7552DF31',
+  ]);
+  assertExpectedLogicalIds(templates.data, 'AWS::AppSync::GraphQLApi', [
+    'amplifyDataGraphQLAPI42A6FA33',
+  ]);
+  assertExpectedLogicalIds(templates.data, 'AWS::CloudFormation::Stack', [
+    'amplifyDataAmplifyTableManagerNestedStackAmplifyTableManagerNestedStackResource86290833',
+    'amplifyDataTodoNestedStackTodoNestedStackResource551CEA56',
+  ]);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Enforce call count limit on defineData to prevent customer from accidentally creating multiple DataFactory. When we detect customer calling defineData multiple times, we should throw descriptive error with resolution steps.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Split up memory-in-test integration tests into separate files. The test suite was bootstrapping multiple projects with specific configurations. This was throwing because all projects had some data resource defined. With this change that limits defineData call, the the test suite had to be split up.


**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
