### PR TITLE
ensure resource access env vars are added to typed shim files

### DIFF
--- a/.changeset/modern-terms-stare.md
+++ b/.changeset/modern-terms-stare.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/backend-function': patch
+---
+
+Ensure resource access env vars are added to function typed shim files

--- a/packages/backend-function/src/function_env_type_generator.test.ts
+++ b/packages/backend-function/src/function_env_type_generator.test.ts
@@ -36,7 +36,7 @@ void describe('FunctionEnvironmentTypeGenerator', () => {
     mock.restoreAll();
   });
 
-  void it('generates a type definition file with dynamic environment variables', () => {
+  void it('generates a type definition file with Amplify backend environment variables', () => {
     const fdCloseMock = mock.fn();
     const fsOpenSyncMock = mock.method(fs, 'openSync');
     const fsWriteFileSyncMock = mock.method(fs, 'writeFileSync', () => null);

--- a/packages/backend-function/src/function_env_type_generator.ts
+++ b/packages/backend-function/src/function_env_type_generator.ts
@@ -36,6 +36,9 @@ export class FunctionEnvironmentTypeGenerator {
     }
 
     // Add Lambda runtime environment variables to the typed shim
+    declarations.push(
+      `/** Lambda runtime environment variables, see https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime */`
+    );
     declarations.push(`type ${lambdaEnvVarTypeName} = {`);
     for (const key in staticEnvironmentVariables) {
       const comment = `/** ${staticEnvironmentVariables[key]} */`;
@@ -50,6 +53,9 @@ export class FunctionEnvironmentTypeGenerator {
      * 1. Defined by the customer passing env vars to the environment parameter for defineFunction
      * 2. Defined by resource access mechanisms
      */
+    declarations.push(
+      `/** Amplify backend environment variables available at runtime, this includes environment variables defined in \`defineFunction\` and by cross resource mechanisms */`
+    );
     declarations.push(`type ${amplifyBackendEnvVarTypeName} = {`);
     this.amplifyBackendEnvVars.forEach((envName) => {
       const declaration = `${envName}: string;`;
@@ -58,11 +64,9 @@ export class FunctionEnvironmentTypeGenerator {
     });
     declarations.push(`};${EOL}`);
 
-    const content =
-      `/** Lambda runtime environment variables, see https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime */${EOL}` +
-      `export const env = process.env as ${lambdaEnvVarTypeName} & ${amplifyBackendEnvVarTypeName};${EOL}${EOL}${declarations.join(
-        EOL
-      )}`;
+    const content = `export const env = process.env as ${lambdaEnvVarTypeName} & ${amplifyBackendEnvVarTypeName};${EOL}${EOL}${declarations.join(
+      EOL
+    )}`;
 
     fs.writeFileSync(this.typeDefFilePath, content);
   }

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/.amplify/function-env/defaultNodeFunction.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/.amplify/function-env/defaultNodeFunction.ts
@@ -1,9 +1,9 @@
 /**
  * This file is here to make Typescript happy for initial type checking and will be overwritten when tests run
  */
-/** Lambda runtime environment variables, see https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime */
-export const env = process.env as LambdaProvidedEnvVars & DefinedEnvVars;
+export const env = process.env as LambdaProvidedEnvVars & AmplifyBackendEnvVars;
 
+/** Lambda runtime environment variables, see https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime */
 type LambdaProvidedEnvVars = {
   /** The handler location configured on the function. */
   _HANDLER: string;
@@ -81,7 +81,9 @@ type LambdaProvidedEnvVars = {
   TZ: string;
 };
 
-type DefinedEnvVars = {
+/** Amplify backend environment variables available at runtime, this includes environment variables defined in `defineFunction` and by cross resource mechanisms */
+type AmplifyBackendEnvVars = {
   TEST_SECRET: string;
   TEST_SHARED_SECRET: string;
+  testName_BUCKET_NAME: string;
 };

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
@@ -11,7 +11,7 @@ Amplify.configure(
   {
     Storage: {
       S3: {
-        bucket: process.env.testName_BUCKET_NAME,
+        bucket: env.testName_BUCKET_NAME,
         region: env.AWS_REGION,
       },
     },


### PR DESCRIPTION
## Problem

E2E tests are not using the typed shim for resource env vars.

**Issue number, if available:**

## Changes

Majority of the work was already done as part of #1076.

- Update E2E tests to use typed `process.env` shim for resource access env vars
- Update typed shim file
  - Move comment about Lambda runtime env vars to where it should be
  - Add comment to explain what the `AmplifyBackendEnvVars` type is

**Corresponding docs PR, if applicable:**

## Validation

E2E test checks

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
