### PR TITLE
fix: populate top level region in the client config

### DIFF
--- a/.changeset/soft-radios-hug.md
+++ b/.changeset/soft-radios-hug.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/client-config': patch
+'@aws-amplify/backend-cli': patch
+---
+
+fix: populate top level region in the client config

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
@@ -12,7 +12,7 @@ import { ClientConfigLifecycleHandler } from '../../client-config/client_config_
 import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'node:path';
-import { printer } from '@aws-amplify/cli-core';
+import { format, printer } from '@aws-amplify/cli-core';
 
 void describe('sandbox_event_handler_factory', () => {
   // client config mocks
@@ -173,12 +173,12 @@ void describe('sandbox_event_handler_factory', () => {
 
     assert.deepStrictEqual(
       printMock.mock.calls[0].arguments[0],
-      'Amplify configuration could not be generated.'
+      format.error('Amplify configuration could not be generated.')
     );
 
     assert.deepStrictEqual(
       printMock.mock.calls[1].arguments[0],
-      'test error message'
+      format.error('test error message')
     );
 
     assert.deepEqual(generateClientConfigMock.mock.calls[0].arguments, [

--- a/packages/client-config/src/client-config-writer/client_config_formatter_legacy.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter_legacy.test.ts
@@ -33,6 +33,7 @@ void describe('client config formatter', () => {
     aws_cognito_region: sampleRegion,
     aws_user_pools_id: sampleUserPoolId,
     aws_user_pools_web_client_id: sampleUserPoolClientId,
+    aws_project_region: sampleRegion,
   };
   const clientConfigMobile: ClientConfigMobile = {
     Version: '1.0',

--- a/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.test.ts
@@ -9,6 +9,7 @@ import {
   CustomClientConfig,
   GeoClientConfig,
   GraphqlClientConfig,
+  PlatformClientConfig,
   RestApiClientConfig,
   StorageClientConfig,
 } from '../index.js';
@@ -61,7 +62,8 @@ void describe('ClientConfigLegacyConverter', () => {
       },
     };
 
-    const expectedLegacyConfig: AuthClientConfig = {
+    const expectedLegacyConfig: AuthClientConfig & PlatformClientConfig = {
+      aws_project_region: 'testRegion',
       aws_user_pools_id: 'testUserPoolId',
       aws_user_pools_web_client_id: 'testWebClientId',
       aws_cognito_region: 'testRegion',
@@ -166,7 +168,8 @@ void describe('ClientConfigLegacyConverter', () => {
       },
     };
 
-    const expectedLegacyConfig: GraphqlClientConfig = {
+    const expectedLegacyConfig: GraphqlClientConfig & PlatformClientConfig = {
+      aws_project_region: 'testRegion',
       aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS',
       aws_appsync_region: 'testRegion',
       aws_appsync_graphqlEndpoint: 'testUrl',
@@ -247,7 +250,8 @@ void describe('ClientConfigLegacyConverter', () => {
       },
     };
 
-    const expectedLegacyConfig: StorageClientConfig = {
+    const expectedLegacyConfig: StorageClientConfig & PlatformClientConfig = {
+      aws_project_region: 'testRegion',
       aws_user_files_s3_bucket_region: 'testRegion',
       aws_user_files_s3_bucket: 'testBucket',
     };

--- a/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.ts
@@ -31,6 +31,15 @@ export class ClientConfigLegacyConverter {
 
     let legacyConfig: ClientConfigLegacy = {};
 
+    // Gen2 backend constructs use the Stack's region and is identical. We use these to
+    // populate the root level aws_project_region in legacy config.
+    if (clientConfig.auth || clientConfig.data || clientConfig.storage) {
+      legacyConfig.aws_project_region =
+        clientConfig.auth?.aws_region ??
+        clientConfig.data?.aws_region ??
+        clientConfig.storage?.aws_region;
+    }
+
     // Auth
     if (clientConfig.auth) {
       const authClientConfig: AuthClientConfig = {


### PR DESCRIPTION
## Problem

aws_project_region was not being populated in the client config.

**Issue number, if available:** https://github.com/aws-amplify/amplify-backend/issues/1170

## Changes

Populate if from one of the constructs.


## Validation

Unit tested and manually tested.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
