### PR TITLE
Bug: API name is undefined in some cases

### DIFF
--- a/.changeset/warm-spoons-approve.md
+++ b/.changeset/warm-spoons-approve.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': patch
+---
+
+Fixes bug where apiName can resolve to undefined

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -216,6 +216,22 @@ void describe('DataFactory', () => {
     });
   });
 
+  void it('sets the api name to default name if a name property is not specified', () => {
+    resetFactoryCount();
+    dataFactory = defineData({
+      schema: testSchema,
+    });
+    const dataConstruct = dataFactory.getInstance(getInstanceProps);
+
+    const template = Template.fromStack(
+      Stack.of(dataConstruct.resources.graphqlApi)
+    );
+    template.resourceCountIs('AWS::AppSync::GraphQLApi', 1);
+    template.hasResourceProperties('AWS::AppSync::GraphQLApi', {
+      Name: 'amplifyData',
+    });
+  });
+
   void it('does not throw if no auth resources are registered and only api key is provided', () => {
     resetFactoryCount();
     dataFactory = defineData({

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -179,6 +179,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
         error instanceof Error ? error : undefined
       );
     }
+    const apiName = this.props.name ?? this.defaultName;
 
     const sandboxModeEnabled = isUsingDefaultApiKeyAuth(
       this.providedAuthConfig,
@@ -194,8 +195,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
     let amplifyApi = undefined;
 
     try {
-      amplifyApi = new AmplifyData(scope, this.defaultName, {
-        apiName: this.props.name,
+      amplifyApi = new AmplifyData(scope, apiName, {
         definition: amplifyGraphqlDefinition,
         authorizationModes,
         outputStorageStrategy: this.outputStorageStrategy,
@@ -231,7 +231,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
 
     const ssmEnvironmentEntries =
       ssmEnvironmentEntriesGenerator.generateSsmEnvironmentEntries({
-        [`${this.props.name}_GRAPHQL_ENDPOINT`]:
+        [`${apiName}_GRAPHQL_ENDPOINT`]:
           amplifyApi.resources.cfnResources.cfnGraphqlApi.attrGraphQlUrl,
       });
 

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -195,7 +195,8 @@ class DataGenerator implements ConstructContainerEntryGenerator {
     let amplifyApi = undefined;
 
     try {
-      amplifyApi = new AmplifyData(scope, apiName, {
+      amplifyApi = new AmplifyData(scope, this.defaultName, {
+        apiName,
         definition: amplifyGraphqlDefinition,
         authorizationModes,
         outputStorageStrategy: this.outputStorageStrategy,


### PR DESCRIPTION
## Problem

The `apiName` isn't handled correctly in some cases and can lead to `undefined` being used as the value.

**Issue number, if available:**
fixes https://github.com/aws-amplify/amplify-backend/issues/1272

## Changes

Resolves the `apiName` consistently and updates all instances of `this.props.name`

## Validation

Updated unit tests


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
