### PR TITLE
chore!: bump data-construct, data-schema, and data-schema-types dependency

### DIFF
--- a/.changeset/proud-balloons-grab.md
+++ b/.changeset/proud-balloons-grab.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/integration-tests': minor
+'@aws-amplify/backend-data': minor
+'@aws-amplify/backend': minor
+---
+
+chore!: update data-construct, data-schema, data-schema-types dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.7.1-gen2-release.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.7.1-gen2-release.2.tgz",
-      "integrity": "sha512-fnlAyVFXq2OSqUutSD3eO6hNh1JI1gC+lvEfXkX5wblSOshLu4S03kBATJrxC8ag1pXJ2BO6K4UtwTBGPSRrXg==",
+      "version": "1.8.0-0411-gen2.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.8.0-0411-gen2.0.tgz",
+      "integrity": "sha512-y3eO0U6Rcc51+YQO/yGTfbC2xTik558brLsSkKCdh914wgAUFIr2RrJKVc/xqPO3K5Anl1hvdzzLQfZLeyavEg==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -756,22 +756,22 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-api-construct": "1.8.0-gen2-release.0",
-        "@aws-amplify/graphql-auth-transformer": "3.4.3-gen2-release.1",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.3-gen2-release.1",
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-http-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-index-transformer": "2.3.9-gen2-release.1",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.10-gen2-release.1",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release.1",
-        "@aws-amplify/graphql-searchable-transformer": "2.6.3-gen2-release.1",
-        "@aws-amplify/graphql-sql-transformer": "0.2.9-gen2-release.1",
-        "@aws-amplify/graphql-transformer": "1.4.1-gen2-release.1",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-api-construct": "1.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer": "1.5.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -780,7 +780,7 @@
         "graceful-fs": "^4.2.11",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
         "is-buffer": "^2.0.5",
@@ -820,18 +820,18 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.4.3-gen2-release.1",
+      "version": "3.5.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release.1",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
@@ -841,35 +841,35 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.3-gen2-release.1",
+      "version": "2.3.4-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "1.1.0-gen2-release.0",
+      "version": "1.1.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.20-gen2-release.1",
+      "version": "2.1.21-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -877,16 +877,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.20-gen2-release.1",
+      "version": "2.1.21-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -894,17 +894,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.3.9-gen2-release.1",
+      "version": "2.4.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -912,15 +912,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.10-gen2-release.1",
+      "version": "3.4.11-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -928,16 +928,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.8.0-gen2-release.0",
+      "version": "2.9.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -945,16 +945,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.20-gen2-release.1",
+      "version": "2.1.21-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -962,18 +962,18 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.0-gen2-release.1",
+      "version": "2.5.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-index-transformer": "2.3.9-gen2-release.1",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
@@ -982,17 +982,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.6.3-gen2-release.1",
+      "version": "2.7.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1000,17 +1000,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.2.9-gen2-release.1",
+      "version": "0.3.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1018,23 +1018,23 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.4.1-gen2-release.1",
+      "version": "1.5.1-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.4.3-gen2-release.1",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.3-gen2-release.1",
-        "@aws-amplify/graphql-function-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-http-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-index-transformer": "2.3.9-gen2-release.1",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.10-gen2-release.1",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release.1",
-        "@aws-amplify/graphql-searchable-transformer": "2.6.3-gen2-release.1",
-        "@aws-amplify/graphql-sql-transformer": "0.2.9-gen2-release.1",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0"
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-0411-gen2.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1042,15 +1042,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.5.2-gen2-release.1",
+      "version": "2.6.1-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -1063,7 +1063,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.6.0-gen2-release.0",
+      "version": "3.7.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1155,7 +1155,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/graphql-transformer-common": {
-      "version": "4.29.1-gen2-release.0",
+      "version": "4.30.1-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1281,9 +1281,9 @@
       }
     },
     "node_modules/@aws-amplify/data-schema": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.14.11.tgz",
-      "integrity": "sha512-6fPGLzBLbZZjiXQVmGG/9MHA9dWk/hDi9hoDlQRKqKu64PmH07cy/hZ8O7Zrf8yssAZcjRZRmY7hmg0CQ41OSg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.15.0.tgz",
+      "integrity": "sha512-JMuVnPN14VTBnfNH1hB2Cdnuxnu63ib2+Z5TU2WnWbFOCjQImkNV45Wx8diky7t+JiBZNlLGLclp46JuZkGM2A==",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
         "@types/aws-lambda": "^8.10.134"
@@ -1341,9 +1341,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.8.0-gen2-release.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.8.0-gen2-release.0.tgz",
-      "integrity": "sha512-P+xJzG2yxiXAmb99V/Kpu3+k4oEiNctsizoNeAiMRlIKQ/LgJDhJ4O3rXXspwiuswZeWMrRP2/hAO1pz0oBfwA==",
+      "version": "1.9.0-0411-gen2.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.9.0-0411-gen2.0.tgz",
+      "integrity": "sha512-UF03jqCxqrbd4/MaKA5llWL6QNi+LnN0gouTwMhOV6lLVnTOCZDHW/+GYPIB34VregH2VdLz6udCMMFhZFZZmg==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -1387,21 +1387,21 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-auth-transformer": "3.4.3-gen2-release.1",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.3-gen2-release.1",
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-http-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-index-transformer": "2.3.9-gen2-release.1",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.10-gen2-release.1",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release.1",
-        "@aws-amplify/graphql-searchable-transformer": "2.6.3-gen2-release.1",
-        "@aws-amplify/graphql-sql-transformer": "0.2.9-gen2-release.1",
-        "@aws-amplify/graphql-transformer": "1.4.1-gen2-release.1",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer": "1.5.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -1410,7 +1410,7 @@
         "graceful-fs": "^4.2.11",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
         "is-buffer": "^2.0.5",
@@ -1450,18 +1450,18 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.4.3-gen2-release.1",
+      "version": "3.5.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release.1",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
@@ -1471,35 +1471,35 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.3-gen2-release.1",
+      "version": "2.3.4-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "1.1.0-gen2-release.0",
+      "version": "1.1.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.20-gen2-release.1",
+      "version": "2.1.21-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1507,16 +1507,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.20-gen2-release.1",
+      "version": "2.1.21-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1524,17 +1524,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.3.9-gen2-release.1",
+      "version": "2.4.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1542,15 +1542,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.10-gen2-release.1",
+      "version": "3.4.11-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1558,16 +1558,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.8.0-gen2-release.0",
+      "version": "2.9.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1575,16 +1575,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.20-gen2-release.1",
+      "version": "2.1.21-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1592,18 +1592,18 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.0-gen2-release.1",
+      "version": "2.5.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-index-transformer": "2.3.9-gen2-release.1",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
@@ -1612,17 +1612,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.6.3-gen2-release.1",
+      "version": "2.7.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1630,17 +1630,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.2.9-gen2-release.1",
+      "version": "0.3.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.29.1-gen2-release.0"
+        "graphql-transformer-common": "4.30.1-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1648,23 +1648,23 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.4.1-gen2-release.1",
+      "version": "1.5.1-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.4.3-gen2-release.1",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.3-gen2-release.1",
-        "@aws-amplify/graphql-function-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-http-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-index-transformer": "2.3.9-gen2-release.1",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.10-gen2-release.1",
-        "@aws-amplify/graphql-model-transformer": "2.8.0-gen2-release.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.20-gen2-release.1",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release.1",
-        "@aws-amplify/graphql-searchable-transformer": "2.6.3-gen2-release.1",
-        "@aws-amplify/graphql-sql-transformer": "0.2.9-gen2-release.1",
-        "@aws-amplify/graphql-transformer-core": "2.5.2-gen2-release.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0"
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-0411-gen2.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-0411-gen2.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-0411-gen2.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1672,15 +1672,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.5.2-gen2-release.1",
+      "version": "2.6.1-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.6.0-gen2-release.0",
+        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.29.1-gen2-release.0",
+        "graphql-transformer-common": "4.30.1-0411-gen2.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -1693,7 +1693,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.6.0-gen2-release.0",
+      "version": "3.7.0-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1785,7 +1785,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql-transformer-common": {
-      "version": "4.29.1-gen2-release.0",
+      "version": "4.30.1-0411-gen2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -18216,7 +18216,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -18829,7 +18828,6 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -25369,12 +25367,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.6.0-beta.9",
+      "version": "0.6.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "@aws-sdk/util-arn-parser": "^3.465.0"
       },
       "peerDependencies": {
@@ -25384,20 +25382,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.15",
+      "version": "0.13.0-beta.16",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.5.0-beta.9",
-        "@aws-amplify/backend-data": "^0.10.0-beta.10",
-        "@aws-amplify/backend-function": "^0.8.0-beta.8",
+        "@aws-amplify/backend-auth": "^0.5.0-beta.10",
+        "@aws-amplify/backend-data": "^0.10.0-beta.11",
+        "@aws-amplify/backend-function": "^0.8.0-beta.9",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
-        "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/backend-storage": "^0.6.0-beta.6",
-        "@aws-amplify/client-config": "^0.9.0-beta.10",
-        "@aws-amplify/data-schema": "^0.14.11",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/backend-secret": "^0.4.5-beta.5",
+        "@aws-amplify/backend-storage": "^0.6.0-beta.7",
+        "@aws-amplify/client-config": "^0.9.0-beta.11",
+        "@aws-amplify/data-schema": "^0.15.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "@aws-sdk/client-amplify": "^3.465.0"
       },
       "devDependencies": {
@@ -25411,16 +25409,16 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.5.0-beta.9",
+      "version": "0.5.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.9",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1"
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.10",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4"
+        "@aws-amplify/platform-core": "^0.5.0-beta.5"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0",
@@ -25429,32 +25427,41 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.10.0-beta.10",
+      "version": "0.10.0-beta.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
-        "@aws-amplify/data-construct": "1.7.1-gen2-release.2",
-        "@aws-amplify/data-schema-types": "^0.7.16",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1"
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/data-construct": "1.8.0-0411-gen2.0",
+        "@aws-amplify/data-schema-types": "^0.8.0",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
-        "@aws-amplify/data-schema": "^0.14.11",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4"
+        "@aws-amplify/data-schema": "^0.15.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0",
         "constructs": "^10.0.0"
       }
     },
+    "packages/backend-data/node_modules/@aws-amplify/data-schema-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.8.0.tgz",
+      "integrity": "sha512-irfYm8uY7H8IfCNYSoep2/rxkk+n9/PTEvWVuEMZ24aYfQoDaS21Kb85DyGVZEr4LtNtTpiE1itFC0W8pCOtvA==",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
+        "rxjs": "^7.8.1"
+      }
+    },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "0.5.1-beta.5",
+      "version": "0.5.1-beta.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -25465,17 +25472,17 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.8.0-beta.8",
+      "version": "0.8.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "execa": "^8.0.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-ssm": "^3.465.0",
         "aws-sdk": "^2.1550.0",
         "uuid": "^9.0.1"
@@ -25490,7 +25497,7 @@
       "version": "0.7.0-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1"
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2"
       },
       "peerDependencies": {
         "zod": "^3.22.2"
@@ -25498,11 +25505,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.4.0-beta.4",
+      "version": "0.4.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4"
+        "@aws-amplify/platform-core": "^0.5.0-beta.5"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0"
@@ -25519,11 +25526,11 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "0.4.5-beta.4",
+      "version": "0.4.5-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "@aws-sdk/client-ssm": "^3.465.0"
       },
       "devDependencies": {
@@ -25532,16 +25539,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.6.0-beta.6",
+      "version": "0.6.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.4",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1"
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4"
+        "@aws-amplify/platform-core": "^0.5.0-beta.5"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0",
@@ -25550,20 +25557,20 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.0-beta.17",
+      "version": "0.12.0-beta.18",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
+        "@aws-amplify/backend-deployer": "^0.5.1-beta.6",
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/cli-core": "^0.5.0-beta.9",
-        "@aws-amplify/client-config": "^0.9.0-beta.10",
-        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
-        "@aws-amplify/form-generator": "^0.8.0-beta.3",
-        "@aws-amplify/model-generator": "^0.5.0-beta.7",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/sandbox": "^0.5.2-beta.14",
-        "@aws-amplify/schema-generator": "^0.1.0-beta.4",
+        "@aws-amplify/backend-secret": "^0.4.5-beta.5",
+        "@aws-amplify/cli-core": "^0.5.0-beta.10",
+        "@aws-amplify/client-config": "^0.9.0-beta.11",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.6",
+        "@aws-amplify/form-generator": "^0.8.0-beta.4",
+        "@aws-amplify/model-generator": "^0.5.0-beta.8",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
+        "@aws-amplify/sandbox": "^0.5.2-beta.15",
+        "@aws-amplify/schema-generator": "^0.1.0-beta.5",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
         "@aws-sdk/region-config-resolver": "^3.465.0",
@@ -25592,10 +25599,10 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "0.5.0-beta.9",
+      "version": "0.5.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@inquirer/prompts": "^3.0.0",
         "execa": "^8.0.1",
         "kleur": "^4.1.5"
@@ -25713,13 +25720,13 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.9.0-beta.10",
+      "version": "0.9.0-beta.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
-        "@aws-amplify/model-generator": "^0.5.0-beta.7",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.6",
+        "@aws-amplify/model-generator": "^0.5.0-beta.8",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",
@@ -25734,12 +25741,12 @@
       }
     },
     "packages/create-amplify": {
-      "version": "0.7.0-beta.11",
+      "version": "0.7.0-beta.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^0.5.0-beta.9",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
+        "@aws-amplify/cli-core": "^0.5.0-beta.10",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "execa": "^8.0.1",
         "kleur": "^4.1.5",
         "yargs": "^17.7.2"
@@ -25863,11 +25870,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.4.0-beta.5",
+      "version": "0.4.0-beta.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
@@ -25888,7 +25895,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "0.8.0-beta.3",
+      "version": "0.8.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
@@ -25908,15 +25915,15 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.5.0-beta.7",
+      "version": "0.5.0-beta.8",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.9",
-        "@aws-amplify/backend": "^0.13.0-beta.15",
-        "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/client-config": "^0.9.0-beta.10",
-        "@aws-amplify/data-schema": "^0.14.11",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.10",
+        "@aws-amplify/backend": "^0.13.0-beta.16",
+        "@aws-amplify/backend-secret": "^0.4.5-beta.5",
+        "@aws-amplify/client-config": "^0.9.0-beta.11",
+        "@aws-amplify/data-schema": "^0.15.0",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-iam": "^3.465.0",
@@ -25938,11 +25945,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.5.0-beta.7",
+      "version": "0.5.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.6",
         "@aws-amplify/graphql-generator": "^0.3.0",
         "@aws-amplify/graphql-types-generator": "^3.4.4",
         "@aws-sdk/client-appsync": "^3.465.0",
@@ -25954,10 +25961,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "0.5.0-beta.4",
+      "version": "0.5.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
+        "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "@aws-sdk/client-sts": "3.445.0",
         "is-ci": "^3.0.1",
         "lodash.mergewith": "^4.6.2",
@@ -26374,7 +26381,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "0.9.0-beta.1",
+      "version": "0.9.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "execa": "^5.1.1"
@@ -26493,15 +26500,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.14",
+      "version": "0.5.2-beta.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^0.5.1-beta.5",
-        "@aws-amplify/backend-secret": "^0.4.5-beta.4",
-        "@aws-amplify/cli-core": "^0.5.0-beta.9",
-        "@aws-amplify/client-config": "^0.9.0-beta.10",
-        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.5",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4",
+        "@aws-amplify/backend-deployer": "^0.5.1-beta.6",
+        "@aws-amplify/backend-secret": "^0.4.5-beta.5",
+        "@aws-amplify/cli-core": "^0.5.0-beta.10",
+        "@aws-amplify/client-config": "^0.9.0-beta.11",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.6",
+        "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
@@ -26522,11 +26529,11 @@
     },
     "packages/schema-generator": {
       "name": "@aws-amplify/schema-generator",
-      "version": "0.1.0-beta.4",
+      "version": "0.1.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-schema-generator": "^0.8.0",
-        "@aws-amplify/platform-core": "^0.5.0-beta.4"
+        "@aws-amplify/platform-core": "^0.5.0-beta.5"
       }
     }
   }

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-amplify/data-schema": "^0.14.11",
+    "@aws-amplify/data-schema": "^0.15.0",
     "@aws-amplify/backend-platform-test-stubs": "^0.3.3-beta.0",
     "@aws-amplify/platform-core": "^0.5.0-beta.5"
   },
@@ -29,8 +29,8 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
     "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-    "@aws-amplify/data-construct": "1.7.1-gen2-release.2",
+    "@aws-amplify/data-construct": "1.8.0-0411-gen2.0",
     "@aws-amplify/plugin-types": "^0.9.0-beta.2",
-    "@aws-amplify/data-schema-types": "^0.7.16"
+    "@aws-amplify/data-schema-types": "^0.8.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-amplify/data-schema": "^0.14.11",
+    "@aws-amplify/data-schema": "^0.15.0",
     "@aws-amplify/backend-auth": "^0.5.0-beta.10",
     "@aws-amplify/backend-function": "^0.8.0-beta.9",
     "@aws-amplify/backend-data": "^0.10.0-beta.11",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -8,7 +8,7 @@
     "@aws-amplify/backend": "^0.13.0-beta.16",
     "@aws-amplify/backend-secret": "^0.4.5-beta.5",
     "@aws-amplify/client-config": "^0.9.0-beta.11",
-    "@aws-amplify/data-schema": "^0.14.11",
+    "@aws-amplify/data-schema": "^0.15.0",
     "@aws-amplify/platform-core": "^0.5.0-beta.5",
     "@aws-sdk/client-amplify": "^3.465.0",
     "@aws-sdk/client-cloudformation": "^3.465.0",


### PR DESCRIPTION
## Problem
N/A

**Issue number, if available:**

## Changes
- Bumps data-construct to current version: 1.8.0-0411-gen2.0
- Bumps data-schema to current version: 0.15.0
- Bumps data-schema-types to current version: 0.8.0

These new versions contain breaking changes for relationship definitions.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] ~If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.~
- [ ] ~If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.~
- [ ] ~If this PR requires a docs update, I have linked to that docs PR above.~
- [ ] ~If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.~

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
