### PR TITLE
Enable user pool group access to storage and modify owner access syntax

### DIFF
--- a/.changeset/spicy-bulldogs-itch.md
+++ b/.changeset/spicy-bulldogs-itch.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-storage': minor
+'@aws-amplify/backend-auth': minor
+---
+
+Enable auth group access to storage and change syntax for specifying owner-based access

--- a/package-lock.json
+++ b/package-lock.json
@@ -23318,7 +23318,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.6.0-beta.2",
+      "version": "0.6.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23333,17 +23333,17 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.3",
+      "version": "0.13.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.5.0-beta.2",
-        "@aws-amplify/backend-data": "^0.10.0-beta.2",
-        "@aws-amplify/backend-function": "^0.8.0-beta.1",
+        "@aws-amplify/backend-auth": "^0.5.0-beta.3",
+        "@aws-amplify/backend-data": "^0.10.0-beta.3",
+        "@aws-amplify/backend-function": "^0.8.0-beta.2",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
-        "@aws-amplify/backend-storage": "^0.6.0-beta.1",
-        "@aws-amplify/client-config": "^0.8.1-beta.2",
+        "@aws-amplify/backend-storage": "^0.6.0-beta.2",
+        "@aws-amplify/client-config": "^0.9.0-beta.3",
         "@aws-amplify/data-schema": "^0.13.8",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-amplify/plugin-types": "^0.9.0-beta.0",
@@ -23360,10 +23360,10 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.5.0-beta.2",
+      "version": "0.5.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.2",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.3",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
         "@aws-amplify/plugin-types": "^0.9.0-beta.0"
       },
@@ -23378,7 +23378,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.10.0-beta.2",
+      "version": "0.10.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23414,7 +23414,7 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.8.0-beta.1",
+      "version": "0.8.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23481,7 +23481,7 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.6.0-beta.1",
+      "version": "0.6.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23499,19 +23499,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.0-beta.3",
+      "version": "0.12.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.1",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
-        "@aws-amplify/cli-core": "^0.4.1-beta.0",
-        "@aws-amplify/client-config": "^0.8.1-beta.2",
+        "@aws-amplify/cli-core": "^0.5.0-beta.1",
+        "@aws-amplify/client-config": "^0.9.0-beta.3",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.2",
         "@aws-amplify/form-generator": "^0.8.0-beta.1",
         "@aws-amplify/model-generator": "^0.4.1-beta.2",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
-        "@aws-amplify/sandbox": "^0.5.2-beta.2",
+        "@aws-amplify/sandbox": "^0.5.2-beta.3",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -23540,7 +23540,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.4.1-beta.0",
+      "version": "0.5.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
@@ -23661,7 +23661,7 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.8.1-beta.2",
+      "version": "0.9.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23679,10 +23679,10 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.6.1-beta.2",
+      "version": "0.7.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.4.1-beta.0",
+        "@aws-amplify/cli-core": "^0.5.0-beta.1",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "execa": "^8.0.1",
@@ -23852,13 +23852,13 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.4.4-beta.0",
+      "version": "0.5.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.2",
-        "@aws-amplify/backend": "^0.13.0-beta.3",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.3",
+        "@aws-amplify/backend": "^0.13.0-beta.4",
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
-        "@aws-amplify/client-config": "^0.8.1-beta.2",
+        "@aws-amplify/client-config": "^0.9.0-beta.3",
         "@aws-amplify/data-schema": "^0.13.8",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-amplify": "^3.465.0",
@@ -24440,13 +24440,13 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.2",
+      "version": "0.5.2-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.1",
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
-        "@aws-amplify/cli-core": "^0.4.1-beta.0",
-        "@aws-amplify/client-config": "^0.8.1-beta.2",
+        "@aws-amplify/cli-core": "^0.5.0-beta.1",
+        "@aws-amplify/client-config": "^0.9.0-beta.3",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.2",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/backend-auth/API.md
+++ b/packages/backend-auth/API.md
@@ -46,7 +46,7 @@ export type AuthLoginWithFactoryProps = Omit<AuthProps['loginWith'], 'externalPr
 };
 
 // @public (undocumented)
-export type BackendAuth = ResourceProvider<AuthResources> & ResourceAccessAcceptorFactory<AuthRoleName>;
+export type BackendAuth = ResourceProvider<AuthResources> & ResourceAccessAcceptorFactory<AuthRoleName | string>;
 
 // @public
 export const defineAuth: (props: AmplifyAuthProps) => ConstructFactory<BackendAuth>;

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -23,7 +23,7 @@ import { UserPool, UserPoolOperation } from 'aws-cdk-lib/aws-cognito';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 export type BackendAuth = ResourceProvider<AuthResources> &
-  ResourceAccessAcceptorFactory<AuthRoleName>;
+  ResourceAccessAcceptorFactory<AuthRoleName | string>;
 
 export type AmplifyAuthProps = Expand<
   Omit<AuthProps, 'outputStorageStrategy' | 'loginWith'> & {
@@ -126,12 +126,24 @@ class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
 
     const authConstructMixin: BackendAuth = {
       ...authConstruct,
+      /**
+       * Returns a resourceAccessAcceptor for the given role
+       * @param roleName Either the auth or unauth role name or the name of a UserPool group
+       */
       getResourceAccessAcceptor: (
-        roleName: AuthRoleName
+        roleName: AuthRoleName | string
       ): ResourceAccessAcceptor => ({
         identifier: `${roleName}ResourceAccessAcceptor`,
         acceptResourceAccess: (policy: Policy) => {
-          const role = authConstruct.resources[roleName];
+          const role = roleNameIsAuthRoleName(roleName)
+            ? authConstruct.resources[roleName]
+            : authConstruct.resources.groups?.[roleName]?.role;
+          if (!role) {
+            throw new AmplifyUserError('InvalidResourceAccessConfig', {
+              message: `No auth IAM role found for ${roleName}.`,
+              resolution: `If you are trying to configure UserPool group access, ensure that the group name is specified correctly.`,
+            });
+          }
           policy.attachToRole(role);
         },
       }),
@@ -139,6 +151,13 @@ class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
     return authConstructMixin;
   };
 }
+
+const roleNameIsAuthRoleName = (roleName: string): roleName is AuthRoleName => {
+  return (
+    roleName === 'authenticatedUserIamRole' ||
+    roleName === 'unauthenticatedUserIamRole'
+  );
+};
 
 /**
  * Provide the settings that will be used for authentication.

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -128,19 +128,19 @@ class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
       ...authConstruct,
       /**
        * Returns a resourceAccessAcceptor for the given role
-       * @param roleName Either the auth or unauth role name or the name of a UserPool group
+       * @param roleIdentifier Either the auth or unauth role name or the name of a UserPool group
        */
       getResourceAccessAcceptor: (
-        roleName: AuthRoleName | string
+        roleIdentifier: AuthRoleName | string
       ): ResourceAccessAcceptor => ({
-        identifier: `${roleName}ResourceAccessAcceptor`,
+        identifier: `${roleIdentifier}ResourceAccessAcceptor`,
         acceptResourceAccess: (policy: Policy) => {
-          const role = roleNameIsAuthRoleName(roleName)
-            ? authConstruct.resources[roleName]
-            : authConstruct.resources.groups?.[roleName]?.role;
+          const role = roleNameIsAuthRoleName(roleIdentifier)
+            ? authConstruct.resources[roleIdentifier]
+            : authConstruct.resources.groups?.[roleIdentifier]?.role;
           if (!role) {
             throw new AmplifyUserError('InvalidResourceAccessConfig', {
-              message: `No auth IAM role found for "${roleName}".`,
+              message: `No auth IAM role found for "${roleIdentifier}".`,
               resolution: `If you are trying to configure UserPool group access, ensure that the group name is specified correctly.`,
             });
           }

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -140,7 +140,7 @@ class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
             : authConstruct.resources.groups?.[roleName]?.role;
           if (!role) {
             throw new AmplifyUserError('InvalidResourceAccessConfig', {
-              message: `No auth IAM role found for ${roleName}.`,
+              message: `No auth IAM role found for "${roleName}".`,
               resolution: `If you are trying to configure UserPool group access, ensure that the group name is specified correctly.`,
             });
           }

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -14,9 +14,6 @@ import { ResourceAccessAcceptorFactory } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { StorageOutput } from '@aws-amplify/backend-output-schemas';
 
-// @public
-export type AccessId = 'identity';
-
 // @public (undocumented)
 export type AmplifyStorageFactoryProps = Omit<AmplifyStorageProps, 'outputStorageStrategy'> & {
     access?: StorageAccessGenerator;
@@ -37,11 +34,14 @@ export type AmplifyStorageTriggerEvent = 'onDelete' | 'onUpload';
 export const defineStorage: (props: AmplifyStorageFactoryProps) => ConstructFactory<ResourceProvider<StorageResources>>;
 
 // @public
+export type EntityId = 'identity';
+
+// @public
 export type StorageAccessBuilder = {
     authenticated: StorageActionBuilder;
     guest: StorageActionBuilder;
     group: (groupName: string) => StorageActionBuilder;
-    id: (accessId: AccessId) => StorageActionBuilder;
+    entity: (entityId: EntityId) => StorageActionBuilder;
     resource: (other: ConstructFactory<ResourceProvider & ResourceAccessAcceptorFactory>) => StorageActionBuilder;
 };
 

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -14,6 +14,9 @@ import { ResourceAccessAcceptorFactory } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { StorageOutput } from '@aws-amplify/backend-output-schemas';
 
+// @public
+export type AccessId = 'identity';
+
 // @public (undocumented)
 export type AmplifyStorageFactoryProps = Omit<AmplifyStorageProps, 'outputStorageStrategy'> & {
     access?: StorageAccessGenerator;
@@ -37,7 +40,8 @@ export const defineStorage: (props: AmplifyStorageFactoryProps) => ConstructFact
 export type StorageAccessBuilder = {
     authenticated: StorageActionBuilder;
     guest: StorageActionBuilder;
-    owner: StorageActionBuilder;
+    group: (groupName: string) => StorageActionBuilder;
+    id: (accessId: AccessId) => StorageActionBuilder;
     resource: (other: ConstructFactory<ResourceProvider & ResourceAccessAcceptorFactory>) => StorageActionBuilder;
 };
 
@@ -45,7 +49,7 @@ export type StorageAccessBuilder = {
 export type StorageAccessDefinition = {
     getResourceAccessAcceptor: (getInstanceProps: ConstructFactoryGetInstanceProps) => ResourceAccessAcceptor;
     actions: StorageAction[];
-    ownerPlaceholderSubstitution: string;
+    idSubstitution: string;
 };
 
 // @public (undocumented)

--- a/packages/backend-storage/src/access_builder.test.ts
+++ b/packages/backend-storage/src/access_builder.test.ts
@@ -95,7 +95,7 @@ void describe('storageAccessBuilder', () => {
   });
   void it('builds storage access definition for IdP identity', () => {
     const accessDefinition = roleAccessBuilder
-      .id('identity')
+      .entity('identity')
       .to(['read', 'write', 'delete']);
     assert.deepStrictEqual(accessDefinition.actions, [
       'read',

--- a/packages/backend-storage/src/access_builder.test.ts
+++ b/packages/backend-storage/src/access_builder.test.ts
@@ -10,11 +10,15 @@ import {
 
 void describe('storageAccessBuilder', () => {
   const resourceAccessAcceptorMock = mock.fn();
+  const groupAccessAcceptorMock = mock.fn();
 
   const getResourceAccessAcceptorMock = mock.fn(
     // allows us to get proper typing on the mock args
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (_: string) => resourceAccessAcceptorMock
+    (roleName: string) =>
+      roleName === 'testGroupName'
+        ? groupAccessAcceptorMock
+        : resourceAccessAcceptorMock
   );
 
   const getConstructFactoryMock = mock.fn(
@@ -50,7 +54,7 @@ void describe('storageAccessBuilder', () => {
       'write',
       'delete',
     ]);
-    assert.equal(accessDefinition.ownerPlaceholderSubstitution, '*');
+    assert.equal(accessDefinition.idSubstitution, '*');
     assert.equal(
       accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
       resourceAccessAcceptorMock
@@ -75,7 +79,7 @@ void describe('storageAccessBuilder', () => {
       'write',
       'delete',
     ]);
-    assert.equal(accessDefinition.ownerPlaceholderSubstitution, '*');
+    assert.equal(accessDefinition.idSubstitution, '*');
     assert.equal(
       accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
       resourceAccessAcceptorMock
@@ -89,19 +93,17 @@ void describe('storageAccessBuilder', () => {
       'unauthenticatedUserIamRole'
     );
   });
-  void it('builds storage access definition for owner', () => {
-    const accessDefinition = roleAccessBuilder.owner.to([
-      'read',
-      'write',
-      'delete',
-    ]);
+  void it('builds storage access definition for IdP identity', () => {
+    const accessDefinition = roleAccessBuilder
+      .id('identity')
+      .to(['read', 'write', 'delete']);
     assert.deepStrictEqual(accessDefinition.actions, [
       'read',
       'write',
       'delete',
     ]);
     assert.equal(
-      accessDefinition.ownerPlaceholderSubstitution,
+      accessDefinition.idSubstitution,
       '${cognito-identity.amazonaws.com:sub}'
     );
     assert.equal(
@@ -133,10 +135,23 @@ void describe('storageAccessBuilder', () => {
       'write',
       'delete',
     ]);
-    assert.equal(accessDefinition.ownerPlaceholderSubstitution, '*');
+    assert.equal(accessDefinition.idSubstitution, '*');
     assert.equal(
       accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
       resourceAccessAcceptorMock
+    );
+  });
+
+  void it('builds storage access definition for user pool groups', () => {
+    const accessDefinition = roleAccessBuilder
+      .group('testGroupName')
+      .to(['read', 'write']);
+
+    assert.deepStrictEqual(accessDefinition.actions, ['read', 'write']);
+    assert.equal(accessDefinition.idSubstitution, '*');
+    assert.equal(
+      accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
+      groupAccessAcceptorMock
     );
   });
 });

--- a/packages/backend-storage/src/access_builder.ts
+++ b/packages/backend-storage/src/access_builder.ts
@@ -21,6 +21,14 @@ export const roleAccessBuilder: StorageAccessBuilder = {
       ownerPlaceholderSubstitution: '*',
     }),
   },
+  group: (groupName) => ({
+    to: (actions) => ({
+      getResourceAccessAcceptor: (getInstanceProps) =>
+        getUserRoleResourceAccessAcceptor(getInstanceProps, groupName),
+      actions,
+      ownerPlaceholderSubstitution: '*',
+    }),
+  }),
   owner: {
     to: (actions) => ({
       getResourceAccessAcceptor: getAuthRoleResourceAccessAcceptor,
@@ -56,11 +64,11 @@ const getUnauthRoleResourceAccessAcceptor = (
 
 const getUserRoleResourceAccessAcceptor = (
   getInstanceProps: ConstructFactoryGetInstanceProps,
-  roleName: AuthRoleName
+  roleName: AuthRoleName | string
 ) => {
   const resourceAccessAcceptor = getInstanceProps.constructContainer
     .getConstructFactory<
-      ResourceProvider & ResourceAccessAcceptorFactory<AuthRoleName>
+      ResourceProvider & ResourceAccessAcceptorFactory<AuthRoleName | string>
     >('AuthResources')
     ?.getInstance(getInstanceProps)
     .getResourceAccessAcceptor(roleName);

--- a/packages/backend-storage/src/access_builder.ts
+++ b/packages/backend-storage/src/access_builder.ts
@@ -76,7 +76,7 @@ const getUserRoleResourceAccessAcceptor = (
     throw new Error(
       `Cannot specify auth access for ${
         roleName as string
-      } users without defining auth. See <defineAuth docs link> for more information.`
+      } users without defining auth. See https://docs.amplify.aws/gen2/build-a-backend/auth/set-up-auth/ for more information.`
     );
   }
   return resourceAccessAcceptor;

--- a/packages/backend-storage/src/access_builder.ts
+++ b/packages/backend-storage/src/access_builder.ts
@@ -11,14 +11,14 @@ export const roleAccessBuilder: StorageAccessBuilder = {
     to: (actions) => ({
       getResourceAccessAcceptor: getAuthRoleResourceAccessAcceptor,
       actions,
-      ownerPlaceholderSubstitution: '*',
+      idSubstitution: '*',
     }),
   },
   guest: {
     to: (actions) => ({
       getResourceAccessAcceptor: getUnauthRoleResourceAccessAcceptor,
       actions,
-      ownerPlaceholderSubstitution: '*',
+      idSubstitution: '*',
     }),
   },
   group: (groupName) => ({
@@ -26,22 +26,22 @@ export const roleAccessBuilder: StorageAccessBuilder = {
       getResourceAccessAcceptor: (getInstanceProps) =>
         getUserRoleResourceAccessAcceptor(getInstanceProps, groupName),
       actions,
-      ownerPlaceholderSubstitution: '*',
+      idSubstitution: '*',
     }),
   }),
-  owner: {
+  id: () => ({
     to: (actions) => ({
       getResourceAccessAcceptor: getAuthRoleResourceAccessAcceptor,
       actions,
-      ownerPlaceholderSubstitution: '${cognito-identity.amazonaws.com:sub}',
+      idSubstitution: '${cognito-identity.amazonaws.com:sub}',
     }),
-  },
+  }),
   resource: (other) => ({
     to: (actions) => ({
       getResourceAccessAcceptor: (getInstanceProps) =>
         other.getInstance(getInstanceProps).getResourceAccessAcceptor(),
       actions,
-      ownerPlaceholderSubstitution: '*',
+      idSubstitution: '*',
     }),
   }),
 };
@@ -74,9 +74,9 @@ const getUserRoleResourceAccessAcceptor = (
     .getResourceAccessAcceptor(roleName);
   if (!resourceAccessAcceptor) {
     throw new Error(
-      `Cannot specify ${
+      `Cannot specify auth access for ${
         roleName as string
-      } user policies without defining auth. See <defineAuth docs link> for more information.`
+      } users without defining auth. See <defineAuth docs link> for more information.`
     );
   }
   return resourceAccessAcceptor;

--- a/packages/backend-storage/src/access_builder.ts
+++ b/packages/backend-storage/src/access_builder.ts
@@ -29,7 +29,7 @@ export const roleAccessBuilder: StorageAccessBuilder = {
       idSubstitution: '*',
     }),
   }),
-  id: () => ({
+  entity: () => ({
     to: (actions) => ({
       getResourceAccessAcceptor: getAuthRoleResourceAccessAcceptor,
       actions,

--- a/packages/backend-storage/src/constants.ts
+++ b/packages/backend-storage/src/constants.ts
@@ -1,1 +1,1 @@
-export const ownerPathPartToken = '{owner}';
+export const idPathToken = '{id}';

--- a/packages/backend-storage/src/constants.ts
+++ b/packages/backend-storage/src/constants.ts
@@ -1,1 +1,1 @@
-export const idPathToken = '{id}';
+export const entityIdPathToken = '{entity_id}';

--- a/packages/backend-storage/src/storage_access_orchestrator.test.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.test.ts
@@ -4,7 +4,7 @@ import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
 import { App, Stack } from 'aws-cdk-lib';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import assert from 'node:assert';
-import { idPathToken } from './constants.js';
+import { entityIdPathToken } from './constants.js';
 import { StorageAccessPolicyFactory } from './storage_access_policy_factory.js';
 
 void describe('StorageAccessOrchestrator', () => {
@@ -260,7 +260,7 @@ void describe('StorageAccessOrchestrator', () => {
       const acceptResourceAccessMock = mock.fn();
       const storageAccessOrchestrator = new StorageAccessOrchestrator(
         () => ({
-          [`/test/${idPathToken}/*`]: [
+          [`/test/${entityIdPathToken}/*`]: [
             {
               actions: ['get', 'write'],
               getResourceAccessAcceptor: () => ({
@@ -393,7 +393,7 @@ void describe('StorageAccessOrchestrator', () => {
 
       const storageAccessOrchestrator = new StorageAccessOrchestrator(
         () => ({
-          '/foo/{id}/*': [
+          '/foo/{entity_id}/*': [
             {
               actions: ['write', 'delete'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
@@ -485,7 +485,7 @@ void describe('StorageAccessOrchestrator', () => {
           ],
           // acceptor 1 is denied write on this path (read still allowed)
           // acceptor 2 has read/write/delete on path with ownerSub
-          '/other/{id}/*': [
+          '/other/{entity_id}/*': [
             {
               actions: ['get', 'write', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,

--- a/packages/backend-storage/src/storage_access_orchestrator.test.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.test.ts
@@ -4,7 +4,7 @@ import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
 import { App, Stack } from 'aws-cdk-lib';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import assert from 'node:assert';
-import { ownerPathPartToken } from './constants.js';
+import { idPathToken } from './constants.js';
 import { StorageAccessPolicyFactory } from './storage_access_policy_factory.js';
 
 void describe('StorageAccessOrchestrator', () => {
@@ -35,7 +35,7 @@ void describe('StorageAccessOrchestrator', () => {
                 identifier: 'testResourceAccessAcceptor',
                 acceptResourceAccess: acceptResourceAccessMock,
               }),
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),
@@ -64,7 +64,7 @@ void describe('StorageAccessOrchestrator', () => {
                 identifier: 'testResourceAccessAcceptor',
                 acceptResourceAccess: acceptResourceAccessMock,
               }),
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),
@@ -111,14 +111,14 @@ void describe('StorageAccessOrchestrator', () => {
             {
               actions: ['get', 'write', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
           '/another/prefix/*': [
             {
               actions: ['get'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),
@@ -178,19 +178,19 @@ void describe('StorageAccessOrchestrator', () => {
             {
               actions: ['get', 'write', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
             {
               actions: ['get'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
           '/another/prefix/*': [
             {
               actions: ['get', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),
@@ -260,14 +260,14 @@ void describe('StorageAccessOrchestrator', () => {
       const acceptResourceAccessMock = mock.fn();
       const storageAccessOrchestrator = new StorageAccessOrchestrator(
         () => ({
-          [`/test/${ownerPathPartToken}/*`]: [
+          [`/test/${idPathToken}/*`]: [
             {
               actions: ['get', 'write'],
               getResourceAccessAcceptor: () => ({
                 identifier: 'testResourceAccessAcceptor',
                 acceptResourceAccess: acceptResourceAccessMock,
               }),
-              ownerPlaceholderSubstitution: '{testOwnerSub}',
+              idSubstitution: '{testOwnerSub}',
             },
           ],
         }),
@@ -314,7 +314,7 @@ void describe('StorageAccessOrchestrator', () => {
                 identifier: 'resourceAccessAcceptor1',
                 acceptResourceAccess: acceptResourceAccessMock1,
               }),
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
           '/foo/bar/*': [
@@ -324,7 +324,7 @@ void describe('StorageAccessOrchestrator', () => {
                 identifier: 'resourceAccessAcceptor2',
                 acceptResourceAccess: acceptResourceAccessMock2,
               }),
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),
@@ -393,16 +393,16 @@ void describe('StorageAccessOrchestrator', () => {
 
       const storageAccessOrchestrator = new StorageAccessOrchestrator(
         () => ({
-          '/foo/{owner}/*': [
+          '/foo/{id}/*': [
             {
               actions: ['write', 'delete'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
-              ownerPlaceholderSubstitution: '{ownerSub}',
+              idSubstitution: '{idSub}',
             },
             {
               actions: ['get'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),
@@ -420,12 +420,12 @@ void describe('StorageAccessOrchestrator', () => {
             {
               Action: 's3:PutObject',
               Effect: 'Allow',
-              Resource: `${bucket.bucketArn}/foo/{ownerSub}/*`,
+              Resource: `${bucket.bucketArn}/foo/{idSub}/*`,
             },
             {
               Action: 's3:DeleteObject',
               Effect: 'Allow',
-              Resource: `${bucket.bucketArn}/foo/{ownerSub}/*`,
+              Resource: `${bucket.bucketArn}/foo/{idSub}/*`,
             },
             {
               Action: 's3:GetObject',
@@ -462,7 +462,7 @@ void describe('StorageAccessOrchestrator', () => {
             {
               actions: ['get', 'write'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
           // acceptor1 should be denied read and write on this path
@@ -471,7 +471,7 @@ void describe('StorageAccessOrchestrator', () => {
             {
               actions: ['get'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
-              ownerPlaceholderSubstitution: '{ownerSub}',
+              idSubstitution: '{idSub}',
             },
           ],
           // acceptor1 should be denied write on this path (read from parent path covers read on this path)
@@ -479,22 +479,22 @@ void describe('StorageAccessOrchestrator', () => {
           '/foo/baz/*': [
             {
               actions: ['get'],
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
               getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
             },
           ],
           // acceptor 1 is denied write on this path (read still allowed)
           // acceptor 2 has read/write/delete on path with ownerSub
-          '/other/{owner}/*': [
+          '/other/{id}/*': [
             {
               actions: ['get', 'write', 'delete'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
-              ownerPlaceholderSubstitution: '{ownerSub}',
+              idSubstitution: '{idSub}',
             },
             {
               actions: ['get'],
               getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),
@@ -554,18 +554,18 @@ void describe('StorageAccessOrchestrator', () => {
               Effect: 'Allow',
               Resource: [
                 `${bucket.bucketArn}/foo/bar/*`,
-                `${bucket.bucketArn}/other/{ownerSub}/*`,
+                `${bucket.bucketArn}/other/{idSub}/*`,
               ],
             },
             {
               Action: 's3:PutObject',
               Effect: 'Allow',
-              Resource: `${bucket.bucketArn}/other/{ownerSub}/*`,
+              Resource: `${bucket.bucketArn}/other/{idSub}/*`,
             },
             {
               Action: 's3:DeleteObject',
               Effect: 'Allow',
-              Resource: `${bucket.bucketArn}/other/{ownerSub}/*`,
+              Resource: `${bucket.bucketArn}/other/{idSub}/*`,
             },
           ],
           Version: '2012-10-17',
@@ -586,17 +586,17 @@ void describe('StorageAccessOrchestrator', () => {
             {
               actions: ['get'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
             {
               actions: ['write'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
-              ownerPlaceholderSubstitution: '{ownerSub}',
+              idSubstitution: '{idSub}',
             },
             {
               actions: ['delete'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),
@@ -649,19 +649,19 @@ void describe('StorageAccessOrchestrator', () => {
             {
               actions: ['read', 'get', 'list'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
             {
               actions: ['list'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
           '/other/baz/*': [
             {
               actions: ['read'],
               getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
-              ownerPlaceholderSubstitution: '*',
+              idSubstitution: '*',
             },
           ],
         }),

--- a/packages/backend-storage/src/storage_access_orchestrator.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.ts
@@ -8,7 +8,7 @@ import {
   StorageAccessGenerator,
   StoragePath,
 } from './types.js';
-import { ownerPathPartToken } from './constants.js';
+import { idPathToken } from './constants.js';
 import { StorageAccessPolicyFactory } from './storage_access_policy_factory.js';
 import { validateStorageAccessPaths as _validateStorageAccessPaths } from './validate_storage_access_paths.js';
 import { roleAccessBuilder as _roleAccessBuilder } from './access_builder.js';
@@ -100,8 +100,8 @@ export class StorageAccessOrchestrator {
 
           // make the owner placeholder substitution in the s3 prefix
           const prefix = s3Prefix.replaceAll(
-            ownerPathPartToken,
-            permission.ownerPlaceholderSubstitution
+            idPathToken,
+            permission.idSubstitution
           ) as StoragePath;
 
           // replace "read" with "get" and "list" in actions

--- a/packages/backend-storage/src/storage_access_orchestrator.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.ts
@@ -8,7 +8,7 @@ import {
   StorageAccessGenerator,
   StoragePath,
 } from './types.js';
-import { idPathToken } from './constants.js';
+import { entityIdPathToken } from './constants.js';
 import { StorageAccessPolicyFactory } from './storage_access_policy_factory.js';
 import { validateStorageAccessPaths as _validateStorageAccessPaths } from './validate_storage_access_paths.js';
 import { roleAccessBuilder as _roleAccessBuilder } from './access_builder.js';
@@ -100,7 +100,7 @@ export class StorageAccessOrchestrator {
 
           // make the owner placeholder substitution in the s3 prefix
           const prefix = s3Prefix.replaceAll(
-            idPathToken,
+            entityIdPathToken,
             permission.idSubstitution
           ) as StoragePath;
 

--- a/packages/backend-storage/src/types.ts
+++ b/packages/backend-storage/src/types.ts
@@ -29,6 +29,7 @@ export type AmplifyStorageFactoryProps = Omit<
 export type StorageAccessBuilder = {
   authenticated: StorageActionBuilder;
   guest: StorageActionBuilder;
+  group: (groupName: string) => StorageActionBuilder;
   owner: StorageActionBuilder;
   resource: (
     other: ConstructFactory<ResourceProvider & ResourceAccessAcceptorFactory>

--- a/packages/backend-storage/src/types.ts
+++ b/packages/backend-storage/src/types.ts
@@ -24,6 +24,8 @@ export type AmplifyStorageFactoryProps = Omit<
  * Types of IDs that can be substituted in access policies
  *
  * 'identity' corresponds to the Cognito Identity Pool IdentityID
+ *
+ * Currently this is the only type of identity supported.
  */
 export type AccessId = 'identity';
 

--- a/packages/backend-storage/src/types.ts
+++ b/packages/backend-storage/src/types.ts
@@ -21,6 +21,13 @@ export type AmplifyStorageFactoryProps = Omit<
 };
 
 /**
+ * Types of IDs that can be substituted in access policies
+ *
+ * 'identity' corresponds to the Cognito Identity Pool IdentityID
+ */
+export type AccessId = 'identity';
+
+/**
  * !EXPERIMENTAL!
  *
  * Resource access patterns are under active development and are subject to breaking changes.
@@ -30,7 +37,7 @@ export type StorageAccessBuilder = {
   authenticated: StorageActionBuilder;
   guest: StorageActionBuilder;
   group: (groupName: string) => StorageActionBuilder;
-  owner: StorageActionBuilder;
+  id: (accessId: AccessId) => StorageActionBuilder;
   resource: (
     other: ConstructFactory<ResourceProvider & ResourceAccessAcceptorFactory>
   ) => StorageActionBuilder;
@@ -60,7 +67,7 @@ export type StorageAccessDefinition = {
   /**
    * The value that will be substituted into the resource string in place of the {owner} token
    */
-  ownerPlaceholderSubstitution: string;
+  idSubstitution: string;
 };
 
 /**

--- a/packages/backend-storage/src/types.ts
+++ b/packages/backend-storage/src/types.ts
@@ -21,13 +21,13 @@ export type AmplifyStorageFactoryProps = Omit<
 };
 
 /**
- * Types of IDs that can be substituted in access policies
+ * Types of entity IDs that can be substituted in access policies
  *
  * 'identity' corresponds to the Cognito Identity Pool IdentityID
  *
- * Currently this is the only type of identity supported.
+ * Currently this is the only supported entity type.
  */
-export type AccessId = 'identity';
+export type EntityId = 'identity';
 
 /**
  * !EXPERIMENTAL!
@@ -39,7 +39,7 @@ export type StorageAccessBuilder = {
   authenticated: StorageActionBuilder;
   guest: StorageActionBuilder;
   group: (groupName: string) => StorageActionBuilder;
-  id: (accessId: AccessId) => StorageActionBuilder;
+  entity: (entityId: EntityId) => StorageActionBuilder;
   resource: (
     other: ConstructFactory<ResourceProvider & ResourceAccessAcceptorFactory>
   ) => StorageActionBuilder;

--- a/packages/backend-storage/src/validate_storage_access_paths.test.ts
+++ b/packages/backend-storage/src/validate_storage_access_paths.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { validateStorageAccessPaths } from './validate_storage_access_paths.js';
 import assert from 'node:assert';
-import { ownerPathPartToken } from './constants.js';
+import { idPathToken } from './constants.js';
 
 void describe('validateStorageAccessPaths', () => {
   void it('is a noop on valid paths', () => {
@@ -10,8 +10,8 @@ void describe('validateStorageAccessPaths', () => {
       '/foo/bar/*',
       '/foo/baz/*',
       '/other/*',
-      '/something/{owner}/*',
-      '/another/{owner}/*',
+      '/something/{id}/*',
+      '/another/{id}/*',
     ]);
     // completing successfully indicates success
   });
@@ -54,43 +54,37 @@ void describe('validateStorageAccessPaths', () => {
   });
 
   void it('throws on path that has multiple owner tokens', () => {
-    assert.throws(
-      () => validateStorageAccessPaths(['/foo/{owner}/{owner}/*']),
-      {
-        message: `The ${ownerPathPartToken} token can only appear once in a path. Found [/foo/{owner}/{owner}/*]`,
-      }
-    );
+    assert.throws(() => validateStorageAccessPaths(['/foo/{id}/{id}/*']), {
+      message: `The ${idPathToken} token can only appear once in a path. Found [/foo/{id}/{id}/*]`,
+    });
   });
 
   void it('throws on path where owner token is not at the end', () => {
-    assert.throws(() => validateStorageAccessPaths(['/foo/{owner}/bar/*']), {
-      message: `The ${ownerPathPartToken} token must be the path part right before the ending wildcard. Found [/foo/{owner}/bar/*].`,
+    assert.throws(() => validateStorageAccessPaths(['/foo/{id}/bar/*']), {
+      message: `The ${idPathToken} token must be the path part right before the ending wildcard. Found [/foo/{id}/bar/*].`,
     });
   });
 
   void it('throws on path that starts with owner token', () => {
-    assert.throws(() => validateStorageAccessPaths(['/{owner}/*']), {
-      message: `The ${ownerPathPartToken} token must not be the first path part. Found [/{owner}/*].`,
+    assert.throws(() => validateStorageAccessPaths(['/{id}/*']), {
+      message: `The ${idPathToken} token must not be the first path part. Found [/{id}/*].`,
     });
   });
 
   void it('throws on path that has owner token and other characters in single path part', () => {
-    assert.throws(() => validateStorageAccessPaths(['/abc{owner}/*']), {
-      message: `A path part that includes the ${ownerPathPartToken} token cannot include any other characters. Found [/abc{owner}/*].`,
+    assert.throws(() => validateStorageAccessPaths(['/abc{id}/*']), {
+      message: `A path part that includes the ${idPathToken} token cannot include any other characters. Found [/abc{id}/*].`,
     });
   });
 
   void it('throws on path that is a prefix of a path with an owner token', () => {
+    assert.throws(() => validateStorageAccessPaths(['/foo/{id}/*', '/foo/*']), {
+      message: `A path cannot be a prefix of another path that contains the ${idPathToken} token.`,
+    });
     assert.throws(
-      () => validateStorageAccessPaths(['/foo/{owner}/*', '/foo/*']),
+      () => validateStorageAccessPaths(['/foo/bar/{id}/*', '/foo/*']),
       {
-        message: `A path cannot be a prefix of another path that contains the ${ownerPathPartToken} token.`,
-      }
-    );
-    assert.throws(
-      () => validateStorageAccessPaths(['/foo/bar/{owner}/*', '/foo/*']),
-      {
-        message: `A path cannot be a prefix of another path that contains the ${ownerPathPartToken} token.`,
+        message: `A path cannot be a prefix of another path that contains the ${idPathToken} token.`,
       }
     );
   });

--- a/packages/backend-storage/src/validate_storage_access_paths.test.ts
+++ b/packages/backend-storage/src/validate_storage_access_paths.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { validateStorageAccessPaths } from './validate_storage_access_paths.js';
 import assert from 'node:assert';
-import { idPathToken } from './constants.js';
+import { entityIdPathToken } from './constants.js';
 
 void describe('validateStorageAccessPaths', () => {
   void it('is a noop on valid paths', () => {
@@ -10,8 +10,8 @@ void describe('validateStorageAccessPaths', () => {
       '/foo/bar/*',
       '/foo/baz/*',
       '/other/*',
-      '/something/{id}/*',
-      '/another/{id}/*',
+      '/something/{entity_id}/*',
+      '/another/{entity_id}/*',
     ]);
     // completing successfully indicates success
   });
@@ -54,37 +54,46 @@ void describe('validateStorageAccessPaths', () => {
   });
 
   void it('throws on path that has multiple owner tokens', () => {
-    assert.throws(() => validateStorageAccessPaths(['/foo/{id}/{id}/*']), {
-      message: `The ${idPathToken} token can only appear once in a path. Found [/foo/{id}/{id}/*]`,
-    });
+    assert.throws(
+      () => validateStorageAccessPaths(['/foo/{entity_id}/{entity_id}/*']),
+      {
+        message: `The ${entityIdPathToken} token can only appear once in a path. Found [/foo/{entity_id}/{entity_id}/*]`,
+      }
+    );
   });
 
   void it('throws on path where owner token is not at the end', () => {
-    assert.throws(() => validateStorageAccessPaths(['/foo/{id}/bar/*']), {
-      message: `The ${idPathToken} token must be the path part right before the ending wildcard. Found [/foo/{id}/bar/*].`,
-    });
+    assert.throws(
+      () => validateStorageAccessPaths(['/foo/{entity_id}/bar/*']),
+      {
+        message: `The ${entityIdPathToken} token must be the path part right before the ending wildcard. Found [/foo/{entity_id}/bar/*].`,
+      }
+    );
   });
 
   void it('throws on path that starts with owner token', () => {
-    assert.throws(() => validateStorageAccessPaths(['/{id}/*']), {
-      message: `The ${idPathToken} token must not be the first path part. Found [/{id}/*].`,
+    assert.throws(() => validateStorageAccessPaths(['/{entity_id}/*']), {
+      message: `The ${entityIdPathToken} token must not be the first path part. Found [/{entity_id}/*].`,
     });
   });
 
   void it('throws on path that has owner token and other characters in single path part', () => {
-    assert.throws(() => validateStorageAccessPaths(['/abc{id}/*']), {
-      message: `A path part that includes the ${idPathToken} token cannot include any other characters. Found [/abc{id}/*].`,
+    assert.throws(() => validateStorageAccessPaths(['/abc{entity_id}/*']), {
+      message: `A path part that includes the ${entityIdPathToken} token cannot include any other characters. Found [/abc{entity_id}/*].`,
     });
   });
 
   void it('throws on path that is a prefix of a path with an owner token', () => {
-    assert.throws(() => validateStorageAccessPaths(['/foo/{id}/*', '/foo/*']), {
-      message: `A path cannot be a prefix of another path that contains the ${idPathToken} token.`,
-    });
     assert.throws(
-      () => validateStorageAccessPaths(['/foo/bar/{id}/*', '/foo/*']),
+      () => validateStorageAccessPaths(['/foo/{entity_id}/*', '/foo/*']),
       {
-        message: `A path cannot be a prefix of another path that contains the ${idPathToken} token.`,
+        message: `A path cannot be a prefix of another path that contains the ${entityIdPathToken} token.`,
+      }
+    );
+    assert.throws(
+      () => validateStorageAccessPaths(['/foo/bar/{entity_id}/*', '/foo/*']),
+      {
+        message: `A path cannot be a prefix of another path that contains the ${entityIdPathToken} token.`,
       }
     );
   });

--- a/packages/backend-storage/src/validate_storage_access_paths.ts
+++ b/packages/backend-storage/src/validate_storage_access_paths.ts
@@ -1,5 +1,5 @@
 import { AmplifyUserError } from '@aws-amplify/platform-core';
-import { idPathToken } from './constants.js';
+import { entityIdPathToken } from './constants.js';
 import { StorageError } from './private_types.js';
 
 /**
@@ -65,13 +65,13 @@ const validateStoragePath = (
  */
 const validateOwnerTokenRules = (path: string, otherPrefixes: string[]) => {
   // if there's no owner token in the path, this validation is a noop
-  if (!path.includes(idPathToken)) {
+  if (!path.includes(entityIdPathToken)) {
     return;
   }
 
   if (otherPrefixes.length > 0) {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `A path cannot be a prefix of another path that contains the ${idPathToken} token.`,
+      message: `A path cannot be a prefix of another path that contains the ${entityIdPathToken} token.`,
       details: `Found [${path}] which has prefixes [${otherPrefixes.join(
         ', '
       )}].`,
@@ -79,12 +79,12 @@ const validateOwnerTokenRules = (path: string, otherPrefixes: string[]) => {
     });
   }
 
-  const ownerSplit = path.split(idPathToken);
+  const ownerSplit = path.split(entityIdPathToken);
 
   if (ownerSplit.length > 2) {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `The ${idPathToken} token can only appear once in a path. Found [${path}]`,
-      resolution: `Remove all but one occurrence of the ${idPathToken} token`,
+      message: `The ${entityIdPathToken} token can only appear once in a path. Found [${path}]`,
+      resolution: `Remove all but one occurrence of the ${entityIdPathToken} token`,
     });
   }
 
@@ -92,22 +92,22 @@ const validateOwnerTokenRules = (path: string, otherPrefixes: string[]) => {
 
   if (substringAfterOwnerToken !== '/*') {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `The ${idPathToken} token must be the path part right before the ending wildcard. Found [${path}].`,
-      resolution: `Update the path such that the owner token is the last path part before the ending wildcard. For example: "/foo/bar/${idPathToken}/*.`,
+      message: `The ${entityIdPathToken} token must be the path part right before the ending wildcard. Found [${path}].`,
+      resolution: `Update the path such that the owner token is the last path part before the ending wildcard. For example: "/foo/bar/${entityIdPathToken}/*.`,
     });
   }
 
   if (substringBeforeOwnerToken === '/') {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `The ${idPathToken} token must not be the first path part. Found [${path}].`,
-      resolution: `Add an additional prefix to the path. For example: "/foo/${idPathToken}/*.`,
+      message: `The ${entityIdPathToken} token must not be the first path part. Found [${path}].`,
+      resolution: `Add an additional prefix to the path. For example: "/foo/${entityIdPathToken}/*.`,
     });
   }
 
   if (!substringBeforeOwnerToken.endsWith('/')) {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `A path part that includes the ${idPathToken} token cannot include any other characters. Found [${path}].`,
-      resolution: `Remove all other characters from the path part with the ${idPathToken} token. For example: "/foo/${idPathToken}/*"`,
+      message: `A path part that includes the ${entityIdPathToken} token cannot include any other characters. Found [${path}].`,
+      resolution: `Remove all other characters from the path part with the ${entityIdPathToken} token. For example: "/foo/${entityIdPathToken}/*"`,
     });
   }
 };

--- a/packages/backend-storage/src/validate_storage_access_paths.ts
+++ b/packages/backend-storage/src/validate_storage_access_paths.ts
@@ -1,5 +1,5 @@
 import { AmplifyUserError } from '@aws-amplify/platform-core';
-import { ownerPathPartToken } from './constants.js';
+import { idPathToken } from './constants.js';
 import { StorageError } from './private_types.js';
 
 /**
@@ -65,13 +65,13 @@ const validateStoragePath = (
  */
 const validateOwnerTokenRules = (path: string, otherPrefixes: string[]) => {
   // if there's no owner token in the path, this validation is a noop
-  if (!path.includes(ownerPathPartToken)) {
+  if (!path.includes(idPathToken)) {
     return;
   }
 
   if (otherPrefixes.length > 0) {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `A path cannot be a prefix of another path that contains the ${ownerPathPartToken} token.`,
+      message: `A path cannot be a prefix of another path that contains the ${idPathToken} token.`,
       details: `Found [${path}] which has prefixes [${otherPrefixes.join(
         ', '
       )}].`,
@@ -79,12 +79,12 @@ const validateOwnerTokenRules = (path: string, otherPrefixes: string[]) => {
     });
   }
 
-  const ownerSplit = path.split(ownerPathPartToken);
+  const ownerSplit = path.split(idPathToken);
 
   if (ownerSplit.length > 2) {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `The ${ownerPathPartToken} token can only appear once in a path. Found [${path}]`,
-      resolution: `Remove all but one occurrence of the ${ownerPathPartToken} token`,
+      message: `The ${idPathToken} token can only appear once in a path. Found [${path}]`,
+      resolution: `Remove all but one occurrence of the ${idPathToken} token`,
     });
   }
 
@@ -92,22 +92,22 @@ const validateOwnerTokenRules = (path: string, otherPrefixes: string[]) => {
 
   if (substringAfterOwnerToken !== '/*') {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `The ${ownerPathPartToken} token must be the path part right before the ending wildcard. Found [${path}].`,
-      resolution: `Update the path such that the owner token is the last path part before the ending wildcard. For example: "/foo/bar/${ownerPathPartToken}/*.`,
+      message: `The ${idPathToken} token must be the path part right before the ending wildcard. Found [${path}].`,
+      resolution: `Update the path such that the owner token is the last path part before the ending wildcard. For example: "/foo/bar/${idPathToken}/*.`,
     });
   }
 
   if (substringBeforeOwnerToken === '/') {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `The ${ownerPathPartToken} token must not be the first path part. Found [${path}].`,
-      resolution: `Add an additional prefix to the path. For example: "/foo/${ownerPathPartToken}/*.`,
+      message: `The ${idPathToken} token must not be the first path part. Found [${path}].`,
+      resolution: `Add an additional prefix to the path. For example: "/foo/${idPathToken}/*.`,
     });
   }
 
   if (!substringBeforeOwnerToken.endsWith('/')) {
     throw new AmplifyUserError<StorageError>('InvalidStorageAccessPathError', {
-      message: `A path part that includes the ${ownerPathPartToken} token cannot include any other characters. Found [${path}].`,
-      resolution: `Remove all other characters from the path part with the ${ownerPathPartToken} token. For example: "/foo/${ownerPathPartToken}/*"`,
+      message: `A path part that includes the ${idPathToken} token cannot include any other characters. Found [${path}].`,
+      resolution: `Remove all other characters from the path part with the ${idPathToken} token. For example: "/foo/${idPathToken}/*"`,
     });
   }
 };

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -182,8 +182,8 @@ export type ResourceAccessAcceptor = {
 };
 
 // @public (undocumented)
-export type ResourceAccessAcceptorFactory<RoleName extends string | undefined = undefined> = {
-    getResourceAccessAcceptor: (...roleName: RoleName extends string ? [RoleName] : []) => ResourceAccessAcceptor;
+export type ResourceAccessAcceptorFactory<RoleIdentifier extends string | undefined = undefined> = {
+    getResourceAccessAcceptor: (...roleIdentifier: RoleIdentifier extends string ? [RoleIdentifier] : []) => ResourceAccessAcceptor;
 };
 
 // @public

--- a/packages/plugin-types/src/resource_access_acceptor.ts
+++ b/packages/plugin-types/src/resource_access_acceptor.ts
@@ -23,14 +23,14 @@ export type ResourceAccessAcceptor = {
 };
 
 export type ResourceAccessAcceptorFactory<
-  RoleName extends string | undefined = undefined
+  RoleIdentifier extends string | undefined = undefined
 > = {
   /**
-   * This type is a little wonky but basically it's saying that if RoleName is undefined, then this is a function with no props
-   * And if RoleName is a string then this is a function with a single roleName prop
+   * This type is a little wonky but basically it's saying that if RoleIdentifier is undefined, then this is a function with no props
+   * And if RoleIdentifier is a string then this is a function with a single roleIdentifier prop
    * See https://github.com/Microsoft/TypeScript/pull/24897
    */
   getResourceAccessAcceptor: (
-    ...roleName: RoleName extends string ? [RoleName] : []
+    ...roleIdentifier: RoleIdentifier extends string ? [RoleIdentifier] : []
   ) => ResourceAccessAcceptor;
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
1. Currently there is no way to define user pool group access to storage (without using overrides).
2. Also, the current syntax for specifying owner-based auth rules is not extensible to additional identification mechanisms we want to support in the future.
**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
1. Add a new `allow.group('groupName')` syntax to the existing storage access builder for specifying group access
2. Change `allow.owner.to(['action'])` to `allow.id('identity').to(['action'])`. This allows us to support different "id types" in the future. Currently "identity" is the only option which maps to the Cognito IdP IdentityId. This name was chosen instead of "owner" because it is not actually the user sub from the Cognito UserPool which is the actual "owner" in the system.
**Corresponding docs PR, if applicable:**
https://github.com/aws-amplify/docs/pull/7009
## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Manually verified and added / updated unit tests
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
