### PR TITLE
chore: Try moving to 4 core CPUs for github workflows

### DIFF
--- a/.github/actions/restore_build_cache/action.yml
+++ b/.github/actions/restore_build_cache/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: ./.github/actions/restore_install_cache
     # restore build output from cache
-    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # version 3.3.3
+    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # version 3.3.1
       id: build-cache
       with:
         path: '**/lib'

--- a/.github/actions/restore_build_cache/action.yml
+++ b/.github/actions/restore_build_cache/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: ./.github/actions/restore_install_cache
     # restore build output from cache
-    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # version 3.3.1
+    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # version 3.3.3
       id: build-cache
       with:
         path: '**/lib'

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -131,12 +131,7 @@ jobs:
       # will finish running other test matrices even if one fails
       fail-fast: false
       matrix:
-        os:
-          [
-            ubuntu-latest,
-            macos-latest-xl,
-            windows-latest,
-          ]
+        os: [ubuntu-latest, macos-latest-xl, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     needs:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -16,7 +16,7 @@ jobs:
         # Windows install must happen on the same worker size as subsequent jobs.
         # Larger workers use different drive (C: instead of D:) to check out project and NPM installation
         # creates file system links that include drive letter.
-        os: [ubuntu-latest, macos-latest, amplify-backend_windows-latest_8-core]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
@@ -35,7 +35,7 @@ jobs:
       - build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, amplify-backend_windows-latest_8-core]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
@@ -133,9 +133,9 @@ jobs:
       matrix:
         os:
           [
-            amplify-backend_ubuntu-latest_4-core,
+            ubuntu-latest,
             macos-latest-xl,
-            amplify-backend_windows-latest_8-core,
+            windows-latest,
           ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
@@ -170,7 +170,7 @@ jobs:
       # will finish running other test matrices even if one fails
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, amplify-backend_windows-latest_8-core]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         pkg-manager: [npm, yarn-classic, yarn-modern, pnpm]
         node-version: [20]
     env:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -16,7 +16,7 @@ jobs:
         # Windows install must happen on the same worker size as subsequent jobs.
         # Larger workers use different drive (C: instead of D:) to check out project and NPM installation
         # creates file system links that include drive letter.
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, amplify-backend_windows-latest_8-core]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
@@ -35,7 +35,7 @@ jobs:
       - build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, amplify-backend_windows-latest_8-core]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
@@ -131,7 +131,12 @@ jobs:
       # will finish running other test matrices even if one fails
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest-xl, windows-latest]
+        os:
+          [
+            ubuntu-latest,
+            macos-latest-xl,
+            amplify-backend_windows-latest_8-core,
+          ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     needs:
@@ -165,7 +170,7 @@ jobs:
       # will finish running other test matrices even if one fails
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, amplify-backend_windows-latest_8-core]
         pkg-manager: [npm, yarn-classic, yarn-modern, pnpm]
         node-version: [20]
     env:


### PR DESCRIPTION
Earlier when the github actions for this repository were implemented, the standard github runners were using 2 core CPUs. Now that github has upgraded those servers to 4, see if we can achieve similar performance with them.

**Issue number, if available:**

## Changes

Change amplify specific action runners to github hosted ones.

## Validation
e2e

## Checklist

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
