### PR TITLE
backend-data: add support for first-class defineFunction

### DIFF
--- a/.changeset/four-peaches-pull.md
+++ b/.changeset/four-peaches-pull.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/backend-data': patch
+---
+
+backend-data: add support for first-class defineFunction

--- a/package-lock.json
+++ b/package-lock.json
@@ -1244,17 +1244,17 @@
       }
     },
     "node_modules/@aws-amplify/data-schema": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.13.11.tgz",
-      "integrity": "sha512-9BD+Qun3ve4Z4F7c1Ri6GrarEdEuCw+OjxFgaSouSZsouJ8a1+oVvMoqeU8Sq4+WvQJfgl8WzloQYGSGHzsznw==",
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.13.14.tgz",
+      "integrity": "sha512-QqU5iuMiwUqj4ej6zyUEkpXg9VKY1WrNFFguTU5MEy9EMcsZ47ZwuG7V7+JmwoN5FKd5yB+SmKOYJ0MprI8RoA==",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*"
       }
     },
     "node_modules/@aws-amplify/data-schema-types": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.7.7.tgz",
-      "integrity": "sha512-DjHeJ2dfTPTG+MjkguTcKTy20OlP4DOo1AORPSz23Yl4W+0P2DfG03VlT6o9xc9jWqreQ3oJGkDsO/2oR81KsA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.7.8.tgz",
+      "integrity": "sha512-ze4Rwlx2V/Snr8o0Yzb2SisIhPmWlWLEFXRYQ8N+RxFX0/gTbBielfR78D2eKVk1ufBEB3RAFCXJFs7KuW9MHg==",
       "dependencies": {
         "rxjs": "^7.8.1"
       }
@@ -23613,7 +23613,7 @@
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
         "@aws-amplify/backend-storage": "^0.6.0-beta.3",
         "@aws-amplify/client-config": "^0.9.0-beta.3",
-        "@aws-amplify/data-schema": "^0.13.11",
+        "@aws-amplify/data-schema": "^0.13.14",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "@aws-sdk/client-amplify": "^3.465.0"
@@ -23653,12 +23653,12 @@
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.1",
         "@aws-amplify/data-construct": "^1.4.1",
-        "@aws-amplify/data-schema-types": "^0.7.7",
+        "@aws-amplify/data-schema-types": "^0.7.8",
         "@aws-amplify/plugin-types": "^0.9.0-beta.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
-        "@aws-amplify/data-schema": "^0.13.11",
+        "@aws-amplify/data-schema": "^0.13.14",
         "@aws-amplify/platform-core": "^0.5.0-beta.1"
       },
       "peerDependencies": {
@@ -24128,7 +24128,7 @@
         "@aws-amplify/backend": "^0.13.0-beta.5",
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
         "@aws-amplify/client-config": "^0.9.0-beta.3",
-        "@aws-amplify/data-schema": "^0.13.11",
+        "@aws-amplify/data-schema": "^0.13.14",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1244,9 +1244,9 @@
       }
     },
     "node_modules/@aws-amplify/data-schema": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.13.14.tgz",
-      "integrity": "sha512-QqU5iuMiwUqj4ej6zyUEkpXg9VKY1WrNFFguTU5MEy9EMcsZ47ZwuG7V7+JmwoN5FKd5yB+SmKOYJ0MprI8RoA==",
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.13.15.tgz",
+      "integrity": "sha512-7rzbNPHVIMqra6do7kX8NEKiLh9ED8SvYbTwE5GwXsguzPhTIP9qjfss5n/Oy83I0KqiG2np26wG7gkM/1WBLw==",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*"
       }
@@ -23613,7 +23613,7 @@
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
         "@aws-amplify/backend-storage": "^0.6.0-beta.3",
         "@aws-amplify/client-config": "^0.9.0-beta.3",
-        "@aws-amplify/data-schema": "^0.13.14",
+        "@aws-amplify/data-schema": "^0.13.15",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "@aws-sdk/client-amplify": "^3.465.0"
@@ -23658,7 +23658,7 @@
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
-        "@aws-amplify/data-schema": "^0.13.14",
+        "@aws-amplify/data-schema": "^0.13.15",
         "@aws-amplify/platform-core": "^0.5.0-beta.1"
       },
       "peerDependencies": {
@@ -24128,7 +24128,7 @@
         "@aws-amplify/backend": "^0.13.0-beta.5",
         "@aws-amplify/backend-secret": "^0.4.5-beta.1",
         "@aws-amplify/client-config": "^0.9.0-beta.3",
-        "@aws-amplify/data-schema": "^0.13.14",
+        "@aws-amplify/data-schema": "^0.13.15",
         "@aws-amplify/platform-core": "^0.5.0-beta.1",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-amplify/data-schema": "^0.13.14",
+    "@aws-amplify/data-schema": "^0.13.15",
     "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
     "@aws-amplify/platform-core": "^0.5.0-beta.1"
   },

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-amplify/data-schema": "^0.13.11",
+    "@aws-amplify/data-schema": "^0.13.14",
     "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
     "@aws-amplify/platform-core": "^0.5.0-beta.1"
   },
@@ -31,6 +31,6 @@
     "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
     "@aws-amplify/data-construct": "^1.4.1",
     "@aws-amplify/plugin-types": "^0.9.0-beta.0",
-    "@aws-amplify/data-schema-types": "^0.7.7"
+    "@aws-amplify/data-schema-types": "^0.7.8"
   }
 }

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -1,5 +1,6 @@
 import { IConstruct } from 'constructs';
 import {
+  AmplifyFunction,
   AuthResources,
   BackendOutputStorageStrategy,
   ConstructContainerEntryGenerator,
@@ -109,9 +110,11 @@ class DataGenerator implements ConstructContainerEntryGenerator {
     let amplifyGraphqlDefinition;
     let jsFunctions: JsResolver[] = [];
     let functionSchemaAccess: FunctionSchemaAccess[] = [];
+    let lambdaFunctions: Record<string, ConstructFactory<AmplifyFunction>>;
     try {
       if (isModelSchema(this.props.schema)) {
-        ({ jsFunctions, functionSchemaAccess } = this.props.schema.transform());
+        ({ jsFunctions, functionSchemaAccess, lambdaFunctions } =
+          this.props.schema.transform());
       }
       amplifyGraphqlDefinition = convertSchemaToCDK(this.props.schema);
     } catch (error) {
@@ -183,7 +186,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
 
     const functionNameMap = convertFunctionNameMapToCDK(
       this.getInstanceProps,
-      this.props.functions ?? {}
+      { ...this.props.functions, ...lambdaFunctions } ?? {}
     );
     const amplifyApi = new AmplifyData(scope, this.defaultName, {
       apiName: this.props.name,

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -110,7 +110,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
     let amplifyGraphqlDefinition;
     let jsFunctions: JsResolver[] = [];
     let functionSchemaAccess: FunctionSchemaAccess[] = [];
-    let lambdaFunctions: Record<string, ConstructFactory<AmplifyFunction>>;
+    let lambdaFunctions: Record<string, ConstructFactory<AmplifyFunction>> = {};
     try {
       if (isModelSchema(this.props.schema)) {
         ({ jsFunctions, functionSchemaAccess, lambdaFunctions } =
@@ -184,10 +184,12 @@ class DataGenerator implements ConstructContainerEntryGenerator {
       this.props.authorizationModes
     );
 
-    const functionNameMap = convertFunctionNameMapToCDK(
-      this.getInstanceProps,
-      { ...this.props.functions, ...lambdaFunctions } ?? {}
-    );
+    const propsFunctions = this.props.functions ?? {};
+
+    const functionNameMap = convertFunctionNameMapToCDK(this.getInstanceProps, {
+      ...propsFunctions,
+      ...lambdaFunctions,
+    });
     const amplifyApi = new AmplifyData(scope, this.defaultName, {
       apiName: this.props.name,
       definition: amplifyGraphqlDefinition,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-amplify/data-schema": "^0.13.11",
+    "@aws-amplify/data-schema": "^0.13.14",
     "@aws-amplify/backend-auth": "^0.5.0-beta.4",
     "@aws-amplify/backend-function": "^0.8.0-beta.3",
     "@aws-amplify/backend-data": "^0.10.0-beta.4",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-amplify/data-schema": "^0.13.14",
+    "@aws-amplify/data-schema": "^0.13.15",
     "@aws-amplify/backend-auth": "^0.5.0-beta.4",
     "@aws-amplify/backend-function": "^0.8.0-beta.3",
     "@aws-amplify/backend-data": "^0.10.0-beta.4",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -8,7 +8,7 @@
     "@aws-amplify/backend": "^0.13.0-beta.5",
     "@aws-amplify/backend-secret": "^0.4.5-beta.1",
     "@aws-amplify/client-config": "^0.9.0-beta.3",
-    "@aws-amplify/data-schema": "^0.13.11",
+    "@aws-amplify/data-schema": "^0.13.14",
     "@aws-amplify/platform-core": "^0.5.0-beta.1",
     "@aws-sdk/client-amplify": "^3.465.0",
     "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -8,7 +8,7 @@
     "@aws-amplify/backend": "^0.13.0-beta.5",
     "@aws-amplify/backend-secret": "^0.4.5-beta.1",
     "@aws-amplify/client-config": "^0.9.0-beta.3",
-    "@aws-amplify/data-schema": "^0.13.14",
+    "@aws-amplify/data-schema": "^0.13.15",
     "@aws-amplify/platform-core": "^0.5.0-beta.1",
     "@aws-sdk/client-amplify": "^3.465.0",
     "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
+++ b/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
@@ -52,6 +52,7 @@ void it('data storage auth with triggers', () => {
   assertExpectedLogicalIds(templates.defaultNodeFunc, 'AWS::Lambda::Function', [
     'defaultNodeFunctionlambda5C194062',
     'echoFunclambdaE17DCA46',
+    'handler2lambda1B9C7EFF',
     'node16Functionlambda97ECC775',
     'onUploadlambdaA252C959',
     'onDeletelambda96BB6F15',

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/data/echo/handler2.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/data/echo/handler2.ts
@@ -1,0 +1,6 @@
+/**
+ * Hello world lambda used for testing
+ */
+export const handler = async () => {
+  return 'hello world lambda';
+};

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/data/resource.ts
@@ -48,7 +48,6 @@ const schema = a.schema({
     .handler(
       a.handler.function(
         defineFunction({
-          name: 'echoFunc',
           entry: './echo/handler2.ts',
         })
       )

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/data/resource.ts
@@ -38,11 +38,18 @@ const schema = a.schema({
     .arguments({ content: a.string() })
     .returns(a.ref('EchoResponse'))
     .authorization([a.allow.private()])
+    .handler(a.handler.function('echo')),
+
+  echoInline: a
+    .query()
+    .arguments({ content: a.string() })
+    .returns(a.ref('EchoResponse'))
+    .authorization([a.allow.private()])
     .handler(
       a.handler.function(
         defineFunction({
           name: 'echoFunc',
-          entry: './echo/handler.ts',
+          entry: './echo/handler2.ts',
         })
       )
     ),
@@ -64,5 +71,11 @@ export const data = defineData({
   },
   functions: {
     reverse: defaultNodeFunc,
+    // Leaving explicit Func invocation here,
+    // ensuring we can use functions not added to `defineBackend`.
+    echo: defineFunction({
+      name: 'echoFunc',
+      entry: './echo/handler.ts',
+    }),
   },
 });

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/data/resource.ts
@@ -38,7 +38,14 @@ const schema = a.schema({
     .arguments({ content: a.string() })
     .returns(a.ref('EchoResponse'))
     .authorization([a.allow.private()])
-    .function('echo'),
+    .handler(
+      a.handler.function(
+        defineFunction({
+          name: 'echoFunc',
+          entry: './echo/handler.ts',
+        })
+      )
+    ),
 }) as never; // Not 100% sure why TS is complaining here. The error I'm getting is "The inferred type of 'schema' references an inaccessible 'unique symbol' type. A type annotation is necessary."
 
 // ^ appears to be caused by these 2 rules in tsconfig.base.json: https://github.com/aws-amplify/amplify-backend/blob/8d9a7a4c3033c474b0fc78379cdd4c1854d890ce/tsconfig.base.json#L7-L8
@@ -57,11 +64,5 @@ export const data = defineData({
   },
   functions: {
     reverse: defaultNodeFunc,
-    // Leaving explicit Func invocation here,
-    // ensuring we can use functions not added to `defineBackend`.
-    echo: defineFunction({
-      name: 'echoFunc',
-      entry: './echo/handler.ts',
-    }),
   },
 });

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/hotswap-update-files/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/hotswap-update-files/data/resource.ts
@@ -38,7 +38,21 @@ const schema = a.schema({
     .arguments({ content: a.string() })
     .returns(a.ref('EchoResponse'))
     .authorization([a.allow.private()])
-    .function('echo'),
+    .handler(a.handler.function('echo')),
+
+  echoInline: a
+    .query()
+    .arguments({ content: a.string() })
+    .returns(a.ref('EchoResponse'))
+    .authorization([a.allow.private()])
+    .handler(
+      a.handler.function(
+        defineFunction({
+          name: 'echoFunc',
+          entry: './echo/handler2.ts',
+        })
+      )
+    ),
 }) as never; // Not 100% sure why TS is complaining here. The error I'm getting is "The inferred type of 'schema' references an inaccessible 'unique symbol' type. A type annotation is necessary."
 
 export type Schema = ClientSchema<typeof schema>;

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/hotswap-update-files/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/hotswap-update-files/data/resource.ts
@@ -48,7 +48,6 @@ const schema = a.schema({
     .handler(
       a.handler.function(
         defineFunction({
-          name: 'echoFunc',
           entry: './echo/handler2.ts',
         })
       )


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Allows inline `defineFunction` in the schema builder without additional configuration in `defineData`
Complement to this data-schema PR: https://github.com/aws-amplify/amplify-api-next/pull/124

Docs PR: https://github.com/aws-amplify/docs/pull/6836/files#diff-dfe0a992e880882948237e578edffdfb4a4548f19487a58118ff900d2c7c233aR146-R161

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**
fixes: https://github.com/aws-amplify/amplify-backend/issues/573

## Changes

Enables the following DX:
```ts
import {
  type ClientSchema,
  a,
  defineData,
  defineFunction,
} from '@aws-amplify/backend';

const fn1 = defineFunction({entry: './echo/handler.ts',});
const fn2 = defineFunction({entry: './echo/handler2.ts',});

const s = a.schema({
  getPostDetails: a
    .query()
    .arguments({ postId: a.string() })
    .handler([
      a.handler.function(fn1),
      a.handler.function(fn2),
    ])
    .authorization([a.allow.private()])
    .returns(a.string()),
});

export type Schema = ClientSchema<typeof schema>;

export const data = defineData({
  schema
});
```

## Validation
* e2e test (updated)

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
