### PR TITLE
store attribution string in function stack

### DIFF
--- a/.changeset/little-baboons-tan.md
+++ b/.changeset/little-baboons-tan.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+store attribution string in funciton stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -23587,7 +23587,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.6.0-beta.3",
+      "version": "0.6.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23602,16 +23602,16 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.4",
+      "version": "0.13.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.5.0-beta.3",
-        "@aws-amplify/backend-data": "^0.10.0-beta.3",
-        "@aws-amplify/backend-function": "^0.8.0-beta.2",
+        "@aws-amplify/backend-auth": "^0.5.0-beta.4",
+        "@aws-amplify/backend-data": "^0.10.0-beta.4",
+        "@aws-amplify/backend-function": "^0.8.0-beta.3",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
-        "@aws-amplify/backend-storage": "^0.6.0-beta.2",
+        "@aws-amplify/backend-storage": "^0.6.0-beta.3",
         "@aws-amplify/client-config": "^0.9.0-beta.3",
         "@aws-amplify/data-schema": "^0.13.11",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
@@ -23629,10 +23629,10 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.5.0-beta.3",
+      "version": "0.5.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.3",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.4",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
         "@aws-amplify/plugin-types": "^0.9.0-beta.0"
       },
@@ -23647,7 +23647,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.10.0-beta.3",
+      "version": "0.10.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23683,7 +23683,7 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.8.0-beta.2",
+      "version": "0.8.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23750,7 +23750,7 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.6.0-beta.2",
+      "version": "0.6.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -23768,7 +23768,7 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.0-beta.4",
+      "version": "0.12.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.1",
@@ -23780,7 +23780,7 @@
         "@aws-amplify/form-generator": "^0.8.0-beta.1",
         "@aws-amplify/model-generator": "^0.4.1-beta.2",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
-        "@aws-amplify/sandbox": "^0.5.2-beta.3",
+        "@aws-amplify/sandbox": "^0.5.2-beta.4",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -24121,11 +24121,11 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.5.0-beta.1",
+      "version": "0.5.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.3",
-        "@aws-amplify/backend": "^0.13.0-beta.4",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.4",
+        "@aws-amplify/backend": "^0.13.0-beta.5",
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
         "@aws-amplify/client-config": "^0.9.0-beta.3",
         "@aws-amplify/data-schema": "^0.13.11",
@@ -24709,7 +24709,7 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.3",
+      "version": "0.5.2-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.1",

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -347,4 +347,24 @@ void describe('AmplifyFunctionFactory', () => {
       });
     });
   });
+
+  void it('stores single attribution data value in stack with multiple functions', () => {
+    const functionFactory = defineFunction({
+      entry: './test-assets/default-lambda/handler.ts',
+      name: 'testLambdaName',
+    });
+    const anotherFunction = defineFunction({
+      entry: './test-assets/default-lambda/handler.ts',
+      name: 'anotherName',
+    });
+    const functionStack = Stack.of(
+      functionFactory.getInstance(getInstanceProps).resources.lambda
+    );
+    anotherFunction.getInstance(getInstanceProps);
+    const template = Template.fromStack(functionStack);
+    assert.equal(
+      JSON.parse(template.toJSON().Description).stackType,
+      'function-Lambda'
+    );
+  });
 });

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -15,7 +15,7 @@ import { Construct } from 'constructs';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as path from 'path';
 import { getCallerDirectory } from './get_caller_directory.js';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, Stack } from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { createRequire } from 'module';
 import { FunctionEnvironmentTranslator } from './function_env_translator.js';
@@ -27,6 +27,10 @@ import {
   functionOutputKey,
 } from '@aws-amplify/backend-output-schemas';
 import { FunctionEnvironmentTypeGenerator } from './function_env_type_generator.js';
+import { AttributionMetadataStorage } from '@aws-amplify/backend-output-storage';
+import { fileURLToPath } from 'url';
+
+const functionStackType = 'function-Lambda';
 
 /**
  * Entry point for defining a function in the Amplify ecosystem
@@ -302,6 +306,12 @@ class AmplifyFunction
     };
 
     this.storeOutput(outputStorageStrategy);
+
+    new AttributionMetadataStorage().storeAttributionMetadata(
+      Stack.of(this),
+      functionStackType,
+      fileURLToPath(new URL('../package.json', import.meta.url))
+    );
   }
 
   getResourceAccessAcceptor = () => ({


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
We need to be able to associate CFN stacks with functions created using Amplify
**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Use the existing `AttributionMetadataStorage` abstraction to store a function attribution string in the stack

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Unit test

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
