### PR TITLE
fix: serialize downstream errors when they are not generic Errors

### DIFF
--- a/.changeset/yellow-peas-wonder.md
+++ b/.changeset/yellow-peas-wonder.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+fix: serialize downstream errors when they are not generic Errors

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -55,6 +55,36 @@ and some after the error message
     assert.deepStrictEqual(actual?.cause?.message, testError.cause?.message);
   });
 
+  void it('serialize and deserialize correctly with non-generic Error cause', () => {
+    class TestError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'TestError';
+      }
+    }
+    const testError = new AmplifyUserError(
+      'SyntaxError',
+      {
+        message: 'test error "message"',
+        details: 'test error details',
+        resolution: 'test resolution',
+      },
+      new TestError('some test error')
+    );
+    const sampleStderr = `some random stderr
+before the actual error message
+${util.inspect(testError, { depth: null })}
+and some after the error message
+    `;
+    const actual = AmplifyError.fromStderr(sampleStderr);
+    assert.deepStrictEqual(actual?.name, testError.name);
+    assert.deepStrictEqual(actual?.classification, testError.classification);
+    assert.deepStrictEqual(actual?.message, testError.message);
+    assert.deepStrictEqual(actual?.details, testError.details);
+    assert.deepStrictEqual(actual?.cause?.name, testError.cause?.name);
+    assert.deepStrictEqual(actual?.cause?.message, testError.cause?.message);
+  });
+
   void it('deserialize when string is encoded with single quote and has double quotes in it', () => {
     const sampleStderr = `some random stderr
     ${util.inspect({

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -141,7 +141,7 @@ export type AmplifyUserErrorOptions = Omit<
 > & { resolution: string };
 
 const errorSerializer = (_: unknown, value: unknown) => {
-  if (value instanceof Error && value?.constructor.name === 'Error') {
+  if (value instanceof Error) {
     return ErrorSerializerDeserializer.serialize(value);
   }
   return value;
@@ -149,21 +149,23 @@ const errorSerializer = (_: unknown, value: unknown) => {
 class ErrorSerializerDeserializer {
   static serialize = (error: Error) => {
     const serializedError: SerializedErrorType = {
-      name: 'Error',
+      name: error.name,
       message: error.message,
     };
     return serializedError;
   };
 
   static deserialize = (deserialized: SerializedErrorType) => {
-    return new Error(deserialized.message);
+    const error = new Error(deserialized.message);
+    error.name = deserialized.name;
+    return error;
   };
 
   static isSerializedErrorType = (obj: unknown): obj is SerializedErrorType => {
     if (
       obj &&
       (obj as SerializedErrorType).name &&
-      (obj as SerializedErrorType).name === 'Error'
+      (obj as SerializedErrorType).message
     )
       return true;
     return false;


### PR DESCRIPTION
## Problem

If the downstream exception/cause was not a generic Error (such as ones thrown by data construct), we were correctly handling their serialization and deserialization.

## Changes

Preserve the `name` of the underlying error and relax the restriction that it has to have the name `Error`

## Validation

Unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
