### PR TITLE
chore: convert errors to AmplifyUserError

### DIFF
--- a/.changeset/angry-bugs-buy.md
+++ b/.changeset/angry-bugs-buy.md
@@ -1,0 +1,9 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/platform-core': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/backend-data': patch
+---
+
+chore: convert errors to AmplifyUserError

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -131,7 +131,19 @@ class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
       outputStorageStrategy: this.getInstanceProps.outputStorageStrategy,
     };
 
-    const authConstruct = new AmplifyAuth(scope, this.defaultName, authProps);
+    let authConstruct: AmplifyAuth;
+    try {
+      authConstruct = new AmplifyAuth(scope, this.defaultName, authProps);
+    } catch (error) {
+      throw new AmplifyUserError(
+        'AmplifyAuthConstructInitializationError',
+        {
+          message: 'Failed to instantiate auth construct',
+          resolution: 'See the underlying error message for more details.',
+        },
+        error as Error
+      );
+    }
     Object.entries(this.props.triggers || {}).forEach(
       ([triggerEvent, handlerFactory]) => {
         (authConstruct.resources.userPool as UserPool).addTrigger(

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -34,7 +34,6 @@ import {
 import { validateAuthorizationModes } from './validate_authorization_modes.js';
 import {
   AmplifyError,
-  AmplifyFault,
   AmplifyUserError,
   CDKContextKey,
 } from '@aws-amplify/platform-core';
@@ -241,9 +240,12 @@ class DataGenerator implements ConstructContainerEntryGenerator {
         },
       });
     } catch (error) {
-      throw new AmplifyFault(
-        'AmplifyDataConstructFault',
-        { message: 'Failed to instantiate data construct' },
+      throw new AmplifyUserError(
+        'AmplifyDataConstructInitializationError',
+        {
+          message: 'Failed to instantiate data construct',
+          resolution: 'See the underlying error message for more details.',
+        },
         error as Error
       );
     }

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -24,11 +24,22 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: 'Access Denied',
   },
   {
-    errorMessage: 'ReferenceError: var is not defined\n',
+    errorMessage: `ReferenceError: var is not defined
+    at lookup(/some_random/path.js: 1: 3005)`,
     expectedTopLevelErrorMessage:
       'Unable to build the Amplify backend definition.',
     errorName: 'SyntaxError',
-    expectedDownstreamErrorMessage: 'ReferenceError: var is not defined\n',
+    expectedDownstreamErrorMessage: `ReferenceError: var is not defined
+    at lookup(/some_random/path.js: 1: 3005)`,
+  },
+  {
+    errorMessage: `TypeError: Cannot read properties of undefined (reading 'post')
+    at lookup(/some_random/path.js: 1: 3005)`,
+    expectedTopLevelErrorMessage:
+      'Unable to build the Amplify backend definition.',
+    errorName: 'SyntaxError',
+    expectedDownstreamErrorMessage: `TypeError: Cannot read properties of undefined (reading 'post')
+    at lookup(/some_random/path.js: 1: 3005)`,
   },
   {
     errorMessage: 'Has the environment been bootstrapped',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -101,7 +101,7 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex: /(SyntaxError|ReferenceError):(.*)\n/,
+      errorRegex: /(SyntaxError|ReferenceError|TypeError):((?:.|\n)*?at .*)/,
       humanReadableErrorMessage:
         'Unable to build the Amplify backend definition.',
       resolutionMessage:

--- a/packages/platform-core/src/backend_entry_point_locator.ts
+++ b/packages/platform-core/src/backend_entry_point_locator.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { AmplifyUserError } from './errors';
 
 /**
  * Find the backend definition file in the customer app that represents a CDK app.
@@ -25,8 +26,10 @@ export class BackendLocator {
       }
     }
 
-    throw new Error(
-      `Amplify Backend not found in ${this.rootDir}. Amplify Backend must be defined in amplify/backend.(ts|js|cjs|mjs)`
-    );
+    throw new AmplifyUserError('FileConventionError', {
+      message: `Amplify Backend not found in ${this.rootDir}.`,
+      resolution:
+        'Amplify Backend must be defined in amplify/backend.(ts|js|cjs|mjs)',
+    });
   };
 }

--- a/packages/platform-core/src/package_json_reader.ts
+++ b/packages/platform-core/src/package_json_reader.ts
@@ -9,9 +9,10 @@ import { AmplifyUserError } from './errors';
 export class PackageJsonReader {
   read = (absolutePackageJsonPath: string): PackageJson => {
     if (!fs.existsSync(absolutePackageJsonPath)) {
-      throw new Error(
-        `Could not find a package.json file at ${absolutePackageJsonPath}`
-      );
+      throw new AmplifyUserError('InvalidPackageJsonError', {
+        message: `Could not find a package.json file at ${absolutePackageJsonPath}`,
+        resolution: `Ensure that ${absolutePackageJsonPath} exists and is a valid JSON file`,
+      });
     }
     let jsonParsedValue: Record<string, unknown>;
     try {

--- a/packages/platform-core/src/parameter_path_conversions.ts
+++ b/packages/platform-core/src/parameter_path_conversions.ts
@@ -1,5 +1,6 @@
 import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
 import { BackendIdentifierConversions } from './backend_identifier_conversions.js';
+import { AmplifyFault } from './errors';
 
 const SHARED_SECRET = 'shared';
 const RESOURCE_REFERENCE = 'resource_reference';
@@ -64,9 +65,9 @@ const getBackendIdentifierPathPart = (parts: BackendIdentifier): string => {
   );
   if (!sanitizedBackendId || !sanitizedBackendId.hash) {
     // this *should* never happen
-    throw new Error(
-      `Could not sanitize the backendId to construct the parameter path`
-    );
+    throw new AmplifyFault('BackendIdConversionFault', {
+      message: `Could not sanitize the backendId to construct the parameter path`,
+    });
   }
   return `${sanitizedBackendId.namespace}/${sanitizedBackendId.name}-${sanitizedBackendId.type}-${sanitizedBackendId.hash}`;
 };


### PR DESCRIPTION
1. More instances updated where `AmplifyUserError` should be thrown.
2. Based on the telemetry, all errors thrown by CDK constructs (L2 or L3) were customer errors. Starting with categorizing all as customer errors until we have a better way to distinguishing between customer and library faults.

## Validation

unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
