### PR TITLE
chore: handle generic error serialization correctly

### DIFF
--- a/.changeset/small-donkeys-yawn.md
+++ b/.changeset/small-donkeys-yawn.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+chore: handle generic error serialization correctly

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -31,6 +31,7 @@
   "debounce",
   "declarator",
   "deployer",
+  "deserializer",
   "disambiguator",
   "downlevel",
   "durations",

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -4,11 +4,11 @@ import assert from 'assert';
 import * as util from 'util';
 
 void describe('amplify error', () => {
-  void it('serialize and deserialize correctly', () => {
+  void it('serialize and deserialize correctly with AmplifyError cause', () => {
     const testError = new AmplifyUserError(
       'SyntaxError',
       {
-        message: 'test error message',
+        message: `"test" error ' message`,
         details: 'test error details',
         resolution: 'test resolution',
       },
@@ -16,6 +16,30 @@ void describe('amplify error', () => {
         message: 'some downstream error message',
         resolution: 'test resolution',
       })
+    );
+    const sampleStderr = `some random stderr
+before the actual error message
+${util.inspect(testError, { depth: null })}
+and some after the error message
+    `;
+    const actual = AmplifyError.fromStderr(sampleStderr);
+    assert.deepStrictEqual(actual?.name, testError.name);
+    assert.deepStrictEqual(actual?.classification, testError.classification);
+    assert.deepStrictEqual(actual?.message, testError.message);
+    assert.deepStrictEqual(actual?.details, testError.details);
+    assert.deepStrictEqual(actual?.cause?.name, testError.cause?.name);
+    assert.deepStrictEqual(actual?.cause?.message, testError.cause?.message);
+  });
+
+  void it('serialize and deserialize correctly with generic Error cause', () => {
+    const testError = new AmplifyUserError(
+      'SyntaxError',
+      {
+        message: 'test error "message"',
+        details: 'test error details',
+        resolution: 'test resolution',
+      },
+      new Error('some generic error')
     );
     const sampleStderr = `some random stderr
 before the actual error message
@@ -73,6 +97,24 @@ and some after the error message
     assert.deepStrictEqual(actual?.name, 'SyntaxError');
     assert.deepStrictEqual(actual?.classification, 'ERROR');
     assert.deepStrictEqual(actual?.message, 'test error message');
+    assert.deepStrictEqual(actual?.resolution, 'test resolution');
+  });
+
+  void it('deserialize when string has single quotes in between', () => {
+    const sampleStderr = `some random stderr
+    ${util.inspect({
+      serializedError:
+        '{"name":"SyntaxError","classification":"ERROR","options":{"message":"Cannot read properties of undefined (reading \'data\')","resolution":"test resolution"}}',
+    })}
+and some after the error message
+    `;
+    const actual = AmplifyError.fromStderr(sampleStderr);
+    assert.deepStrictEqual(actual?.name, 'SyntaxError');
+    assert.deepStrictEqual(actual?.classification, 'ERROR');
+    assert.deepStrictEqual(
+      actual?.message,
+      `Cannot read properties of undefined (reading 'data')`
+    );
     assert.deepStrictEqual(actual?.resolution, 'test resolution');
   });
 });

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -59,6 +59,11 @@ export abstract class AmplifyError<T extends string = string> extends Error {
   }
 
   static fromStderr = (_stderr: string): AmplifyError | undefined => {
+    /**
+     * `["']?serializedError["']?:[ ]?` captures the start of the serialized error. The quotes depend on which OS is being used
+     * `(?:`(.+?)`|'(.+?)'|"((?:\\"|[^"])*?)")` captures the rest of the serialized string enclosed in either single quote,
+     * double quotes or backticks.
+     */
     const extractionRegex =
       /["']?serializedError["']?:[ ]?(?:`(.+?)`|'(.+?)'|"((?:\\"|[^"])*?)")/;
     const serialized = _stderr.match(extractionRegex);

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -84,8 +84,8 @@ export abstract class AmplifyError<T extends string = string> extends Error {
           JSON.parse(serializedString);
 
         let serializedCause = cause;
-        if (cause && ErrorSerDe.isSerializedErrorType(cause)) {
-          serializedCause = ErrorSerDe.deserialize(cause);
+        if (cause && ErrorSerializerDeserializer.isSerializedErrorType(cause)) {
+          serializedCause = ErrorSerializerDeserializer.deserialize(cause);
         }
         return classification === 'ERROR'
           ? new AmplifyUserError(name, options, serializedCause)
@@ -142,11 +142,11 @@ export type AmplifyUserErrorOptions = Omit<
 
 const errorSerializer = (_: unknown, value: unknown) => {
   if (value instanceof Error && value?.constructor.name === 'Error') {
-    return ErrorSerDe.serialize(value);
+    return ErrorSerializerDeserializer.serialize(value);
   }
   return value;
 };
-class ErrorSerDe {
+class ErrorSerializerDeserializer {
   static serialize = (error: Error) => {
     const serializedError: SerializedErrorType = {
       name: 'Error',

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -62,7 +62,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     /**
      * `["']?serializedError["']?:[ ]?` captures the start of the serialized error. The quotes depend on which OS is being used
      * `(?:`(.+?)`|'(.+?)'|"((?:\\"|[^"])*?)")` captures the rest of the serialized string enclosed in either single quote,
-     * double quotes or backticks.
+     * double quotes or back-ticks.
      */
     const extractionRegex =
       /["']?serializedError["']?:[ ]?(?:`(.+?)`|'(.+?)'|"((?:\\"|[^"])*?)")/;


### PR DESCRIPTION
## Problem

`Error` object in javascript cannot be serialized using `JSON.serialize()`. Often times a `Error` from a downstream library is wrapped inside the `AmplifyError` while keeping the `Error` in the `cause` of `AmplifyError`. However due to serialization issues, the `Error` object was not being reconstructed from the `stderr`.

## Changes

This change manually serializes and deserialize the `Error` object.

Another unrelated change here is to ensure single quotes are handled correctly in the error serialization.

## Checklist

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
