### PR TITLE
storage access path validation

### DIFF
--- a/.changeset/quiet-pets-scream.md
+++ b/.changeset/quiet-pets-scream.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': patch
+---
+
+Add validation for allowed path patterns in storage access definition

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -149,6 +149,8 @@
   "versioned",
   "versioning",
   "whoami",
+  "wildcard",
+  "wildcards",
   "workspace",
   "yaml",
   "yargs"

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -15,7 +15,7 @@ import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { StorageOutput } from '@aws-amplify/backend-output-schemas';
 
 // @public (undocumented)
-export type AccessGenerator = (allow: RoleAccessBuilder) => Record<StoragePrefix, StorageAccessDefinition[]>;
+export type AccessGenerator = (allow: RoleAccessBuilder) => StorageAccessRecord;
 
 // @public (undocumented)
 export type AmplifyStorageFactoryProps = Omit<AmplifyStorageProps, 'outputStorageStrategy'> & {
@@ -57,10 +57,13 @@ export type StorageAccessDefinition = {
 };
 
 // @public (undocumented)
+export type StorageAccessRecord = Record<StoragePath, StorageAccessDefinition[]>;
+
+// @public (undocumented)
 export type StorageAction = 'read' | 'write' | 'delete';
 
 // @public
-export type StoragePrefix = `/${string}/*`;
+export type StoragePath = `/${string}/*`;
 
 // @public (undocumented)
 export type StorageResources = {

--- a/packages/backend-storage/src/access_builder.ts
+++ b/packages/backend-storage/src/access_builder.ts
@@ -9,7 +9,7 @@ import {
 
 export type StorageAction = 'read' | 'write' | 'delete';
 
-export type StorageAccessDefinition = {
+export type StoragePathAccessDefinition = {
   getResourceAccessAcceptor: (
     getInstanceProps: ConstructFactoryGetInstanceProps
   ) => ResourceAccessAcceptor;
@@ -24,7 +24,7 @@ export type StorageAccessDefinition = {
 };
 
 export type StorageAccessBuilder = {
-  to: (...actions: StorageAction[]) => StorageAccessDefinition;
+  to: (...actions: StorageAction[]) => StoragePathAccessDefinition;
 };
 
 /**

--- a/packages/backend-storage/src/constants.ts
+++ b/packages/backend-storage/src/constants.ts
@@ -1,0 +1,1 @@
+export const ownerPathPartToken = '{owner}';

--- a/packages/backend-storage/src/index.ts
+++ b/packages/backend-storage/src/index.ts
@@ -2,7 +2,7 @@ export * from './factory.js';
 export { StorageResources, AmplifyStorageProps } from './construct.js';
 export {
   RoleAccessBuilder,
-  StorageAccessDefinition,
+  StoragePathAccessDefinition as StorageAccessDefinition,
   StorageAccessBuilder,
   StorageAction,
 } from './access_builder.js';

--- a/packages/backend-storage/src/storage_access_policy_arbiter.test.ts
+++ b/packages/backend-storage/src/storage_access_policy_arbiter.test.ts
@@ -17,6 +17,7 @@ import {
 import { App, Stack } from 'aws-cdk-lib';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import assert from 'node:assert';
+import { ownerPathPartToken } from './constants.js';
 
 void describe('StorageAccessPolicyArbiter', () => {
   void describe('arbitratePolicies', () => {
@@ -240,7 +241,7 @@ void describe('StorageAccessPolicyArbiter', () => {
       const storageAccessPolicyArbiter = new StorageAccessPolicyArbiter(
         'testName',
         {
-          '/test/{owner}/*': [
+          [`/test/${ownerPathPartToken}/*`]: [
             {
               actions: ['read', 'write'],
               getResourceAccessAcceptor: () => ({

--- a/packages/backend-storage/src/storage_access_policy_arbiter.ts
+++ b/packages/backend-storage/src/storage_access_policy_arbiter.ts
@@ -3,13 +3,14 @@ import {
   ResourceAccessAcceptor,
   SsmEnvironmentEntriesGenerator,
 } from '@aws-amplify/plugin-types';
-import { StoragePrefix } from './types.js';
+import { StoragePath } from './types.js';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
-import { StorageAccessDefinition } from './access_builder.js';
+import { StoragePathAccessDefinition } from './access_builder.js';
 import {
   Permission,
   StorageAccessPolicyFactory,
 } from './storage_access_policy_factory.js';
+import { ownerPathPartToken } from './constants.js';
 
 /**
  * Middleman between creating bucket policies and attaching those policies to corresponding roles
@@ -21,8 +22,8 @@ export class StorageAccessPolicyArbiter {
   constructor(
     private readonly name: string,
     private readonly accessDefinition: Record<
-      StoragePrefix,
-      StorageAccessDefinition[]
+      StoragePath,
+      StoragePathAccessDefinition[]
     >,
     private readonly ssmEnvironmentEntriesGenerator: SsmEnvironmentEntriesGenerator,
     private readonly getInstanceProps: ConstructFactoryGetInstanceProps,
@@ -65,7 +66,7 @@ export class StorageAccessPolicyArbiter {
 
           // make the owner placeholder substitution in the s3 prefix
           const prefix = s3Prefix.replaceAll(
-            '{owner}',
+            ownerPathPartToken,
             permission.ownerPlaceholderSubstitution
           );
 
@@ -101,7 +102,7 @@ export class StorageAccessPolicyArbiter {
 export class StorageAccessPolicyArbiterFactory {
   getInstance = (
     name: string,
-    accessDefinition: Record<StoragePrefix, StorageAccessDefinition[]>,
+    accessDefinition: Record<StoragePath, StoragePathAccessDefinition[]>,
     ssmEnvironmentEntriesGenerator: SsmEnvironmentEntriesGenerator,
     getInstanceProps: ConstructFactoryGetInstanceProps,
     bucket: IBucket,

--- a/packages/backend-storage/src/storage_container_entry_generator.test.ts
+++ b/packages/backend-storage/src/storage_container_entry_generator.test.ts
@@ -72,6 +72,24 @@ void describe('StorageGenerator', () => {
       assert.ok(storageInstance instanceof AmplifyStorage);
     });
 
+    void it('throws if access prefixes are invalid', () => {
+      const storageGenerator = new StorageContainerEntryGenerator(
+        { name: 'testName', access: () => ({}) },
+        getInstanceProps,
+        new StorageAccessPolicyArbiterFactory(),
+        undefined,
+        () => {
+          throw new Error('test validation error');
+        }
+      );
+
+      assert.throws(
+        () =>
+          storageGenerator.generateContainerEntry(generateContainerEntryProps),
+        { message: 'test validation error' }
+      );
+    });
+
     void it('invokes the policy arbiter with correct accessDefinition if access is defined', () => {
       const arbitratePoliciesMock = mock.fn();
       const bucketPolicyArbiterFactory =

--- a/packages/backend-storage/src/storage_container_entry_generator.ts
+++ b/packages/backend-storage/src/storage_container_entry_generator.ts
@@ -14,6 +14,7 @@ import {
   roleAccessBuilder as _roleAccessBuilder,
 } from './access_builder.js';
 import { EventType } from 'aws-cdk-lib/aws-s3';
+import { validateStorageAccessPaths as _validateStorageAccessPaths } from './validate_storage_access_paths.js';
 
 /**
  * Generates a single instance of storage resources
@@ -30,7 +31,8 @@ export class StorageContainerEntryGenerator
     private readonly props: AmplifyStorageFactoryProps,
     private readonly getInstanceProps: ConstructFactoryGetInstanceProps,
     private readonly bucketPolicyArbiterFactory: StorageAccessPolicyArbiterFactory = new StorageAccessPolicyArbiterFactory(),
-    private readonly roleAccessBuilder: RoleAccessBuilder = _roleAccessBuilder
+    private readonly roleAccessBuilder: RoleAccessBuilder = _roleAccessBuilder,
+    private readonly validateStorageAccessPaths = _validateStorageAccessPaths
   ) {}
 
   generateContainerEntry = ({
@@ -68,6 +70,8 @@ export class StorageContainerEntryGenerator
     // here we inject the roleAccessBuilder into the callback and run it
     // this produces the access definition that will be used to create the storage policies
     const accessDefinition = this.props.access(this.roleAccessBuilder);
+
+    this.validateStorageAccessPaths(Object.keys(accessDefinition));
 
     // we pass the access definition along with other dependencies to the bucketPolicyArbiter
     const bucketPolicyArbiter = this.bucketPolicyArbiterFactory.getInstance(

--- a/packages/backend-storage/src/types.ts
+++ b/packages/backend-storage/src/types.ts
@@ -1,6 +1,6 @@
 import {
   RoleAccessBuilder,
-  StorageAccessDefinition,
+  StoragePathAccessDefinition,
 } from './access_builder.js';
 import { AmplifyStorageProps } from './construct.js';
 
@@ -9,7 +9,7 @@ export type AmplifyStorageTriggerEvent = 'onDelete' | 'onUpload';
 /**
  * Storage access keys must start with / and end with /*
  */
-export type StoragePrefix = `/${string}/*`;
+export type StoragePath = `/${string}/*`;
 
 export type AmplifyStorageFactoryProps = Omit<
   AmplifyStorageProps,
@@ -24,6 +24,9 @@ export type AmplifyStorageFactoryProps = Omit<
   access?: AccessGenerator;
 };
 
-export type AccessGenerator = (
-  allow: RoleAccessBuilder
-) => Record<StoragePrefix, StorageAccessDefinition[]>;
+export type StorageAccessRecord = Record<
+  StoragePath,
+  StoragePathAccessDefinition[]
+>;
+
+export type AccessGenerator = (allow: RoleAccessBuilder) => StorageAccessRecord;

--- a/packages/backend-storage/src/validate_storage_access_paths.test.ts
+++ b/packages/backend-storage/src/validate_storage_access_paths.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test';
+import { validateStorageAccessPaths } from './validate_storage_access_paths.js';
+import assert from 'node:assert';
+import { ownerPathPartToken } from './constants.js';
+
+void describe('validateStorageAccessPaths', () => {
+  void it('is a noop on valid paths', () => {
+    validateStorageAccessPaths([
+      '/foo/*',
+      '/foo/bar/*',
+      '/foo/baz/*',
+      '/other/*',
+      '/something/{owner}/*',
+      '/another/{owner}/*',
+    ]);
+    // completing successfully indicates success
+  });
+
+  void it('throws on path that does not start with /', () => {
+    assert.throws(() => validateStorageAccessPaths(['foo/*']), {
+      message:
+        'All storage access paths must start with "/" and end with "/*. Found [foo/*].',
+    });
+  });
+
+  void it('throws on path that does not end with /*', () => {
+    assert.throws(() => validateStorageAccessPaths(['/foo']), {
+      message:
+        'All storage access paths must start with "/" and end with "/*. Found [/foo].',
+    });
+  });
+
+  void it('throws on path that has wildcards in the middle', () => {
+    assert.throws(() => validateStorageAccessPaths(['/foo/*/bar/*']), {
+      message: `Wildcards are only allowed as the final part of a path. Found [/foo/*/bar/*].`,
+    });
+  });
+
+  void it('throws on path that has more that one other path that is a prefix of it', () => {
+    assert.throws(
+      () =>
+        validateStorageAccessPaths(['/foo/*', '/foo/bar/*', '/foo/bar/baz/*']),
+      {
+        message:
+          'For any given path, only one other path can be a prefix of it. Found [/foo/bar/baz/*] which has prefixes [/foo/*, /foo/bar/*].',
+      }
+    );
+  });
+
+  void it('throws on path that has multiple owner tokens', () => {
+    assert.throws(
+      () => validateStorageAccessPaths(['/foo/{owner}/{owner}/*']),
+      {
+        message: `The ${ownerPathPartToken} token can only appear once in a path. Found [/foo/{owner}/{owner}/*]`,
+      }
+    );
+  });
+
+  void it('throws on path where owner token is not at the end', () => {
+    assert.throws(() => validateStorageAccessPaths(['/foo/{owner}/bar/*']), {
+      message: `The ${ownerPathPartToken} token must be the path part right before the ending wildcard. Found [/foo/{owner}/bar/*].`,
+    });
+  });
+
+  void it('throws on path that starts with owner token', () => {
+    assert.throws(() => validateStorageAccessPaths(['/{owner}/*']), {
+      message: `The ${ownerPathPartToken} token must not be the first path part. Found [/{owner}/*].`,
+    });
+  });
+
+  void it('throws on path that has owner token and other characters in single path part', () => {
+    assert.throws(() => validateStorageAccessPaths(['/abc{owner}/*']), {
+      message: `A path part that includes the ${ownerPathPartToken} token cannot include any other characters. Found [/abc{owner}/*].`,
+    });
+  });
+
+  void it('throws on path where owner token conflicts with wildcard in another path', () => {
+    assert.throws(
+      () => validateStorageAccessPaths(['/foo/{owner}/*', '/foo/*']),
+      {
+        message: `Wildcard conflict detected with an ${ownerPathPartToken} token.`,
+      }
+    );
+  });
+});

--- a/packages/backend-storage/src/validate_storage_access_paths.ts
+++ b/packages/backend-storage/src/validate_storage_access_paths.ts
@@ -1,0 +1,118 @@
+import { AmplifyUserError } from '@aws-amplify/platform-core';
+import { ownerPathPartToken } from './constants.js';
+
+/**
+ * Validate that the storage path record keys match our conventions and restrictions.
+ * If all of the paths are valid, this function is a noop.
+ * If some path is invalid, an error is thrown with details
+ */
+export const validateStorageAccessPaths = (storagePaths: string[]) => {
+  storagePaths.forEach(validateStoragePath);
+};
+
+const validateStoragePath = (
+  path: string,
+  index: number,
+  allPaths: string[]
+) => {
+  if (!(path.startsWith('/') && path.endsWith('/*'))) {
+    throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
+      message: `All storage access paths must start with "/" and end with "/*. Found [${path}].`,
+      resolution: 'Update all paths to match the format requirements.',
+    });
+  }
+
+  if (path.indexOf('*') < path.length - 1) {
+    throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
+      message: `Wildcards are only allowed as the final part of a path. Found [${path}].`,
+      resolution:
+        'Remove all wildcards that are not the final part of the path.',
+    });
+  }
+
+  /**
+   * For any path, at most one other path can be a prefix of that path
+   *
+   * For example, consider an access definition with the following paths defined:
+   * /foo - OK (0 other paths are a prefix of this one)
+   * /foo/bar - OK (1 other path is a prefix of this one)
+   * /foo/bar/baz - NOT OK (2 other paths are a prefix of this one (/foo and /foo/bar))
+   * /foo/baz - OK (1 other path is a prefix of this one)
+   */
+  const otherPrefixes = getPrefixes(path, allPaths);
+  if (otherPrefixes.length > 1) {
+    throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
+      message: `For any given path, only one other path can be a prefix of it. Found [${path}] which has prefixes [${otherPrefixes.join(
+        ', '
+      )}].`,
+      resolution: `Update the storage access paths such that any given path has at most one other path that is a prefix.`,
+    });
+  }
+
+  // if there's no owner token, we don't need to do any more checks
+  if (!path.includes(ownerPathPartToken)) {
+    return;
+  }
+
+  // owner token checks
+
+  const ownerSplit = path.split(ownerPathPartToken);
+
+  if (ownerSplit.length > 2) {
+    throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
+      message: `The ${ownerPathPartToken} token can only appear once in a path. Found [${path}]`,
+      resolution: `Remove all but one occurrence of the ${ownerPathPartToken} token`,
+    });
+  }
+
+  const [before, after] = ownerSplit;
+
+  if (after !== '/*') {
+    throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
+      message: `The ${ownerPathPartToken} token must be the path part right before the ending wildcard. Found [${path}].`,
+      resolution: `Update the path such that the owner token is the last path part before the ending wildcard. For example: "/foo/bar/${ownerPathPartToken}/*.`,
+    });
+  }
+
+  if (before === '/') {
+    throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
+      message: `The ${ownerPathPartToken} token must not be the first path part. Found [${path}].`,
+      resolution: `Add an additional prefix to the path. For example: "/foo/${ownerPathPartToken}/*.`,
+    });
+  }
+
+  if (!before.endsWith('/')) {
+    throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
+      message: `A path part that includes the ${ownerPathPartToken} token cannot include any other characters. Found [${path}].`,
+      resolution: `Remove all other characters from the path part with the ${ownerPathPartToken} token. For example: "/foo/${ownerPathPartToken}/*"`,
+    });
+  }
+
+  /**
+   * If the path includes the owner token, we need to do one more pass through the prefixes where we substitute the owner toke with a * and check for prefixes again
+   * This is because the owner token becomes a * for all access except owner rules so we need to make sure there are no other prefix conflicts
+   */
+
+  const substitutionPrefixes = getPrefixes(
+    path.replace(ownerPathPartToken, '*'),
+    allPaths
+  );
+  if (substitutionPrefixes.length > 0) {
+    throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
+      message: `Wildcard conflict detected with an ${ownerPathPartToken} token.`,
+      details: `Paths [${substitutionPrefixes.join(
+        ', '
+      )}] conflicts with ${ownerPathPartToken} token in path [${path}].`,
+      resolution: `Update the storage access paths such that no path has a wildcard that conflicts with an ${ownerPathPartToken} token.`,
+    });
+  }
+};
+
+/**
+ * Returns a subset of paths where each element is a prefix of path
+ * Equivalent paths are NOT considered prefixes of each other (mainly just for simplicity of the calling logic)
+ */
+const getPrefixes = (path: string, paths: string[]): string[] =>
+  paths.filter((p) => path !== p && path.startsWith(p.replace('*', '')));
+
+type StorageError = 'InvalidStorageAccessPathError';

--- a/packages/backend-storage/src/validate_storage_access_paths.ts
+++ b/packages/backend-storage/src/validate_storage_access_paths.ts
@@ -34,10 +34,10 @@ const validateStoragePath = (
    * For any path, at most one other path can be a prefix of that path
    *
    * For example, consider an access definition with the following paths defined:
-   * /foo - OK (0 other paths are a prefix of this one)
-   * /foo/bar - OK (1 other path is a prefix of this one)
-   * /foo/bar/baz - NOT OK (2 other paths are a prefix of this one (/foo and /foo/bar))
-   * /foo/baz - OK (1 other path is a prefix of this one)
+   * /foo/* - OK (0 other paths are a prefix of this one)
+   * /foo/bar/* - OK (1 other path is a prefix of this one)
+   * /foo/bar/baz/* - NOT OK (2 other paths are a prefix of this one (/foo and /foo/bar))
+   * /foo/baz/* - OK (1 other path is a prefix of this one)
    */
   const otherPrefixes = getPrefixes(path, allPaths);
   if (otherPrefixes.length > 1) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
To make access policies easy to reason about, and to work within the constraints of IAM policy generation, we are enforcing some conventions and rules around what storage paths are allowed in the storage access definition.
**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
The following describes the rules that are being enforced:
```ts

defineStorage({
  access: allow => ({
    // allowed
    '/foo/*': [rules],

    // allowed
    '/foo/bar/*': [rules], 

    // allowed
    '/foo/baz/*': [rules],

    // not allowed because there's no way to model IAM policies for 3 levels of /foo/*, /foo/bar/*, and /foo/bar/baz/*
    '/foo/bar/baz/*': [rules],

    // not allowed, all paths must explicitly start with the root
    'thing/*': [rules]

    // not allowed, all paths must explicitly end with /* to make it clear that the access will apply to everything under that prefix
    '/thing': [rules]

    // not allowed because the owner token conflicts with the wildcard in /foo/*
    '/foo/{owner}/*': [rules]

    // not allowed because it's confusing to have the owner token at the top level
    '/{owner}/*': [rules]

    // not allowed to have other characters in a path part with the owner token
    '/abc{owner}/*': [rules]

    // not allowed to have owner in the middle of the path
    '/foo/{owner}/bar/*': [rules]

    // allowed
    '/other/{owner}/*': [rules]
  })
})
```

Note that this PR is focused strictly on path validation. Additional policy generation behavior will come later.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Added unit tests
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
