### PR TITLE
expose subset of plugin-types from backend submodule export

### DIFF
--- a/.changeset/afraid-flies-repair.md
+++ b/.changeset/afraid-flies-repair.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': minor
+---
+
+Re-export plugin-types from submodule export @aws-amplify/backend/types/platform

--- a/.changeset/afraid-flies-repair.md
+++ b/.changeset/afraid-flies-repair.md
@@ -2,4 +2,4 @@
 '@aws-amplify/backend': minor
 ---
 
-Re-export plugin-types from submodule export @aws-amplify/backend/types/platform
+Re-export some plugin-types from submodule export @aws-amplify/backend/types/platform

--- a/packages/backend/API.md
+++ b/packages/backend/API.md
@@ -5,18 +5,38 @@
 ```ts
 
 import { a } from '@aws-amplify/data-schema';
+import { AuthCfnResources } from '@aws-amplify/plugin-types';
+import { AuthResources } from '@aws-amplify/plugin-types';
+import { AuthRoleName } from '@aws-amplify/plugin-types';
+import { BackendOutputEntry } from '@aws-amplify/plugin-types';
+import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { BackendSecret } from '@aws-amplify/plugin-types';
+import { BackendSecretResolver } from '@aws-amplify/plugin-types';
 import { ClientConfig } from '@aws-amplify/client-config';
 import { ClientSchema } from '@aws-amplify/data-schema';
+import { ConstructContainer } from '@aws-amplify/plugin-types';
+import { ConstructContainerEntryGenerator } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
+import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
 import { defineAuth } from '@aws-amplify/backend-auth';
 import { defineData } from '@aws-amplify/backend-data';
 import { defineFunction } from '@aws-amplify/backend-function';
 import { defineStorage } from '@aws-amplify/backend-storage';
+import { FunctionResources } from '@aws-amplify/plugin-types';
+import { GenerateContainerEntryProps } from '@aws-amplify/plugin-types';
+import { ImportPathVerifier } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
+import { SsmEnvironmentEntriesGenerator } from '@aws-amplify/plugin-types';
+import { SsmEnvironmentEntry } from '@aws-amplify/plugin-types';
 import { Stack } from 'aws-cdk-lib';
 
 export { a }
+
+export { AuthCfnResources }
+
+export { AuthResources }
+
+export { AuthRoleName }
 
 // @public
 export type Backend<T extends DefineBackendProps> = BackendBase & {
@@ -29,7 +49,21 @@ export type BackendBase = {
     addOutput: (clientConfigPart: Partial<ClientConfig>) => void;
 };
 
+export { BackendOutputEntry }
+
+export { BackendOutputStorageStrategy }
+
+export { BackendSecretResolver }
+
 export { ClientSchema }
+
+export { ConstructContainer }
+
+export { ConstructContainerEntryGenerator }
+
+export { ConstructFactory }
+
+export { ConstructFactoryGetInstanceProps }
 
 export { defineAuth }
 
@@ -47,8 +81,20 @@ export { defineFunction }
 
 export { defineStorage }
 
+export { FunctionResources }
+
+export { GenerateContainerEntryProps }
+
+export { ImportPathVerifier }
+
+export { ResourceProvider }
+
 // @public
 export const secret: (name: string) => BackendSecret;
+
+export { SsmEnvironmentEntriesGenerator }
+
+export { SsmEnvironmentEntry }
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/backend/api-extractor.json
+++ b/packages/backend/api-extractor.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../api-extractor.base.json"
+  "extends": "../../api-extractor.base.json",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.internal.d.ts"
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,6 +10,9 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "require": "./lib/index.js"
+    },
+    "./types/platform": {
+      "types": "./lib/types/platform.d.ts"
     }
   },
   "imports": {

--- a/packages/backend/src/index.internal.ts
+++ b/packages/backend/src/index.internal.ts
@@ -1,0 +1,9 @@
+export * from './index.js';
+
+/*
+ Api-extractor does not ([yet](https://github.com/microsoft/rushstack/issues/1596)) support multiple package entry points
+ Because this package has a submodule export, we are working around this issue by including that export here and directing api-extract to this entry point instead
+ This allows api-extractor to pick up the submodule exports in its analysis
+ */
+
+export * from './types/platform.js';

--- a/packages/backend/src/types/platform.ts
+++ b/packages/backend/src/types/platform.ts
@@ -1,0 +1,1 @@
+export * from '@aws-amplify/plugin-types';

--- a/packages/backend/src/types/platform.ts
+++ b/packages/backend/src/types/platform.ts
@@ -1,1 +1,21 @@
-export * from '@aws-amplify/plugin-types';
+/**
+ * Subset of types exported from @aws-amplify/plugin-types that are useful when building additional abstractions around the `define*` functions.
+ */
+export {
+  AuthCfnResources,
+  AuthResources,
+  FunctionResources,
+  AuthRoleName,
+  ConstructFactory,
+  ResourceProvider,
+  ConstructFactoryGetInstanceProps,
+  ConstructContainer,
+  ConstructContainerEntryGenerator,
+  GenerateContainerEntryProps,
+  BackendSecretResolver,
+  SsmEnvironmentEntriesGenerator,
+  BackendOutputStorageStrategy,
+  BackendOutputEntry,
+  ImportPathVerifier,
+  SsmEnvironmentEntry,
+} from '@aws-amplify/plugin-types';

--- a/packages/integration-tests/src/test-in-memory/backend_submodule_type_exports.test.ts
+++ b/packages/integration-tests/src/test-in-memory/backend_submodule_type_exports.test.ts
@@ -1,0 +1,23 @@
+/**
+ * If this "test" builds, then it means that these types are available in the types/platform submodule export from @aws-amplify/backend
+ */
+// prettier-ignore-start
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+  AuthCfnResources,
+  AuthResources,
+  AuthRoleName,
+  BackendOutputEntry,
+  BackendOutputStorageStrategy,
+  BackendSecretResolver,
+  ConstructContainer,
+  ConstructContainerEntryGenerator,
+  ConstructFactory,
+  ConstructFactoryGetInstanceProps,
+  FunctionResources,
+  GenerateContainerEntryProps,
+  ImportPathVerifier,
+  ResourceProvider,
+  SsmEnvironmentEntriesGenerator,
+  SsmEnvironmentEntry,
+} from '@aws-amplify/backend/types/platform';

--- a/packages/integration-tests/src/test-in-memory/backend_submodule_type_exports.test.ts
+++ b/packages/integration-tests/src/test-in-memory/backend_submodule_type_exports.test.ts
@@ -1,8 +1,6 @@
 /**
  * If this "test" builds, then it means that these types are available in the types/platform submodule export from @aws-amplify/backend
  */
-// prettier-ignore-start
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   AuthCfnResources,
   AuthResources,
@@ -21,3 +19,23 @@ import {
   SsmEnvironmentEntriesGenerator,
   SsmEnvironmentEntry,
 } from '@aws-amplify/backend/types/platform';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type UseAllTheThings = {
+  thing1?: AuthCfnResources;
+  thing2?: AuthResources;
+  thing3?: AuthRoleName;
+  thing4?: BackendOutputEntry;
+  thing5?: BackendOutputStorageStrategy<BackendOutputEntry>;
+  thing6?: BackendSecretResolver;
+  thing7?: ConstructContainer;
+  thing8?: ConstructContainerEntryGenerator;
+  thing9?: ConstructFactory;
+  thing10?: ConstructFactoryGetInstanceProps;
+  thing11?: FunctionResources;
+  thing12?: GenerateContainerEntryProps;
+  thing13?: ImportPathVerifier;
+  thing14?: ResourceProvider;
+  thing15?: SsmEnvironmentEntriesGenerator;
+  thing16?: SsmEnvironmentEntry;
+};


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
When building additional abstractions around `defineBackend` or other `define*` functions, you often need access to the input our output types from these functions and the objects they return. These types come from `@aws-amplify/plugin-types`, but declaring a direct dependency on that package can lead to version conflicts and incompatible types.

**Issue number, if available:**
fixes https://github.com/aws-amplify/amplify-backend/issues/340
## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Re-export a subset of the types in `@aws-amplify/plugin-types` from `@aws-amplify/backend`. The submodule import is `@aws-amplify/backend/types/platform`

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Added a build-time check in the integration-tests package to make sure that the expected submodule exports are available from the backend package

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
