### PR TITLE
chore: bump data construct and schema generator

### DIFF
--- a/.changeset/three-lamps-impress.md
+++ b/.changeset/three-lamps-impress.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/schema-generator': patch
+'@aws-amplify/backend-data': patch
+---
+
+Fix dependent bot alert for mysql2

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.8.0-0411-gen2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.8.0-0411-gen2.0.tgz",
-      "integrity": "sha512-y3eO0U6Rcc51+YQO/yGTfbC2xTik558brLsSkKCdh914wgAUFIr2RrJKVc/xqPO3K5Anl1hvdzzLQfZLeyavEg==",
+      "version": "1.8.0-gen2-release-0416.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.8.0-gen2-release-0416.0.tgz",
+      "integrity": "sha512-lZJQRpvnzCiOsG9hCONfYSf9Z3OEwGf5Z0JbHjfkV8gFYA5thfoq3u91A726q/ZC1/0NtPxjv3GCoeXbHBRweA==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -756,22 +756,22 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-api-construct": "1.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-auth-transformer": "3.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.4-0411-gen2.0",
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-http-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.0-0411-gen2.0",
-        "@aws-amplify/graphql-sql-transformer": "0.3.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer": "1.5.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-api-construct": "1.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0416.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer": "1.5.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -780,7 +780,7 @@
         "graceful-fs": "^4.2.11",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
         "is-buffer": "^2.0.5",
@@ -820,18 +820,18 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.5.0-0411-gen2.0",
+      "version": "3.5.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
@@ -841,35 +841,35 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.4-0411-gen2.0",
+      "version": "2.3.4-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "1.1.0-0411-gen2.0",
+      "version": "1.1.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.21-0411-gen2.0",
+      "version": "2.1.21-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -877,16 +877,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.21-0411-gen2.0",
+      "version": "2.1.21-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -894,17 +894,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.4.0-0411-gen2.0",
+      "version": "2.4.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -912,15 +912,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.11-0411-gen2.0",
+      "version": "3.4.11-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -928,16 +928,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.9.0-0411-gen2.0",
+      "version": "2.9.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -945,16 +945,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.21-0411-gen2.0",
+      "version": "2.1.21-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -962,18 +962,18 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.0-0411-gen2.0",
+      "version": "2.5.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
@@ -982,17 +982,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.7.0-0411-gen2.0",
+      "version": "2.7.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1000,17 +1000,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.3.0-0411-gen2.0",
+      "version": "0.3.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1018,23 +1018,23 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.5.1-0411-gen2.0",
+      "version": "1.5.1-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.4-0411-gen2.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-http-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.0-0411-gen2.0",
-        "@aws-amplify/graphql-sql-transformer": "0.3.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0"
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0416.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1042,15 +1042,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.6.1-0411-gen2.0",
+      "version": "2.6.1-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -1063,7 +1063,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.7.0-0411-gen2.0",
+      "version": "3.7.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1155,7 +1155,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/graphql-transformer-common": {
-      "version": "4.30.1-0411-gen2.0",
+      "version": "4.30.1-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1341,9 +1341,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.9.0-0411-gen2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.9.0-0411-gen2.0.tgz",
-      "integrity": "sha512-UF03jqCxqrbd4/MaKA5llWL6QNi+LnN0gouTwMhOV6lLVnTOCZDHW/+GYPIB34VregH2VdLz6udCMMFhZFZZmg==",
+      "version": "1.9.0-gen2-release-0416.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.9.0-gen2-release-0416.0.tgz",
+      "integrity": "sha512-Bx6/2founFhc/kzMytjnX/zUcvRNz+d3+Y0WmmsqonevXCdZPF04N0vu3w1uaoLxMhuX1ByBNcDMVm4pryNz7Q==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -1387,21 +1387,21 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-auth-transformer": "3.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.4-0411-gen2.0",
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-http-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.0-0411-gen2.0",
-        "@aws-amplify/graphql-sql-transformer": "0.3.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer": "1.5.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0416.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer": "1.5.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -1410,7 +1410,7 @@
         "graceful-fs": "^4.2.11",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
         "is-buffer": "^2.0.5",
@@ -1450,18 +1450,18 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.5.0-0411-gen2.0",
+      "version": "3.5.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
@@ -1471,35 +1471,35 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.4-0411-gen2.0",
+      "version": "2.3.4-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "1.1.0-0411-gen2.0",
+      "version": "1.1.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.21-0411-gen2.0",
+      "version": "2.1.21-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1507,16 +1507,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.21-0411-gen2.0",
+      "version": "2.1.21-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1524,17 +1524,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.4.0-0411-gen2.0",
+      "version": "2.4.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1542,15 +1542,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.11-0411-gen2.0",
+      "version": "3.4.11-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1558,16 +1558,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.9.0-0411-gen2.0",
+      "version": "2.9.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1575,16 +1575,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.21-0411-gen2.0",
+      "version": "2.1.21-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1592,18 +1592,18 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.0-0411-gen2.0",
+      "version": "2.5.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
@@ -1612,17 +1612,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.7.0-0411-gen2.0",
+      "version": "2.7.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1630,17 +1630,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.3.0-0411-gen2.0",
+      "version": "0.3.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1648,23 +1648,23 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.5.1-0411-gen2.0",
+      "version": "1.5.1-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.4-0411-gen2.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-http-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-0411-gen2.0",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-0411-gen2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-0411-gen2.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21-0411-gen2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-0411-gen2.0",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.0-0411-gen2.0",
-        "@aws-amplify/graphql-sql-transformer": "0.3.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0"
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0416.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.11-gen2-release-0416.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0416.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1672,15 +1672,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.6.1-0411-gen2.0",
+      "version": "2.6.1-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-0411-gen2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-0411-gen2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.30.1-0411-gen2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -1693,7 +1693,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.7.0-0411-gen2.0",
+      "version": "3.7.0-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1785,7 +1785,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql-transformer-common": {
-      "version": "4.30.1-0411-gen2.0",
+      "version": "4.30.1-gen2-release-0416.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2185,12 +2185,12 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@aws-amplify/graphql-schema-generator": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-schema-generator/-/graphql-schema-generator-0.8.0.tgz",
-      "integrity": "sha512-t35CNoaT+ySZIdE1aJMeremNzhwZ/Buiu+bGOqBrgmUyjzM4ZP56Z911/1xpDHDq61oqLnkwdp7Pl4ESvEc+PA==",
+      "version": "0.8.2-gen2-release-0416.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-schema-generator/-/graphql-schema-generator-0.8.2-gen2-release-0416.0.tgz",
+      "integrity": "sha512-gRgj2R1/aAfVw/xgBYNd/1BWc1oIf13gz4XjlpTiSvY+hp/Ed570eAiXtY7VWUwpMd9QCrUUjfrDckBb95O8fQ==",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "@aws-sdk/client-ec2": "3.338.0",
         "@aws-sdk/client-iam": "3.338.0",
         "@aws-sdk/client-lambda": "3.338.0",
@@ -2198,9 +2198,9 @@
         "csv-parse": "^5.5.2",
         "fs-extra": "11.1.1",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.29.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "knex": "~2.4.0",
-        "mysql2": "~2.3.3",
+        "mysql2": "~3.9.4",
         "ora": "^4.0.3",
         "pg": "~8.11.3",
         "pluralize": "^8.0.0",
@@ -2739,6 +2739,17 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/graphql-transformer-common": {
+      "version": "4.30.1-gen2-release-0416.0",
+      "resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.30.1-gen2-release-0416.0.tgz",
+      "integrity": "sha512-YmRMfXt+fJmXj64OnFz2yiImdOstaSyRuavym/A2qSA8jO11VypsAMduERAUFFHz/BVNuQJ0WzVD6ufjpg0bhQ==",
+      "dependencies": {
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.15",
+        "md5": "^2.2.1",
+        "pluralize": "8.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-schema-generator/node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -2752,15 +2763,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-2.5.1.tgz",
-      "integrity": "sha512-eayaj2GMG1hAReuQb7upEyDf2HbzHz04Cmj/HhHG5y/wtCy7OVt3bR1qAvFYYjAsPQoUooC8MmJV7Bhw33m9Vw==",
+      "version": "2.6.1-gen2-release-0416.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-2.6.1-gen2-release-0416.0.tgz",
+      "integrity": "sha512-IJsRWoJCBfyfrGQ/cQKNytWNBPZ3i2KOGnrWX3tFrG4zekVRaLtVoMS5IEDL6ZPnEiKX96Oo2F6yO8KUr/OHvg==",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.0.1",
-        "@aws-amplify/graphql-transformer-interfaces": "3.5.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0416.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0416.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.29.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0416.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -2771,6 +2782,11 @@
         "aws-cdk-lib": "^2.80.0",
         "constructs": "^10.0.5"
       }
+    },
+    "node_modules/@aws-amplify/graphql-transformer-core/node_modules/@aws-amplify/graphql-directives": {
+      "version": "1.1.0-gen2-release-0416.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-directives/-/graphql-directives-1.1.0-gen2-release-0416.0.tgz",
+      "integrity": "sha512-bx5w+O85TavTwqy4H3qrfKqeh+rwqFtthjlyaMJwzsun/Td4WMn5ugd+YhTEC4sD/1q9tQDqvRjp6pM/2s5Dqw=="
     },
     "node_modules/@aws-amplify/graphql-transformer-core/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -2783,6 +2799,17 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-transformer-core/node_modules/graphql-transformer-common": {
+      "version": "4.30.1-gen2-release-0416.0",
+      "resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.30.1-gen2-release-0416.0.tgz",
+      "integrity": "sha512-YmRMfXt+fJmXj64OnFz2yiImdOstaSyRuavym/A2qSA8jO11VypsAMduERAUFFHz/BVNuQJ0WzVD6ufjpg0bhQ==",
+      "dependencies": {
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "4.20.15",
+        "md5": "^2.2.1",
+        "pluralize": "8.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-transformer-core/node_modules/jsonfile": {
@@ -2810,9 +2837,9 @@
       }
     },
     "node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.5.0.tgz",
-      "integrity": "sha512-YIFC0b8hqBKBdYBzpJImQDezTPUeOh9WVE0uFv6JM0NZRP917YbdA1RSJDMT6VZTN38d2nDxfxjjbPXDVxu4YQ==",
+      "version": "3.7.0-gen2-release-0416.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.7.0-gen2-release-0416.0.tgz",
+      "integrity": "sha512-w1AWE4YWas52XYUItimAmIXi6ipzRsRYhmnEuKKZ+Gngy1x96/6bICaVljLdUSJc8O3rkd2VjGnq4twrpgSgAA==",
       "dependencies": {
         "graphql": "^15.5.0"
       },
@@ -18216,7 +18243,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -18829,7 +18855,6 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -20285,9 +20310,9 @@
       }
     },
     "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -20702,16 +20727,16 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
-      "integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.4.tgz",
+      "integrity": "sha512-OEESQuwxMza803knC1YSt7NMuc1BrK9j7gZhCSs2WAyxr1vfiI7QLaLOKTh5c9SWGz98qVyQUbK8/WckevNQhg==",
       "dependencies": {
-        "denque": "^2.0.1",
+        "denque": "^2.1.0",
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
-        "long": "^4.0.0",
-        "lru-cache": "^6.0.0",
-        "named-placeholders": "^1.1.2",
+        "long": "^5.2.1",
+        "lru-cache": "^8.0.0",
+        "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
       },
@@ -20731,20 +20756,12 @@
       }
     },
     "node_modules/mysql2/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=16.14"
       }
-    },
-    "node_modules/mysql2/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/named-placeholders": {
       "version": "1.1.3",
@@ -25434,7 +25451,7 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
         "@aws-amplify/backend-output-storage": "^0.4.0-beta.6",
-        "@aws-amplify/data-construct": "1.8.0-0411-gen2.0",
+        "@aws-amplify/data-construct": "1.8.0-gen2-release-0416.0",
         "@aws-amplify/data-schema-types": "^0.8.0",
         "@aws-amplify/plugin-types": "^0.9.0-beta.2"
       },
@@ -26534,7 +26551,7 @@
       "version": "0.1.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-schema-generator": "^0.8.0",
+        "@aws-amplify/graphql-schema-generator": "0.8.2-gen2-release-0416.0",
         "@aws-amplify/platform-core": "^0.5.0-beta.5"
       }
     }

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "^0.4.0-beta.6",
     "@aws-amplify/backend-output-schemas": "^0.7.0-beta.1",
-    "@aws-amplify/data-construct": "1.8.0-0411-gen2.0",
+    "@aws-amplify/data-construct": "1.8.0-gen2-release-0416.0",
     "@aws-amplify/plugin-types": "^0.9.0-beta.2",
     "@aws-amplify/data-schema-types": "^0.8.0"
   }

--- a/packages/schema-generator/package.json
+++ b/packages/schema-generator/package.json
@@ -17,7 +17,7 @@
     "update:api": "api-extractor run --local"
   },
   "dependencies": {
-    "@aws-amplify/graphql-schema-generator": "^0.8.0",
+    "@aws-amplify/graphql-schema-generator": "0.8.2-gen2-release-0416.0",
     "@aws-amplify/platform-core": "^0.5.0-beta.5"
   },
   "license": "Apache-2.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

https://github.com/aws-amplify/amplify-backend/security/dependabot/31

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes
Bumped data construct and schema generator to the tag version released on 4/16 to resolve dependent bot alert issue
<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
