### PR TITLE
Improved error message for package manager

### DIFF
--- a/.changeset/modern-balloons-wave.md
+++ b/.changeset/modern-balloons-wave.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/cli-core': patch
+---
+
+Improved error message when attempting to run amplify directly

--- a/package-lock.json
+++ b/package-lock.json
@@ -17978,6 +17978,7 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -18590,6 +18591,7 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -25102,7 +25104,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.6.0-beta.7",
+      "version": "0.6.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -25117,17 +25119,17 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.12",
+      "version": "0.13.0-beta.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.5.0-beta.7",
-        "@aws-amplify/backend-data": "^0.10.0-beta.8",
+        "@aws-amplify/backend-auth": "^0.5.0-beta.8",
+        "@aws-amplify/backend-data": "^0.10.0-beta.9",
         "@aws-amplify/backend-function": "^0.8.0-beta.8",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
         "@aws-amplify/backend-storage": "^0.6.0-beta.6",
-        "@aws-amplify/client-config": "^0.9.0-beta.9",
+        "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/data-schema": "^0.14.0",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
         "@aws-amplify/plugin-types": "^0.9.0-beta.1",
@@ -25144,10 +25146,10 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.5.0-beta.7",
+      "version": "0.5.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.7",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.8",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
         "@aws-amplify/plugin-types": "^0.9.0-beta.1"
       },
@@ -25162,7 +25164,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.10.0-beta.8",
+      "version": "0.10.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -25283,19 +25285,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.0-beta.14",
+      "version": "0.12.0-beta.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
         "@aws-amplify/cli-core": "^0.5.0-beta.7",
-        "@aws-amplify/client-config": "^0.9.0-beta.9",
+        "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
-        "@aws-amplify/form-generator": "^0.8.0-beta.1",
-        "@aws-amplify/model-generator": "^0.5.0-beta.6",
+        "@aws-amplify/form-generator": "^0.8.0-beta.2",
+        "@aws-amplify/model-generator": "^0.5.0-beta.7",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/sandbox": "^0.5.2-beta.11",
+        "@aws-amplify/sandbox": "^0.5.2-beta.12",
         "@aws-amplify/schema-generator": "^0.1.0-beta.3",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
@@ -25446,12 +25448,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.9.0-beta.9",
+      "version": "0.9.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
-        "@aws-amplify/model-generator": "^0.5.0-beta.6",
+        "@aws-amplify/model-generator": "^0.5.0-beta.7",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -25621,7 +25623,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "0.8.0-beta.1",
+      "version": "0.8.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
@@ -25643,10 +25645,10 @@
       "version": "0.5.0-beta.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.7",
-        "@aws-amplify/backend": "^0.13.0-beta.12",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.8",
+        "@aws-amplify/backend": "^0.13.0-beta.13",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/client-config": "^0.9.0-beta.9",
+        "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/data-schema": "^0.14.0",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
         "@aws-sdk/client-amplify": "^3.465.0",
@@ -25670,7 +25672,7 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.5.0-beta.6",
+      "version": "0.5.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -26225,13 +26227,13 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.11",
+      "version": "0.5.2-beta.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
         "@aws-amplify/cli-core": "^0.5.0-beta.7",
-        "@aws-amplify/client-config": "^0.9.0-beta.9",
+        "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
         "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/cli-core/src/package-manager-controller/package_manager_controller_factory.ts
+++ b/packages/cli-core/src/package-manager-controller/package_manager_controller_factory.ts
@@ -5,6 +5,7 @@ import { NpmPackageManagerController } from './npm_package_manager_controller.js
 import { PnpmPackageManagerController } from './pnpm_package_manager_controller.js';
 import { YarnClassicPackageManagerController } from './yarn_classic_package_manager_controller.js';
 import { YarnModernPackageManagerController } from './yarn_modern_package_manager_controller.js';
+import { format } from '../format/format.js';
 
 /**
  * PackageManagerControllerFactory is a factory for an abstraction around package manager commands that are needed to initialize a project and install dependencies
@@ -58,7 +59,9 @@ export class PackageManagerControllerFactory {
     const userAgent = process.env.npm_config_user_agent;
     if (userAgent === undefined) {
       throw new AmplifyUserError('NoPackageManagerError', {
-        resolution: `This is usually caused by attempting to run \`amplify\` directly. Try running \`npx amplify\``,
+        resolution: `This is usually caused by attempting to run ${format.command(
+          'amplify'
+        )} directly. Try running ${format.command('npx amplify')}`,
         message: `npm_config_user_agent is undefined`,
       });
     }

--- a/packages/cli-core/src/package-manager-controller/package_manager_controller_factory.ts
+++ b/packages/cli-core/src/package-manager-controller/package_manager_controller_factory.ts
@@ -57,7 +57,9 @@ export class PackageManagerControllerFactory {
   private getPackageManagerName() {
     const userAgent = process.env.npm_config_user_agent;
     if (userAgent === undefined) {
-      throw new Error('npm_config_user_agent is undefined');
+      throw new Error(
+        `npm_config_user_agent is undefined\n\nThis is usually caused by attempting to run \`amplify\` directly. Try running \`npx amplify\``
+      );
     }
     const packageManagerAndVersion = userAgent.split(' ')[0];
     const [packageManagerName, packageManagerVersion] =

--- a/packages/cli-core/src/package-manager-controller/package_manager_controller_factory.ts
+++ b/packages/cli-core/src/package-manager-controller/package_manager_controller_factory.ts
@@ -57,9 +57,10 @@ export class PackageManagerControllerFactory {
   private getPackageManagerName() {
     const userAgent = process.env.npm_config_user_agent;
     if (userAgent === undefined) {
-      throw new Error(
-        `npm_config_user_agent is undefined\n\nThis is usually caused by attempting to run \`amplify\` directly. Try running \`npx amplify\``
-      );
+      throw new AmplifyUserError('NoPackageManagerError', {
+        resolution: `This is usually caused by attempting to run \`amplify\` directly. Try running \`npx amplify\``,
+        message: `npm_config_user_agent is undefined`,
+      });
     }
     const packageManagerAndVersion = userAgent.split(' ')[0];
     const [packageManagerName, packageManagerVersion] =


### PR DESCRIPTION


## Problem

Directs users to use `npx amplify` if the CLI errors when not being run with a package manager.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
