### PR TITLE
chore: Translate secrets not set error to a more user friendly error message

### DIFF
--- a/.changeset/three-kings-sin.md
+++ b/.changeset/three-kings-sin.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+chore: Translate secrets not set error to a more user friendly error message

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -68,6 +68,12 @@ const testErrorMappings = [
       '❌ Deployment failed: something bad happened\n',
   },
   {
+    errorMessage: `Received response status [FAILED] from custom resource. Message returned: Failed to retrieve backend secret 'non-existent-secret' for 'project-name'. Reason: {"cause":{"name":"ParameterNotFound","$fault":"client"},"__type":"ParameterNotFound","message":"UnknownError"},"httpStatusCode":400,"name":"SecretError"}`,
+    expectedTopLevelErrorMessage: `The secret 'non-existent-secret' specified in the backend does not exist.`,
+    errorName: 'SecretNotSetError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
     errorMessage:
       'CFN error happened: Updates are not allowed for property: some property',
     expectedTopLevelErrorMessage:

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -219,7 +219,7 @@ export class CdkErrorMapper {
         /Failed to retrieve backend secret (.*) for.*ParameterNotFound/,
       humanReadableErrorMessage: `The secret ${this.placeHolder} specified in the backend does not exist.`,
       resolutionMessage:
-        'Please create the secret using `npx amplify sandbox secret set`. For more information, see https://docs.amplify.aws/gen2/deploy-and-host/sandbox-environments/features/#set-secrets',
+        'Create secrets using the command `npx amplify sandbox secret set`. For more information, see https://docs.amplify.aws/gen2/deploy-and-host/sandbox-environments/features/#set-secrets',
       errorName: 'SecretNotSetError',
       classification: 'ERROR',
     },

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -219,7 +219,7 @@ export class CdkErrorMapper {
         /Failed to retrieve backend secret (.*) for.*ParameterNotFound/,
       humanReadableErrorMessage: `The secret ${this.placeHolder} specified in the backend does not exist.`,
       resolutionMessage:
-        'Please create the secret using `npx amplify sandbox secret set`',
+        'Please create the secret using `npx amplify sandbox secret set`. For more information, see https://docs.amplify.aws/gen2/deploy-and-host/sandbox-environments/features/#set-secrets',
       errorName: 'SecretNotSetError',
       classification: 'ERROR',
     },


### PR DESCRIPTION
chore: Translate secrets not set error to a more user friendly error message

## Problem

The existing error message is too verbose and could be confusing. Since it's quite a common pitfall to use the secrets before setting them, this error perhaps help customers know exactly how to fix.

**Issue number, if available:**

## Changes

As part of this PR, I also made contextual data extracted from the `stderr` to be also used in the human readable error messages if they have a placeholder.

## Validation

Unit tests

## Checklist

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
