### PR TITLE
fix how paths is added to tsconfig

### DIFF
--- a/.changeset/little-books-press.md
+++ b/.changeset/little-books-press.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/cli-core': patch
+---
+
+Fix how paths is added to tsconfig

--- a/packages/cli-core/src/package-manager-controller/npm_package_manager_controller.test.ts
+++ b/packages/cli-core/src/package-manager-controller/npm_package_manager_controller.test.ts
@@ -7,7 +7,12 @@ import { NpmPackageManagerController } from './npm_package_manager_controller.js
 import { executeWithDebugLogger } from './execute_with_debugger_logger.js';
 
 void describe('NpmPackageManagerController', () => {
-  const fspMock = mock.fn(() => Promise.resolve());
+  const fspMock = {
+    readFile: mock.fn(() =>
+      Promise.resolve(JSON.stringify({ compilerOptions: {} }))
+    ),
+    writeFile: mock.fn(() => Promise.resolve()),
+  };
   const pathMock = {
     resolve: mock.fn(),
   };
@@ -15,7 +20,8 @@ void describe('NpmPackageManagerController', () => {
   const executeWithDebugLoggerMock = mock.fn(() => Promise.resolve());
 
   beforeEach(() => {
-    fspMock.mock.resetCalls();
+    fspMock.readFile.mock.resetCalls();
+    fspMock.writeFile.mock.resetCalls();
     pathMock.resolve.mock.resetCalls();
     execaMock.mock.resetCalls();
     executeWithDebugLoggerMock.mock.resetCalls();

--- a/packages/cli-core/src/package-manager-controller/package_manager_controller_base.ts
+++ b/packages/cli-core/src/package-manager-controller/package_manager_controller_base.ts
@@ -129,7 +129,11 @@ Get started by running \`${this.binaryRunner} amplify sandbox\`.`;
 
     // Add paths object and overwrite the tsconfig file
     tsConfigObject.compilerOptions.paths = pathsObj;
-    await this.fsp.writeFile(tsConfigPath, tsConfigObject, 'utf-8');
+    await this.fsp.writeFile(
+      tsConfigPath,
+      JSON.stringify(tsConfigObject),
+      'utf-8'
+    );
   }
 
   /**

--- a/packages/cli-core/src/package-manager-controller/pnpm_package_manager_controller.test.ts
+++ b/packages/cli-core/src/package-manager-controller/pnpm_package_manager_controller.test.ts
@@ -7,7 +7,12 @@ import { PnpmPackageManagerController } from './pnpm_package_manager_controller.
 import { executeWithDebugLogger } from './execute_with_debugger_logger.js';
 
 void describe('PnpmPackageManagerController', () => {
-  const fspMock = mock.fn(() => Promise.resolve());
+  const fspMock = {
+    readFile: mock.fn(() =>
+      Promise.resolve(JSON.stringify({ compilerOptions: {} }))
+    ),
+    writeFile: mock.fn(() => Promise.resolve()),
+  };
   const pathMock = {
     resolve: mock.fn(),
   };
@@ -15,7 +20,8 @@ void describe('PnpmPackageManagerController', () => {
   const executeWithDebugLoggerMock = mock.fn(() => Promise.resolve());
 
   beforeEach(() => {
-    fspMock.mock.resetCalls();
+    fspMock.readFile.mock.resetCalls();
+    fspMock.writeFile.mock.resetCalls();
     pathMock.resolve.mock.resetCalls();
     execaMock.mock.resetCalls();
     executeWithDebugLoggerMock.mock.resetCalls();

--- a/packages/cli-core/src/package-manager-controller/yarn_classic_package_manager_controller.test.ts
+++ b/packages/cli-core/src/package-manager-controller/yarn_classic_package_manager_controller.test.ts
@@ -7,7 +7,12 @@ import { YarnClassicPackageManagerController } from './yarn_classic_package_mana
 import { executeWithDebugLogger } from './execute_with_debugger_logger.js';
 
 void describe('YarnClassicPackageManagerController', () => {
-  const fspMock = mock.fn(() => Promise.resolve());
+  const fspMock = {
+    readFile: mock.fn(() =>
+      Promise.resolve(JSON.stringify({ compilerOptions: {} }))
+    ),
+    writeFile: mock.fn(() => Promise.resolve()),
+  };
   const pathMock = {
     resolve: mock.fn(),
   };
@@ -15,7 +20,8 @@ void describe('YarnClassicPackageManagerController', () => {
   const executeWithDebugLoggerMock = mock.fn(() => Promise.resolve());
 
   beforeEach(() => {
-    fspMock.mock.resetCalls();
+    fspMock.readFile.mock.resetCalls();
+    fspMock.writeFile.mock.resetCalls();
     pathMock.resolve.mock.resetCalls();
     execaMock.mock.resetCalls();
     executeWithDebugLoggerMock.mock.resetCalls();

--- a/packages/cli-core/src/package-manager-controller/yarn_modern_package_manager_controller.test.ts
+++ b/packages/cli-core/src/package-manager-controller/yarn_modern_package_manager_controller.test.ts
@@ -8,7 +8,12 @@ import { YarnModernPackageManagerController } from './yarn_modern_package_manage
 import { executeWithDebugLogger } from './execute_with_debugger_logger.js';
 
 void describe('YarnModernPackageManagerController', () => {
-  const fspMock = { writeFile: mock.fn(() => Promise.resolve()) };
+  const fspMock = {
+    readFile: mock.fn(() =>
+      Promise.resolve(JSON.stringify({ compilerOptions: {} }))
+    ),
+    writeFile: mock.fn(() => Promise.resolve()),
+  };
   const pathMock = {
     resolve: mock.fn(() => '/testProjectRoot'),
   };
@@ -17,6 +22,7 @@ void describe('YarnModernPackageManagerController', () => {
   const printerMock = { log: mock.fn() } as unknown as Printer;
 
   beforeEach(() => {
+    fspMock.readFile.mock.resetCalls();
     fspMock.writeFile.mock.resetCalls();
     pathMock.resolve.mock.resetCalls();
     execaMock.mock.resetCalls();
@@ -135,7 +141,7 @@ void describe('YarnModernPackageManagerController', () => {
 
       await yarnModernPackageManagerController.initializeTsConfig('./amplify');
       assert.equal(executeWithDebugLoggerMock.mock.callCount(), 2);
-      assert.equal(fspMock.writeFile.mock.callCount(), 1);
+      assert.equal(fspMock.writeFile.mock.callCount(), 2);
     });
   });
 });

--- a/packages/integration-tests/src/test-e2e/create_amplify.test.ts
+++ b/packages/integration-tests/src/test-e2e/create_amplify.test.ts
@@ -168,6 +168,10 @@ void describe(
             'bundler'
           );
           assert.equal(tsConfigObject.compilerOptions.resolveJsonModule, true);
+          assert.equal(tsConfigObject.compilerOptions.paths, {
+            // The path here is coupled with backend-function's generated typedef file path
+            '@env/*': ['../.amplify/function-env/*'],
+          });
 
           const pathPrefix = path.join(tempDir, 'amplify');
 

--- a/packages/integration-tests/src/test-e2e/create_amplify.test.ts
+++ b/packages/integration-tests/src/test-e2e/create_amplify.test.ts
@@ -168,7 +168,7 @@ void describe(
             'bundler'
           );
           assert.equal(tsConfigObject.compilerOptions.resolveJsonModule, true);
-          assert.equal(tsConfigObject.compilerOptions.paths, {
+          assert.deepStrictEqual(tsConfigObject.compilerOptions.paths, {
             // The path here is coupled with backend-function's generated typedef file path
             '@env/*': ['../.amplify/function-env/*'],
           });


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

E2E tests are failing when adding `--paths` option to `tsc` with error:
```
error TS6064: Option 'paths' can only be specified in 'tsconfig.json' file or set to 'null' on command line.npm ERR! code 1
```

**Issue number, if available:**

## Changes

Update to add `paths` by reading tsconfig file after `tsc` and overriding file with `paths` added.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
