### PR TITLE
Fix workflow input wiring for `deprecate_release` and `restore_release` workflows

### DIFF
--- a/.github/workflows/deprecate_release.yml
+++ b/.github/workflows/deprecate_release.yml
@@ -36,6 +36,11 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # mapping the inputs to these environment variables allows the @actions/core toolkit to pick up the inputs
+      INPUT_DEPRECATIONMESSAGE: ${{ inputs.deprecationMessage }}
+      INPUT_USENPMREGISTRY: ${{ inputs.useNpmRegistry }}
+      INPUT_SEARCHFORRELEASESTARTINGFRON: ${{ inputs.searchForReleaseStartingFrom }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
         with:

--- a/.github/workflows/deprecate_release.yml
+++ b/.github/workflows/deprecate_release.yml
@@ -40,7 +40,7 @@ jobs:
       # mapping the inputs to these environment variables allows the @actions/core toolkit to pick up the inputs
       INPUT_DEPRECATIONMESSAGE: ${{ inputs.deprecationMessage }}
       INPUT_USENPMREGISTRY: ${{ inputs.useNpmRegistry }}
-      INPUT_SEARCHFORRELEASESTARTINGFRON: ${{ inputs.searchForReleaseStartingFrom }}
+      INPUT_SEARCHFORRELEASESTARTINGFROM: ${{ inputs.searchForReleaseStartingFrom }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
         with:

--- a/.github/workflows/restore_release.yml
+++ b/.github/workflows/restore_release.yml
@@ -35,7 +35,7 @@ jobs:
 
       # mapping the inputs to these environment variables allows the @actions/core toolkit to pick up the inputs
       INPUT_USENPMREGISTRY: ${{ inputs.useNpmRegistry }}
-      INPUT_SEARCHFORRELEASESTARTINGFRON: ${{ inputs.searchForReleaseStartingFrom }}
+      INPUT_SEARCHFORRELEASESTARTINGFROM: ${{ inputs.searchForReleaseStartingFrom }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
         with:

--- a/.github/workflows/restore_release.yml
+++ b/.github/workflows/restore_release.yml
@@ -32,6 +32,10 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # mapping the inputs to these environment variables allows the @actions/core toolkit to pick up the inputs
+      INPUT_USENPMREGISTRY: ${{ inputs.useNpmRegistry }}
+      INPUT_SEARCHFORRELEASESTARTINGFRON: ${{ inputs.searchForReleaseStartingFrom }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
         with:

--- a/scripts/restore_release.ts
+++ b/scripts/restore_release.ts
@@ -8,7 +8,8 @@ import { DistTagMover } from './components/dist_tag_mover.js';
 const searchForReleaseStartingFrom = getInput('searchForReleaseStartingFrom', {
   required: true,
 });
-const useNpmRegistry = getInput('useNpmRegistry', { required: true });
+const useNpmRegistry =
+  getInput('useNpmRegistry', { required: true }) === 'true';
 
 if (useNpmRegistry) {
   console.log(


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

When testing these workflows before merging, there was no way to kick off the workflow using the GH UI so I was manually setting these env vars in the branch push workflow. I thought they would be set automatically by the workflow inputs, but they are not.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Wire the workflow inputs to corresponding environment variables so they are picked up by the @actions/core toolkit `getInput()` function.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Now that the workflow exists on `main`, the workflow dispatch UI can be used to trigger the workflow: 

Successful dryrun `restore_release` workflow: https://github.com/aws-amplify/amplify-backend/actions/runs/8710549954/job/23892707554
Successful dryrun `deprecate_release` workflow: https://github.com/aws-amplify/amplify-backend/actions/runs/8710626570/job/23892943477

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
