### PR TITLE
Use array instead of var args for defining resource access actions

### DIFF
--- a/.changeset/khaki-pants-sniff.md
+++ b/.changeset/khaki-pants-sniff.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': patch
+---
+
+Use array input instead of var args for defining resource access actions

--- a/package-lock.json
+++ b/package-lock.json
@@ -21732,12 +21732,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.5.7-beta.1",
+      "version": "0.6.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/backend-output-storage": "^0.3.1-beta.0",
-        "@aws-amplify/plugin-types": "^0.8.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "@aws-sdk/util-arn-parser": "^3.465.0"
       },
       "peerDependencies": {
@@ -21747,20 +21747,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.1",
+      "version": "0.13.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.4.8-beta.1",
-        "@aws-amplify/backend-data": "^0.10.0-beta.1",
-        "@aws-amplify/backend-function": "^0.7.2-beta.0",
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/backend-output-storage": "^0.3.1-beta.0",
-        "@aws-amplify/backend-secret": "^0.4.5-beta.0",
-        "@aws-amplify/backend-storage": "^0.5.1-beta.0",
-        "@aws-amplify/client-config": "^0.8.1-beta.0",
+        "@aws-amplify/backend-auth": "^0.5.0-beta.2",
+        "@aws-amplify/backend-data": "^0.10.0-beta.2",
+        "@aws-amplify/backend-function": "^0.8.0-beta.1",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
+        "@aws-amplify/backend-secret": "^0.4.5-beta.1",
+        "@aws-amplify/backend-storage": "^0.6.0-beta.1",
+        "@aws-amplify/client-config": "^0.8.1-beta.1",
         "@aws-amplify/data-schema": "^0.13.2",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
-        "@aws-amplify/plugin-types": "^0.8.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "@aws-sdk/client-amplify": "^3.465.0"
       },
       "devDependencies": {
@@ -21774,16 +21774,16 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.4.8-beta.1",
+      "version": "0.5.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.5.7-beta.1",
-        "@aws-amplify/backend-output-storage": "^0.3.1-beta.0",
-        "@aws-amplify/plugin-types": "^0.8.0"
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.2",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0",
@@ -21792,19 +21792,19 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.10.0-beta.1",
+      "version": "0.10.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/backend-output-storage": "^0.3.1-beta.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
         "@aws-amplify/data-construct": "^1.4.1",
         "@aws-amplify/data-schema-types": "^0.7.2",
-        "@aws-amplify/plugin-types": "^0.8.0"
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
         "@aws-amplify/data-schema": "^0.13.2",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0"
+        "@aws-amplify/platform-core": "^0.5.0-beta.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0",
@@ -21813,11 +21813,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.5.1-beta.0",
+      "version": "0.5.1-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
-        "@aws-amplify/plugin-types": "^0.8.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -21828,17 +21828,17 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.7.2-beta.0",
+      "version": "0.8.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/backend-output-storage": "^0.3.1-beta.0",
-        "@aws-amplify/plugin-types": "^0.8.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "execa": "^8.0.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-ssm": "^3.465.0",
         "aws-sdk": "^2.1550.0",
         "uuid": "^9.0.1"
@@ -21850,10 +21850,10 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.8.0"
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0"
       },
       "peerDependencies": {
         "zod": "^3.22.2"
@@ -21861,11 +21861,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.3.1-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0"
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0"
@@ -21873,7 +21873,7 @@
     },
     "packages/backend-platform-test-stubs": {
       "name": "@aws-amplify/backend-platform-test-stubs",
-      "version": "0.3.2",
+      "version": "0.3.3-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-cdk-lib": "^2.127.0",
@@ -21882,11 +21882,11 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "0.4.5-beta.0",
+      "version": "0.4.5-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
-        "@aws-amplify/plugin-types": "^0.8.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "@aws-sdk/client-ssm": "^3.465.0"
       },
       "devDependencies": {
@@ -21895,16 +21895,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.5.1-beta.0",
+      "version": "0.6.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/backend-output-storage": "^0.3.1-beta.0",
-        "@aws-amplify/plugin-types": "^0.8.0"
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.2",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0",
@@ -21913,19 +21913,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.11.2-beta.1",
+      "version": "0.12.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^0.5.1-beta.0",
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/backend-secret": "^0.4.5-beta.0",
-        "@aws-amplify/cli-core": "^0.4.0",
-        "@aws-amplify/client-config": "^0.8.1-beta.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.11-beta.0",
+        "@aws-amplify/backend-deployer": "^0.5.1-beta.1",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-secret": "^0.4.5-beta.1",
+        "@aws-amplify/cli-core": "^0.4.1-beta.0",
+        "@aws-amplify/client-config": "^0.8.1-beta.1",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.1",
         "@aws-amplify/form-generator": "^0.8.0-beta.1",
-        "@aws-amplify/model-generator": "^0.4.1-beta.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
-        "@aws-amplify/sandbox": "^0.5.2-beta.0",
+        "@aws-amplify/model-generator": "^0.4.1-beta.1",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
+        "@aws-amplify/sandbox": "^0.5.2-beta.1",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -21954,7 +21954,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.4.0",
+      "version": "0.4.1-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^3.0.0",
@@ -22073,13 +22073,13 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.8.1-beta.0",
+      "version": "0.8.1-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.11-beta.0",
-        "@aws-amplify/model-generator": "^0.4.1-beta.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.1",
+        "@aws-amplify/model-generator": "^0.4.1-beta.1",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",
@@ -22091,12 +22091,12 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.6.1-beta.1",
+      "version": "0.6.1-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.4.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
-        "@aws-amplify/plugin-types": "^0.8.0",
+        "@aws-amplify/cli-core": "^0.4.1-beta.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "execa": "^8.0.1",
         "yargs": "^17.7.2"
       },
@@ -22219,11 +22219,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.3.11-beta.0",
+      "version": "0.4.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
@@ -22263,15 +22263,15 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.4.3",
+      "version": "0.4.4-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.5.7-beta.1",
-        "@aws-amplify/backend": "^0.13.0-beta.1",
-        "@aws-amplify/backend-secret": "^0.4.5-beta.0",
-        "@aws-amplify/client-config": "^0.8.1-beta.0",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.2",
+        "@aws-amplify/backend": "^0.13.0-beta.2",
+        "@aws-amplify/backend-secret": "^0.4.5-beta.1",
+        "@aws-amplify/client-config": "^0.8.1-beta.1",
         "@aws-amplify/data-schema": "^0.13.2",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-lambda": "^3.465.0",
@@ -22290,11 +22290,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.4.1-beta.0",
+      "version": "0.4.1-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.6.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.11-beta.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.1",
         "@aws-amplify/graphql-generator": "^0.2.4",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.465.0",
@@ -22310,10 +22310,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.5.0-beta.0",
+      "version": "0.5.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^0.8.0",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "@aws-sdk/client-sts": "3.445.0",
         "is-ci": "^3.0.1",
         "lodash.mergewith": "^4.6.2",
@@ -22730,7 +22730,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.8.0",
+      "version": "0.9.0-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "execa": "^5.1.1"
@@ -22849,15 +22849,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.0",
+      "version": "0.5.2-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^0.5.1-beta.0",
-        "@aws-amplify/backend-secret": "^0.4.5-beta.0",
-        "@aws-amplify/cli-core": "^0.4.0",
-        "@aws-amplify/client-config": "^0.8.1-beta.0",
-        "@aws-amplify/deployed-backend-client": "^0.3.11-beta.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.0",
+        "@aws-amplify/backend-deployer": "^0.5.1-beta.1",
+        "@aws-amplify/backend-secret": "^0.4.5-beta.1",
+        "@aws-amplify/cli-core": "^0.4.1-beta.0",
+        "@aws-amplify/client-config": "^0.8.1-beta.1",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.1",
+        "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/types": "^3.465.0",

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -46,7 +46,7 @@ export type RoleAccessBuilder = {
 
 // @public (undocumented)
 export type StorageAccessBuilder = {
-    to: (...actions: StorageAction[]) => StorageAccessDefinition;
+    to: (actions: StorageAction[]) => StorageAccessDefinition;
 };
 
 // @public (undocumented)

--- a/packages/backend-storage/src/access_builder.test.ts
+++ b/packages/backend-storage/src/access_builder.test.ts
@@ -40,11 +40,11 @@ void describe('storageAccessBuilder', () => {
   });
 
   void it('builds storage access definition for authenticated role', () => {
-    const accessDefinition = roleAccessBuilder.authenticated.to(
+    const accessDefinition = roleAccessBuilder.authenticated.to([
       'read',
       'write',
-      'delete'
-    );
+      'delete',
+    ]);
     assert.deepStrictEqual(accessDefinition.actions, [
       'read',
       'write',
@@ -65,11 +65,11 @@ void describe('storageAccessBuilder', () => {
     );
   });
   void it('builds storage access definition for guest role', () => {
-    const accessDefinition = roleAccessBuilder.guest.to(
+    const accessDefinition = roleAccessBuilder.guest.to([
       'read',
       'write',
-      'delete'
-    );
+      'delete',
+    ]);
     assert.deepStrictEqual(accessDefinition.actions, [
       'read',
       'write',
@@ -90,11 +90,11 @@ void describe('storageAccessBuilder', () => {
     );
   });
   void it('builds storage access definition for owner', () => {
-    const accessDefinition = roleAccessBuilder.owner.to(
+    const accessDefinition = roleAccessBuilder.owner.to([
       'read',
       'write',
-      'delete'
-    );
+      'delete',
+    ]);
     assert.deepStrictEqual(accessDefinition.actions, [
       'read',
       'write',
@@ -126,7 +126,7 @@ void describe('storageAccessBuilder', () => {
             getResourceAccessAcceptor: getResourceAccessAcceptorMock,
           } as unknown as ResourceProvider & ResourceAccessAcceptorFactory),
       })
-      .to('read', 'write', 'delete');
+      .to(['read', 'write', 'delete']);
 
     assert.deepStrictEqual(accessDefinition.actions, [
       'read',

--- a/packages/backend-storage/src/access_builder.ts
+++ b/packages/backend-storage/src/access_builder.ts
@@ -24,7 +24,7 @@ export type StorageAccessDefinition = {
 };
 
 export type StorageAccessBuilder = {
-  to: (...actions: StorageAction[]) => StorageAccessDefinition;
+  to: (actions: StorageAction[]) => StorageAccessDefinition;
 };
 
 /**
@@ -44,28 +44,28 @@ export type RoleAccessBuilder = {
 
 export const roleAccessBuilder: RoleAccessBuilder = {
   authenticated: {
-    to: (...actions) => ({
+    to: (actions) => ({
       getResourceAccessAcceptor: getAuthRoleResourceAccessAcceptor,
       actions,
       ownerPlaceholderSubstitution: '*',
     }),
   },
   guest: {
-    to: (...actions) => ({
+    to: (actions) => ({
       getResourceAccessAcceptor: getUnauthRoleResourceAccessAcceptor,
       actions,
       ownerPlaceholderSubstitution: '*',
     }),
   },
   owner: {
-    to: (...actions) => ({
+    to: (actions) => ({
       getResourceAccessAcceptor: getAuthRoleResourceAccessAcceptor,
       actions,
       ownerPlaceholderSubstitution: '${cognito-identity.amazon.com:sub}',
     }),
   },
   resource: (other) => ({
-    to: (...actions) => ({
+    to: (actions) => ({
       getResourceAccessAcceptor: (getInstanceProps) =>
         other.getInstance(getInstanceProps).getResourceAccessAcceptor(),
       actions,

--- a/packages/backend-storage/src/storage_container_entry_generator.test.ts
+++ b/packages/backend-storage/src/storage_container_entry_generator.test.ts
@@ -103,30 +103,30 @@ void describe('StorageGenerator', () => {
 
       const stubRoleAccessBuilder: RoleAccessBuilder = {
         authenticated: {
-          to: (...actions) => ({
+          to: (actions) => ({
             getResourceAccessAcceptor: authenticatedAccessAcceptorMock,
-            actions: actions,
+            actions,
             ownerPlaceholderSubstitution: '*',
           }),
         },
         guest: {
-          to: (...actions) => ({
+          to: (actions) => ({
             getResourceAccessAcceptor: guestAccessAcceptorMock,
-            actions: actions,
+            actions,
             ownerPlaceholderSubstitution: '*',
           }),
         },
         owner: {
-          to: (...actions) => ({
+          to: (actions) => ({
             getResourceAccessAcceptor: ownerAccessAcceptorMock,
-            actions: actions,
+            actions,
             ownerPlaceholderSubstitution: 'testOwnerSubstitution',
           }),
         },
         resource: () => ({
-          to: (...actions) => ({
+          to: (actions) => ({
             getResourceAccessAcceptor: resourceAccessAcceptorMock,
-            actions: actions,
+            actions,
             ownerPlaceholderSubstitution: '*',
           }),
         }),
@@ -137,16 +137,16 @@ void describe('StorageGenerator', () => {
           name: 'testName',
           access: (allow) => ({
             '/test/*': [
-              allow.authenticated.to('read', 'write'),
-              allow.guest.to('read'),
-              allow.owner.to('read', 'write', 'delete'),
+              allow.authenticated.to(['read', 'write']),
+              allow.guest.to(['read']),
+              allow.owner.to(['read', 'write', 'delete']),
               allow
                 .resource(
                   {} as unknown as ConstructFactory<
                     ResourceProvider & ResourceAccessAcceptorFactory
                   >
                 )
-                .to('read'),
+                .to(['read']),
             ],
           }),
         },

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/storage/resource.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/storage/resource.ts
@@ -14,8 +14,8 @@ export const storage = defineStorage({
   },
   access: (allow) => ({
     '/public/*': [
-      allow.resource(defaultNodeFunc).to('read', 'write'),
-      allow.resource(node16Func).to('read', 'write'),
+      allow.resource(defaultNodeFunc).to(['read', 'write']),
+      allow.resource(node16Func).to(['read', 'write']),
     ],
   }),
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Per product team recommendation, using var args for the actions doesn't make it obvious that multiple actions can be specified. Using an array explicitly makes this behavior obvious
**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Update the method signature of the `allow.<user>.to('action')` helper to `allow.<user>.to(['action'])` to make it clear that multiple actions can be specified
**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Existing tests updated to match new shape.
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
