### PR TITLE
fix generate config for ~/ relative paths

### DIFF
--- a/.changeset/silent-penguins-accept.md
+++ b/.changeset/silent-penguins-accept.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+Fix generate config for ~/ relative paths

--- a/packages/client-config/src/paths/get_client_config_path.test.ts
+++ b/packages/client-config/src/paths/get_client_config_path.test.ts
@@ -119,6 +119,29 @@ void describe('getClientConfigPath', () => {
     );
   });
 
+  void it('returns correct path if path starts with ~', async () => {
+    const originalProcessEnv = process.env;
+    const homeDir = '/test/home/';
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+
+    const configPath = await getClientConfigPath(
+      ClientConfigFileBaseName.DEFAULT,
+      `~/${testPath}`
+    );
+    assert.equal(
+      configPath,
+      path.join(
+        homeDir,
+        testPath,
+        `${ClientConfigFileBaseName.DEFAULT}.${ClientConfigFormat.JSON}`
+      )
+    );
+
+    // reset process.env back
+    process.env = originalProcessEnv;
+  });
+
   const expectedFileExtensions = [
     {
       format: ClientConfigFormat.MJS,

--- a/packages/client-config/src/paths/get_client_config_path.test.ts
+++ b/packages/client-config/src/paths/get_client_config_path.test.ts
@@ -125,10 +125,14 @@ void describe('getClientConfigPath', () => {
     process.env.HOME = homeDir;
     process.env.USERPROFILE = homeDir;
 
-    const configPath = await getClientConfigPath(
+    let configPath = await getClientConfigPath(
       ClientConfigFileBaseName.DEFAULT,
       `~/${testPath}`
     );
+
+    // strip out drive letter for windows tests
+    configPath = configPath.replace('^[a-zA-Z]:', '');
+
     assert.equal(
       configPath,
       path.join(

--- a/packages/client-config/src/paths/get_client_config_path.test.ts
+++ b/packages/client-config/src/paths/get_client_config_path.test.ts
@@ -131,7 +131,7 @@ void describe('getClientConfigPath', () => {
     );
 
     // strip out drive letter for windows tests
-    configPath = configPath.replace('^[a-zA-Z]:', '');
+    configPath = configPath.replace(/^[a-zA-Z]:/, '');
 
     assert.equal(
       configPath,

--- a/packages/client-config/src/paths/get_client_config_path.ts
+++ b/packages/client-config/src/paths/get_client_config_path.ts
@@ -24,7 +24,7 @@ export const getClientConfigPath = async (
   let targetPath = defaultArgs.out;
 
   if (outDir) {
-    // if outDir starts with "~/" or "~$" or "~\" replace tilde with home directory
+    // if outDir starts with "~/" or "~\" or outDir is "~", replace tilde with home directory
     const outDirNoTilde = outDir.replace(/^~(?=$|\/|\\)/, homedir());
     targetPath = path.isAbsolute(outDirNoTilde)
       ? outDirNoTilde


### PR DESCRIPTION
## Problem

Running something like `amplify generate config --out-dir=~/test` creates a `~` folder at the current working directory which may not be `$HOME/test`.

**Issue number, if available:**

## Changes

If `outDir` starts with `~/` then expand the tilde to be the home directory.

**Corresponding docs PR, if applicable:**

## Validation

Unit test and manually:

![Screenshot 2024-04-10 at 4 38 42 PM](https://github.com/aws-amplify/amplify-backend/assets/23459628/241b05fd-0d38-4e44-8e1f-d6ed17f01178)

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
