### PR TITLE
Named sandbox secrets

### DIFF
--- a/.changeset/dry-yaks-kiss.md
+++ b/.changeset/dry-yaks-kiss.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+Support --name option in `sandbox secret` commands

--- a/packages/cli/src/commands/sandbox/option_types.ts
+++ b/packages/cli/src/commands/sandbox/option_types.ts
@@ -1,0 +1,13 @@
+/**
+ * CLI options that apply to all sandbox commands
+ */
+export type SandboxCommandGlobalOptions = {
+  /**
+   * AWS profile to use for sandbox operations
+   */
+  profile?: string;
+  /**
+   * Optional name to use to distinguish multiple sandboxes
+   */
+  name?: string;
+};

--- a/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.ts
@@ -1,12 +1,14 @@
 import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { SandboxSingletonFactory } from '@aws-amplify/sandbox';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
+import { SandboxCommandGlobalOptions } from '../option_types.js';
+import { ArgumentsKebabCase } from '../../../kebab_case.js';
 
 /**
  * Command that deletes the sandbox environment.
  */
 export class SandboxDeleteCommand
-  implements CommandModule<object, SandboxDeleteCommandOptions>
+  implements CommandModule<object, SandboxDeleteCommandOptionsKebabCase>
 {
   /**
    * @inheritDoc
@@ -30,7 +32,7 @@ export class SandboxDeleteCommand
    * @inheritDoc
    */
   handler = async (
-    args: ArgumentsCamelCase<SandboxDeleteCommandOptions>
+    args: ArgumentsCamelCase<SandboxDeleteCommandOptionsKebabCase>
   ): Promise<void> => {
     let isConfirmed = args.yes;
     if (!isConfirmed) {
@@ -50,36 +52,19 @@ export class SandboxDeleteCommand
   /**
    * @inheritDoc
    */
-  builder = (yargs: Argv): Argv<SandboxDeleteCommandOptions> => {
-    return yargs
-      .option('yes', {
-        describe:
-          'Do not ask for confirmation before deleting the sandbox environment',
-        type: 'boolean',
-        array: false,
-        alias: 'y',
-      })
-      .option('name', {
-        describe:
-          'An optional name to distinguish between different sandbox environments. Default is the name in your package.json',
-        type: 'string',
-        array: false,
-      })
-      .check((argv) => {
-        if (argv.name) {
-          const projectNameRegex = /^[a-zA-Z0-9-]{1,15}$/;
-          if (!argv.name.match(projectNameRegex)) {
-            throw new Error(
-              `--name should match [a-zA-Z0-9-] and less than 15 characters.`
-            );
-          }
-        }
-        return true;
-      });
+  builder = (yargs: Argv): Argv<SandboxDeleteCommandOptionsKebabCase> => {
+    return yargs.option('yes', {
+      describe:
+        'Do not ask for confirmation before deleting the sandbox environment',
+      type: 'boolean',
+      array: false,
+      alias: 'y',
+    });
   };
 }
 
-export type SandboxDeleteCommandOptions = {
-  yes?: boolean;
-  name?: string;
-};
+type SandboxDeleteCommandOptionsKebabCase = ArgumentsKebabCase<
+  {
+    yes?: boolean;
+  } & SandboxCommandGlobalOptions
+>;

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command.ts
@@ -19,7 +19,7 @@ export class SandboxSecretCommand implements CommandModule<object> {
    */
   constructor(private readonly secretSubCommands: CommandModule[]) {
     this.command = 'secret <command>';
-    this.describe = 'Manage sandbox secret';
+    this.describe = 'Manage sandbox secrets';
   }
 
   /**

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.test.ts
@@ -34,10 +34,10 @@ void describe('sandbox secret get command', () => {
   );
 
   const sandboxIdResolver: SandboxBackendIdResolver = {
-    resolve: () =>
+    resolve: (nameOverride?: string) =>
       Promise.resolve({
         namespace: testBackendId,
-        name: testSandboxName,
+        name: nameOverride || testSandboxName,
         type: 'sandbox',
       }),
   } as SandboxBackendIdResolver;
@@ -66,6 +66,26 @@ void describe('sandbox secret get command', () => {
       {
         namespace: testBackendId,
         name: testSandboxName,
+        type: 'sandbox',
+      },
+      testSecretIdentifier,
+    ]);
+
+    assert.equal(printMock.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      printMock.mock.calls[0].arguments[0],
+      format.record(testSecret)
+    );
+  });
+
+  void it('gets secret for named sandbox', async () => {
+    await commandRunner.runCommand(`get ${testSecretName} --name anotherName`);
+
+    assert.equal(secretGetMock.mock.callCount(), 1);
+    assert.deepStrictEqual(secretGetMock.mock.calls[0].arguments, [
+      {
+        namespace: testBackendId,
+        name: 'anotherName',
         type: 'sandbox',
       },
       testSecretIdentifier,

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.ts
@@ -1,14 +1,15 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
 import { format, printer } from '@aws-amplify/cli-core';
+import { SandboxCommandGlobalOptions } from '../option_types.js';
 
 /**
  * Command to get sandbox secret.
  */
 export class SandboxSecretGetCommand
-  implements CommandModule<object, SecretGetCommandOptions>
+  implements CommandModule<object, SecretGetCommandOptionsKebabCase>
 {
   /**
    * @inheritDoc
@@ -34,8 +35,12 @@ export class SandboxSecretGetCommand
   /**
    * @inheritDoc
    */
-  handler = async (args: SecretGetCommandOptions): Promise<void> => {
-    const sandboxBackendIdentifier = await this.sandboxIdResolver.resolve();
+  handler = async (
+    args: ArgumentsCamelCase<SecretGetCommandOptionsKebabCase>
+  ): Promise<void> => {
+    const sandboxBackendIdentifier = await this.sandboxIdResolver.resolve(
+      args.name
+    );
     const secret = await this.secretClient.getSecret(sandboxBackendIdentifier, {
       name: args['secret-name'],
     });
@@ -45,7 +50,7 @@ export class SandboxSecretGetCommand
   /**
    * @inheritDoc
    */
-  builder = (yargs: Argv): Argv<SecretGetCommandOptions> => {
+  builder = (yargs: Argv): Argv<SecretGetCommandOptionsKebabCase> => {
     return yargs
       .positional('secret-name', {
         describe: 'Name of the secret to get',
@@ -56,9 +61,8 @@ export class SandboxSecretGetCommand
   };
 }
 
-type SecretGetCommandOptions =
-  ArgumentsKebabCase<SecretGetCommandOptionsCamelCase>;
-
-type SecretGetCommandOptionsCamelCase = {
-  secretName: string;
-};
+type SecretGetCommandOptionsKebabCase = ArgumentsKebabCase<
+  {
+    secretName: string;
+  } & SandboxCommandGlobalOptions
+>;

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.test.ts
@@ -31,10 +31,10 @@ void describe('sandbox secret list command', () => {
     listSecretsResponseMock
   );
   const sandboxIdResolver: SandboxBackendIdResolver = {
-    resolve: () =>
+    resolve: (nameOverride?: string) =>
       Promise.resolve({
         namespace: testBackendId,
-        name: testSandboxName,
+        name: nameOverride || testSandboxName,
         type: 'sandbox',
       }),
   } as SandboxBackendIdResolver;
@@ -53,7 +53,7 @@ void describe('sandbox secret list command', () => {
   });
 
   void it('list secrets', async () => {
-    await commandRunner.runCommand(`list`);
+    await commandRunner.runCommand('list');
     assert.equal(secretListMock.mock.callCount(), 1);
 
     assert.deepStrictEqual(secretListMock.mock.calls[0].arguments[0], {
@@ -69,9 +69,26 @@ void describe('sandbox secret list command', () => {
     );
   });
 
+  void it('lists secrets for named sandbox', async () => {
+    await commandRunner.runCommand('list --name anotherName');
+    assert.equal(secretListMock.mock.callCount(), 1);
+
+    assert.deepStrictEqual(secretListMock.mock.calls[0].arguments[0], {
+      namespace: testBackendId,
+      name: 'anotherName',
+      type: 'sandbox',
+    });
+
+    assert.equal(printMock.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      printMock.mock.calls[0].arguments[0],
+      format.list(testSecrets.map((s) => s.name))
+    );
+  });
+
   void it('prints no secrets message if no secrets found', async () => {
     listSecretsResponseMock.mock.mockImplementationOnce(async () => []);
-    await commandRunner.runCommand(`list`);
+    await commandRunner.runCommand('list');
     assert.equal(secretListMock.mock.callCount(), 1);
 
     assert.deepStrictEqual(secretListMock.mock.calls[0].arguments[0], {

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.ts
@@ -1,12 +1,17 @@
-import { CommandModule } from 'yargs';
+import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { format, printer } from '@aws-amplify/cli-core';
+import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { SandboxCommandGlobalOptions } from '../option_types.js';
 
 /**
  * Command to list sandbox secrets.
  */
-export class SandboxSecretListCommand implements CommandModule<object> {
+export class SandboxSecretListCommand
+  implements
+    CommandModule<object, ArgumentsKebabCase<SandboxCommandGlobalOptions>>
+{
   /**
    * @inheritDoc
    */
@@ -31,8 +36,12 @@ export class SandboxSecretListCommand implements CommandModule<object> {
   /**
    * @inheritDoc
    */
-  handler = async (): Promise<void> => {
-    const sandboxBackendIdentifier = await this.sandboxIdResolver.resolve();
+  handler = async (
+    args: ArgumentsCamelCase<SandboxCommandGlobalOptions>
+  ): Promise<void> => {
+    const sandboxBackendIdentifier = await this.sandboxIdResolver.resolve(
+      args.name
+    );
     const secrets = await this.secretClient.listSecrets(
       sandboxBackendIdentifier
     );

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.test.ts
@@ -19,10 +19,10 @@ void describe('sandbox secret remove command', () => {
   );
 
   const sandboxIdResolver: SandboxBackendIdResolver = {
-    resolve: () =>
+    resolve: (nameOverride?: string) =>
       Promise.resolve({
         namespace: testBackendId,
-        name: testSandboxName,
+        name: nameOverride || testSandboxName,
         type: 'sandbox',
       }),
   } as SandboxBackendIdResolver;
@@ -50,6 +50,21 @@ void describe('sandbox secret remove command', () => {
         type: 'sandbox',
         namespace: testBackendId,
         name: testSandboxName,
+      },
+      testSecretName,
+    ]);
+  });
+
+  void it('removes secret from named sandbox', async () => {
+    await commandRunner.runCommand(
+      `remove ${testSecretName} --name anotherName`
+    );
+    assert.equal(secretRemoveMock.mock.callCount(), 1);
+    assert.deepStrictEqual(secretRemoveMock.mock.calls[0].arguments, [
+      {
+        type: 'sandbox',
+        namespace: testBackendId,
+        name: 'anotherName',
       },
       testSecretName,
     ]);

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
@@ -2,12 +2,13 @@ import { Argv, CommandModule } from 'yargs';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { SandboxCommandGlobalOptions } from '../option_types.js';
 
 /**
  * Command to remove sandbox secret.
  */
 export class SandboxSecretRemoveCommand
-  implements CommandModule<object, SecretRemoveCommandOptions>
+  implements CommandModule<object, SecretRemoveCommandOptionsKebabCase>
 {
   /**
    * @inheritDoc
@@ -33,8 +34,12 @@ export class SandboxSecretRemoveCommand
   /**
    * @inheritDoc
    */
-  handler = async (args: SecretRemoveCommandOptions): Promise<void> => {
-    const sandboxBackendIdentifier = await this.sandboxIdResolver.resolve();
+  handler = async (
+    args: SecretRemoveCommandOptionsKebabCase
+  ): Promise<void> => {
+    const sandboxBackendIdentifier = await this.sandboxIdResolver.resolve(
+      args.name
+    );
     await this.secretClient.removeSecret(
       sandboxBackendIdentifier,
       args['secret-name']
@@ -44,7 +49,7 @@ export class SandboxSecretRemoveCommand
   /**
    * @inheritDoc
    */
-  builder = (yargs: Argv): Argv<SecretRemoveCommandOptions> => {
+  builder = (yargs: Argv): Argv<SecretRemoveCommandOptionsKebabCase> => {
     return yargs.positional('secret-name', {
       describe: 'Name of the secret to remove',
       type: 'string',
@@ -53,9 +58,8 @@ export class SandboxSecretRemoveCommand
   };
 }
 
-type SecretRemoveCommandOptions =
-  ArgumentsKebabCase<SecretRemoveCommandOptionsCamelCase>;
-
-type SecretRemoveCommandOptionsCamelCase = {
-  secretName: string;
-};
+type SecretRemoveCommandOptionsKebabCase = ArgumentsKebabCase<
+  {
+    secretName: string;
+  } & SandboxCommandGlobalOptions
+>;

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
@@ -26,10 +26,10 @@ void describe('sandbox secret set command', () => {
   );
 
   const sandboxIdResolver: SandboxBackendIdResolver = {
-    resolve: () =>
+    resolve: (nameOverride?: string) =>
       Promise.resolve({
         namespace: testBackendId,
-        name: testSandboxName,
+        name: nameOverride || testSandboxName,
         type: 'sandbox',
       }),
   } as SandboxBackendIdResolver;
@@ -65,6 +65,28 @@ void describe('sandbox secret set command', () => {
         type: 'sandbox',
         namespace: testBackendId,
         name: testSandboxName,
+      },
+      testSecretName,
+      testSecretValue,
+    ]);
+  });
+
+  void it('sets a secret in a named sandbox', async (contextual) => {
+    const mockSecretValue = contextual.mock.method(
+      AmplifyPrompter,
+      'secretValue',
+      () => Promise.resolve(testSecretValue)
+    );
+
+    await commandRunner.runCommand(`set ${testSecretName} --name anotherName`);
+    assert.equal(mockSecretValue.mock.callCount(), 1);
+    assert.equal(secretSetMock.mock.callCount(), 1);
+
+    assert.deepStrictEqual(secretSetMock.mock.calls[0].arguments, [
+      {
+        type: 'sandbox',
+        namespace: testBackendId,
+        name: 'anotherName',
       },
       testSecretName,
       testSecretValue,

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
@@ -1,15 +1,16 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
 
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { SandboxCommandGlobalOptions } from '../option_types.js';
 
 /**
  * Command to set sandbox secret.
  */
 export class SandboxSecretSetCommand
-  implements CommandModule<object, SecretSetCommandOptions>
+  implements CommandModule<object, SecretSetCommandOptionsKebabCase>
 {
   /**
    * @inheritDoc
@@ -35,10 +36,12 @@ export class SandboxSecretSetCommand
   /**
    * @inheritDoc
    */
-  handler = async (args: SecretSetCommandOptions): Promise<void> => {
+  handler = async (
+    args: ArgumentsCamelCase<SecretSetCommandOptionsKebabCase>
+  ): Promise<void> => {
     const secretVal = await AmplifyPrompter.secretValue();
     await this.secretClient.setSecret(
-      await this.sandboxIdResolver.resolve(),
+      await this.sandboxIdResolver.resolve(args.name),
       args['secret-name'],
       secretVal
     );
@@ -47,7 +50,7 @@ export class SandboxSecretSetCommand
   /**
    * @inheritDoc
    */
-  builder = (yargs: Argv): Argv<SecretSetCommandOptions> => {
+  builder = (yargs: Argv): Argv<SecretSetCommandOptionsKebabCase> => {
     return yargs.positional('secret-name', {
       describe: 'Name of the secret to set',
       type: 'string',
@@ -56,9 +59,8 @@ export class SandboxSecretSetCommand
   };
 }
 
-type SecretSetCommandOptions =
-  ArgumentsKebabCase<SecretSetCommandOptionsCamelCase>;
-
-type SecretSetCommandOptionsCamelCase = {
-  secretName: string;
-};
+type SecretSetCommandOptionsKebabCase = ArgumentsKebabCase<
+  {
+    secretName: string;
+  } & SandboxCommandGlobalOptions
+>;

--- a/packages/cli/src/commands/sandbox/sandbox_id_resolver.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_id_resolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { SandboxBackendIdResolver } from './sandbox_id_resolver.js';
 
@@ -14,5 +14,19 @@ void describe('SandboxIdResolver', () => {
     const result = await resolverRef();
     assert.equal(result.namespace, 'testAppName');
     assert.equal(result.name, 'testUsername');
+  });
+
+  void it('uses nameOverride if present', async () => {
+    const userInfoMock = mock.fn<() => never>();
+    const resolver = new SandboxBackendIdResolver(
+      {
+        resolve: () => Promise.resolve('testAppName'),
+      },
+      userInfoMock
+    );
+    const result = await resolver.resolve('differentName');
+    assert.equal(result.namespace, 'testAppName');
+    assert.equal(result.name, 'differentName');
+    assert.equal(userInfoMock.mock.callCount(), 0);
   });
 });

--- a/packages/cli/src/commands/sandbox/sandbox_id_resolver.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_id_resolver.ts
@@ -17,9 +17,9 @@ export class SandboxBackendIdResolver {
   /**
    * Returns a concatenation of the resolved appName and the current username
    */
-  resolve = async (): Promise<BackendIdentifier> => {
+  resolve = async (nameOverride?: string): Promise<BackendIdentifier> => {
     const namespace = await this.namespaceResolver.resolve();
-    const name = this.userInfo().username;
+    const name = nameOverride || this.userInfo().username;
 
     return {
       namespace,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

Sandbox secret commands do not recognize the `--name` argument. This means that there is no way to manage secrets for named sandboxes from the CLI

**Issue number, if available:**
fixes: https://github.com/aws-amplify/amplify-backend/issues/1125
## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Modified the `--name` arg to be global to all sandbox commands and make necessary plumbing refactors to use the name arg in the `sandbox secret` commands. I also included some type refactoring that wasn't strictly required, but makes the types across the arg objects more consistent

**Corresponding docs PR, if applicable:**
https://github.com/aws-amplify/docs/pull/7108

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
