### PR TITLE
remove allowListedRoleNames from defineData

### DIFF
--- a/.changeset/famous-glasses-know.md
+++ b/.changeset/famous-glasses-know.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': minor
+---
+
+remove allowListedRoleNames from defineData

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -21,7 +21,6 @@ export type AuthorizationModes = {
     apiKeyAuthorizationMode?: ApiKeyAuthorizationModeProps;
     lambdaAuthorizationMode?: LambdaAuthorizationModeProps;
     oidcAuthorizationMode?: OIDCAuthorizationModeProps;
-    allowListedRoleNames?: string[];
 };
 
 // @public

--- a/packages/backend-data/src/convert_authorization_modes.test.ts
+++ b/packages/backend-data/src/convert_authorization_modes.test.ts
@@ -216,50 +216,6 @@ void describe('convertAuthorizationModesToCDK', () => {
       expectedOutput
     );
   });
-
-  void it('allows for specifying allow listed roles with an empty list', () => {
-    const authModes: AuthorizationModes = {
-      allowListedRoleNames: [],
-    };
-
-    const expectedOutput: CDKAuthorizationModes = {
-      userPoolConfig: { userPool },
-      iamConfig: {
-        identityPoolId,
-        authenticatedUserRole,
-        unauthenticatedUserRole,
-        allowListedRoles: [],
-      },
-    };
-
-    assert.deepStrictEqual(
-      convertAuthorizationModesToCDK(
-        getInstancePropsStub,
-        providedAuthConfig,
-        authModes
-      ),
-      expectedOutput
-    );
-  });
-
-  void it('allows for specifying allow listed roles roles with values specified', () => {
-    const authModes: AuthorizationModes = {
-      allowListedRoleNames: ['MyAdminRole', 'MyQARole'],
-    };
-
-    const convertedOutput = convertAuthorizationModesToCDK(
-      getInstancePropsStub,
-      providedAuthConfig,
-      authModes
-    );
-
-    assert.equal(convertedOutput.iamConfig?.allowListedRoles?.length, 2);
-    assert.equal(
-      convertedOutput.iamConfig?.allowListedRoles?.[0],
-      'MyAdminRole'
-    );
-    assert.equal(convertedOutput.iamConfig?.allowListedRoles?.[1], 'MyQARole');
-  });
 });
 
 void describe('isUsingDefaultApiKeyAuth', () => {

--- a/packages/backend-data/src/convert_authorization_modes.ts
+++ b/packages/backend-data/src/convert_authorization_modes.ts
@@ -128,15 +128,11 @@ const computeIAMAuthFromResource = (
   additionalRoles: IRole[] = []
 ): CDKIAMAuthorizationConfig | undefined => {
   if (providedAuthConfig) {
-    const allowListedRoles = [
-      ...(authModes?.allowListedRoleNames || []),
-      ...additionalRoles,
-    ];
     return {
       authenticatedUserRole: providedAuthConfig.authenticatedUserRole,
       unauthenticatedUserRole: providedAuthConfig.unauthenticatedUserRole,
       identityPoolId: providedAuthConfig.identityPoolId,
-      allowListedRoles,
+      allowListedRoles: additionalRoles,
     };
   }
   return;

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -97,11 +97,6 @@ export type AuthorizationModes = {
    * OIDC authorization config if oidc provider is specified in the api definition.
    */
   oidcAuthorizationMode?: OIDCAuthorizationModeProps;
-
-  /**
-   * IAM Role names which are provided full r/w access to the API for models with IAM authorization.
-   */
-  allowListedRoleNames?: string[];
 };
 
 /**

--- a/packages/backend-data/src/validate_authorization_modes.test.ts
+++ b/packages/backend-data/src/validate_authorization_modes.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
-import { Duration, Stack } from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
 import { Role } from 'aws-cdk-lib/aws-iam';
 import { validateAuthorizationModes } from './validate_authorization_modes.js';
 
@@ -13,44 +13,22 @@ void describe('validateAuthorizationModes', () => {
 
   void it('does not throw on well-formed input', () => {
     assert.doesNotThrow(() =>
-      validateAuthorizationModes(
-        {
-          allowListedRoleNames: ['MyAdminRole'],
+      validateAuthorizationModes(undefined, {
+        iamConfig: {
+          identityPoolId: 'testIdentityPool',
+          authenticatedUserRole: Role.fromRoleName(
+            stack,
+            'AuthUserRole',
+            'MyAuthUserRole'
+          ),
+          unauthenticatedUserRole: Role.fromRoleName(
+            stack,
+            'UnauthUserRole',
+            'MyUnauthUserRole'
+          ),
+          allowListedRoles: ['MyAdminRole'],
         },
-        {
-          iamConfig: {
-            identityPoolId: 'testIdentityPool',
-            authenticatedUserRole: Role.fromRoleName(
-              stack,
-              'AuthUserRole',
-              'MyAuthUserRole'
-            ),
-            unauthenticatedUserRole: Role.fromRoleName(
-              stack,
-              'UnauthUserRole',
-              'MyUnauthUserRole'
-            ),
-            allowListedRoles: ['MyAdminRole'],
-          },
-        }
-      )
-    );
-  });
-
-  void it('throws if admin roles are specified and there is no iam auth configured', () => {
-    assert.throws(
-      () =>
-        validateAuthorizationModes(
-          {
-            allowListedRoleNames: ['MyAdminRole'],
-          },
-          {
-            apiKeyConfig: {
-              expires: Duration.days(7),
-            },
-          }
-        ),
-      /Specifying allowListedRoleNames requires presence of IAM Authorization config. Auth must be added to the backend./
+      })
     );
   });
 

--- a/packages/backend-data/src/validate_authorization_modes.ts
+++ b/packages/backend-data/src/validate_authorization_modes.ts
@@ -7,25 +7,6 @@ type AuthorizationModeValidator = (
 ) => void;
 
 /**
- * Admin roles require iam config be specified.
- */
-const validateAdminRolesHaveIAMAuthorizationConfig: AuthorizationModeValidator =
-  (
-    inputAuthorizationModes: AuthorizationModes | undefined,
-    transformedAuthorizationModes: CDKAuthorizationModes
-  ): void => {
-    if (
-      inputAuthorizationModes?.allowListedRoleNames &&
-      inputAuthorizationModes?.allowListedRoleNames.length > 0 &&
-      !transformedAuthorizationModes.iamConfig
-    ) {
-      throw new Error(
-        'Specifying allowListedRoleNames requires presence of IAM Authorization config. Auth must be added to the backend.'
-      );
-    }
-  };
-
-/**
  * At least one auth mode is required on the API, otherwise an exception will be thrown.
  */
 const validateAtLeastOneAuthModeIsConfigured: AuthorizationModeValidator = (
@@ -60,9 +41,6 @@ export const validateAuthorizationModes = (
   inputAuthorizationModes: AuthorizationModes | undefined,
   transformedAuthorizationModes: CDKAuthorizationModes
 ): void =>
-  [
-    validateAdminRolesHaveIAMAuthorizationConfig,
-    validateAtLeastOneAuthModeIsConfigured,
-  ].forEach((validate) =>
+  [validateAtLeastOneAuthModeIsConfigured].forEach((validate) =>
     validate(inputAuthorizationModes, transformedAuthorizationModes)
   );


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

This change removes `allowListedRoleNames` from `defineData`.
This field is getting deprecated at data construct and will be replaced with alternative IAM access mechanism.


<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

1. Remove `allowListedRoleNames`
2. Amend rest of the codebase.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

Tests

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
