### PR TITLE
feat: add manageGroups as an IAM action

### DIFF
--- a/.changeset/popular-stingrays-talk.md
+++ b/.changeset/popular-stingrays-talk.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-auth': patch
+---
+
+Added manageGroups as an IAM action.

--- a/packages/backend-auth/API.md
+++ b/packages/backend-auth/API.md
@@ -26,7 +26,7 @@ import { TriggerEvent } from '@aws-amplify/auth-construct-alpha';
 export type ActionIam = 'addUserToGroup' | 'createUser' | 'deleteUser' | 'deleteUserAttributes' | 'disableUser' | 'enableUser' | 'forgetDevice' | 'getDevice' | 'getUser' | 'listDevices' | 'listGroupsForUser' | 'removeUserFromGroup' | 'resetUserPassword' | 'setUserMfaPreference' | 'setUserPassword' | 'setUserSettings' | 'updateDeviceStatus' | 'updateUserAttributes';
 
 // @public
-export type ActionMeta = 'manageUsers' | 'manageGroupMembership' | 'manageUserDevices' | 'managePasswordRecovery';
+export type ActionMeta = 'manageUsers' | 'manageGroups' | 'manageGroupMembership' | 'manageUserDevices' | 'managePasswordRecovery';
 
 // @public
 export type AmazonProviderFactoryProps = Omit<AmazonProviderProps, 'clientId' | 'clientSecret'> & {

--- a/packages/backend-auth/src/types.ts
+++ b/packages/backend-auth/src/types.ts
@@ -211,6 +211,7 @@ export type AuthAction = ActionIam | ActionMeta;
 /** @todo https://github.com/aws-amplify/amplify-backend/issues/1111 */
 export type ActionMeta =
   | 'manageUsers'
+  | 'manageGroups'
   | 'manageGroupMembership'
   | 'manageUserDevices'
   | 'managePasswordRecovery';

--- a/packages/backend-auth/src/userpool_access_policy_factory.ts
+++ b/packages/backend-auth/src/userpool_access_policy_factory.ts
@@ -80,6 +80,13 @@ const iamActionMap: IamActionMap = {
     'cognito-idp:AdminAddUserToGroup',
     'cognito-idp:AdminRemoveUserFromGroup',
   ],
+  manageGroups: [
+    'cognito-idp:GetGroup',
+    'cognito-idp:ListGroups',
+    'cognito-idp:CreateGroup',
+    'cognito-idp:DeleteGroup',
+    'cognito-idp:UpdateGroup',
+  ],
   manageUserDevices: [
     'cognito-idp:AdminForgetDevice',
     'cognito-idp:AdminGetDevice',


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
Currently we are unable to define group-related access beyond managing user membership. 
Creating policy documents and managing (or avoiding) circular dependencies is painful.
**Issue number, if available:**

## Changes
This change adds manageGroups as a meta action.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
