### PR TITLE
adds no-notice to info command

### DIFF
--- a/.changeset/poor-items-swim.md
+++ b/.changeset/poor-items-swim.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+add no-notice to info command

--- a/packages/cli/src/info/cdk_info_provider.ts
+++ b/packages/cli/src/info/cdk_info_provider.ts
@@ -25,9 +25,6 @@ export class CdkInfoProvider {
 
     const output = await this.execa('npx', cdkDoctorArgs, {
       all: true,
-      // env: {
-      //   CDK_NOTICES: 'false',
-      // },
     });
 
     return this.formatCdkInfo(output.all ?? output.stderr);

--- a/packages/cli/src/info/cdk_info_provider.ts
+++ b/packages/cli/src/info/cdk_info_provider.ts
@@ -15,10 +15,19 @@ export class CdkInfoProvider {
    * @returns The cdk doctor output.
    */
   async getCdkInfo(): Promise<string> {
-    const cdkDoctorArgs: string[] = ['cdk', 'doctor', '--', ' --no-color'];
+    const cdkDoctorArgs: string[] = [
+      'cdk',
+      'doctor',
+      '--no-notices',
+      '--',
+      ' --no-color',
+    ];
 
     const output = await this.execa('npx', cdkDoctorArgs, {
       all: true,
+      // env: {
+      //   CDK_NOTICES: 'false',
+      // },
     });
 
     return this.formatCdkInfo(output.all ?? output.stderr);


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

notices may not be ideal when using info command

example of notices when using cdk version 2.132.0
```

NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)

29420(cli): List stack output change issue.

Overview: v2.132.0 introduced functionality to the cdk list command to
display stack dependencies. This feature introduced a change
that displays stack ids over displayName altering the
existing list functionality

Affected versions: cli: 2.132.0

More information at: https://github.com/aws/aws-cdk/issues/29420


29483(cli): Upgrading to v2.132.0 or v2.132.1 breaks cdk diff functionality

Overview: cdk diff functionality used to rely on assuming lookup-role.
With a recent change present in v2.132.0 and v2.132.1, it is
now trying to assume deploy-role with the lookup-role. This
leads to an authorization error if permissions were not
defined to assume deploy-role.

Affected versions: cli: >=2.132.0 <=2.132.1

More information at: https://github.com/aws/aws-cdk/issues/29483
```

`--no-notices`` disable notices on info command. verified the flag works locally. 


**Issue number, if available:**
closes: https://github.com/aws-amplify/amplify-backend/issues/1152
## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
