### PR TITLE
Update text to match sandbox default behavior

### DIFF
--- a/.changeset/modern-moons-fail.md
+++ b/.changeset/modern-moons-fail.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Update text to match sandbox default behavior

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -120,7 +120,7 @@ export class SandboxCommand
         .version(false)
         .option('dir-to-watch', {
           describe:
-            'Directory to watch for file changes. All subdirectories and files will be included. defaults to the current directory.',
+            'Directory to watch for file changes. All subdirectories and files will be included. Defaults to the amplify directory.',
           type: 'string',
           array: false,
           global: false,


### PR DESCRIPTION
## Problem

The description for `amplify sandbox --dir-to-watch` was not updated to match the new behavior of watching the amplify directory.

**Issue number, if available:**

## Changes

Change description from
`Directory to watch for file changes. All subdirectories and files will be included. defaults to the current directory.`
to
`Directory to watch for file changes. All subdirectories and files will be included. Defaults to the amplify directory.`

**Corresponding docs PR, if applicable:**
https://github.com/aws-amplify/docs/pull/7031

## Validation

![Screenshot 2024-03-08 at 3 48 27 PM](https://github.com/aws-amplify/amplify-backend/assets/23459628/c0c198fa-2f48-424a-8d87-f421bf351f4f)

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
