### PR TITLE
fix(client-config): add legacy analytics configuration keys

### DIFF
--- a/.changeset/modern-files-arrive.md
+++ b/.changeset/modern-files-arrive.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/client-config': patch
+'@aws-amplify/client-config': minor
 ---
 
 fix(client-config): add legacy analytics configuration key

--- a/.changeset/modern-files-arrive.md
+++ b/.changeset/modern-files-arrive.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+fix(client-config): add legacy analytics configuration key

--- a/packages/client-config/API.md
+++ b/packages/client-config/API.md
@@ -9,8 +9,10 @@ import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client'
 
 // @public (undocumented)
 export type AnalyticsClientConfig = {
+    aws_mobile_analytics_app_id?: string;
+    aws_mobile_analytics_app_region?: string;
     Analytics?: {
-        AWSPinpoint: {
+        Pinpoint: {
             appId: string;
             region: string;
         };

--- a/packages/client-config/src/client-config-types/analytics_client_config.ts
+++ b/packages/client-config/src/client-config-types/analytics_client_config.ts
@@ -1,6 +1,10 @@
 export type AnalyticsClientConfig = {
+  // legacy
+  aws_mobile_analytics_app_id?: string;
+  aws_mobile_analytics_app_region?: string;
+
   Analytics?: {
-    AWSPinpoint: {
+    Pinpoint: {
       appId: string;
       region: string;
     };

--- a/packages/client-config/src/client-config-writer/client_config_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.test.ts
@@ -283,7 +283,7 @@ void describe('client config converter', () => {
   void it('converts analytics config', () => {
     const clientConfig: ClientConfig = {
       Analytics: {
-        AWSPinpoint: {
+        Pinpoint: {
           appId: 'test_pinpoint_id',
           region: 'us-west-2',
         },

--- a/packages/client-config/src/client-config-writer/client_config_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_converter.ts
@@ -150,11 +150,11 @@ export class ClientConfigConverter {
         plugins: {
           awsPinpointAnalyticsPlugin: {
             pinpointAnalytics: {
-              region: clientConfig.Analytics.AWSPinpoint.region,
-              appId: clientConfig.Analytics.AWSPinpoint.appId,
+              region: clientConfig.Analytics.Pinpoint.region,
+              appId: clientConfig.Analytics.Pinpoint.appId,
             },
             pinpointTargeting: {
-              region: clientConfig.Analytics.AWSPinpoint.region,
+              region: clientConfig.Analytics.Pinpoint.region,
             },
           },
         },


### PR DESCRIPTION
## Problem

JS V6 config expects the analytics configuration to be passed differently. See J[S Parsing](https://github.com/aws-amplify/amplify-js/blob/9c916d1337b99751d9c286bace5873ae62936828/packages/core/src/parseAWSExports.ts#L61-L62) and [a test ](https://github.com/aws-amplify/amplify-js/blob/468f979ad07f66816fa44cd0f8e86cf27f5ffd60/packages/core/__tests__/parseAWSExports.test.ts#L173-L174)



Moreover, the [converted config](https://github.com/aws-amplify/amplify-js/blob/9c916d1337b99751d9c286bace5873ae62936828/packages/core/src/parseAWSExports.ts#L80) in JS has the key name as `Pinpoint` instead of `AWSPinpoint`for manually configuring it. 

**Issue number, if available:** fixes #1061

## Changes

Changing the name of the keys


## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
