### PR TITLE
feat: support sandbox deployment without watcher with --once flag

### DIFF
--- a/.changeset/hot-tigers-impress.md
+++ b/.changeset/hot-tigers-impress.md
@@ -1,5 +1,6 @@
 ---
 '@aws-amplify/sandbox': patch
+'@aws-amplify/backend-cli': patch
 ---
 
 support single sandbox deployment with --once flag

--- a/.changeset/hot-tigers-impress.md
+++ b/.changeset/hot-tigers-impress.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+support single sandbox deployment with --once flag

--- a/.changeset/thin-timers-double.md
+++ b/.changeset/thin-timers-double.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/integration-tests': patch
+---
+
+add e2e test for sandbox --once deployment

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -113,6 +113,7 @@ void describe('sandbox command', () => {
     assert.match(output, /--exclude/);
     assert.match(output, /--config-format/);
     assert.match(output, /--config-out-dir/);
+    assert.match(output, /--once/);
     assert.equal(mockHandleProfile.mock.callCount(), 0);
   });
 
@@ -315,6 +316,19 @@ void describe('sandbox command', () => {
     assert.strictEqual(
       sandboxStartMock.mock.calls[0].arguments[0].watchForChanges,
       false
+    );
+  });
+
+  void it('--once flag is mutually exclusive with dir-to-watch & exclude', async () => {
+    assert.match(
+      await commandRunner.runCommand(
+        'sandbox --once --dir-to-watch nonExistentDir'
+      ),
+      /Arguments once and dir-to-watch are mutually exclusive/
+    );
+    assert.match(
+      await commandRunner.runCommand('sandbox --once --exclude test'),
+      /Arguments once and exclude are mutually exclusive/
     );
   });
 });

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -314,7 +314,7 @@ void describe('sandbox command', () => {
     assert.equal(sandboxStartMock.mock.callCount(), 1);
     assert.strictEqual(
       sandboxStartMock.mock.calls[0].arguments[0].watchForChanges,
-      true
+      false
     );
   });
 });

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -309,11 +309,11 @@ void describe('sandbox command', () => {
     );
   });
 
-  void it('starts sandbox with disableWatcher when --once flag is set', async () => {
+  void it('starts sandbox with watchForChanges when --once flag is set', async () => {
     await commandRunner.runCommand('sandbox --once');
     assert.equal(sandboxStartMock.mock.callCount(), 1);
     assert.strictEqual(
-      sandboxStartMock.mock.calls[0].arguments[0].disableWatcher,
+      sandboxStartMock.mock.calls[0].arguments[0].watchForChanges,
       true
     );
   });

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -308,4 +308,13 @@ void describe('sandbox command', () => {
       [path.join(process.cwd(), 'existentDir', 'amplifyconfiguration.ts')]
     );
   });
+
+  void it('starts sandbox with disableWatcher when --once flag is set', async () => {
+    await commandRunner.runCommand('sandbox --once');
+    assert.equal(sandboxStartMock.mock.callCount(), 1);
+    assert.strictEqual(
+      sandboxStartMock.mock.calls[0].arguments[0].disableWatcher,
+      true
+    );
+  });
 });

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -178,9 +178,9 @@ export class SandboxCommand
           array: false,
         })
         .option('once', {
-          describe: 'Execute a single sandbox deployment without watching for future file changes',
+          describe:
+            'Execute a single sandbox deployment without watching for future file changes',
           boolean: true,
-          default: false,
           global: false,
         })
         .check(async (argv) => {
@@ -197,6 +197,7 @@ export class SandboxCommand
           }
           return true;
         })
+        .conflicts('once', ['exclude', 'dir-to-watch'])
         .middleware([this.commandMiddleware.ensureAwsCredentialAndRegion])
     );
   };

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -116,7 +116,7 @@ export class SandboxCommand
       exclude: watchExclusions,
       identifier: args.identifier,
       profile: args.profile,
-      disableWatcher: args.once,
+      watchForChanges: !args.once,
     });
     process.once('SIGINT', () => void this.sigIntHandler());
   };
@@ -177,7 +177,12 @@ export class SandboxCommand
           type: 'string',
           array: false,
         })
-        .boolean('once')
+        .option('once', {
+          describe: 'Deploys sandbox environment without file watcher',
+          boolean: true,
+          default: false,
+          global: false,
+        })
         .check(async (argv) => {
           if (argv['dir-to-watch']) {
             await this.validateDirectory('dir-to-watch', argv['dir-to-watch']);

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -178,7 +178,7 @@ export class SandboxCommand
           array: false,
         })
         .option('once', {
-          describe: 'Deploys sandbox environment without file watcher',
+          describe: 'Execute a single sandbox deployment without watching for future file changes',
           boolean: true,
           default: false,
           global: false,

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -23,6 +23,7 @@ export type SandboxCommandOptionsKebabCase = ArgumentsKebabCase<
     configFormat: ClientConfigFormat | undefined;
     configOutDir: string | undefined;
     configVersion: string;
+    once: boolean | undefined;
   } & SandboxCommandGlobalOptions
 >;
 
@@ -115,6 +116,7 @@ export class SandboxCommand
       exclude: watchExclusions,
       identifier: args.identifier,
       profile: args.profile,
+      disableWatcher: args.once,
     });
     process.once('SIGINT', () => void this.sigIntHandler());
   };
@@ -175,6 +177,7 @@ export class SandboxCommand
           type: 'string',
           array: false,
         })
+        .boolean('once')
         .check(async (argv) => {
           if (argv['dir-to-watch']) {
             await this.validateDirectory('dir-to-watch', argv['dir-to-watch']);

--- a/packages/integration-tests/src/process-controller/predicated_action_macros.ts
+++ b/packages/integration-tests/src/process-controller/predicated_action_macros.ts
@@ -15,6 +15,14 @@ export const waitForSandboxDeploymentToPrintTotalTime = () =>
   new PredicatedActionBuilder().waitForLineIncludes('Total time');
 
 /**
+ * Reusable predicates: Wait for sandbox to finish and emit "File written: amplifyconfiguration.json"
+ */
+export const waitForConfigUpdateAfterDeployment = () =>
+  new PredicatedActionBuilder().waitForLineIncludes(
+    'File written: amplifyconfiguration.json'
+  );
+
+/**
  * Reusable predicates: Wait for sandbox to become idle and emit "Watching for file changes..."
  */
 export const waitForSandboxToBecomeIdle = () =>

--- a/packages/integration-tests/src/test-e2e/deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment.test.ts
@@ -17,6 +17,7 @@ import {
   interruptSandbox,
   rejectCleanupSandbox,
   replaceFiles,
+  waitForConfigUpdateAfterDeployment,
 } from '../process-controller/predicated_action_macros.js';
 import assert from 'node:assert';
 import { TestBranch, amplifyAppPool } from '../amplify_app_pool.js';
@@ -157,6 +158,21 @@ void describe('deployment tests', { concurrency: testConcurrencyLevel }, () => {
             await processController
               .do(interruptSandbox())
               .do(rejectCleanupSandbox())
+              .run();
+
+            await testProject.assertPostDeployment(sandboxBackendIdentifier);
+          });
+
+          void describe('generates config after sandbox --once deployment', async () => {
+            const processController = amplifyCli(
+              ['sandbox', '--once'],
+              testProject.projectDirPath,
+              {
+                env: sharedSecretsEnv,
+              }
+            );
+            await processController
+              .do(waitForConfigUpdateAfterDeployment())
               .run();
 
             await testProject.assertPostDeployment(sandboxBackendIdentifier);

--- a/packages/integration-tests/src/test-e2e/deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment.test.ts
@@ -138,6 +138,21 @@ void describe('deployment tests', { concurrency: testConcurrencyLevel }, () => {
             await testProject.assertPostDeployment(sandboxBackendIdentifier);
           });
 
+          void it('generates config after sandbox --once deployment', async () => {
+            const processController = amplifyCli(
+              ['sandbox', '--once'],
+              testProject.projectDirPath,
+              {
+                env: sharedSecretsEnv,
+              }
+            );
+            await processController
+              .do(waitForConfigUpdateAfterDeployment())
+              .run();
+
+            await testProject.assertPostDeployment(sandboxBackendIdentifier);
+          });
+
           void it(`[${testProjectCreator.name}] hot-swaps a change`, async () => {
             const processController = amplifyCli(
               ['sandbox', '--dirToWatch', 'amplify'],
@@ -158,21 +173,6 @@ void describe('deployment tests', { concurrency: testConcurrencyLevel }, () => {
             await processController
               .do(interruptSandbox())
               .do(rejectCleanupSandbox())
-              .run();
-
-            await testProject.assertPostDeployment(sandboxBackendIdentifier);
-          });
-
-          void describe('generates config after sandbox --once deployment', async () => {
-            const processController = amplifyCli(
-              ['sandbox', '--once'],
-              testProject.projectDirPath,
-              {
-                env: sharedSecretsEnv,
-              }
-            );
-            await processController
-              .do(waitForConfigUpdateAfterDeployment())
               .run();
 
             await testProject.assertPostDeployment(sandboxBackendIdentifier);

--- a/packages/sandbox/API.md
+++ b/packages/sandbox/API.md
@@ -36,7 +36,7 @@ export type SandboxOptions = {
     identifier?: string;
     format?: ClientConfigFormat;
     profile?: string;
-    disableWatcher?: boolean;
+    watchForChanges?: boolean;
 };
 
 // @public

--- a/packages/sandbox/API.md
+++ b/packages/sandbox/API.md
@@ -36,6 +36,7 @@ export type SandboxOptions = {
     identifier?: string;
     format?: ClientConfigFormat;
     profile?: string;
+    disableWatcher?: boolean;
 };
 
 // @public

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -277,7 +277,6 @@ void describe('Sandbox using local project name resolver', () => {
         // imaginary dir does not have any ts files
         dir: 'testDir',
         exclude: ['exclude1', 'exclude2'],
-        watchForChanges: true,
       },
       false
     ));
@@ -307,7 +306,6 @@ void describe('Sandbox using local project name resolver', () => {
       {
         dir: testDir,
         exclude: ['exclude1', 'exclude2'],
-        watchForChanges: true,
       },
       false
     ));
@@ -334,7 +332,6 @@ void describe('Sandbox using local project name resolver', () => {
       {
         dir: 'testDir',
         exclude: ['exclude1', 'exclude2'],
-        watchForChanges: true,
       }
     ));
     await fileChangeEventCallback(null, [
@@ -669,7 +666,6 @@ void describe('Sandbox using local project name resolver', () => {
       {
         dir: 'testDir',
         exclude: ['exclude1', 'exclude2'],
-        watchForChanges: true,
       }
     ));
     const contextualBackendDeployerMock = contextual.mock.method(
@@ -692,7 +688,7 @@ void describe('Sandbox using local project name resolver', () => {
         executor: sandboxExecutor,
         cfnClient: cfnClientMock,
       },
-      { identifier: 'customSandboxName', watchForChanges: true }
+      { identifier: 'customSandboxName' }
     ));
     await fileChangeEventCallback(null, [
       { type: 'update', path: 'foo/test1.ts' },
@@ -722,7 +718,7 @@ void describe('Sandbox using local project name resolver', () => {
         executor: sandboxExecutor,
         cfnClient: cfnClientMock,
       },
-      { identifier: 'customSandboxName', watchForChanges: true }
+      { identifier: 'customSandboxName' }
     ));
     await sandboxInstance.delete({ identifier: 'customSandboxName' });
 
@@ -759,7 +755,6 @@ void describe('Sandbox using local project name resolver', () => {
       },
       {
         exclude: ['customer_exclude1', 'customer_exclude2'],
-        watchForChanges: true,
       }
     ));
     await fileChangeEventCallback(null, [
@@ -805,7 +800,6 @@ void describe('Sandbox using local project name resolver', () => {
       },
       {
         exclude: ['customer_exclude1', 'customer_exclude2'],
-        watchForChanges: true,
       }
     ));
     await fileChangeEventCallback(null, [
@@ -882,7 +876,7 @@ void describe('Sandbox using local project name resolver', () => {
  */
 const setupAndStartSandbox = async (
   testData: SandboxTestData,
-  sandboxOptions: SandboxOptions = { watchForChanges: true },
+  sandboxOptions: SandboxOptions = {},
   resetMocksAfterStart = true
 ) => {
   const sandboxInstance = new FileWatchingSandbox(
@@ -911,8 +905,15 @@ const setupAndStartSandbox = async (
     listSecretMock.mock.resetCalls();
   }
 
-  if (!sandboxOptions.watchForChanges) {
-    return { sandboxInstance, fileChangeEventCallback: () => null };
+  if (sandboxOptions.watchForChanges === false) {
+    return {
+      sandboxInstance,
+      fileChangeEventCallback: () => {
+        throw new Error(
+          'When not watching for changes, file change event callback is not available'
+        );
+      },
+    };
   }
   /**
    * For each test we start the sandbox and hence file watcher and get hold of

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -830,13 +830,13 @@ void describe('Sandbox using local project name resolver', () => {
     assert.equal(mockListener.mock.callCount(), 1);
   });
 
-  void it('should trigger single deployment without watcher if disableWatcher is true', async () => {
+  void it('should trigger single deployment without watcher if watchForChanges is true', async () => {
     const mockListener = mock.fn();
     sandboxInstance.on('successfulDeployment', mockListener);
 
     await sandboxInstance.start({
       dir: 'testDir',
-      disableWatcher: true,
+      watchForChanges: true,
     });
 
     assert.strictEqual(subscribeMock.mock.callCount(), 0);

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -829,6 +829,19 @@ void describe('Sandbox using local project name resolver', () => {
 
     assert.equal(mockListener.mock.callCount(), 1);
   });
+
+  void it('should trigger single deployment without watcher if disableWatcher is true', async () => {
+    const mockListener = mock.fn();
+    sandboxInstance.on('successfulDeployment', mockListener);
+
+    await sandboxInstance.start({
+      dir: 'testDir',
+      disableWatcher: true,
+    });
+
+    assert.strictEqual(subscribeMock.mock.callCount(), 0);
+    assert.strictEqual(mockListener.mock.callCount(), 1);
+  });
 });
 
 /**

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -152,7 +152,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       this.emitWatching();
     });
 
-    if (options.watchForChanges == null || options.watchForChanges) {
+    if (options.watchForChanges !== false)) {
       this.watcherSubscription = await parcelWatcher.subscribe(
         watchDir,
         async (_, events) => {

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -152,7 +152,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       this.emitWatching();
     });
 
-    if (options.watchForChanges !== false)) {
+    if (options.watchForChanges !== false) {
       this.watcherSubscription = await parcelWatcher.subscribe(
         watchDir,
         async (_, events) => {

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -152,7 +152,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       this.emitWatching();
     });
 
-    if (!options.disableWatcher) {
+    if (options.watchForChanges) {
       this.watcherSubscription = await parcelWatcher.subscribe(
         watchDir,
         async (_, events) => {

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -92,6 +92,8 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
    */
   start = async (options: SandboxOptions) => {
     const watchDir = options.dir ?? './amplify';
+    const watchForChanges = options.watchForChanges ?? true;
+
     if (!fs.existsSync(watchDir)) {
       throw new AmplifyUserError('PathNotFoundError', {
         message: `${watchDir} does not exist.`,
@@ -152,7 +154,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       this.emitWatching();
     });
 
-    if (options.watchForChanges !== false) {
+    if (watchForChanges) {
       this.watcherSubscription = await parcelWatcher.subscribe(
         watchDir,
         async (_, events) => {

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -152,7 +152,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       this.emitWatching();
     });
 
-    if (options.watchForChanges) {
+    if (options.watchForChanges == null || options.watchForChanges) {
       this.watcherSubscription = await parcelWatcher.subscribe(
         watchDir,
         async (_, events) => {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -36,6 +36,7 @@ export type SandboxOptions = {
   identifier?: string;
   format?: ClientConfigFormat;
   profile?: string;
+  disableWatcher?: boolean;
 };
 
 export type SandboxDeleteOptions = {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -36,7 +36,7 @@ export type SandboxOptions = {
   identifier?: string;
   format?: ClientConfigFormat;
   profile?: string;
-  disableWatcher?: boolean;
+  watchForChanges?: boolean;
 };
 
 export type SandboxDeleteOptions = {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
Support sandbox deployment without running watcher using `--once` flag
```npx amplify sandbox --once```

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**
https://github.com/aws-amplify/amplify-backend/issues/1062
## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
