### PR TITLE
feat: Allow defineData to process combined and RDS schemas

### DIFF
--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -7,7 +7,7 @@
 import { AmplifyData } from '@aws-amplify/data-construct';
 import { AmplifyFunction } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
-import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
+import { DerivedModelSchema, DerivedModelSchemas } from '@aws-amplify/data-schema-types';
 
 // @public
 export type ApiKeyAuthorizationModeProps = {
@@ -32,7 +32,7 @@ export type DataProps = {
 };
 
 // @public
-export type DataSchema = string | DerivedModelSchema;
+export type DataSchema = string | DerivedModelSchema | DerivedModelSchemas;
 
 // @public
 export type DefaultAuthorizationMode = 'iam' | 'userPool' | 'oidc' | 'apiKey' | 'lambda';

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -7,7 +7,7 @@
 import { AmplifyData } from '@aws-amplify/data-construct';
 import { AmplifyFunction } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
-import { DerivedModelSchema, DerivedModelSchemas } from '@aws-amplify/data-schema-types';
+import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
 
 // @public
 export type ApiKeyAuthorizationModeProps = {
@@ -32,7 +32,7 @@ export type DataProps = {
 };
 
 // @public
-export type DataSchema = string | DerivedModelSchema | DerivedModelSchemas;
+export type DataSchema = string | DerivedModelSchema;
 
 // @public
 export type DefaultAuthorizationMode = 'iam' | 'userPool' | 'oidc' | 'apiKey' | 'lambda';

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -1,4 +1,7 @@
-import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
+import {
+  DerivedCombinedSchema,
+  DerivedModelSchema,
+} from '@aws-amplify/data-schema-types';
 import { AmplifyFunction, ConstructFactory } from '@aws-amplify/plugin-types';
 
 /**
@@ -100,6 +103,14 @@ export type AuthorizationModes = {
 };
 
 /**
+ * Schemas type definition, can be either a raw Graphql string, or a typed model schema, or a collection of combined Schemas.
+ */
+export type DataSchemasCollection =
+  | string
+  | DerivedModelSchema
+  | DerivedCombinedSchema;
+
+/**
  * Schema type definition, can be either a raw Graphql string, or a typed model schema.
  */
 export type DataSchema = string | DerivedModelSchema;
@@ -111,7 +122,7 @@ export type DataProps = {
   /**
    * Graphql Schema as a string to be passed into the CDK construct.
    */
-  schema: DataSchema;
+  schema: DataSchemasCollection;
 
   /**
    * Optional name for the generated Api.


### PR DESCRIPTION
## Problem
The backend `defineData` behavior cannot consume RDS schemas or combined schemas. Doing any sort of combining outside this call is lossy/problematic, so migrating to combining within the backend. Also speccing out the datasource configuration mapping that is [actively changing in another PR](https://github.com/aws-amplify/amplify-category-api/pull/2358/files#diff-ad69408b01687c0895260b2174a250e000cdd604bc62779c147674275de89727).

## Changes
- Consume new `data-schema-types` exposed by [this PR](https://github.com/aws-amplify/amplify-api-next/pull/146)
- Add type guards to distinguish model schemas from combined schemas
- Process and combine new combined schemas
- Conversion logic for rds data strategy config

**Corresponding docs PR, if applicable:**

## Validation
TBD - Creating a draft to share direction with peers prior to testing

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
