### PR TITLE
Target language type name

### DIFF
--- a/.changeset/clean-pets-join.md
+++ b/.changeset/clean-pets-join.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/model-generator': minor
+'@aws-amplify/backend-cli': patch
+---
+
+Rename target format type and prop in model gen package

--- a/packages/cli/src/form-generation/form_generation_handler.ts
+++ b/packages/cli/src/form-generation/form_generation_handler.ts
@@ -31,7 +31,7 @@ export class FormGenerationHandler {
       credentialProvider,
     });
     const modelsResult = await graphqlClientGenerator.generateModels({
-      language: 'typescript',
+      targetFormat: 'typescript',
     });
     await modelsResult.writeToDirectory(modelsOutDir, (message) =>
       printer.log(message)

--- a/packages/model-generator/API.md
+++ b/packages/model-generator/API.md
@@ -15,7 +15,7 @@ export const createGraphqlDocumentGenerator: ({ backendIdentifier, credentialPro
 
 // @public (undocumented)
 export type DocumentGenerationParameters = {
-    language: TargetLanguage;
+    targetFormat: StatementsTarget;
     maxDepth?: number;
     typenameIntrospection?: boolean;
     relativeTypesPath?: string;
@@ -165,9 +165,6 @@ export type ModelsGenerationParameters = {
     addTimestampFields?: boolean;
     handleListNullabilityTransparently?: boolean;
 };
-
-// @public (undocumented)
-export type TargetLanguage = StatementsTarget;
 
 // @public (undocumented)
 export type TypesGenerationParameters = {

--- a/packages/model-generator/src/generate_api_code.ts
+++ b/packages/model-generator/src/generate_api_code.ts
@@ -145,7 +145,7 @@ export class ApiCodeGenerator {
     props: GenerateGraphqlCodegenOptions
   ): Promise<GenerationResult> {
     const generateModelsParams: DocumentGenerationParameters = {
-      language: props.statementTarget,
+      targetFormat: props.statementTarget,
       maxDepth: props.maxDepth,
       typenameIntrospection: props.typeNameIntrospection,
     };

--- a/packages/model-generator/src/graphql_document_generator.test.ts
+++ b/packages/model-generator/src/graphql_document_generator.test.ts
@@ -12,7 +12,7 @@ void describe('client generator', () => {
       })
     );
     await assert.rejects(() =>
-      generator.generateModels({ language: 'typescript' })
+      generator.generateModels({ targetFormat: 'typescript' })
     );
   });
 });

--- a/packages/model-generator/src/graphql_document_generator.ts
+++ b/packages/model-generator/src/graphql_document_generator.ts
@@ -19,7 +19,7 @@ export class AppSyncGraphqlDocumentGenerator
     private resultBuilder: (fileMap: Record<string, string>) => GenerationResult
   ) {}
   generateModels = async ({
-    language,
+    targetFormat,
     maxDepth,
     typenameIntrospection,
     relativeTypesPath,
@@ -32,7 +32,7 @@ export class AppSyncGraphqlDocumentGenerator
 
     const generatedStatements = generateStatements({
       schema,
-      target: language,
+      target: targetFormat,
       maxDepth,
       typenameIntrospection,
       relativeTypesPath,

--- a/packages/model-generator/src/model_generator.ts
+++ b/packages/model-generator/src/model_generator.ts
@@ -3,10 +3,9 @@ import {
   StatementsTarget,
   TypesTarget,
 } from '@aws-amplify/graphql-generator';
-export type TargetLanguage = StatementsTarget;
 
 export type DocumentGenerationParameters = {
-  language: TargetLanguage;
+  targetFormat: StatementsTarget;
   maxDepth?: number;
   typenameIntrospection?: boolean;
   relativeTypesPath?: string;


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

Addresses tech-debt item to revisit type name

**Issue number, if available:**
fixes: https://github.com/aws-amplify/amplify-backend/issues/247

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Removes the `TargetLanguage` type in the model gen package in favor of using the existing `StatementsTarget` type. Also renamed the prop name in the input payload to match.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Updated existing tests, build passes

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
