### PR TITLE
chore: rename the new client config file name

### DIFF
--- a/.changeset/beige-dragons-boil.md
+++ b/.changeset/beige-dragons-boil.md
@@ -1,0 +1,8 @@
+---
+'@aws-amplify/integration-tests': patch
+'create-amplify': patch
+'@aws-amplify/client-config': patch
+'@aws-amplify/backend-cli': patch
+---
+
+chore: rename the new client config file name

--- a/package-lock.json
+++ b/package-lock.json
@@ -25110,7 +25110,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.6.0-beta.8",
+      "version": "0.6.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -25125,10 +25125,10 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.14",
+      "version": "0.13.0-beta.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.5.0-beta.8",
+        "@aws-amplify/backend-auth": "^0.5.0-beta.9",
         "@aws-amplify/backend-data": "^0.10.0-beta.10",
         "@aws-amplify/backend-function": "^0.8.0-beta.8",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -25152,10 +25152,10 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.5.0-beta.8",
+      "version": "0.5.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.8",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.9",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
         "@aws-amplify/plugin-types": "^0.9.0-beta.1"
       },
@@ -25291,20 +25291,20 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.0-beta.16",
+      "version": "0.12.0-beta.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/cli-core": "^0.5.0-beta.8",
+        "@aws-amplify/cli-core": "^0.5.0-beta.9",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
         "@aws-amplify/form-generator": "^0.8.0-beta.3",
         "@aws-amplify/model-generator": "^0.5.0-beta.7",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/sandbox": "^0.5.2-beta.13",
-        "@aws-amplify/schema-generator": "^0.1.0-beta.3",
+        "@aws-amplify/sandbox": "^0.5.2-beta.14",
+        "@aws-amplify/schema-generator": "^0.1.0-beta.4",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -25333,7 +25333,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.5.0-beta.8",
+      "version": "0.5.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
@@ -25475,10 +25475,10 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.7.0-beta.10",
+      "version": "0.7.0-beta.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.5.0-beta.8",
+        "@aws-amplify/cli-core": "^0.5.0-beta.9",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
         "@aws-amplify/plugin-types": "^0.9.0-beta.1",
         "execa": "^8.0.1",
@@ -25651,8 +25651,8 @@
       "version": "0.5.0-beta.7",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.8",
-        "@aws-amplify/backend": "^0.13.0-beta.14",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.9",
+        "@aws-amplify/backend": "^0.13.0-beta.15",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/data-schema": "^0.14.5",
@@ -26233,12 +26233,12 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.13",
+      "version": "0.5.2-beta.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/cli-core": "^0.5.0-beta.8",
+        "@aws-amplify/cli-core": "^0.5.0-beta.9",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
@@ -26262,7 +26262,7 @@
     },
     "packages/schema-generator": {
       "name": "@aws-amplify/schema-generator",
-      "version": "0.1.0-beta.3",
+      "version": "0.1.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-schema-generator": "^0.8.0",

--- a/packages/cli/src/commands/generate/config/generate_config_command.ts
+++ b/packages/cli/src/commands/generate/config/generate_config_command.ts
@@ -111,7 +111,7 @@ export class GenerateConfigCommand
       })
       .option('config-version', {
         describe:
-          'Version of the client config. Version 0 represents classic amplify-cli client config amplify-configuration (Default) and 1 represents new unified client config amplify-outputs',
+          'Version of the client config. Version 0 represents classic amplify-cli client config amplify-configuration (Default) and 1 represents new unified client config amplify_outputs',
         type: 'string',
         array: false,
         choices: Object.values(ClientConfigVersionOption),

--- a/packages/client-config/API.md
+++ b/packages/client-config/API.md
@@ -149,7 +149,7 @@ export type ClientConfig = clientConfigTypesV1.AWSAmplifyBackendOutputs;
 // @public (undocumented)
 export enum ClientConfigFileBaseName {
     // (undocumented)
-    DEFAULT = "amplify-outputs",
+    DEFAULT = "amplify_outputs",
     // (undocumented)
     LEGACY = "amplifyconfiguration"
 }

--- a/packages/client-config/src/client-config-types/client_config.ts
+++ b/packages/client-config/src/client-config-types/client_config.ts
@@ -69,7 +69,7 @@ export enum ClientConfigFormat {
 
 export enum ClientConfigFileBaseName {
   LEGACY = 'amplifyconfiguration',
-  DEFAULT = 'amplify-outputs',
+  DEFAULT = 'amplify_outputs',
 }
 
 export type GenerateClientConfigToFileResult = {

--- a/packages/create-amplify/src/gitignore_initializer.test.ts
+++ b/packages/create-amplify/src/gitignore_initializer.test.ts
@@ -27,6 +27,7 @@ void describe('GitIgnoreInitializer', () => {
       `node_modules${os.EOL}`,
       `.amplify${os.EOL}`,
       `amplifyconfiguration*${os.EOL}`,
+      `amplify_outputs*${os.EOL}`,
     ];
     await gitIgnoreInitializer.ensureInitialized();
     assert.equal(
@@ -56,6 +57,7 @@ void describe('GitIgnoreInitializer', () => {
       `# amplify${os.EOL}`,
       `.amplify${os.EOL}`,
       `amplifyconfiguration*${os.EOL}`,
+      `amplify_outputs*${os.EOL}`,
     ];
     await gitIgnoreInitializer.ensureInitialized();
     assert.deepStrictEqual(fsMock.appendFile.mock.calls[0].arguments, [
@@ -81,6 +83,7 @@ void describe('GitIgnoreInitializer', () => {
       `# amplify${os.EOL}`,
       `.amplify${os.EOL}`,
       `amplifyconfiguration*${os.EOL}`,
+      `amplify_outputs*${os.EOL}`,
     ];
     await gitIgnoreInitializer.ensureInitialized();
     assert.deepStrictEqual(fsMock.appendFile.mock.calls[0].arguments, [
@@ -106,6 +109,7 @@ void describe('GitIgnoreInitializer', () => {
       `# amplify${os.EOL}`,
       `.amplify${os.EOL}`,
       `amplifyconfiguration*${os.EOL}`,
+      `amplify_outputs*${os.EOL}`,
     ];
     await gitIgnoreInitializer.ensureInitialized();
     assert.deepStrictEqual(fsMock.appendFile.mock.calls[0].arguments, [
@@ -131,6 +135,7 @@ void describe('GitIgnoreInitializer', () => {
       `# amplify${os.EOL}`,
       `.amplify${os.EOL}`,
       `amplifyconfiguration*${os.EOL}`,
+      `amplify_outputs*${os.EOL}`,
     ];
     await gitIgnoreInitializer.ensureInitialized();
     assert.deepStrictEqual(fsMock.appendFile.mock.calls[0].arguments, [
@@ -156,6 +161,7 @@ void describe('GitIgnoreInitializer', () => {
       `# amplify${os.EOL}`,
       `.amplify${os.EOL}`,
       `amplifyconfiguration*${os.EOL}`,
+      `amplify_outputs*${os.EOL}`,
     ];
     await gitIgnoreInitializer.ensureInitialized();
     assert.deepStrictEqual(fsMock.appendFile.mock.calls[0].arguments, [
@@ -190,6 +196,7 @@ void describe('GitIgnoreInitializer', () => {
       `node_modules${os.EOL}`,
       `.amplify${os.EOL}`,
       `amplifyconfiguration*${os.EOL}`,
+      `amplify_outputs*${os.EOL}`,
     ];
     await gitIgnoreInitializer.ensureInitialized();
     assert.deepStrictEqual(fsMock.appendFile.mock.calls[0].arguments, [

--- a/packages/create-amplify/src/gitignore_initializer.ts
+++ b/packages/create-amplify/src/gitignore_initializer.ts
@@ -29,6 +29,7 @@ export class GitIgnoreInitializer {
       'node_modules',
       '.amplify',
       'amplifyconfiguration*',
+      'amplify_outputs*',
     ];
     const gitIgnoreContent = await this.getGitIgnoreContent();
 

--- a/packages/integration-tests/src/test-e2e/create_amplify.test.ts
+++ b/packages/integration-tests/src/test-e2e/create_amplify.test.ts
@@ -170,6 +170,7 @@ void describe(
             '# amplify',
             '.amplify',
             'amplifyconfiguration*',
+            'amplify_outputs*',
             'node_modules',
           ]);
 


### PR DESCRIPTION

## Problem

Current `amplify-outputs.json` doesn't work with android as the character `-` is not allowed in the resource names


## Changes

1. This PR changes the name of the file to `amplify_outputs` for all platforms.
2. Add this file to the gitignore as well.


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
