### PR TITLE
fix: remove name validation on defineStorage

### DIFF
--- a/.changeset/nice-cooks-laugh.md
+++ b/.changeset/nice-cooks-laugh.md
@@ -1,5 +1,0 @@
----
-'@aws-amplify/backend-storage': patch
----
-
-remove name check on storage

--- a/.changeset/nice-cooks-laugh.md
+++ b/.changeset/nice-cooks-laugh.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': patch
+---
+
+remove name check on storage

--- a/.changeset/tough-shirts-repeat.md
+++ b/.changeset/tough-shirts-repeat.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': patch
+---
+
+sanitize name for defineStorage

--- a/packages/backend-storage/src/factory.test.ts
+++ b/packages/backend-storage/src/factory.test.ts
@@ -108,12 +108,4 @@ void describe('AmplifyStorageFactory', () => {
       )
     );
   });
-
-  void it('throws on invalid name', () => {
-    const storageFactory = defineStorage({ name: '!$87++|' });
-    assert.throws(() => storageFactory.getInstance(getInstanceProps), {
-      message:
-        'defineStorage name can only contain alphanumeric characters, found !$87++|',
-    });
-  });
 });

--- a/packages/backend-storage/src/factory.test.ts
+++ b/packages/backend-storage/src/factory.test.ts
@@ -112,8 +112,23 @@ void describe('AmplifyStorageFactory', () => {
   void it('throws on invalid name', () => {
     const storageFactory = defineStorage({ name: '!$87++|' });
     assert.throws(() => storageFactory.getInstance(getInstanceProps), {
-      message:
-        'defineStorage name can only contain alphanumeric characters, found !$87++|',
+      message: 'defineStorage name contains invalid characters, found !$87++|',
     });
+  });
+
+  void it('should convert name to kebab case if possible', () => {
+    const mockGetOrCompute = mock.fn();
+    const storageFactory = defineStorage({ name: 'camelCase with whiteSpace' });
+    storageFactory.getInstance({
+      ...getInstanceProps,
+      constructContainer: {
+        getOrCompute: mockGetOrCompute,
+      } as unknown as ConstructContainer,
+    });
+
+    assert.strictEqual(
+      mockGetOrCompute.mock.calls[0].arguments[0].props.name,
+      'camel-case-with-white-space'
+    );
   });
 });

--- a/packages/backend-storage/src/factory.test.ts
+++ b/packages/backend-storage/src/factory.test.ts
@@ -108,4 +108,12 @@ void describe('AmplifyStorageFactory', () => {
       )
     );
   });
+
+  void it('throws on invalid name', () => {
+    const storageFactory = defineStorage({ name: '!$87++|' });
+    assert.throws(() => storageFactory.getInstance(getInstanceProps), {
+      message:
+        'defineStorage name can only contain alphanumeric characters, found !$87++|',
+    });
+  });
 });

--- a/packages/backend-storage/src/factory.ts
+++ b/packages/backend-storage/src/factory.ts
@@ -38,26 +38,37 @@ class AmplifyStorageFactory
       path.join('amplify', 'storage', 'resource'),
       'Amplify Storage must be defined in amplify/storage/resource.ts'
     );
-    this.validateName(this.props.name);
     if (!this.generator) {
       this.generator = new StorageContainerEntryGenerator(
-        this.props,
+        {
+          ...this.props,
+          name: this.sanitizeName(this.props.name),
+        },
         getInstanceProps
       );
     }
     return constructContainer.getOrCompute(this.generator) as AmplifyStorage;
   };
 
-  private validateName = (name: string): void => {
-    const nameIsAlphanumeric = /^[a-zA-Z0-9]+$/.test(name);
-    if (!nameIsAlphanumeric) {
+  private sanitizeName = (name: string): string => {
+    const sanitizedName = this.kebabCase(name);
+
+    if (!/^[a-z0-9-]+$/.test(sanitizedName)) {
       throw new AmplifyUserError('InvalidResourceNameError', {
-        message: `defineStorage name can only contain alphanumeric characters, found ${name}`,
+        message: `defineStorage name contains invalid characters, found ${name}`,
         resolution:
-          'Change the name parameter of defineStorage to only use alphanumeric characters',
+          'Change the name parameter of defineStorage to only use alphanumeric characters or -',
       });
     }
+
+    return sanitizedName;
   };
+
+  private kebabCase = (str: string): string =>
+    str
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      .replace(/[\s_]+/g, '-')
+      .toLowerCase();
 }
 
 /**

--- a/packages/backend-storage/src/factory.ts
+++ b/packages/backend-storage/src/factory.ts
@@ -6,6 +6,7 @@ import {
 } from '@aws-amplify/plugin-types';
 import * as path from 'path';
 import { AmplifyStorage, StorageResources } from './construct.js';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 import { AmplifyStorageFactoryProps } from './types.js';
 import { StorageContainerEntryGenerator } from './storage_container_entry_generator.js';
 
@@ -37,6 +38,7 @@ class AmplifyStorageFactory
       path.join('amplify', 'storage', 'resource'),
       'Amplify Storage must be defined in amplify/storage/resource.ts'
     );
+    this.validateName(this.props.name);
     if (!this.generator) {
       this.generator = new StorageContainerEntryGenerator(
         this.props,
@@ -44,6 +46,17 @@ class AmplifyStorageFactory
       );
     }
     return constructContainer.getOrCompute(this.generator) as AmplifyStorage;
+  };
+
+  private validateName = (name: string): void => {
+    const nameIsAlphanumeric = /^[a-zA-Z0-9]+$/.test(name);
+    if (!nameIsAlphanumeric) {
+      throw new AmplifyUserError('InvalidResourceNameError', {
+        message: `defineStorage name can only contain alphanumeric characters, found ${name}`,
+        resolution:
+          'Change the name parameter of defineStorage to only use alphanumeric characters',
+      });
+    }
   };
 }
 

--- a/packages/backend-storage/src/factory.ts
+++ b/packages/backend-storage/src/factory.ts
@@ -51,20 +51,20 @@ class AmplifyStorageFactory
   };
 
   private sanitizeName = (name: string): string => {
-    const sanitizedName = this.kebabCase(name);
+    const sanitizedName = this.toKebabCase(name);
 
     if (!/^[a-z0-9-]+$/.test(sanitizedName)) {
       throw new AmplifyUserError('InvalidResourceNameError', {
         message: `defineStorage name contains invalid characters, found ${name}`,
         resolution:
-          'Change the name parameter of defineStorage to only use alphanumeric characters or -',
+          'Update name to use only alphanumeric characters and dashes',
       });
     }
 
     return sanitizedName;
   };
 
-  private kebabCase = (str: string): string =>
+  private toKebabCase = (str: string): string =>
     str
       .replace(/([a-z])([A-Z])/g, '$1-$2')
       .replace(/[\s_]+/g, '-')

--- a/packages/backend-storage/src/factory.ts
+++ b/packages/backend-storage/src/factory.ts
@@ -6,7 +6,6 @@ import {
 } from '@aws-amplify/plugin-types';
 import * as path from 'path';
 import { AmplifyStorage, StorageResources } from './construct.js';
-import { AmplifyUserError } from '@aws-amplify/platform-core';
 import { AmplifyStorageFactoryProps } from './types.js';
 import { StorageContainerEntryGenerator } from './storage_container_entry_generator.js';
 
@@ -38,7 +37,6 @@ class AmplifyStorageFactory
       path.join('amplify', 'storage', 'resource'),
       'Amplify Storage must be defined in amplify/storage/resource.ts'
     );
-    this.validateName(this.props.name);
     if (!this.generator) {
       this.generator = new StorageContainerEntryGenerator(
         this.props,
@@ -46,17 +44,6 @@ class AmplifyStorageFactory
       );
     }
     return constructContainer.getOrCompute(this.generator) as AmplifyStorage;
-  };
-
-  private validateName = (name: string): void => {
-    const nameIsAlphanumeric = /^[a-zA-Z0-9]+$/.test(name);
-    if (!nameIsAlphanumeric) {
-      throw new AmplifyUserError('InvalidResourceNameError', {
-        message: `defineStorage name can only contain alphanumeric characters, found ${name}`,
-        resolution:
-          'Change the name parameter of defineStorage to only use alphanumeric characters',
-      });
-    }
   };
 }
 

--- a/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
+++ b/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
@@ -45,8 +45,8 @@ void it('data storage auth with triggers', () => {
   ]);
 
   assertExpectedLogicalIds(templates.storage, 'AWS::Lambda::Permission', [
-    'testNameBucketAllowBucketNotificationsToamplifytestAppIdtestBranchNamebranch7d6f6c854afunctiononDeletelambda572CB9D7EA473960',
-    'testNameBucketAllowBucketNotificationsToamplifytestAppIdtestBranchNamebranch7d6f6c854afunctiononUploadlambda74F01BD6AFF08959',
+    'testnameBucketAllowBucketNotificationsToamplifytestAppIdtestBranchNamebranch7d6f6c854afunctiononDeletelambda572CB9D7AB18435C',
+    'testnameBucketAllowBucketNotificationsToamplifytestAppIdtestBranchNamebranch7d6f6c854afunctiononUploadlambda74F01BD6AEEF6C37',
   ]);
 
   assertExpectedLogicalIds(templates.defaultNodeFunc, 'AWS::Lambda::Function', [

--- a/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
+++ b/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
@@ -37,7 +37,7 @@ void it('data storage auth with triggers', () => {
 
   /* eslint-disable spellcheck/spell-checker */
   assertExpectedLogicalIds(templates.storage, 'AWS::S3::Bucket', [
-    'testNameBucketB4152AD5',
+    'testnameBucket0C94C29E',
   ]);
 
   assertExpectedLogicalIds(templates.storage, 'Custom::S3BucketNotifications', [

--- a/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
+++ b/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
@@ -41,7 +41,7 @@ void it('data storage auth with triggers', () => {
   ]);
 
   assertExpectedLogicalIds(templates.storage, 'Custom::S3BucketNotifications', [
-    'testNameBucketNotificationsB9BE9A01',
+    'testnameBucketNotifications61871662',
   ]);
 
   assertExpectedLogicalIds(templates.storage, 'AWS::Lambda::Permission', [


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
Removing the name restriction on `defineStorage` for consistency with other resources like function, auth, data.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Removing name check on getInstance for storage.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
