### PR TITLE
add cfnResources to function resource

### DIFF
--- a/.changeset/tiny-experts-hammer.md
+++ b/.changeset/tiny-experts-hammer.md
@@ -1,0 +1,9 @@
+---
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend-storage': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/plugin-types': patch
+---
+
+Add cfnFunction to function resources

--- a/packages/backend-auth/src/factory.test.ts
+++ b/packages/backend-auth/src/factory.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@aws-amplify/backend-platform-test-stubs';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
+import { CfnFunction } from 'aws-cdk-lib/aws-lambda';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -178,15 +179,19 @@ void describe('AmplifyAuthFactory', () => {
 
   triggerEvents.forEach((event) => {
     void it(`resolves ${event} trigger and attaches handler to auth construct`, () => {
+      const testFunc = new aws_lambda.Function(stack, 'testFunc', {
+        code: aws_lambda.Code.fromInline('test placeholder'),
+        runtime: aws_lambda.Runtime.NODEJS_18_X,
+        handler: 'index.handler',
+      });
       const funcStub: ConstructFactory<ResourceProvider<FunctionResources>> = {
         getInstance: () => {
           return {
             resources: {
-              lambda: new aws_lambda.Function(stack, 'testFunc', {
-                code: aws_lambda.Code.fromInline('test placeholder'),
-                runtime: aws_lambda.Runtime.NODEJS_18_X,
-                handler: 'index.handler',
-              }),
+              lambda: testFunc,
+              cfnResources: {
+                cfnFunction: testFunc.node.findChild('Resource') as CfnFunction,
+              },
             },
           };
         },

--- a/packages/backend-data/src/convert_authorization_modes.test.ts
+++ b/packages/backend-data/src/convert_authorization_modes.test.ts
@@ -11,7 +11,7 @@ import {
   convertAuthorizationModesToCDK,
   isUsingDefaultApiKeyAuth,
 } from './convert_authorization_modes.js';
-import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { CfnFunction, Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import {
   AmplifyFunction,
   AuthResources,
@@ -268,6 +268,9 @@ void describe('convertAuthorizationModesToCDK', () => {
       getInstance: () => ({
         resources: {
           lambda: authFn,
+          cfnResources: {
+            cfnFunction: authFn.node.findChild('Resource') as CfnFunction,
+          },
         },
       }),
     };
@@ -313,6 +316,9 @@ void describe('convertAuthorizationModesToCDK', () => {
       getInstance: () => ({
         resources: {
           lambda: authFn,
+          cfnResources: {
+            cfnFunction: authFn.node.findChild('Resource') as CfnFunction,
+          },
         },
       }),
     };

--- a/packages/backend-data/src/convert_functions.test.ts
+++ b/packages/backend-data/src/convert_functions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { Stack } from 'aws-cdk-lib';
-import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { CfnFunction, Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import {
   AmplifyFunction,
   ConstructFactory,
@@ -35,6 +35,9 @@ void describe('convertFunctionNameMapToCDK', () => {
       getInstance: () => ({
         resources: {
           lambda: echoFn,
+          cfnResources: {
+            cfnFunction: echoFn.node.findChild('Resource') as CfnFunction,
+          },
         },
       }),
     };
@@ -49,6 +52,9 @@ void describe('convertFunctionNameMapToCDK', () => {
       getInstance: () => ({
         resources: {
           lambda: updateFn,
+          cfnResources: {
+            cfnFunction: echoFn.node.findChild('Resource') as CfnFunction,
+          },
         },
       }),
     };

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -26,7 +26,7 @@ import {
   UserPool,
   UserPoolClient,
 } from 'aws-cdk-lib/aws-cognito';
-import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { CfnFunction, Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
 import {
   ConstructContainerStub,
@@ -239,17 +239,21 @@ void describe('DataFactory', () => {
   });
 
   void it('does not throw if no auth resources are registered and only lambda is provided', () => {
+    const myEchoFn = new Function(stack, 'MyEchoFn', {
+      runtime: Runtime.NODEJS_18_X,
+      code: Code.fromInline(
+        'module.handler = async () => console.log("Hello");'
+      ),
+      handler: 'index.handler',
+    });
     resetFactoryCount();
     const echo: ConstructFactory<AmplifyFunction> = {
       getInstance: () => ({
         resources: {
-          lambda: new Function(stack, 'MyEchoFn', {
-            runtime: Runtime.NODEJS_18_X,
-            code: Code.fromInline(
-              'module.handler = async () => console.log("Hello");'
-            ),
-            handler: 'index.handler',
-          }),
+          lambda: myEchoFn,
+          cfnResources: {
+            cfnFunction: myEchoFn.node.findChild('Resource') as CfnFunction,
+          },
         },
       }),
     };
@@ -357,16 +361,20 @@ void describe('DataFactory', () => {
 
   void it('accepts functions as inputs to the defineData call', () => {
     resetFactoryCount();
+    const myEchoFn = new Function(stack, 'MyEchoFn', {
+      runtime: Runtime.NODEJS_18_X,
+      code: Code.fromInline(
+        'module.handler = async () => console.log("Hello");'
+      ),
+      handler: 'index.handler',
+    });
     const echo: ConstructFactory<AmplifyFunction> = {
       getInstance: () => ({
         resources: {
-          lambda: new Function(stack, 'MyEchoFn', {
-            runtime: Runtime.NODEJS_18_X,
-            code: Code.fromInline(
-              'module.handler = async () => console.log("Hello");'
-            ),
-            handler: 'index.handler',
-          }),
+          lambda: myEchoFn,
+          cfnResources: {
+            cfnFunction: myEchoFn.node.findChild('Resource') as CfnFunction,
+          },
         },
       }),
     };
@@ -433,6 +441,9 @@ void describe('DataFactory', () => {
         getInstance: () => ({
           resources: {
             lambda,
+            cfnResources: {
+              cfnFunction: lambda.node.findChild('Resource') as CfnFunction,
+            },
           },
           getResourceAccessAcceptor: () => ({
             identifier: 'testId',
@@ -584,6 +595,9 @@ void describe('DataFactory', () => {
         getInstance: () => ({
           resources: {
             lambda: lambda1,
+            cfnResources: {
+              cfnFunction: lambda1.node.findChild('Resource') as CfnFunction,
+            },
           },
           getResourceAccessAcceptor: () => ({
             identifier: 'testId1',
@@ -609,6 +623,9 @@ void describe('DataFactory', () => {
         getInstance: () => ({
           resources: {
             lambda: lambda2,
+            cfnResources: {
+              cfnFunction: lambda2.node.findChild('Resource') as CfnFunction,
+            },
           },
           getResourceAccessAcceptor: () => ({
             identifier: 'testId2',

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -348,6 +348,26 @@ void describe('AmplifyFunctionFactory', () => {
     });
   });
 
+  void describe('function overrides', () => {
+    void it('can override function properties', () => {
+      const lambda = defineFunction({
+        entry: './test-assets/default-lambda/handler.ts',
+        name: 'myCoolLambda',
+        memoryMB: 512,
+      }).getInstance(getInstanceProps);
+      lambda.resources.cfnResources.cfnFunction.addPropertyOverride(
+        'MemorySize',
+        256
+      );
+      const template = Template.fromStack(
+        Stack.of(lambda.resources.cfnResources.cfnFunction)
+      );
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        MemorySize: 256,
+      });
+    });
+  });
+
   void it('stores single attribution data value in stack with multiple functions', () => {
     const functionFactory = defineFunction({
       entry: './test-assets/default-lambda/handler.ts',

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -16,7 +16,7 @@ import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as path from 'path';
 import { getCallerDirectory } from './get_caller_directory.js';
 import { Duration, Stack } from 'aws-cdk-lib';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { CfnFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { createRequire } from 'module';
 import { FunctionEnvironmentTranslator } from './function_env_translator.js';
 import { Policy } from 'aws-cdk-lib/aws-iam';
@@ -313,6 +313,9 @@ class AmplifyFunction
 
     this.resources = {
       lambda: functionLambda,
+      cfnResources: {
+        cfnFunction: functionLambda.node.findChild('Resource') as CfnFunction,
+      },
     };
 
     this.storeOutput(outputStorageStrategy);

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { CfnFunction } from 'aws-cdk-lib/aws-lambda';
 import { CfnIdentityPool } from 'aws-cdk-lib/aws-cognito';
 import { CfnIdentityPoolRoleAttachment } from 'aws-cdk-lib/aws-cognito';
 import { CfnUserPool } from 'aws-cdk-lib/aws-cognito';
@@ -137,6 +138,9 @@ export type DeploymentType = 'branch' | 'sandbox';
 // @public (undocumented)
 export type FunctionResources = {
     lambda: IFunction;
+    cfnResources: {
+        cfnFunction: CfnFunction;
+    };
 };
 
 // @public (undocumented)

--- a/packages/plugin-types/src/function_resources.ts
+++ b/packages/plugin-types/src/function_resources.ts
@@ -1,5 +1,8 @@
-import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import { CfnFunction, IFunction } from 'aws-cdk-lib/aws-lambda';
 
 export type FunctionResources = {
   lambda: IFunction;
+  cfnResources: {
+    cfnFunction: CfnFunction;
+  };
 };


### PR DESCRIPTION
## Problem

Functions are missing `cfnResources` for L1 constructs.

**Issue number, if available:**
Fixes #1248 

## Changes

Add `resources.cfnResources` for functions.

**Corresponding docs PR, if applicable:**
Docs PR will be created soon

## Validation

Unit tests and manually (also tested overriding memory):

`backend.ts`:
<img width="654" alt="Screenshot 2024-04-09 at 9 58 01 AM" src="https://github.com/aws-amplify/amplify-backend/assets/23459628/305398e3-1361-493a-b22b-aab273d5db1b">

CloudFormation template for function stack:
<img width="244" alt="Screenshot 2024-04-09 at 9 58 22 AM" src="https://github.com/aws-amplify/amplify-backend/assets/23459628/9e29abd8-4f87-442d-bd82-343baab07c10">


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
