### PR TITLE
update publish job to depend on e2e and unit test jobs

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -302,7 +302,9 @@ jobs:
   update_or_publish_versions:
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
     needs:
-      - build
+      - run_package_manager_e2e_tests
+      - test_with_coverage
+      - run_e2e_tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Currently we have to manually verify that e2e tests on main are passing before merging version bump PRs
**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Move the release step in the merge workflow to the end so that the release only happen once all tests are passing on the version commit. New workflow looks like
![Screenshot 2024-02-29 at 14 40 12](https://github.com/aws-amplify/amplify-backend/assets/19419978/ef000080-9296-4f07-b3f5-4ef70929db6d)

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
