### PR TITLE
add amplify secret name to the generated typescript data schema file

### DIFF
--- a/.changeset/nasty-snails-speak.md
+++ b/.changeset/nasty-snails-speak.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/schema-generator': patch
+'@aws-amplify/backend-cli': patch
+---
+
+Include secret name in the generated typescript data schema file

--- a/package-lock.json
+++ b/package-lock.json
@@ -25125,11 +25125,11 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.13",
+      "version": "0.13.0-beta.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^0.5.0-beta.8",
-        "@aws-amplify/backend-data": "^0.10.0-beta.9",
+        "@aws-amplify/backend-data": "^0.10.0-beta.10",
         "@aws-amplify/backend-function": "^0.8.0-beta.8",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
@@ -25170,7 +25170,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.10.0-beta.9",
+      "version": "0.10.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -25291,19 +25291,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.0-beta.15",
+      "version": "0.12.0-beta.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/cli-core": "^0.5.0-beta.7",
+        "@aws-amplify/cli-core": "^0.5.0-beta.8",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
-        "@aws-amplify/form-generator": "^0.8.0-beta.2",
+        "@aws-amplify/form-generator": "^0.8.0-beta.3",
         "@aws-amplify/model-generator": "^0.5.0-beta.7",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/sandbox": "^0.5.2-beta.12",
+        "@aws-amplify/sandbox": "^0.5.2-beta.13",
         "@aws-amplify/schema-generator": "^0.1.0-beta.3",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
@@ -25333,7 +25333,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.5.0-beta.7",
+      "version": "0.5.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
@@ -25475,10 +25475,10 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.7.0-beta.9",
+      "version": "0.7.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.5.0-beta.7",
+        "@aws-amplify/cli-core": "^0.5.0-beta.8",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
         "@aws-amplify/plugin-types": "^0.9.0-beta.1",
         "execa": "^8.0.1",
@@ -25629,7 +25629,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "0.8.0-beta.2",
+      "version": "0.8.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
@@ -25648,11 +25648,11 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.5.0-beta.6",
+      "version": "0.5.0-beta.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.8",
-        "@aws-amplify/backend": "^0.13.0-beta.13",
+        "@aws-amplify/backend": "^0.13.0-beta.14",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/data-schema": "^0.14.5",
@@ -26233,12 +26233,12 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.12",
+      "version": "0.5.2-beta.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/cli-core": "^0.5.0-beta.7",
+        "@aws-amplify/cli-core": "^0.5.0-beta.8",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
@@ -26265,7 +26265,7 @@
       "version": "0.1.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-schema-generator": "^0.7.2",
+        "@aws-amplify/graphql-schema-generator": "^0.8.0",
         "@aws-amplify/platform-core": "^0.5.0-beta.4"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1828,6 +1828,11 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@aws-amplify/graphql-directives": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-directives/-/graphql-directives-1.0.1.tgz",
+      "integrity": "sha512-oUUQJU1syzUfU4P4z+fLDLklU9wmEZokgQOAKHBN5Szest/mDkjZEbG9VVBiMaQbq1Rw0jkRJmVU9WA1vxjT2A=="
+    },
     "node_modules/@aws-amplify/graphql-docs-generator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-4.2.1.tgz",
@@ -2097,12 +2102,12 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@aws-amplify/graphql-schema-generator": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-schema-generator/-/graphql-schema-generator-0.7.2.tgz",
-      "integrity": "sha512-eg2HZsdtv0HaQ1VXQhPQC1itUB7EfTdQARLuf04WwV8SFor6Ju0cgD3kfL4GYV4jZ6uYDClPUYUux5fGQTE7bw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-schema-generator/-/graphql-schema-generator-0.8.0.tgz",
+      "integrity": "sha512-t35CNoaT+ySZIdE1aJMeremNzhwZ/Buiu+bGOqBrgmUyjzM4ZP56Z911/1xpDHDq61oqLnkwdp7Pl4ESvEc+PA==",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.5.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.4.0",
+        "@aws-amplify/graphql-transformer-core": "2.5.1",
+        "@aws-amplify/graphql-transformer-interfaces": "3.5.0",
         "@aws-sdk/client-ec2": "3.338.0",
         "@aws-sdk/client-iam": "3.338.0",
         "@aws-sdk/client-lambda": "3.338.0",
@@ -2110,7 +2115,7 @@
         "csv-parse": "^5.5.2",
         "fs-extra": "11.1.1",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.28.1",
+        "graphql-transformer-common": "4.29.0",
         "knex": "~2.4.0",
         "mysql2": "~2.3.3",
         "ora": "^4.0.3",
@@ -2664,14 +2669,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-2.5.0.tgz",
-      "integrity": "sha512-vM1o6q2hJpHsBbSGufFhEwe/lkZaRkQKbWhzQ/QGQCZkVZN5isBEYi2fmQlD4lVZe1bBTBwOhUFuFcNYcMVLwA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-2.5.1.tgz",
+      "integrity": "sha512-eayaj2GMG1hAReuQb7upEyDf2HbzHz04Cmj/HhHG5y/wtCy7OVt3bR1qAvFYYjAsPQoUooC8MmJV7Bhw33m9Vw==",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-interfaces": "3.4.0",
+        "@aws-amplify/graphql-directives": "1.0.1",
+        "@aws-amplify/graphql-transformer-interfaces": "3.5.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.28.1",
+        "graphql-transformer-common": "4.29.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -2721,9 +2727,9 @@
       }
     },
     "node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.4.0.tgz",
-      "integrity": "sha512-vnPP/JPm/+oGQQQ3/5k7TSDWy9pF1eNtNPBpO238cNeFsS21FNEHT7x3goFSijRZUVYeDgwT4/B4agjc7D74Aw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.5.0.tgz",
+      "integrity": "sha512-YIFC0b8hqBKBdYBzpJImQDezTPUeOh9WVE0uFv6JM0NZRP917YbdA1RSJDMT6VZTN38d2nDxfxjjbPXDVxu4YQ==",
       "dependencies": {
         "graphql": "^15.5.0"
       },
@@ -18312,9 +18318,9 @@
       }
     },
     "node_modules/graphql-transformer-common": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.28.1.tgz",
-      "integrity": "sha512-ui+6DGStFWBu92G6oUXdRJ3Rb8qeT0f+GgCko2xMeDPqy52VUanVAI/2NtuOh+jBwpcrH/sygKQJJOg7orCEag==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.29.0.tgz",
+      "integrity": "sha512-A9/vyU7hdZsbihYyxqCODG2ZFAT/UIpvi9vnx9mEugK8UN1GpyQXsgQ9S3uWr/fW7dm2ferzw0JGIcUwv1QO2w==",
       "dependencies": {
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
@@ -87,9 +87,11 @@ void describe('generate graphql-client-code command', () => {
     assert.equal(secretClientGetSecret.mock.callCount(), 1);
     assert.equal(schemaGeneratorGenerateMethod.mock.callCount(), 1);
     assert.deepEqual(schemaGeneratorGenerateMethod.mock.calls[0].arguments[0], {
-      connectionUri: 'FAKE_CONN_STRING_VALUE',
+      connectionUri: {
+        secretName: 'CONN_STRING',
+        value: 'FAKE_CONN_STRING_VALUE',
+      },
       out: 'schema.rds.ts',
-      secretName: 'CONN_STRING',
     });
   });
 
@@ -100,9 +102,11 @@ void describe('generate graphql-client-code command', () => {
     assert.equal(secretClientGetSecret.mock.callCount(), 1);
     assert.equal(schemaGeneratorGenerateMethod.mock.callCount(), 1);
     assert.deepEqual(schemaGeneratorGenerateMethod.mock.calls[0].arguments[0], {
-      connectionUri: 'FAKE_CONN_STRING_VALUE',
+      connectionUri: {
+        secretName: 'CONN_STRING',
+        value: 'FAKE_CONN_STRING_VALUE',
+      },
       out: 'schema.rds.ts',
-      secretName: 'CONN_STRING',
     });
   });
 

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
@@ -89,6 +89,7 @@ void describe('generate graphql-client-code command', () => {
     assert.deepEqual(schemaGeneratorGenerateMethod.mock.calls[0].arguments[0], {
       connectionUri: 'FAKE_CONN_STRING_VALUE',
       out: 'schema.rds.ts',
+      secretName: 'CONN_STRING',
     });
   });
 
@@ -101,6 +102,7 @@ void describe('generate graphql-client-code command', () => {
     assert.deepEqual(schemaGeneratorGenerateMethod.mock.calls[0].arguments[0], {
       connectionUri: 'FAKE_CONN_STRING_VALUE',
       out: 'schema.rds.ts',
+      secretName: 'CONN_STRING',
     });
   });
 

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
@@ -74,8 +74,10 @@ export class GenerateSchemaCommand
     );
 
     await this.schemaGenerator.generate({
-      secretName,
-      connectionUri: connectionUriSecret.value,
+      connectionUri: {
+        secretName,
+        value: connectionUriSecret.value,
+      },
       out: outputFile,
     });
   };

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
@@ -74,6 +74,7 @@ export class GenerateSchemaCommand
     );
 
     await this.schemaGenerator.generate({
+      secretName,
       connectionUri: connectionUriSecret.value,
       out: outputFile,
     });

--- a/packages/schema-generator/API.md
+++ b/packages/schema-generator/API.md
@@ -12,8 +12,10 @@ export class SchemaGenerator {
 
 // @public (undocumented)
 export type SchemaGeneratorConfig = {
-    secretName: string;
-    connectionUri: string;
+    connectionUri: {
+        secretName: string;
+        value: string;
+    };
     out: string;
 };
 

--- a/packages/schema-generator/API.md
+++ b/packages/schema-generator/API.md
@@ -12,6 +12,7 @@ export class SchemaGenerator {
 
 // @public (undocumented)
 export type SchemaGeneratorConfig = {
+    secretName: string;
     connectionUri: string;
     out: string;
 };

--- a/packages/schema-generator/package.json
+++ b/packages/schema-generator/package.json
@@ -17,7 +17,7 @@
     "update:api": "api-extractor run --local"
   },
   "dependencies": {
-    "@aws-amplify/graphql-schema-generator": "^0.7.2",
+    "@aws-amplify/graphql-schema-generator": "^0.8.0",
     "@aws-amplify/platform-core": "^0.5.0-beta.4"
   },
   "license": "Apache-2.0"

--- a/packages/schema-generator/src/generate_schema.test.ts
+++ b/packages/schema-generator/src/generate_schema.test.ts
@@ -20,9 +20,11 @@ void describe('SchemaGenerator', () => {
   void it('should generate schema', async () => {
     const schemaGenerator = new SchemaGenerator();
     await schemaGenerator.generate({
-      connectionUri: 'mysql://user:password@hostname:3306/db',
+      connectionUri: {
+        secretName: 'FAKE_SECRET_NAME',
+        value: 'mysql://user:password@hostname:3306/db',
+      },
       out: 'schema.ts',
-      secretName: 'FAKE_SECRET_NAME',
     });
     assert.strictEqual(mockGenerateMethod.mock.calls.length, 1);
     assert.strictEqual(mockFsWriteFileSync.mock.calls.length, 1);

--- a/packages/schema-generator/src/generate_schema.test.ts
+++ b/packages/schema-generator/src/generate_schema.test.ts
@@ -22,6 +22,7 @@ void describe('SchemaGenerator', () => {
     await schemaGenerator.generate({
       connectionUri: 'mysql://user:password@hostname:3306/db',
       out: 'schema.ts',
+      secretName: 'FAKE_SECRET_NAME',
     });
     assert.strictEqual(mockGenerateMethod.mock.calls.length, 1);
     assert.strictEqual(mockFsWriteFileSync.mock.calls.length, 1);

--- a/packages/schema-generator/src/generate_schema.ts
+++ b/packages/schema-generator/src/generate_schema.ts
@@ -3,8 +3,10 @@ import fs from 'fs/promises';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 export type SchemaGeneratorConfig = {
-  secretName: string;
-  connectionUri: string;
+  connectionUri: {
+    secretName: string;
+    value: string;
+  };
   out: string;
 };
 
@@ -17,12 +19,12 @@ type AmplifyGenerateSchemaError =
  */
 export class SchemaGenerator {
   generate = async (props: SchemaGeneratorConfig) => {
-    const dbConfig = parseDatabaseUrl(props.connectionUri);
+    const dbConfig = parseDatabaseUrl(props.connectionUri.value);
 
     try {
       const schema = await TypescriptDataSchemaGenerator.generate({
         ...dbConfig,
-        connectionUriSecretName: props.secretName,
+        connectionUriSecretName: props.connectionUri.secretName,
       });
       await fs.writeFile(props.out, schema);
     } catch (err) {

--- a/packages/schema-generator/src/generate_schema.ts
+++ b/packages/schema-generator/src/generate_schema.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 export type SchemaGeneratorConfig = {
+  secretName: string;
   connectionUri: string;
   out: string;
 };
@@ -19,7 +20,10 @@ export class SchemaGenerator {
     const dbConfig = parseDatabaseUrl(props.connectionUri);
 
     try {
-      const schema = await TypescriptDataSchemaGenerator.generate(dbConfig);
+      const schema = await TypescriptDataSchemaGenerator.generate({
+        ...dbConfig,
+        connectionUriSecretName: props.secretName,
+      });
       await fs.writeFile(props.out, schema);
     } catch (err) {
       const databaseError = err as DatabaseConnectError;


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Adds the amplify secret name to the generated typescript data schema file.
- The core functionality exists in the API repo `@aws-amplify/graphql-schema-generator` package. Gen2 CLI is responsible for passing the amplify secret name option from the below command to the library.

```sh
npx amplify generate schema-from-database --connection-uri-secret CONN_STRING_SECRET --out schema.rds.ts
```

The underlying library uses the secret name in the generated file as shown in the below link. This file is later used to deploy the backend.
https://github.com/aws-amplify/amplify-category-api/blob/2c8ee6b16c1bb2b5dececa70354d7f4fff616497/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap#L115

The PR also upgrades the `@aws-amplify/graphql-schema-generator` version to `0.8.0` which auto detects the database vpc configuration from the given connection uri.

**Issue number, if available:**
NA

## Changes
- Unit tests
- Manual test

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**
NA. No changes in the command structure.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
