### PR TITLE
chore: add more cdk errors in the error mapper

### DIFF
--- a/.changeset/silly-pots-know.md
+++ b/.changeset/silly-pots-know.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/sandbox': patch
+---
+
+chore: add more cdk errors in the error mapper

--- a/package-lock.json
+++ b/package-lock.json
@@ -26237,6 +26237,7 @@
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.4",
         "@aws-amplify/platform-core": "^0.5.0-beta.3",
         "@aws-sdk/client-cloudformation": "^3.465.0",
+        "@aws-sdk/client-ssm": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/types": "^3.465.0",
         "@parcel/watcher": "^2.4.1",

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -133,6 +133,36 @@ Error: some cdk synth error
     errorName: 'ModuleNotFoundError',
     expectedDownstreamErrorMessage: `[ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/user/work-space/shared_secret.js' imported from /Users/user/work-space/amplify-app/amplify/function.ts\n`,
   },
+  {
+    errorMessage: `Error: node:internal/modules/cjs/loader:1098
+    const err = new Error('Cannot find module ');
+                ^
+  
+  Error: Cannot find module '/Users/user/work-space/amplify/resources/module.ts'
+      at createEsmNotFoundErr (node:internal/modules/cjs/loader:1098:15)
+    code: 'MODULE_NOT_FOUND',
+  }
+  
+  Node.js v18.17.1`,
+    expectedTopLevelErrorMessage: 'Cannot find module',
+    errorName: 'ModuleNotFoundError',
+    expectedDownstreamErrorMessage: `Error: Cannot find module '/Users/user/work-space/amplify/resources/module.ts'`,
+  },
+  {
+    errorMessage:
+      'Unable to resolve AWS account to use. It must be either configured when you define your CDK Stack, or through the environment',
+    expectedTopLevelErrorMessage:
+      'Unable to resolve AWS account to use. It must be either configured when you define your CDK Stack, or through the environment',
+    errorName: 'CDKResolveAWSAccountError',
+    expectedDownstreamErrorMessage:
+      'Unable to resolve AWS account to use. It must be either configured when you define your CDK Stack, or through the environment',
+  },
+  {
+    errorMessage: `EACCES: permission denied, unlink '.amplify/artifacts/cdk.out/synth.lock'`,
+    expectedTopLevelErrorMessage: 'File permissions error',
+    errorName: 'FilePermissionsError',
+    expectedDownstreamErrorMessage: `EACCES: permission denied, unlink '.amplify/artifacts/cdk.out/synth.lock'`,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -51,7 +51,25 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex: /\[ERR_MODULE_NOT_FOUND\]:(.*)\n/,
+      errorRegex: /Unable to resolve AWS account to use/,
+      humanReadableErrorMessage:
+        'Unable to resolve AWS account to use. It must be either configured when you define your CDK Stack, or through the environment',
+      resolutionMessage:
+        'You can retry your last request as this is most likely a transient issue: https://github.com/aws/aws-cdk/issues/24744',
+      errorName: 'CDKResolveAWSAccountError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex: /EACCES(.*)/,
+      humanReadableErrorMessage: 'File permissions error',
+      resolutionMessage:
+        'Check that you have the right access permissions to the mentioned file',
+      errorName: 'FilePermissionsError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
+        /\[ERR_MODULE_NOT_FOUND\]:(.*)\n|Error: Cannot find module (.*)/,
       humanReadableErrorMessage: 'Cannot find module',
       resolutionMessage:
         'Check your backend definition in the `amplify` folder for missing file or package imports. Try installing them with your package manager.',
@@ -195,8 +213,10 @@ export type CDKDeploymentError =
   | 'BackendBuildError'
   | 'BackendSynthError'
   | 'BootstrapNotDetectedError'
+  | 'CDKResolveAWSAccountError'
   | 'CFNUpdateNotSupportedError'
   | 'CloudFormationDeploymentError'
+  | 'FilePermissionsError'
   | 'MultipleSandboxInstancesError'
   | 'ESBuildError'
   | 'ExpiredTokenError'

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -55,7 +55,7 @@ export class CdkErrorMapper {
       humanReadableErrorMessage:
         'Unable to resolve AWS account to use. It must be either configured when you define your CDK Stack, or through the environment',
       resolutionMessage:
-        'You can retry your last request as this is most likely a transient issue: https://github.com/aws/aws-cdk/issues/24744',
+        'You can retry your last request as this is most likely a transient issue: https://github.com/aws/aws-cdk/issues/24744. If the error persists ensure your local AWS credentials are valid.',
       errorName: 'CDKResolveAWSAccountError',
       classification: 'ERROR',
     },

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -26,6 +26,7 @@
     "@aws-amplify/platform-core": "^0.5.0-beta.3",
     "@aws-sdk/client-cloudformation": "^3.465.0",
     "@aws-sdk/credential-providers": "^3.465.0",
+    "@aws-sdk/client-ssm": "^3.465.0",
     "@aws-sdk/types": "^3.465.0",
     "@parcel/watcher": "^2.4.1",
     "debounce-promise": "^3.1.2",

--- a/packages/sandbox/src/sandbox_executor.ts
+++ b/packages/sandbox/src/sandbox_executor.ts
@@ -7,6 +7,7 @@ import {
 } from '@aws-amplify/backend-deployer';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { LogLevel, Printer } from '@aws-amplify/cli-core';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 /**
  * Execute CDK commands.
@@ -64,7 +65,19 @@ export class AmplifySandboxExecutor {
   private getSecretLastUpdated = async (
     backendId: BackendIdentifier
   ): Promise<Date | undefined> => {
-    const secrets = await this.secretClient.listSecrets(backendId);
+    let secrets = undefined;
+    try {
+      secrets = await this.secretClient.listSecrets(backendId);
+    } catch (err) {
+      throw new AmplifyUserError(
+        'ListSecretsFailedError',
+        {
+          message: 'Fetching the list of secrets failed',
+          resolution: 'Check the message in downstream exception',
+        },
+        err as Error
+      );
+    }
     let latestTimestamp = -1;
     let secretLastUpdate: Date | undefined;
 


### PR DESCRIPTION
## Changes

Extract more types of user errors from CDK log and map/classify them as `AmplifyErrors` to give less clutter in the sandbox log.

## Validation

unit tests

## Checklist

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
