### PR TITLE
chore: make all cli commands strict

### DIFF
--- a/.changeset/light-papayas-count.md
+++ b/.changeset/light-papayas-count.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+chore: make all cli commands strict

--- a/packages/cli/src/main_parser_factory.test.ts
+++ b/packages/cli/src/main_parser_factory.test.ts
@@ -24,4 +24,12 @@ void describe('main parser', { concurrency: false }, () => {
     assert.match(output, /Commands:/);
     assert.match(output, /Not enough non-option arguments:/);
   });
+
+  void it('errors and prints help if invalid option is given', async () => {
+    const output = await commandRunner.runCommand(
+      'sandbox --non-existing-option 1'
+    );
+    assert.match(output, /Commands:/);
+    assert.match(output, /Unknown arguments: non-existing-option/);
+  });
 });

--- a/packages/cli/src/main_parser_factory.ts
+++ b/packages/cli/src/main_parser_factory.ts
@@ -24,6 +24,7 @@ export const createMainParser = (): Argv => {
       default: false,
       description: 'Print debug logs to the console',
     })
+    .strict()
     .command(createGenerateCommand())
     .command(createSandboxCommand())
     .command(createPipelineDeployCommand())


### PR DESCRIPTION
## Problem

Currently amplify backend cli will accept any arbitrary arguments whether they are supported or not.

**Issue number, if available:**

## Changes

Made the main parser factor only accept strict command inputs.


## Validation

Uni tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
