### PR TITLE
throw for generate commands while deployment is still in progress

### DIFF
--- a/.changeset/strong-cooks-call.md
+++ b/.changeset/strong-cooks-call.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/deployed-backend-client': patch
+---
+
+throw for generate commands while deployment is still in progress

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.test.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.test.ts
@@ -79,7 +79,109 @@ void describe('StackMetadataBackendOutputRetrievalStrategy', () => {
       });
     });
 
-    void it('throws if stack is still in progress', async () => {
+    void it('throws if sandbox stack is still in progress', async () => {
+      const cfnClientMock = {
+        send: mock.fn((command) => {
+          if (command instanceof GetTemplateSummaryCommand) {
+            return {
+              Metadata: JSON.stringify({
+                [authOutputKey]: {
+                  version: '1',
+                  stackOutputs: ['testName1', 'testName2'],
+                },
+              }),
+            };
+          } else if (command instanceof DescribeStacksCommand) {
+            return {
+              Stacks: [
+                {
+                  StackName: 'testStackName',
+                  StackStatus: 'CREATE_IN_PROGRESS',
+                  Tags: [
+                    {
+                      Key: 'amplify:deployment-type',
+                      Value: 'sandbox',
+                    },
+                    {
+                      Key: 'created-by',
+                      Value: 'amplify',
+                    },
+                  ],
+                },
+              ],
+            };
+          }
+          assert.fail(`Unknown command ${typeof command}`);
+        }),
+      } as unknown as CloudFormationClient;
+
+      const stackNameResolverMock: MainStackNameResolver = {
+        resolveMainStackName: mock.fn(async () => 'testMainStack'),
+      };
+
+      const retrievalStrategy = new StackMetadataBackendOutputRetrievalStrategy(
+        cfnClientMock,
+        stackNameResolverMock
+      );
+
+      await assert.rejects(retrievalStrategy.fetchBackendOutput(), {
+        message:
+          'A sandbox deployment is in progress. Please re-run this command once the deployment completes',
+      });
+    });
+
+    void it('throws if branch stack is still in progress', async () => {
+      const cfnClientMock = {
+        send: mock.fn((command) => {
+          if (command instanceof GetTemplateSummaryCommand) {
+            return {
+              Metadata: JSON.stringify({
+                [authOutputKey]: {
+                  version: '1',
+                  stackOutputs: ['testName1', 'testName2'],
+                },
+              }),
+            };
+          } else if (command instanceof DescribeStacksCommand) {
+            return {
+              Stacks: [
+                {
+                  StackName: 'testStackName',
+                  StackStatus: 'CREATE_IN_PROGRESS',
+                  Tags: [
+                    {
+                      Key: 'amplify:deployment-type',
+                      Value: 'branch',
+                    },
+                    {
+                      Key: 'created-by',
+                      Value: 'amplify',
+                    },
+                  ],
+                },
+              ],
+            };
+          }
+          assert.fail(`Unknown command ${typeof command}`);
+        }),
+      } as unknown as CloudFormationClient;
+
+      const stackNameResolverMock: MainStackNameResolver = {
+        resolveMainStackName: mock.fn(async () => 'testMainStack'),
+      };
+
+      const retrievalStrategy = new StackMetadataBackendOutputRetrievalStrategy(
+        cfnClientMock,
+        stackNameResolverMock
+      );
+
+      await assert.rejects(retrievalStrategy.fetchBackendOutput(), {
+        message:
+          'A branch deployment is in progress. Please re-run this command once the deployment completes',
+      });
+    });
+
+    void it('throws if stack is still in progress - defaults to sandbox', async () => {
       const cfnClientMock = {
         send: mock.fn((command) => {
           if (command instanceof GetTemplateSummaryCommand) {
@@ -116,7 +218,7 @@ void describe('StackMetadataBackendOutputRetrievalStrategy', () => {
 
       await assert.rejects(retrievalStrategy.fetchBackendOutput(), {
         message:
-          'testStackName is currently in CREATE_IN_PROGRESS. Metadata will be available after stack completes processing.',
+          'A sandbox deployment is in progress. Please re-run this command once the deployment completes',
       });
     });
 

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.test.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.test.ts
@@ -126,7 +126,7 @@ void describe('StackMetadataBackendOutputRetrievalStrategy', () => {
 
       await assert.rejects(retrievalStrategy.fetchBackendOutput(), {
         message:
-          'A sandbox deployment is in progress. Please re-run this command once the deployment completes',
+          'This sandbox deployment is in progress. Re-run this command once the deployment completes.',
       });
     });
 
@@ -177,7 +177,7 @@ void describe('StackMetadataBackendOutputRetrievalStrategy', () => {
 
       await assert.rejects(retrievalStrategy.fetchBackendOutput(), {
         message:
-          'A branch deployment is in progress. Please re-run this command once the deployment completes',
+          'This branch deployment is in progress. Re-run this command once the deployment completes.',
       });
     });
 
@@ -218,7 +218,7 @@ void describe('StackMetadataBackendOutputRetrievalStrategy', () => {
 
       await assert.rejects(retrievalStrategy.fetchBackendOutput(), {
         message:
-          'A sandbox deployment is in progress. Please re-run this command once the deployment completes',
+          'This sandbox deployment is in progress. Re-run this command once the deployment completes.',
       });
     });
 

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
@@ -60,17 +60,17 @@ export class StackMetadataBackendOutputRetrievalStrategy
     );
 
     const outputs = stackDescription?.Stacks?.[0]?.Outputs;
+    if (stackDescription.Stacks?.[0].StackStatus?.endsWith('_IN_PROGRESS')) {
+      const deploymentType =
+        stackDescription.Stacks?.[0].Tags?.find(
+          (tag) => tag.Key === 'amplify:deployment-type'
+        )?.Value ?? 'sandbox';
+      throw new BackendOutputClientError(
+        BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR,
+        `A ${deploymentType} deployment is in progress. Please re-run this command once the deployment completes`
+      );
+    }
     if (outputs === undefined) {
-      if (stackDescription.Stacks?.[0].StackStatus?.endsWith('_IN_PROGRESS')) {
-        throw new BackendOutputClientError(
-          BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR,
-          `${
-            stackDescription.Stacks?.[0].StackName ?? 'Stack'
-          } is currently in ${
-            stackDescription.Stacks?.[0].StackStatus
-          }. Metadata will be available after stack completes processing.`
-        );
-      }
       throw new BackendOutputClientError(
         BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR,
         'Stack outputs are undefined'

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
@@ -67,7 +67,7 @@ export class StackMetadataBackendOutputRetrievalStrategy
         )?.Value ?? 'sandbox';
       throw new BackendOutputClientError(
         BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR,
-        `A ${deploymentType} deployment is in progress. Please re-run this command once the deployment completes`
+        `This ${deploymentType} deployment is in progress. Re-run this command once the deployment completes.`
       );
     }
     if (outputs === undefined) {


### PR DESCRIPTION
## Problem

When running `npx amplify generate *` commands while the stack is in a `*_IN_PROGRESS` status, there may not be metadata/outputs available yet so users get an error like `Error: Output userPoolId not found in stack`.

**Issue number, if available:**

## Changes

Update when to check if the stack is in a status that ends with `_IN_PROGRESS` and throw a helpful error message.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests and manually while sandbox is updating the stack:

<img width="708" alt="Screenshot 2024-04-16 at 11 58 56 AM" src="https://github.com/aws-amplify/amplify-backend/assets/23459628/91877e35-6bf4-405e-8da0-b0bdff4e32fe">

-----------
<img width="711" alt="Screenshot 2024-04-16 at 11 59 14 AM" src="https://github.com/aws-amplify/amplify-backend/assets/23459628/9fa7e10a-a89d-48e4-8499-c958ef4c0139">

-----------
<img width="712" alt="Screenshot 2024-04-16 at 11 59 29 AM" src="https://github.com/aws-amplify/amplify-backend/assets/23459628/36c240b8-690c-4c06-a778-c1281294a484">

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
