### PR TITLE
cleanup instances where we use kebab case in yargs handler methods

### DIFF
--- a/.changeset/kind-lemons-compare.md
+++ b/.changeset/kind-lemons-compare.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+cleanup instances where we use kebab case in yargs handler methods

--- a/packages/cli/src/commands/configure/configure_profile_command.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.ts
@@ -1,4 +1,4 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { AmplifyPrompter, printer } from '@aws-amplify/cli-core';
 import { DEFAULT_PROFILE } from '@smithy/shared-ini-file-loader';
 import { EOL } from 'os';
@@ -38,7 +38,9 @@ export class ConfigureProfileCommand
   /**
    * @inheritDoc
    */
-  handler = async (args: ConfigureProfileCommandOptions): Promise<void> => {
+  handler = async (
+    args: ArgumentsCamelCase<ConfigureProfileCommandOptions>
+  ): Promise<void> => {
     const profileName = args.name;
     const profileExists = await this.profileController.profileExists(
       profileName

--- a/packages/cli/src/commands/generate/config/generate_config_command.ts
+++ b/packages/cli/src/commands/generate/config/generate_config_command.ts
@@ -1,4 +1,4 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import {
   ClientConfigFormat,
   ClientConfigVersion,
@@ -51,7 +51,9 @@ export class GenerateConfigCommand
   /**
    * @inheritDoc
    */
-  handler = async (args: GenerateConfigCommandOptions): Promise<void> => {
+  handler = async (
+    args: ArgumentsCamelCase<GenerateConfigCommandOptions>
+  ): Promise<void> => {
     const backendIdentifier = await this.backendIdentifierResolver.resolve(
       args
     );
@@ -62,8 +64,8 @@ export class GenerateConfigCommand
 
     await this.clientConfigGenerator.generateClientConfigToFile(
       backendIdentifier,
-      args['config-version'] as ClientConfigVersion,
-      args['out-dir'],
+      args.configVersion as ClientConfigVersion,
+      args.outDir,
       args.format
     );
   };

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { BackendOutputClient } from '@aws-amplify/deployed-backend-client';
 import { graphqlOutputKey } from '@aws-amplify/backend-output-schemas';
 import { BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
@@ -53,7 +53,9 @@ export class GenerateFormsCommand
   /**
    * @inheritDoc
    */
-  handler = async (args: GenerateFormsCommandOptions): Promise<void> => {
+  handler = async (
+    args: ArgumentsCamelCase<GenerateFormsCommandOptions>
+  ): Promise<void> => {
     const backendIdentifier = await this.backendIdentifierResolver.resolve(
       args
     );
@@ -72,11 +74,11 @@ export class GenerateFormsCommand
 
     const apiUrl = output[graphqlOutputKey].payload.amplifyApiModelSchemaS3Uri;
 
-    if (!args['out-dir']) {
+    if (!args.outDir) {
       throw new Error('out-dir must be defined');
     }
 
-    const outDir = args['out-dir'];
+    const outDir = args.outDir;
 
     await this.formGenerationHandler.generate({
       modelsOutDir: path.join(outDir, 'graphql'),

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
@@ -1,4 +1,4 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { isAbsolute, resolve } from 'path';
 import {
@@ -87,7 +87,7 @@ export class GenerateGraphqlClientCodeCommand
    * @inheritDoc
    */
   handler = async (
-    args: GenerateGraphqlClientCodeCommandOptions
+    args: ArgumentsCamelCase<GenerateGraphqlClientCodeCommandOptions>
   ): Promise<void> => {
     const backendIdentifier = await this.backendIdentifierResolver.resolve(
       args

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
@@ -1,4 +1,4 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
 import { SecretClient } from '@aws-amplify/backend-secret';
@@ -50,7 +50,9 @@ export class GenerateSchemaCommand
   /**
    * @inheritDoc
    */
-  handler = async (args: GenerateSchemaCommandOptions): Promise<void> => {
+  handler = async (
+    args: ArgumentsCamelCase<GenerateSchemaCommandOptions>
+  ): Promise<void> => {
     const backendIdentifier = await this.backendIdentifierResolver.resolve(
       args
     );
@@ -61,8 +63,8 @@ export class GenerateSchemaCommand
       });
     }
 
-    const secretName = args['connection-uri-secret'] as string;
-    const outputFile = args['out'] as string;
+    const secretName = args.connectionUriSecret as string;
+    const outputFile = args.out as string;
 
     const connectionUriSecret = await this.secretClient.getSecret(
       backendIdentifier as BackendIdentifier,

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -1,5 +1,5 @@
 import _isCI from 'is-ci';
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { BackendDeployer } from '@aws-amplify/backend-deployer';
 import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
 import { ArgumentsKebabCase } from '../../kebab_case.js';
@@ -52,7 +52,9 @@ export class PipelineDeployCommand
   /**
    * @inheritDoc
    */
-  handler = async (args: PipelineDeployCommandOptions): Promise<void> => {
+  handler = async (
+    args: ArgumentsCamelCase<PipelineDeployCommandOptions>
+  ): Promise<void> => {
     if (!this.isCiEnvironment) {
       throw new Error(
         'It looks like this command is being run outside of a CI/CD workflow. To deploy locally use `amplify sandbox` instead.'
@@ -60,7 +62,7 @@ export class PipelineDeployCommand
     }
 
     const backendId: BackendIdentifier = {
-      namespace: args['app-id'],
+      namespace: args.appId,
       name: args.branch,
       type: 'branch',
     };
@@ -69,8 +71,8 @@ export class PipelineDeployCommand
     });
     await this.clientConfigGenerator.generateClientConfigToFile(
       backendId,
-      args['config-version'] as ClientConfigVersion,
-      args['config-out-dir']
+      args.configVersion as ClientConfigVersion,
+      args.configOutDir
     );
   };
 

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.ts
@@ -42,7 +42,7 @@ export class SandboxSecretGetCommand
       args.name
     );
     const secret = await this.secretClient.getSecret(sandboxBackendIdentifier, {
-      name: args['secret-name'],
+      name: args.secretName,
     });
     printer.print(format.record(secret));
   };

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
@@ -1,4 +1,4 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
@@ -35,14 +35,14 @@ export class SandboxSecretRemoveCommand
    * @inheritDoc
    */
   handler = async (
-    args: SecretRemoveCommandOptionsKebabCase
+    args: ArgumentsCamelCase<SecretRemoveCommandOptionsKebabCase>
   ): Promise<void> => {
     const sandboxBackendIdentifier = await this.sandboxIdResolver.resolve(
       args.name
     );
     await this.secretClient.removeSecret(
       sandboxBackendIdentifier,
-      args['secret-name']
+      args.secretName
     );
   };
 

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
@@ -42,7 +42,7 @@ export class SandboxSecretSetCommand
     const secretVal = await AmplifyPrompter.secretValue();
     await this.secretClient.setSecret(
       await this.sandboxIdResolver.resolve(args.name),
-      args['secret-name'],
+      args.secretName,
       secretVal
     );
   };


### PR DESCRIPTION
## Problem

There are inconsistencies on how we handle yargs arg object in handler methods, some args are kebab-case and others are camelCase.

**Issue number, if available:**
Fixes #1203 

## Changes

Update all handler methods to handle args in handler methods as camelCase to keep things consistent.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
