### PR TITLE
add support for function dependencies that require .node files

### DIFF
--- a/.changeset/smart-gifts-teach.md
+++ b/.changeset/smart-gifts-teach.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/integration-tests': minor
+'@aws-amplify/backend-function': minor
+---
+
+add support for function dependencies that require .node files

--- a/package-lock.json
+++ b/package-lock.json
@@ -14799,6 +14799,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -15553,6 +15563,21 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.9.tgz",
+      "integrity": "sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.17.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/create-amplify": {
@@ -20502,6 +20527,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/nan": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/nanoclone": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
@@ -23106,6 +23138,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+      "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.9",
+        "nan": "^2.18.0"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -25616,6 +25666,7 @@
         "glob": "^10.2.7",
         "node-fetch": "^3.3.2",
         "semver": "^7.5.4",
+        "ssh2": "^1.15.0",
         "uuid": "^9.0.1"
       }
     },

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -298,6 +298,9 @@ class AmplifyFunction
         format: OutputFormat.ESM,
         banner: bannerCode,
         inject: shims,
+        loader: {
+          '.node': 'file',
+        },
       },
     });
 

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -25,6 +25,7 @@
     "glob": "^10.2.7",
     "node-fetch": "^3.3.2",
     "semver": "^7.5.4",
+    "ssh2": "^1.15.0",
     "uuid": "^9.0.1"
   },
   "license": "Apache-2.0"

--- a/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
+++ b/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
@@ -201,6 +201,7 @@ class DataStorageAuthWithTriggerTestProject extends TestProjectBase {
       s3TestContent: 'this is some test content',
       testSecret: 'amazonSecret-e2eTestValue',
       testSharedSecret: `${this.amplifySharedSecret}-e2eTestSharedValue`,
+      testNodeAddon: '[object Object]', // just need to test dependency returns key pair object
     };
 
     await this.checkLambdaResponse(defaultNodeLambda[0], expectedResponse);

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
@@ -1,5 +1,10 @@
 import { Amplify } from 'aws-amplify';
 import { downloadData, uploadData } from 'aws-amplify/storage';
+// This is needed to test dependencies that require .node files
+const {
+  utils: { generateKeyPairSync },
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+} = require('ssh2');
 /**
  * This import is for tests to use the generated type generation file.
  * Currently we only use defaultNodeFunction because node16Function has the same environment variables at runtime.
@@ -44,6 +49,7 @@ export const getResponse = async () => {
     s3TestContent: await s3RoundTrip(),
     testSecret: env.TEST_SECRET,
     testSharedSecret: env.TEST_SHARED_SECRET,
+    testNodeAddon: generateKeyPairSync('ed25519') as string,
   };
 };
 

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
@@ -49,7 +49,7 @@ export const getResponse = async () => {
     s3TestContent: await s3RoundTrip(),
     testSecret: env.TEST_SECRET,
     testSharedSecret: env.TEST_SHARED_SECRET,
-    testNodeAddon: generateKeyPairSync('ed25519') as string,
+    testNodeAddon: `${generateKeyPairSync('ed25519')}`,
   };
 };
 


### PR DESCRIPTION
## Problem

If a function handler code uses a 3p dependency that requires `.node` files it fails to bundle because there is no loader configured for `.node` files.

**Issue number, if available:**
fixes #1153 

## Changes

- Add `loader` option to load `.node` files as `file`
- Add 3p dependency that requires `.node` files for E2E tests

**Corresponding docs PR, if applicable:**

## Validation

E2E tests and verified locally.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
