### PR TITLE
set default port for database if not provided in connection uri

### DIFF
--- a/.changeset/serious-dolphins-peel.md
+++ b/.changeset/serious-dolphins-peel.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/schema-generator': patch
+---
+
+Assign default port if it is not provided in the connection uri.

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -106,6 +106,7 @@
   "pnpm",
   "positionals",
   "posix",
+  "postgres",
   "postgresql",
   "readdir",
   "readline",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25110,7 +25110,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.6.0-beta.8",
+      "version": "0.6.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -25125,10 +25125,10 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.14",
+      "version": "0.13.0-beta.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.5.0-beta.8",
+        "@aws-amplify/backend-auth": "^0.5.0-beta.9",
         "@aws-amplify/backend-data": "^0.10.0-beta.10",
         "@aws-amplify/backend-function": "^0.8.0-beta.8",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
@@ -25152,10 +25152,10 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.5.0-beta.8",
+      "version": "0.5.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.8",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.9",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
         "@aws-amplify/plugin-types": "^0.9.0-beta.1"
       },
@@ -25291,20 +25291,20 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.0-beta.16",
+      "version": "0.12.0-beta.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/cli-core": "^0.5.0-beta.8",
+        "@aws-amplify/cli-core": "^0.5.0-beta.9",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
         "@aws-amplify/form-generator": "^0.8.0-beta.3",
         "@aws-amplify/model-generator": "^0.5.0-beta.7",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/sandbox": "^0.5.2-beta.13",
-        "@aws-amplify/schema-generator": "^0.1.0-beta.3",
+        "@aws-amplify/sandbox": "^0.5.2-beta.14",
+        "@aws-amplify/schema-generator": "^0.1.0-beta.4",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -25333,7 +25333,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.5.0-beta.8",
+      "version": "0.5.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
@@ -25475,10 +25475,10 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.7.0-beta.10",
+      "version": "0.7.0-beta.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.5.0-beta.8",
+        "@aws-amplify/cli-core": "^0.5.0-beta.9",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
         "@aws-amplify/plugin-types": "^0.9.0-beta.1",
         "execa": "^8.0.1",
@@ -25651,8 +25651,8 @@
       "version": "0.5.0-beta.7",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.8",
-        "@aws-amplify/backend": "^0.13.0-beta.14",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.9",
+        "@aws-amplify/backend": "^0.13.0-beta.15",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/data-schema": "^0.14.5",
@@ -26233,12 +26233,12 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.13",
+      "version": "0.5.2-beta.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
         "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/cli-core": "^0.5.0-beta.8",
+        "@aws-amplify/cli-core": "^0.5.0-beta.9",
         "@aws-amplify/client-config": "^0.9.0-beta.10",
         "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
         "@aws-amplify/platform-core": "^0.5.0-beta.4",
@@ -26262,7 +26262,7 @@
     },
     "packages/schema-generator": {
       "name": "@aws-amplify/schema-generator",
-      "version": "0.1.0-beta.3",
+      "version": "0.1.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-schema-generator": "^0.8.0",

--- a/packages/schema-generator/src/generate_schema.test.ts
+++ b/packages/schema-generator/src/generate_schema.test.ts
@@ -54,22 +54,60 @@ void describe('SchemaGenerator', () => {
     assert.strictEqual(dbConfig.port, 3306);
   });
 
+  void it('should parse postgres url correctly', async () => {
+    const dbConfig = parseDatabaseUrl(
+      'postgresql://user:password@test-host-name:5432/db'
+    );
+    assert.strictEqual(dbConfig.engine, 'postgresql');
+    assert.strictEqual(dbConfig.username, 'user');
+    assert.strictEqual(dbConfig.password, 'password');
+    assert.strictEqual(dbConfig.host, 'test-host-name');
+    assert.strictEqual(dbConfig.database, 'db');
+    assert.strictEqual(dbConfig.port, 5432);
+  });
+
+  void it('should parse database url with postgres protocol correctly', async () => {
+    const dbConfig = parseDatabaseUrl(
+      'postgres://user:password@test-host-name:5432/db'
+    );
+    assert.strictEqual(dbConfig.engine, 'postgresql');
+    assert.strictEqual(dbConfig.username, 'user');
+    assert.strictEqual(dbConfig.password, 'password');
+    assert.strictEqual(dbConfig.host, 'test-host-name');
+    assert.strictEqual(dbConfig.database, 'db');
+    assert.strictEqual(dbConfig.port, 5432);
+  });
+
+  void it('should assign default port for mysql db url', async () => {
+    const dbConfig = parseDatabaseUrl(
+      'mysql://user:password@test-host-name/db'
+    );
+    assert.strictEqual(dbConfig.engine, 'mysql');
+    assert.strictEqual(dbConfig.username, 'user');
+    assert.strictEqual(dbConfig.password, 'password');
+    assert.strictEqual(dbConfig.host, 'test-host-name');
+    assert.strictEqual(dbConfig.database, 'db');
+    assert.strictEqual(dbConfig.port, 3306);
+  });
+
+  void it('should assign default port for postgres db url', async () => {
+    const dbConfig = parseDatabaseUrl(
+      'postgres://user:password@test-host-name/db'
+    );
+    assert.strictEqual(dbConfig.engine, 'postgresql');
+    assert.strictEqual(dbConfig.username, 'user');
+    assert.strictEqual(dbConfig.password, 'password');
+    assert.strictEqual(dbConfig.host, 'test-host-name');
+    assert.strictEqual(dbConfig.database, 'db');
+    assert.strictEqual(dbConfig.port, 5432);
+  });
+
   void it('should throw error if one or more parts are missing in the database url', async () => {
     const parse = () => parseDatabaseUrl('mysql://hostname/db');
     assert.throws(parse, {
       name: 'DatabaseUrlParseError',
       message:
-        'Unable to parse the database URL. One or more parts of the database URL is missing. Missing [username, password, port].',
-    });
-  });
-
-  void it('should throw error if the connection uri is missing port', async () => {
-    const parse = () =>
-      parseDatabaseUrl('mysql://user:password@mysql-hostname/db');
-    assert.throws(parse, {
-      name: 'DatabaseUrlParseError',
-      message:
-        'Unable to parse the database URL. One or more parts of the database URL is missing. Missing [port].',
+        'Unable to parse the database URL. One or more parts of the database URL is missing. Missing [username, password].',
     });
   });
 });

--- a/packages/schema-generator/src/generate_schema.ts
+++ b/packages/schema-generator/src/generate_schema.ts
@@ -46,6 +46,7 @@ export class SchemaGenerator {
 }
 
 export type SQLEngine = 'mysql' | 'postgresql';
+const DEFAULT_ENGINE = 'mysql';
 
 export type SQLDataSourceConfig = {
   engine: SQLEngine;
@@ -85,8 +86,13 @@ export const parseDatabaseUrl = (databaseUrl: string): SQLDataSourceConfig => {
     const password = decodeURIComponent(encodedPassword);
     const host = decodeURIComponent(encodedHost);
     const database = decodeURIComponent(parsedDatabaseUrl?.pathname?.slice(1));
-    const port = parseInt(parsedDatabaseUrl?.port, 10);
-    const engine = parsedDatabaseUrl?.protocol?.slice(0, -1) as SQLEngine;
+    // Default engine is MySQL
+    const engine = constructDBEngine(
+      parsedDatabaseUrl?.protocol?.slice(0, -1) ?? DEFAULT_ENGINE
+    );
+    const port = parsedDatabaseUrl?.port
+      ? parseInt(parsedDatabaseUrl?.port, 10)
+      : getDefaultPort(engine);
 
     const config = {
       engine,
@@ -124,5 +130,26 @@ export const parseDatabaseUrl = (databaseUrl: string): SQLDataSourceConfig => {
         resolution: 'Check if the database URL is correct and accessible.',
       }
     );
+  }
+};
+
+const constructDBEngine = (engine: string): SQLEngine => {
+  switch (engine) {
+    case 'mysql':
+      return 'mysql';
+    case 'postgresql':
+    case 'postgres':
+      return 'postgresql';
+    default:
+      throw new Error(`Unsupported database engine: ${engine}`);
+  }
+};
+
+const getDefaultPort = (engine: SQLEngine): number => {
+  switch (engine) {
+    case 'mysql':
+      return 3306;
+    case 'postgresql':
+      return 5432;
   }
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Customer have to explicitly mention port number in database connection uri even if there are using the default port number. This is not a good DX.

**Issue number, if available:**
NA
## Changes

For `npx amplify generate schema-from-database ...` command,
- If port is not provided in the connection uri secret, we will assign the default port for the database engine. (3306 for MySQL and 5432 for Postgres)
- If protocol in connection uri is `postgres`, resolve it to `postgresql`.

**Corresponding docs PR, if applicable:**
NA

## Validation
- Added new tests
- Manual testing

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
