### PR TITLE
Add "list" action to storage resource access

### DIFF
--- a/.changeset/short-olives-bow.md
+++ b/.changeset/short-olives-bow.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': minor
+---
+
+Add "list" to available storage resource actions

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -54,8 +54,8 @@ export type StorageAccessGenerator = (allow: StorageAccessBuilder) => StorageAcc
 // @public (undocumented)
 export type StorageAccessRecord = Record<StoragePath, StorageAccessDefinition[]>;
 
-// @public (undocumented)
-export type StorageAction = 'read' | 'write' | 'delete';
+// @public
+export type StorageAction = 'read' | 'get' | 'list' | 'write' | 'delete';
 
 // @public (undocumented)
 export type StorageActionBuilder = {

--- a/packages/backend-storage/src/private_types.ts
+++ b/packages/backend-storage/src/private_types.ts
@@ -2,7 +2,14 @@
  * Types that should remain internal to the package
  */
 
+import { StorageAction } from './types.js';
+
 /**
  * Storage user error types
  */
 export type StorageError = 'InvalidStorageAccessPathError';
+
+/**
+ * StorageAction type intended to be used after mapping "read" to "get" and "list"
+ */
+export type InternalStorageAction = Exclude<StorageAction, 'read'>;

--- a/packages/backend-storage/src/storage_access_orchestrator.test.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.test.ts
@@ -659,7 +659,7 @@ void describe('StorageAccessOrchestrator', () => {
           ],
           '/other/baz/*': [
             {
-              actions: ['read', 'list', 'get'],
+              actions: ['read'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
               ownerPlaceholderSubstitution: '*',
             },

--- a/packages/backend-storage/src/storage_access_orchestrator.test.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.test.ts
@@ -689,7 +689,7 @@ void describe('StorageAccessOrchestrator', () => {
               Effect: 'Allow',
               Resource: bucket.bucketArn,
               Condition: {
-                StringEquals: {
+                StringLike: {
                   's3:prefix': [
                     'foo/bar/*',
                     'foo/bar/',

--- a/packages/backend-storage/src/storage_access_orchestrator.test.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.test.ts
@@ -30,7 +30,7 @@ void describe('StorageAccessOrchestrator', () => {
         () => ({
           '/test/prefix/*': [
             {
-              actions: ['read', 'write'],
+              actions: ['get', 'write'],
               getResourceAccessAcceptor: () => ({
                 identifier: 'testResourceAccessAcceptor',
                 acceptResourceAccess: acceptResourceAccessMock,
@@ -59,7 +59,7 @@ void describe('StorageAccessOrchestrator', () => {
         () => ({
           '/test/prefix/*': [
             {
-              actions: ['read', 'write'],
+              actions: ['get', 'write'],
               getResourceAccessAcceptor: () => ({
                 identifier: 'testResourceAccessAcceptor',
                 acceptResourceAccess: acceptResourceAccessMock,
@@ -109,14 +109,14 @@ void describe('StorageAccessOrchestrator', () => {
         () => ({
           '/test/prefix/*': [
             {
-              actions: ['read', 'write', 'delete'],
+              actions: ['get', 'write', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub,
               ownerPlaceholderSubstitution: '*',
             },
           ],
           '/another/prefix/*': [
             {
-              actions: ['read'],
+              actions: ['get'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub,
               ownerPlaceholderSubstitution: '*',
             },
@@ -176,19 +176,19 @@ void describe('StorageAccessOrchestrator', () => {
         () => ({
           '/test/prefix/*': [
             {
-              actions: ['read', 'write', 'delete'],
+              actions: ['get', 'write', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
               ownerPlaceholderSubstitution: '*',
             },
             {
-              actions: ['read'],
+              actions: ['get'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
               ownerPlaceholderSubstitution: '*',
             },
           ],
           '/another/prefix/*': [
             {
-              actions: ['read', 'delete'],
+              actions: ['get', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
               ownerPlaceholderSubstitution: '*',
             },
@@ -262,7 +262,7 @@ void describe('StorageAccessOrchestrator', () => {
         () => ({
           [`/test/${ownerPathPartToken}/*`]: [
             {
-              actions: ['read', 'write'],
+              actions: ['get', 'write'],
               getResourceAccessAcceptor: () => ({
                 identifier: 'testResourceAccessAcceptor',
                 acceptResourceAccess: acceptResourceAccessMock,
@@ -309,7 +309,7 @@ void describe('StorageAccessOrchestrator', () => {
         () => ({
           '/foo/*': [
             {
-              actions: ['read', 'write'],
+              actions: ['get', 'write'],
               getResourceAccessAcceptor: () => ({
                 identifier: 'resourceAccessAcceptor1',
                 acceptResourceAccess: acceptResourceAccessMock1,
@@ -319,7 +319,7 @@ void describe('StorageAccessOrchestrator', () => {
           ],
           '/foo/bar/*': [
             {
-              actions: ['read'],
+              actions: ['get'],
               getResourceAccessAcceptor: () => ({
                 identifier: 'resourceAccessAcceptor2',
                 acceptResourceAccess: acceptResourceAccessMock2,
@@ -400,7 +400,7 @@ void describe('StorageAccessOrchestrator', () => {
               ownerPlaceholderSubstitution: '{ownerSub}',
             },
             {
-              actions: ['read'],
+              actions: ['get'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
               ownerPlaceholderSubstitution: '*',
             },
@@ -460,7 +460,7 @@ void describe('StorageAccessOrchestrator', () => {
           // acceptor2 should not have any rules for this path
           '/foo/*': [
             {
-              actions: ['read', 'write'],
+              actions: ['get', 'write'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
               ownerPlaceholderSubstitution: '*',
             },
@@ -469,7 +469,7 @@ void describe('StorageAccessOrchestrator', () => {
           // acceptor2 should have only read on this path
           '/foo/bar/*': [
             {
-              actions: ['read'],
+              actions: ['get'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
               ownerPlaceholderSubstitution: '{ownerSub}',
             },
@@ -478,7 +478,7 @@ void describe('StorageAccessOrchestrator', () => {
           // acceptor2 should not have any rules for this path
           '/foo/baz/*': [
             {
-              actions: ['read'],
+              actions: ['get'],
               ownerPlaceholderSubstitution: '*',
               getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
             },
@@ -487,12 +487,12 @@ void describe('StorageAccessOrchestrator', () => {
           // acceptor 2 has read/write/delete on path with ownerSub
           '/other/{owner}/*': [
             {
-              actions: ['read', 'write', 'delete'],
+              actions: ['get', 'write', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
               ownerPlaceholderSubstitution: '{ownerSub}',
             },
             {
-              actions: ['read'],
+              actions: ['get'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
               ownerPlaceholderSubstitution: '*',
             },
@@ -584,7 +584,7 @@ void describe('StorageAccessOrchestrator', () => {
         () => ({
           '/foo/*': [
             {
-              actions: ['read'],
+              actions: ['get'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
               ownerPlaceholderSubstitution: '*',
             },
@@ -625,6 +625,79 @@ void describe('StorageAccessOrchestrator', () => {
               Action: 's3:DeleteObject',
               Effect: 'Allow',
               Resource: `${bucket.bucketArn}/foo/*`,
+            },
+          ],
+          Version: '2012-10-17',
+        }
+      );
+      assert.deepStrictEqual(
+        acceptResourceAccessMock.mock.calls[0].arguments[1],
+        ssmEnvironmentEntriesStub
+      );
+    });
+
+    void it('replaces "read" access with "get" and "list" and merges duplicate actions', () => {
+      const acceptResourceAccessMock = mock.fn();
+      const authenticatedResourceAccessAcceptor = () => ({
+        identifier: 'authenticatedResourceAccessAcceptor',
+        acceptResourceAccess: acceptResourceAccessMock,
+      });
+
+      const storageAccessOrchestrator = new StorageAccessOrchestrator(
+        () => ({
+          '/foo/bar/*': [
+            {
+              actions: ['read', 'get', 'list'],
+              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              ownerPlaceholderSubstitution: '*',
+            },
+            {
+              actions: ['list'],
+              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              ownerPlaceholderSubstitution: '*',
+            },
+          ],
+          '/other/baz/*': [
+            {
+              actions: ['read', 'list', 'get'],
+              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              ownerPlaceholderSubstitution: '*',
+            },
+          ],
+        }),
+        {} as unknown as ConstructFactoryGetInstanceProps,
+        ssmEnvironmentEntriesStub,
+        storageAccessPolicyFactory
+      );
+
+      storageAccessOrchestrator.orchestrateStorageAccess();
+      assert.equal(acceptResourceAccessMock.mock.callCount(), 1);
+      assert.deepStrictEqual(
+        acceptResourceAccessMock.mock.calls[0].arguments[0].document.toJSON(),
+        {
+          Statement: [
+            {
+              Action: 's3:GetObject',
+              Effect: 'Allow',
+              Resource: [
+                `${bucket.bucketArn}/foo/bar/*`,
+                `${bucket.bucketArn}/other/baz/*`,
+              ],
+            },
+            {
+              Action: 's3:ListBucket',
+              Effect: 'Allow',
+              Resource: bucket.bucketArn,
+              Condition: {
+                StringEquals: {
+                  's3:prefix': [
+                    'foo/bar/*',
+                    'foo/bar/',
+                    'other/baz/*',
+                    'other/baz/',
+                  ],
+                },
+              },
             },
           ],
           Version: '2012-10-17',

--- a/packages/backend-storage/src/storage_access_orchestrator.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.ts
@@ -6,13 +6,13 @@ import {
 import {
   StorageAccessBuilder,
   StorageAccessGenerator,
-  StorageAction,
   StoragePath,
 } from './types.js';
 import { ownerPathPartToken } from './constants.js';
 import { StorageAccessPolicyFactory } from './storage_access_policy_factory.js';
 import { validateStorageAccessPaths as _validateStorageAccessPaths } from './validate_storage_access_paths.js';
 import { roleAccessBuilder as _roleAccessBuilder } from './access_builder.js';
+import { InternalStorageAction } from './private_types.js';
 
 /* some types internal to this file to improve readability */
 
@@ -36,7 +36,7 @@ export class StorageAccessOrchestrator {
     {
       acceptor: ResourceAccessAcceptor;
       accessMap: Map<
-        StorageAction,
+        InternalStorageAction,
         { allow: Set<StoragePath>; deny: Set<StoragePath> }
       >;
     }
@@ -104,10 +104,20 @@ export class StorageAccessOrchestrator {
             permission.ownerPlaceholderSubstitution
           ) as StoragePath;
 
+          // replace "read" with "get" and "list" in actions
+          const replaceReadWithGetAndList = permission.actions.flatMap(
+            (action) => (action === 'read' ? ['get', 'list'] : [action])
+          ) as InternalStorageAction[];
+
+          // ensure the actions list has no duplicates
+          const noDuplicateActions = Array.from(
+            new Set(replaceReadWithGetAndList)
+          );
+
           // set an entry that maps this permission to the resource acceptor
           this.addAccessDefinition(
             resourceAccessAcceptor,
-            permission.actions,
+            noDuplicateActions,
             prefix
           );
         });
@@ -124,7 +134,7 @@ export class StorageAccessOrchestrator {
    */
   private addAccessDefinition = (
     resourceAccessAcceptor: ResourceAccessAcceptor,
-    actions: StorageAction[],
+    actions: InternalStorageAction[],
     s3Prefix: StoragePath
   ) => {
     const acceptorToken = resourceAccessAcceptor.identifier;

--- a/packages/backend-storage/src/storage_access_policy_factory.test.ts
+++ b/packages/backend-storage/src/storage_access_policy_factory.test.ts
@@ -21,7 +21,7 @@ void describe('StorageAccessPolicyFactory', () => {
     const bucketPolicyFactory = new StorageAccessPolicyFactory(bucket);
     const policy = bucketPolicyFactory.createPolicy(
       new Map([
-        ['read', { allow: new Set(['/some/prefix/*']), deny: new Set() }],
+        ['get', { allow: new Set(['/some/prefix/*']), deny: new Set() }],
       ])
     );
 
@@ -135,7 +135,7 @@ void describe('StorageAccessPolicyFactory', () => {
     const policy = bucketPolicyFactory.createPolicy(
       new Map([
         [
-          'read',
+          'get',
           {
             allow: new Set(['/some/prefix/*', '/another/path/*']),
             deny: new Set(),
@@ -191,7 +191,7 @@ void describe('StorageAccessPolicyFactory', () => {
     const bucketPolicyFactory = new StorageAccessPolicyFactory(bucket);
     const policy = bucketPolicyFactory.createPolicy(
       new Map([
-        ['read', { allow: new Set(['/some/prefix/*']), deny: new Set() }],
+        ['get', { allow: new Set(['/some/prefix/*']), deny: new Set() }],
         ['write', { allow: new Set(['/another/path/*']), deny: new Set() }],
       ])
     );
@@ -244,7 +244,7 @@ void describe('StorageAccessPolicyFactory', () => {
     const bucketPolicyFactory = new StorageAccessPolicyFactory(bucket);
     const policy = bucketPolicyFactory.createPolicy(
       new Map([
-        ['read', { allow: new Set(['/some/prefix/*']), deny: new Set() }],
+        ['get', { allow: new Set(['/some/prefix/*']), deny: new Set() }],
         ['write', { allow: new Set(['/some/prefix/*']), deny: new Set() }],
         ['delete', { allow: new Set(['/some/prefix/*']), deny: new Set() }],
       ])
@@ -312,7 +312,7 @@ void describe('StorageAccessPolicyFactory', () => {
     const bucketPolicyFactory = new StorageAccessPolicyFactory(bucket);
     const policy = bucketPolicyFactory.createPolicy(
       new Map([
-        ['read', { allow: new Set(['/foo/*', '/foo/bar/*']), deny: new Set() }],
+        ['get', { allow: new Set(['/foo/*', '/foo/bar/*']), deny: new Set() }],
         [
           'write',
           { allow: new Set(['/foo/*']), deny: new Set(['/foo/bar/*']) },
@@ -397,7 +397,7 @@ void describe('StorageAccessPolicyFactory', () => {
     const policy = bucketPolicyFactory.createPolicy(
       new Map([
         [
-          'read',
+          'get',
           {
             allow: new Set(['/foo/*']),
             deny: new Set(['/foo/bar/*']),
@@ -489,7 +489,7 @@ void describe('StorageAccessPolicyFactory', () => {
     const policy = bucketPolicyFactory.createPolicy(
       new Map([
         [
-          'read',
+          'get',
           {
             allow: new Set(['/foo/*']),
             deny: new Set(['/foo/bar/*', '/other/path/*', '/something/else/*']),
@@ -561,6 +561,59 @@ void describe('StorageAccessPolicyFactory', () => {
                 ],
               },
             ],
+          },
+        ],
+      },
+    });
+  });
+
+  void it('handles allow and deny on "list" action', () => {
+    const bucketPolicyFactory = new StorageAccessPolicyFactory(bucket);
+    const policy = bucketPolicyFactory.createPolicy(
+      new Map([
+        [
+          'list',
+          {
+            allow: new Set(['/some/prefix/*']),
+            deny: new Set(['/some/prefix/subpath/*']),
+          },
+        ],
+      ])
+    );
+
+    // we have to attach the policy to a role, otherwise CDK erases the policy from the stack
+    policy.attachToRole(
+      new Role(stack, 'testRole', { assumedBy: new AccountPrincipal('1234') })
+    );
+
+    assert.ok(policy instanceof Policy);
+
+    const template = Template.fromStack(Stack.of(bucket));
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 's3:ListBucket',
+            Resource: {
+              'Fn::GetAtt': ['testBucketDF4D7D1A', 'Arn'],
+            },
+            Condition: {
+              StringEquals: {
+                's3:prefix': ['some/prefix/*', 'some/prefix/'],
+              },
+            },
+          },
+          {
+            Action: 's3:ListBucket',
+            Effect: 'Deny',
+            Resource: {
+              'Fn::GetAtt': ['testBucketDF4D7D1A', 'Arn'],
+            },
+            Condition: {
+              StringEquals: {
+                's3:prefix': ['some/prefix/subpath/*', 'some/prefix/subpath/'],
+              },
+            },
           },
         ],
       },

--- a/packages/backend-storage/src/storage_access_policy_factory.test.ts
+++ b/packages/backend-storage/src/storage_access_policy_factory.test.ts
@@ -598,7 +598,7 @@ void describe('StorageAccessPolicyFactory', () => {
               'Fn::GetAtt': ['testBucketDF4D7D1A', 'Arn'],
             },
             Condition: {
-              StringEquals: {
+              StringLike: {
                 's3:prefix': ['some/prefix/*', 'some/prefix/'],
               },
             },
@@ -610,7 +610,7 @@ void describe('StorageAccessPolicyFactory', () => {
               'Fn::GetAtt': ['testBucketDF4D7D1A', 'Arn'],
             },
             Condition: {
-              StringEquals: {
+              StringLike: {
                 's3:prefix': ['some/prefix/subpath/*', 'some/prefix/subpath/'],
               },
             },

--- a/packages/backend-storage/src/storage_access_policy_factory.ts
+++ b/packages/backend-storage/src/storage_access_policy_factory.ts
@@ -90,7 +90,7 @@ export class StorageAccessPolicyFactory {
           actions: actionMap[action],
           resources: [this.bucket.bucketArn],
           conditions: {
-            StringEquals: {
+            StringLike: {
               's3:prefix': Array.from(s3Prefixes).flatMap(toConditionPrefix),
             },
           },

--- a/packages/backend-storage/src/types.ts
+++ b/packages/backend-storage/src/types.ts
@@ -62,9 +62,22 @@ export type StorageAccessDefinition = {
   ownerPlaceholderSubstitution: string;
 };
 
-export type StorageAction = 'read' | 'write' | 'delete';
+/**
+ * Actions that can be granted to specific paths within the storage resource.
+ *
+ * 'read' grants both 'get' and 'list' actions.
+ *
+ * 'get' grants the ability to fetch objects matching the path prefix.
+ *
+ * 'list' grants the ability to list object names matching the path prefix. It does NOT grant the ability to get the content of those objects.
+ *
+ * 'write' grants the ability to upload objects with a certain prefix. Note that this allows both creating new objects and updating existing ones.
+ *
+ * 'delete' grant the ability to delete objects with a certain prefix.
+ */
+export type StorageAction = 'read' | 'get' | 'list' | 'write' | 'delete';
 
 /**
- * Storage access keys must start with / and end with /*
+ * Storage access paths must start with / and end with /*
  */
 export type StoragePath = `/${string}/*`;


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
The "read" action currently only grants "GetObject" access. Read should also include the ability to list objects (within the specific prefix).
**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Add the ListBucket action to the behavior of the "read" action. Additionally, two new actions, "get" and "list" are added so that behavior can be scoped to only get or list if desired. "read" is a convenience action that includes both "get" and "list".
**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Updated unit tests and manually validated the generated policies
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
