### PR TITLE
build: handle namespaced types in api check

### DIFF
--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -86,6 +86,7 @@
   "modelgen",
   "multifactor",
   "namespace",
+  "namespaces",
   "nodejs",
   "nodenext",
   "nodir",

--- a/scripts/components/api-changes-validator/api_usage_generator.test.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.test.ts
@@ -295,6 +295,30 @@ const someClassInheritanceUsageFunction = <T1, T2, T3, T4>(someClassInheritanceU
 }
     `,
   },
+  {
+    description: 'generates type usage',
+    apiReportCode: `
+export type SomeTypeUnderNamespace = {
+  someProperty: string;
+}
+
+declare namespace someNamespace {
+  export {
+    SomeTypeUnderNamespace
+  }
+}
+    `,
+    expectedApiUsage: `
+import { someNamespace } from 'samplePackageName';
+
+type SomeTypeUnderNamespaceBaseline = {
+  someProperty: string;
+}
+const someTypeUnderNamespaceUsageFunction = (someTypeUnderNamespaceFunctionParameter: SomeTypeUnderNamespaceBaseline) => {
+  const someTypeUnderNamespace: someNamespace.SomeTypeUnderNamespace = someTypeUnderNamespaceFunctionParameter;
+}
+    `,
+  },
 ];
 
 const nestInMarkdownCodeBlock = (apiReportCode: string) => {

--- a/scripts/components/api-changes-validator/api_usage_generator.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import { EOL } from 'os';
-import { UsageStatements } from './types.js';
+import { NamespaceDefinitions, UsageStatements } from './types.js';
 import {
   ClassUsageStatementsGenerator,
   EnumUsageStatementsGenerator,
@@ -13,13 +13,17 @@ import {
  * Generates API usage using API.md definition.
  */
 export class ApiUsageGenerator {
+  private readonly namespaceDefinitions: NamespaceDefinitions;
+
   /**
    * Creates generator.
    */
   constructor(
     private readonly packageName: string,
     private readonly apiReportAST: ts.SourceFile
-  ) {}
+  ) {
+    this.namespaceDefinitions = this.getNamespaceDefinitions();
+  }
 
   generate = (): string => {
     const importStatements: Array<string> = [];
@@ -38,6 +42,12 @@ export class ApiUsageGenerator {
       }
     }
 
+    for (const namespaceName of this.namespaceDefinitions.namespaceNames) {
+      importStatements.push(
+        `import { ${namespaceName} } from '${this.packageName}';`
+      );
+    }
+
     return `${importStatements.join(EOL)}${EOL}${EOL}${usageStatements.join(
       EOL
     )}${EOL}`;
@@ -54,7 +64,8 @@ export class ApiUsageGenerator {
       case ts.SyntaxKind.TypeAliasDeclaration:
         return new TypeUsageStatementsGenerator(
           node as ts.TypeAliasDeclaration,
-          this.packageName
+          this.packageName,
+          this.namespaceDefinitions
         ).generate();
       case ts.SyntaxKind.EnumDeclaration:
         return new EnumUsageStatementsGenerator(
@@ -78,5 +89,44 @@ export class ApiUsageGenerator {
 
         return undefined;
     }
+  };
+
+  private getNamespaceDefinitions = (): NamespaceDefinitions => {
+    const namespaceDefinitions: NamespaceDefinitions = {
+      namespaceBySymbol: new Map<string, string>(),
+      namespaceNames: [],
+    };
+    for (const statement of this.apiReportAST.statements) {
+      if (statement.kind === ts.SyntaxKind.ModuleDeclaration) {
+        const moduleDeclaration = statement as ts.ModuleDeclaration;
+        const namespaceName = moduleDeclaration.name.getText();
+        namespaceDefinitions.namespaceNames.push(namespaceName);
+        if (moduleDeclaration.body?.kind === ts.SyntaxKind.ModuleBlock) {
+          const moduleBody = moduleDeclaration.body as ts.ModuleBlock;
+          for (const moduleBodyStatement of moduleBody.statements) {
+            if (moduleBodyStatement.kind === ts.SyntaxKind.ExportDeclaration) {
+              const exportDeclaration =
+                moduleBodyStatement as ts.ExportDeclaration;
+              if (
+                exportDeclaration.exportClause?.kind ===
+                ts.SyntaxKind.NamedExports
+              ) {
+                const namedExports =
+                  exportDeclaration.exportClause as ts.NamedExports;
+                for (const namedExport of namedExports.elements) {
+                  const symbolName = namedExport.name.getText();
+                  namespaceDefinitions.namespaceBySymbol.set(
+                    symbolName,
+                    namespaceName
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return namespaceDefinitions;
   };
 }

--- a/scripts/components/api-changes-validator/api_usage_generator.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.ts
@@ -91,6 +91,9 @@ export class ApiUsageGenerator {
     }
   };
 
+  /**
+   * This method scans top level AST statements to find namespaces and symbols exported via namespace.
+   */
   private getNamespaceDefinitions = (): NamespaceDefinitions => {
     const namespaceDefinitions: NamespaceDefinitions = {
       namespaceBySymbol: new Map<string, string>(),

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
@@ -1,0 +1,13 @@
+```ts
+
+export type SomeTypeUnderNamespace = {
+  someProperty: string;
+}
+
+declare namespace someNamespace {
+  export {
+    SomeTypeUnderNamespace
+  }
+}
+
+```

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/package.json
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@aws-amplify/project-with-namespace",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./lib/index.js",
+      "require": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    }
+  },
+  "types": "lib/index.d.ts"
+}

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/index.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/index.ts
@@ -1,0 +1,3 @@
+import * as someNamespace from './some_namespace.js';
+
+export { someNamespace };

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
@@ -1,0 +1,3 @@
+export type SomeTypeUnderNamespace = {
+  someProperty: string;
+};

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/tsconfig.json
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "lib" }
+}

--- a/scripts/components/api-changes-validator/types.ts
+++ b/scripts/components/api-changes-validator/types.ts
@@ -9,3 +9,8 @@ export type UsageStatementsGenerator = {
    */
   generate: () => UsageStatements;
 };
+
+export type NamespaceDefinitions = {
+  namespaceNames: Array<string>;
+  namespaceBySymbol: Map<string, string>;
+};


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

API check generates incorrect usage statements for types declared in API extract like this:

```ts

export type SomeTypeUnderNamespace = {
  someProperty: string;
}

declare namespace someNamespace {
  export {
    SomeTypeUnderNamespace
  }
}

```

I.e.

```
Validation of backend completed successfully
/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:[87](https://github.com/aws-amplify/amplify-backend/actions/runs/8349176781/job/22852847929#step:7:88)
  throw new AggregateError(
        ^


AggregateError: Breaking API changes detected. See below for details.
    If these changes are intentional, this is okay.
    Otherwise, update the PR to remove the unintentional breaks
    at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:87:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:[95](https://github.com/aws-amplify/amplify-backend/actions/runs/8349176781/job/22852847929#step:7:96):5) {
  [errors]: [
    Error: Validation of @aws-amplify/client-config failed, compiler output:
    index.ts(5,10): error TS2305: Module '"@aws-amplify/client-config"' has no exported member 'AwsAppsyncAuthorizationType'.
    index.ts(6,10): error TS2305: Module '"@aws-amplify/client-config"' has no exported member 'AwsRegion'.
    index.ts(81,29): error TS2503: Cannot find namespace 'clientConfigTypesV1'.
    index.ts(111,67): error TS2503: Cannot find namespace 'clientConfigTypesV1'.
        at ApiChangesValidator.validate (/home/runner/work/amplify-backend/amplify-backend/scripts/components/api-changes-validator/api_changes_validator.ts:61:13)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:70:5)
        at async Promise.allSettled (index 9)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:50:27)
  ]
}
```

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Detect and include namespaces in usage snippet generation logic.
1. First scan AST and detect namespaces.
2. Use this information to generate correct imports and type usage.

**Out of scope:**
I covered types since this is failing now. We'll add more later if needed.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

This PR's checks. Added unit tests.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
