### PR TITLE
enforce "resolution" in `AmplifyUserError` ctor

### DIFF
--- a/.changeset/serious-maps-wait.md
+++ b/.changeset/serious-maps-wait.md
@@ -1,6 +1,6 @@
 ---
 '@aws-amplify/backend-deployer': patch
-'@aws-amplify/platform-core': patch
+'@aws-amplify/platform-core': minor
 '@aws-amplify/backend-auth': patch
 '@aws-amplify/backend-data': patch
 '@aws-amplify/cli-core': patch

--- a/.changeset/serious-maps-wait.md
+++ b/.changeset/serious-maps-wait.md
@@ -1,0 +1,11 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/platform-core': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/cli-core': patch
+'@aws-amplify/sandbox': patch
+'@aws-amplify/backend-cli': patch
+---
+
+require "resolution" in AmplifyUserError options

--- a/packages/backend-auth/src/userpool_access_policy_factory.ts
+++ b/packages/backend-auth/src/userpool_access_policy_factory.ts
@@ -23,7 +23,9 @@ export class UserPoolAccessPolicyFactory {
   createPolicy = (actions: AuthAction[]) => {
     if (actions.length === 0) {
       throw new AmplifyUserError('EmptyPolicyError', {
-        message: 'At least one action must be specified',
+        message: 'At least one action must be specified.',
+        resolution:
+          'Ensure all resource access rules specify at least one action.',
       });
     }
 

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -121,7 +121,9 @@ class DataGenerator implements ConstructContainerEntryGenerator {
           message:
             error instanceof Error
               ? error.message
-              : 'Cannot covert user schema',
+              : 'Failed to parse schema definition.',
+          resolution:
+            'Check your data schema definition for syntax and type errors.',
         },
         error instanceof Error ? error : undefined
       );
@@ -152,7 +154,8 @@ class DataGenerator implements ConstructContainerEntryGenerator {
           message:
             error instanceof Error
               ? error.message
-              : 'Cannot covert authorization modes',
+              : 'Failed to parse authorization modes.',
+          resolution: 'Ensure the auth rules on your schema are valid.',
         },
         error instanceof Error ? error : undefined
       );
@@ -171,6 +174,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
             error instanceof Error
               ? error.message
               : 'Failed to validate authorization modes',
+          resolution: 'Ensure the auth rules on your schema are valid.',
         },
         error instanceof Error ? error : undefined
       );

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -156,8 +156,9 @@ export class CDKDeployer implements BackendDeployer {
       throw new AmplifyUserError<CDKDeploymentError>(
         'SyntaxError',
         {
-          message:
-            'TypeScript validation check failed, check your backend definition',
+          message: 'TypeScript validation check failed.',
+          resolution:
+            'Fix the syntax and type errors in your backend definition.',
         },
         err instanceof Error ? err : undefined
       );

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -26,21 +26,21 @@ const testErrorMappings = [
   {
     errorMessage: 'ReferenceError: var is not defined\n',
     expectedTopLevelErrorMessage:
-      'Unable to build Amplify backend. Check your backend definition in the `amplify` folder.',
+      'Unable to build the Amplify backend definition.',
     errorName: 'SyntaxError',
     expectedDownstreamErrorMessage: 'ReferenceError: var is not defined\n',
   },
   {
     errorMessage: 'Has the environment been bootstrapped',
     expectedTopLevelErrorMessage:
-      'This AWS account and region has not been bootstrapped. Run `cdk bootstrap aws://{YOUR_ACCOUNT_ID}/{YOUR_REGION}` locally to resolve this.',
+      'This AWS account and region has not been bootstrapped.',
     errorName: 'BootstrapNotDetectedError',
     expectedDownstreamErrorMessage: 'Has the environment been bootstrapped',
   },
   {
     errorMessage: 'Amplify Backend not found in amplify/backend.ts',
     expectedTopLevelErrorMessage:
-      'Backend definition could not be found in amplify directory',
+      'Backend definition could not be found in amplify directory.',
     errorName: 'FileConventionError',
     expectedDownstreamErrorMessage:
       'Amplify Backend not found in amplify/backend.ts',
@@ -48,23 +48,21 @@ const testErrorMappings = [
   {
     errorMessage: 'Amplify Auth must be defined in amplify/auth/resource.ts',
     expectedTopLevelErrorMessage:
-      'File name or path for backend definition are incorrect',
+      'File name or path for backend definition are incorrect.',
     errorName: 'FileConventionError',
     expectedDownstreamErrorMessage:
       'Amplify Auth must be defined in amplify/auth/resource.ts',
   },
   {
     errorMessage: 'amplify/backend.ts',
-    expectedTopLevelErrorMessage:
-      'Unable to build Amplify backend. Check your backend definition in the `amplify` folder.',
+    expectedTopLevelErrorMessage: 'Unable to build Amplify backend.',
     errorName: 'BackendBuildError',
     expectedDownstreamErrorMessage: 'amplify/backend.ts',
   },
   {
     errorMessage:
       'Overall error message had other stuff before ❌ Deployment failed: something bad happened\n and after',
-    expectedTopLevelErrorMessage:
-      'The CloudFormation deployment has failed. Find more information in the CloudFormation AWS Console for this stack.',
+    expectedTopLevelErrorMessage: 'The CloudFormation deployment has failed.',
     errorName: 'CloudFormationDeploymentError',
     expectedDownstreamErrorMessage:
       '❌ Deployment failed: something bad happened\n',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -11,6 +11,7 @@ export class CdkErrorMapper {
   private knownErrors: Array<{
     errorRegex: RegExp;
     humanReadableErrorMessage: string;
+    resolutionMessage: string;
     errorName: CDKDeploymentError;
     classification: AmplifyErrorClassification;
   }> = [
@@ -18,6 +19,7 @@ export class CdkErrorMapper {
       errorRegex: /ExpiredToken/,
       humanReadableErrorMessage:
         'The security token included in the request is invalid.',
+      resolutionMessage: 'Ensure your local AWS credentials are valid.',
       errorName: 'ExpiredTokenError',
       classification: 'ERROR',
     },
@@ -25,20 +27,26 @@ export class CdkErrorMapper {
       errorRegex: /Access Denied/,
       humanReadableErrorMessage:
         'The deployment role does not have sufficient permissions to perform this deployment.',
+      resolutionMessage:
+        'Ensure your deployment role has the AmplifyBackendDeployFullAccess role along with any additional permissions required to deploy your backend definition.',
       errorName: 'AccessDeniedError',
       classification: 'ERROR',
     },
     {
       errorRegex: /Has the environment been bootstrapped/,
       humanReadableErrorMessage:
-        'This AWS account and region has not been bootstrapped. Run `cdk bootstrap aws://{YOUR_ACCOUNT_ID}/{YOUR_REGION}` locally to resolve this.',
+        'This AWS account and region has not been bootstrapped',
+      resolutionMessage:
+        'Run `cdk bootstrap aws://{YOUR_ACCOUNT_ID}/{YOUR_REGION}` locally to resolve this.',
       errorName: 'BootstrapNotDetectedError',
       classification: 'ERROR',
     },
     {
       errorRegex: /(SyntaxError|ReferenceError):(.*)\n/,
       humanReadableErrorMessage:
-        'Unable to build Amplify backend. Check your backend definition in the `amplify` folder.',
+        'Unable to build the Amplify backend definition',
+      resolutionMessage:
+        'Check your backend definition in the `amplify` folder for syntax and type errors.',
       errorName: 'SyntaxError',
       classification: 'ERROR',
     },
@@ -46,6 +54,7 @@ export class CdkErrorMapper {
       errorRegex: /Amplify Backend not found in/,
       humanReadableErrorMessage:
         'Backend definition could not be found in amplify directory',
+      resolutionMessage: 'Ensure that the amplify/backend.(ts|js) file exists',
       errorName: 'FileConventionError',
       classification: 'ERROR',
     },
@@ -53,14 +62,16 @@ export class CdkErrorMapper {
       errorRegex: /Amplify (.*) must be defined in (.*)/,
       humanReadableErrorMessage:
         'File name or path for backend definition are incorrect',
+      resolutionMessage: 'Ensure that the amplify/backend.(ts|js) file exists',
       errorName: 'FileConventionError',
       classification: 'ERROR',
     },
     {
       // the backend entry point file is referenced in the stack indicating a problem in customer code
       errorRegex: /amplify\/backend/,
-      humanReadableErrorMessage:
-        'Unable to build Amplify backend. Check your backend definition in the `amplify` folder.',
+      humanReadableErrorMessage: 'Unable to build Amplify backend.',
+      resolutionMessage:
+        'Check your backend definition in the `amplify` folder for syntax and type errors.',
       errorName: 'BackendBuildError',
       classification: 'ERROR',
     },
@@ -68,6 +79,8 @@ export class CdkErrorMapper {
       errorRegex: /Updates are not allowed for property/,
       humanReadableErrorMessage:
         'The changes that you are trying to apply are not supported.',
+      resolutionMessage:
+        'The resources referenced in the error message must be deleted and recreated to apply the changes.',
       errorName: 'CFNUpdateNotSupportedError',
       classification: 'ERROR',
     },
@@ -79,14 +92,17 @@ export class CdkErrorMapper {
         /Invalid AttributeDataType input, consider using the provided AttributeDataType enum/,
       humanReadableErrorMessage:
         'User pool attributes cannot be changed after a user pool has been created.',
+      resolutionMessage:
+        'To change these attributes, remove `defineAuth` from your backend, then add it back.',
       errorName: 'CFNUpdateNotSupportedError',
       classification: 'ERROR',
     },
     {
       // Note that the order matters, this should be the last as it captures generic CFN error
       errorRegex: /❌ Deployment failed: (.*)\n/,
-      humanReadableErrorMessage:
-        'The CloudFormation deployment has failed. Find more information in the CloudFormation AWS Console for this stack.',
+      humanReadableErrorMessage: 'The CloudFormation deployment has failed',
+      resolutionMessage:
+        'Find more information in the CloudFormation AWS Console for this stack.',
       errorName: 'CloudFormationDeploymentError',
       classification: 'ERROR',
     },
@@ -116,12 +132,18 @@ export class CdkErrorMapper {
       return matchingError.classification === 'ERROR'
         ? new AmplifyUserError(
             matchingError.errorName,
-            { message: matchingError.humanReadableErrorMessage },
+            {
+              message: matchingError.humanReadableErrorMessage,
+              resolution: matchingError.resolutionMessage,
+            },
             error
           )
         : new AmplifyFault(
             matchingError.errorName,
-            { message: matchingError.humanReadableErrorMessage },
+            {
+              message: matchingError.humanReadableErrorMessage,
+              resolution: matchingError.resolutionMessage,
+            },
             error
           );
     }

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -35,7 +35,7 @@ export class CdkErrorMapper {
     {
       errorRegex: /Has the environment been bootstrapped/,
       humanReadableErrorMessage:
-        'This AWS account and region has not been bootstrapped',
+        'This AWS account and region has not been bootstrapped.',
       resolutionMessage:
         'Run `cdk bootstrap aws://{YOUR_ACCOUNT_ID}/{YOUR_REGION}` locally to resolve this.',
       errorName: 'BootstrapNotDetectedError',
@@ -44,7 +44,7 @@ export class CdkErrorMapper {
     {
       errorRegex: /(SyntaxError|ReferenceError):(.*)\n/,
       humanReadableErrorMessage:
-        'Unable to build the Amplify backend definition',
+        'Unable to build the Amplify backend definition.',
       resolutionMessage:
         'Check your backend definition in the `amplify` folder for syntax and type errors.',
       errorName: 'SyntaxError',
@@ -53,7 +53,7 @@ export class CdkErrorMapper {
     {
       errorRegex: /Amplify Backend not found in/,
       humanReadableErrorMessage:
-        'Backend definition could not be found in amplify directory',
+        'Backend definition could not be found in amplify directory.',
       resolutionMessage: 'Ensure that the amplify/backend.(ts|js) file exists',
       errorName: 'FileConventionError',
       classification: 'ERROR',
@@ -61,7 +61,7 @@ export class CdkErrorMapper {
     {
       errorRegex: /Amplify (.*) must be defined in (.*)/,
       humanReadableErrorMessage:
-        'File name or path for backend definition are incorrect',
+        'File name or path for backend definition are incorrect.',
       resolutionMessage: 'Ensure that the amplify/backend.(ts|js) file exists',
       errorName: 'FileConventionError',
       classification: 'ERROR',
@@ -100,7 +100,7 @@ export class CdkErrorMapper {
     {
       // Note that the order matters, this should be the last as it captures generic CFN error
       errorRegex: /❌ Deployment failed: (.*)\n/,
-      humanReadableErrorMessage: 'The CloudFormation deployment has failed',
+      humanReadableErrorMessage: 'The CloudFormation deployment has failed.',
       resolutionMessage:
         'Find more information in the CloudFormation AWS Console for this stack.',
       errorName: 'CloudFormationDeploymentError',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -93,7 +93,7 @@ export class CdkErrorMapper {
       humanReadableErrorMessage:
         'User pool attributes cannot be changed after a user pool has been created.',
       resolutionMessage:
-        'To change these attributes, remove `defineAuth` from your backend, then add it back.',
+        'To change these attributes, remove `defineAuth` from your backend, deploy, then add it back. Note that removing `defineAuth` and deploying will delete any users stored in your UserPool.',
       errorName: 'CFNUpdateNotSupportedError',
       classification: 'ERROR',
     },

--- a/packages/cli-core/src/package-manager-controller/package_manager_controller_factory.ts
+++ b/packages/cli-core/src/package-manager-controller/package_manager_controller_factory.ts
@@ -36,6 +36,7 @@ export class PackageManagerControllerFactory {
           throw new AmplifyUserError('UnsupportedPackageManagerError', {
             message,
             details,
+            resolution: 'Use a supported package manager for your OS',
           });
         }
         return new PnpmPackageManagerController(this.cwd);

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
@@ -89,6 +89,7 @@ void describe('sandbox_event_handler_factory', () => {
   void it('calls the usage emitter on the failedDeployment event with AmplifyError', async () => {
     const testError = new AmplifyUserError('BackendBuildError', {
       message: 'test message',
+      resolution: 'test resolution',
     });
     await Promise.all(
       eventFactory

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -42,7 +42,7 @@ export type AmplifyErrorClassification = 'FAULT' | 'ERROR';
 export type AmplifyErrorOptions = {
     message: string;
     details?: string;
-    resolution: string;
+    resolution?: string;
     link?: string;
     code?: string;
 };
@@ -54,8 +54,13 @@ export class AmplifyFault<T extends string = string> extends AmplifyError<T> {
 
 // @public
 export class AmplifyUserError<T extends string = string> extends AmplifyError<T> {
-    constructor(name: T, options: AmplifyErrorOptions, cause?: Error);
+    constructor(name: T, options: AmplifyUserErrorOptions, cause?: Error);
 }
+
+// @public
+export type AmplifyUserErrorOptions = Omit<AmplifyErrorOptions, 'resolution'> & {
+    resolution: string;
+};
 
 // @public
 export class BackendIdentifierConversions {

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -42,7 +42,7 @@ export type AmplifyErrorClassification = 'FAULT' | 'ERROR';
 export type AmplifyErrorOptions = {
     message: string;
     details?: string;
-    resolution?: string;
+    resolution: string;
     link?: string;
     code?: string;
 };

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -7,9 +7,14 @@ void describe('amplify error', () => {
   void it('serialize and deserialize correctly', () => {
     const testError = new AmplifyUserError(
       'SyntaxError',
-      { message: 'test error message', details: 'test error details' },
+      {
+        message: 'test error message',
+        details: 'test error details',
+        resolution: 'test resolution',
+      },
       new AmplifyUserError('AccessDeniedError', {
         message: 'some downstream error message',
+        resolution: 'test resolution',
       })
     );
     const sampleStderr = `some random stderr

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -107,3 +107,11 @@ export type AmplifyErrorOptions = {
   // CloudFormation or NodeJS error codes
   code?: string;
 };
+
+/**
+ * Same as AmplifyErrorOptions except resolution is required
+ */
+export type AmplifyUserErrorOptions = Omit<
+  AmplifyErrorOptions,
+  'resolution'
+> & { resolution: string };

--- a/packages/platform-core/src/errors/amplify_user_error.ts
+++ b/packages/platform-core/src/errors/amplify_user_error.ts
@@ -1,4 +1,4 @@
-import { AmplifyError, AmplifyErrorOptions } from './amplify_error';
+import { AmplifyError, AmplifyUserErrorOptions } from './amplify_error';
 
 /**
  * Base class for all Amplify user errors
@@ -19,7 +19,7 @@ export class AmplifyUserError<
    *    throw new AmplifyError(...,...,error);
    * }
    */
-  constructor(name: T, options: AmplifyErrorOptions, cause?: Error) {
+  constructor(name: T, options: AmplifyUserErrorOptions, cause?: Error) {
     super(name, 'ERROR', options, cause);
   }
 }

--- a/packages/platform-core/src/usage-data/usage_data_emitter.test.ts
+++ b/packages/platform-core/src/usage-data/usage_data_emitter.test.ts
@@ -83,6 +83,7 @@ void describe('UsageDataEmitter', () => {
       'BackendBuildError',
       {
         message: 'some error message',
+        resolution: 'test resolution',
       },
       new Error('some downstream exception')
     );

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -532,6 +532,7 @@ void describe('Sandbox using local project name resolver', () => {
         Promise.reject(
           new AmplifyUserError('CFNUpdateNotSupportedError', {
             message: 'some error message',
+            resolution: 'test resolution',
           })
         ),
       { times: 1 } //mock implementation once
@@ -574,6 +575,7 @@ void describe('Sandbox using local project name resolver', () => {
         Promise.reject(
           new AmplifyUserError('CFNUpdateNotSupportedError', {
             message: 'some error message',
+            resolution: 'test resolution',
           })
         ),
       { times: 1 } //mock implementation once


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

Setting a resolution for customer errors is not enforced by the type system and relies on engineer best-effort.

**Issue number, if available:**
Fixes: https://github.com/aws-amplify/amplify-backend/issues/873
## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Make the resolution field required in the ctor for `AmplifyUserError` and add a resolution in places where it is now required.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Build passes, updated existing unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
