### PR TITLE
fix: bump model introspection schema generation packages for references relationships

### DIFF
--- a/.changeset/weak-bottles-camp.md
+++ b/.changeset/weak-bottles-camp.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/model-generator': patch
+'@aws-amplify/form-generator': patch
+---
+
+fix: update model introspection schema generation packages for references relationships

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,9 +450,9 @@
       }
     },
     "node_modules/@aws-amplify/appsync-modelgen-plugin": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.10.0.tgz",
-      "integrity": "sha512-ZyUJJcS7wXITMfMu9u19uQjF+4V1mmNv06p0etic1DqCLFM6gxDAsLEN45TuKYsPx9Kgq2v0qvaQiCEV6f+C0A==",
+      "version": "2.11.0-gen2-release-0411.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.11.0-gen2-release-0411.0.tgz",
+      "integrity": "sha512-ge16Gb+trcY36sowqL4Y9VK7wdDj5QfkLG4cbAGIBK8PBv4dd5Mr5CCEtSjJ73e9icCUTpYc5X/5HS9Ak0rBQQ==",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^1.18.8",
         "@graphql-codegen/visitor-plugin-common": "^1.22.0",
@@ -2069,14 +2069,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-generator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.3.0.tgz",
-      "integrity": "sha512-q801PTzlD4F7wCEjrxBMf5ZCXTXCf2tHN/awCJXbfFmx7sWpZVSZuFfpKrvcDKC1889/bs4ZBY6W2Y54EqUf0A==",
+      "version": "0.4.0-gen2-release-0411.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.0-gen2-release-0411.0.tgz",
+      "integrity": "sha512-7WRXr2TYBFh/YRjzfoXb3ZUnCAvfg48p8v7OMHd+7TDMDC5YG+BoUxRirACg5G2rmnr7R3yv8OcNtF5EmkbZdg==",
       "dependencies": {
-        "@aws-amplify/appsync-modelgen-plugin": "2.10.0",
+        "@aws-amplify/appsync-modelgen-plugin": "2.11.0-gen2-release-0411.0",
         "@aws-amplify/graphql-directives": "^1.0.1",
         "@aws-amplify/graphql-docs-generator": "4.2.1",
-        "@aws-amplify/graphql-types-generator": "3.5.0",
+        "@aws-amplify/graphql-types-generator": "3.6.0-gen2-release-0411.0",
         "@graphql-codegen/core": "^2.6.6",
         "@graphql-tools/apollo-engine-loader": "^8.0.0",
         "graphql": "^15.5.0",
@@ -2822,9 +2822,9 @@
       }
     },
     "node_modules/@aws-amplify/graphql-types-generator": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.5.0.tgz",
-      "integrity": "sha512-Fm8M/CetzwI1dXSxAov38zOm10HpRlfRIEGEWDToDSAxIvYqddm9sn2Dn98r3uGDsoH8WFtVXrGrjRKkOzGFZQ==",
+      "version": "3.6.0-gen2-release-0411.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.6.0-gen2-release-0411.0.tgz",
+      "integrity": "sha512-s3ivNmm6wTQ98L3UHCsiIud0qOEGF2j6WGM+kbTLh4Ej7DxGitl4oKfExTeRvfGiW/WmfWlRF5u0yDcvpsvKJA==",
       "dependencies": {
         "@babel/generator": "7.0.0-beta.4",
         "@babel/types": "7.0.0-beta.4",
@@ -18216,6 +18216,7 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -18828,6 +18829,7 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -25367,11 +25369,11 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct-alpha",
-      "version": "0.6.0-beta.10",
+      "version": "0.6.0-beta.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.6",
         "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "@aws-sdk/util-arn-parser": "^3.465.0"
       },
@@ -25382,17 +25384,17 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.0-beta.16",
+      "version": "0.13.0-beta.17",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^0.5.0-beta.10",
-        "@aws-amplify/backend-data": "^0.10.0-beta.11",
-        "@aws-amplify/backend-function": "^0.8.0-beta.9",
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/backend-auth": "^0.5.0-beta.11",
+        "@aws-amplify/backend-data": "^0.10.0-beta.12",
+        "@aws-amplify/backend-function": "^0.8.0-beta.10",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.6",
         "@aws-amplify/backend-secret": "^0.4.5-beta.5",
-        "@aws-amplify/backend-storage": "^0.6.0-beta.7",
-        "@aws-amplify/client-config": "^0.9.0-beta.11",
+        "@aws-amplify/backend-storage": "^0.6.0-beta.8",
+        "@aws-amplify/client-config": "^0.9.0-beta.12",
         "@aws-amplify/data-schema": "^0.15.0",
         "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-amplify/plugin-types": "^0.9.0-beta.2",
@@ -25409,11 +25411,11 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "0.5.0-beta.10",
+      "version": "0.5.0-beta.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.10",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.11",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.6",
         "@aws-amplify/plugin-types": "^0.9.0-beta.2"
       },
       "devDependencies": {
@@ -25427,11 +25429,11 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.10.0-beta.11",
+      "version": "0.10.0-beta.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.6",
         "@aws-amplify/data-construct": "1.8.0-0411-gen2.0",
         "@aws-amplify/data-schema-types": "^0.8.0",
         "@aws-amplify/plugin-types": "^0.9.0-beta.2"
@@ -25472,11 +25474,11 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "0.8.0-beta.9",
+      "version": "0.8.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.6",
         "@aws-amplify/plugin-types": "^0.9.0-beta.2",
         "execa": "^8.0.1"
       },
@@ -25494,7 +25496,7 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "0.7.0-beta.0",
+      "version": "0.7.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/plugin-types": "^0.9.0-beta.2"
@@ -25505,10 +25507,10 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "0.4.0-beta.5",
+      "version": "0.4.0-beta.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
         "@aws-amplify/platform-core": "^0.5.0-beta.5"
       },
       "peerDependencies": {
@@ -25539,11 +25541,11 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.6.0-beta.7",
+      "version": "0.6.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/backend-output-storage": "^0.4.0-beta.5",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
+        "@aws-amplify/backend-output-storage": "^0.4.0-beta.6",
         "@aws-amplify/plugin-types": "^0.9.0-beta.2"
       },
       "devDependencies": {
@@ -25557,19 +25559,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.0-beta.18",
+      "version": "0.12.0-beta.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.6",
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
         "@aws-amplify/backend-secret": "^0.4.5-beta.5",
         "@aws-amplify/cli-core": "^0.5.0-beta.10",
-        "@aws-amplify/client-config": "^0.9.0-beta.11",
-        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.6",
+        "@aws-amplify/client-config": "^0.9.0-beta.12",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.7",
         "@aws-amplify/form-generator": "^0.8.0-beta.4",
-        "@aws-amplify/model-generator": "^0.5.0-beta.8",
+        "@aws-amplify/model-generator": "^0.5.0-beta.9",
         "@aws-amplify/platform-core": "^0.5.0-beta.5",
-        "@aws-amplify/sandbox": "^0.5.2-beta.15",
+        "@aws-amplify/sandbox": "^0.5.2-beta.16",
         "@aws-amplify/schema-generator": "^0.1.0-beta.5",
         "@aws-sdk/credential-provider-ini": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
@@ -25720,12 +25722,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.9.0-beta.11",
+      "version": "0.9.0-beta.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.6",
-        "@aws-amplify/model-generator": "^0.5.0-beta.8",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.7",
+        "@aws-amplify/model-generator": "^0.5.0-beta.9",
         "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -25870,10 +25872,10 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.4.0-beta.6",
+      "version": "0.4.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
         "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -25898,7 +25900,7 @@
       "version": "0.8.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
+        "@aws-amplify/appsync-modelgen-plugin": "2.11.0-gen2-release-0411.0",
         "@aws-amplify/codegen-ui": "^2.19.4",
         "@aws-amplify/codegen-ui-react": "^2.19.4",
         "@aws-amplify/graphql-directives": "^1.0.1",
@@ -25915,13 +25917,13 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.5.0-beta.8",
+      "version": "0.5.0-beta.9",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.10",
-        "@aws-amplify/backend": "^0.13.0-beta.16",
+        "@aws-amplify/auth-construct-alpha": "^0.6.0-beta.11",
+        "@aws-amplify/backend": "^0.13.0-beta.17",
         "@aws-amplify/backend-secret": "^0.4.5-beta.5",
-        "@aws-amplify/client-config": "^0.9.0-beta.11",
+        "@aws-amplify/client-config": "^0.9.0-beta.12",
         "@aws-amplify/data-schema": "^0.15.0",
         "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-amplify": "^3.465.0",
@@ -25945,13 +25947,13 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.5.0-beta.8",
+      "version": "0.5.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.0",
-        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.6",
-        "@aws-amplify/graphql-generator": "^0.3.0",
-        "@aws-amplify/graphql-types-generator": "^3.4.4",
+        "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.7",
+        "@aws-amplify/graphql-generator": "0.4.0-gen2-release-0411.0",
+        "@aws-amplify/graphql-types-generator": "3.6.0-gen2-release-0411.0",
         "@aws-sdk/client-appsync": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
@@ -26500,14 +26502,14 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.2-beta.15",
+      "version": "0.5.2-beta.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1-beta.6",
         "@aws-amplify/backend-secret": "^0.4.5-beta.5",
         "@aws-amplify/cli-core": "^0.5.0-beta.10",
-        "@aws-amplify/client-config": "^0.9.0-beta.11",
-        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.6",
+        "@aws-amplify/client-config": "^0.9.0-beta.12",
+        "@aws-amplify/deployed-backend-client": "^0.4.0-beta.7",
         "@aws-amplify/platform-core": "^0.5.0-beta.5",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",

--- a/packages/form-generator/package.json
+++ b/packages/form-generator/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-amplify/appsync-modelgen-plugin": "^2.6.0",
+    "@aws-amplify/appsync-modelgen-plugin": "2.11.0-gen2-release-0411.0",
     "@aws-amplify/codegen-ui": "^2.19.4",
     "@aws-amplify/codegen-ui-react": "^2.19.4",
     "@aws-amplify/graphql-docs-generator": "^4.1.0",

--- a/packages/model-generator/package.json
+++ b/packages/model-generator/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
     "@aws-amplify/deployed-backend-client": "^0.4.0-beta.7",
-    "@aws-amplify/graphql-generator": "^0.3.0",
-    "@aws-amplify/graphql-types-generator": "^3.4.4",
+    "@aws-amplify/graphql-generator": "0.4.0-gen2-release-0411.0",
+    "@aws-amplify/graphql-types-generator": "3.6.0-gen2-release-0411.0",
     "@aws-sdk/client-appsync": "^3.465.0",
     "@aws-sdk/client-s3": "^3.465.0",
     "@aws-sdk/credential-providers": "^3.465.0",


### PR DESCRIPTION
## Problem
`@aws-amplify/backend@0.13.0-beta.17` depends on updated `data-schema` and `data-schema-types` packages that change how relationships are defined and their implementation details.

The model introspection schema is currently generated for the new outdated relationship paradigm, resulting in client side errors when querying related models in relationships.

**Issue number, if available:**

## Changes
Bumps the following packages involved in model introspection schema generation:
- @aws-amplify/appsync-modelgen-plugin: 2.11.0-gen2-release-0411.0
- @aws-amplify/graphql-generator: 0.4.0-gen2-release-0411.0
- @aws-amplify/graphql-types-generator: 3.6.0-gen2-release-0411.0

**Corresponding docs PR, if applicable:**

## Validation
Manually tested relational queries with updated packages.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] ~If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.~
- [ ] ~If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.~
- [ ] ~If this PR requires a docs update, I have linked to that docs PR above.~
- [ ] ~If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.~

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
