### PR TITLE
Increase canary timeout

### DIFF
--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         region: [us-west-2, us-east-1, ca-central-1, eu-central-1]
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       AWS_REGION: ${{ matrix.region }}
     permissions:


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

After adding retry canaries may cross 15 minutes threshold.


<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

The usual run time for canaries is around 7-8 minutes. If there's retry it may cross 15 minutes.
Therefore bumping threshold to 20 minutes.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
