### PR TITLE
fix info command unsupported warning

### DIFF
--- a/.changeset/late-ducks-impress.md
+++ b/.changeset/late-ducks-impress.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+fix info command warning

--- a/.changeset/late-ducks-impress.md
+++ b/.changeset/late-ducks-impress.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/backend-cli': minor
+'@aws-amplify/backend-cli': patch
 ---
 
 fix info command warning

--- a/packages/cli/src/info/cdk_info_provider.ts
+++ b/packages/cli/src/info/cdk_info_provider.ts
@@ -19,6 +19,9 @@ export class CdkInfoProvider {
 
     const output = await this.execa('npx', cdkDoctorArgs, {
       all: true,
+      env: {
+        JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION: 'true',
+      },
     });
 
     return this.formatCdkInfo(output.all ?? output.stderr);


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**
closes: https://github.com/aws-amplify/amplify-backend/issues/1000

when using node versions such as node 21, the cdk info command shows

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!                                                                                                                      !!
!!  This software has not been tested with node v21.6.1.                                                                !!
!!  Should you encounter odd runtime issues, please try using one of the supported release before filing a bug report.  !!
!!                                                                                                                      !!
!!  This software is currently running on node v21.6.1.                                                                 !!
!!  As of the current release of this software, supported node releases are:                                            !!
!!  - ^20.0.0 (Planned end-of-life: 2026-04-30)                                                                         !!
!!  - ^18.0.0 (Planned end-of-life: 2025-04-30)                                                                         !!
!!                                                                                                                      !!
!!  This warning can be silenced by setting the JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION environment variable.        !!
!!                                                                                                                      !!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```


## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**
add env variable to `JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION` this execa process to silence the warning

tested locally with node 21
<img width="434" alt="image" src="https://github.com/aws-amplify/amplify-backend/assets/87995712/9ec66206-2081-4bea-8ea0-449469cfb163">


## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
