### PR TITLE
chore: increase timeout for e2e tests

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -134,7 +134,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest-xl, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 35
     needs:
       - do_include_e2e
       - build


### PR DESCRIPTION
Increase the timeout for `run-e2e-tests` to 35 minutes 

## Problem

After this [PR to replace windows github runner from 8 core CPUs to standard 4 core CPUs](https://github.com/aws-amplify/amplify-backend/pull/1106), the `run-e2e-tests` on windows platform is more consistently timing out.

## Checklist

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
