### PR TITLE
set default function memory to 512

### DIFF
--- a/.changeset/brave-shirts-push.md
+++ b/.changeset/brave-shirts-push.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+Set default function memory to 512

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -182,6 +182,17 @@ void describe('AmplifyFunctionFactory', () => {
       });
     });
 
+    void it('sets default memory', () => {
+      const lambda = defineFunction({
+        entry: './test-assets/default-lambda/handler.ts',
+      }).getInstance(getInstanceProps);
+      const template = Template.fromStack(Stack.of(lambda.resources.lambda));
+
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        MemorySize: 512,
+      });
+    });
+
     void it('throws on memory below 128 MB', () => {
       assert.throws(
         () =>

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -176,7 +176,7 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
   private resolveMemory = () => {
     const memoryMin = 128;
     const memoryMax = 10240;
-    const memoryDefault = memoryMin;
+    const memoryDefault = 512;
     if (this.props.memoryMB === undefined) {
       return memoryDefault;
     }


### PR DESCRIPTION
## Problem

It is very easy to hit memory limits and have a heavy performance hit as memory is swapped in and out of the disk.

For example, a lambda in my test project with the following handler code uses around 89MB:
```ts
export const handler = async () => {
    return 'it works!'
}
```
Function log:
```
START RequestId: 6045161b-ea8f-43d1-947b-e3d9afd962f9 Version: $LATEST
END RequestId: 6045161b-ea8f-43d1-947b-e3d9afd962f9
REPORT RequestId: 6045161b-ea8f-43d1-947b-e3d9afd962f9	Duration: 24.52 ms	Billed Duration: 25 ms	Memory Size: 128 MB	Max Memory Used: 89 MB
```

**Issue number, if available:**

## Changes

Set default function memory to 512MB from 128MB. Function memory can still be set between 128MB - 10240MB, no change there.

**Corresponding docs PR, if applicable:**
https://github.com/aws-amplify/docs/pull/7009

## Validation

Unit test for checking if default memory is what we expect.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
