### PR TITLE
Allow specifying multiple groups in one group access rule

### DIFF
--- a/.changeset/strange-trainers-invite.md
+++ b/.changeset/strange-trainers-invite.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': minor
+---
+
+Change group access to allow multiple group names in one rule. Also enforce that there are no duplicate access targets for a single path.

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AmplifyUserErrorOptions } from '@aws-amplify/platform-core';
 import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
@@ -40,16 +41,20 @@ export type EntityId = 'identity';
 export type StorageAccessBuilder = {
     authenticated: StorageActionBuilder;
     guest: StorageActionBuilder;
-    group: (groupName: string) => StorageActionBuilder;
+    groups: (groupNames: string[]) => StorageActionBuilder;
     entity: (entityId: EntityId) => StorageActionBuilder;
     resource: (other: ConstructFactory<ResourceProvider & ResourceAccessAcceptorFactory>) => StorageActionBuilder;
 };
 
 // @public (undocumented)
 export type StorageAccessDefinition = {
-    getResourceAccessAcceptor: (getInstanceProps: ConstructFactoryGetInstanceProps) => ResourceAccessAcceptor;
+    getResourceAccessAcceptors: ((getInstanceProps: ConstructFactoryGetInstanceProps) => ResourceAccessAcceptor)[];
     actions: StorageAction[];
     idSubstitution: string;
+    uniqueDefinitionIdValidations: {
+        uniqueDefinitionId: string;
+        validationErrorOptions: AmplifyUserErrorOptions;
+    }[];
 };
 
 // @public (undocumented)

--- a/packages/backend-storage/src/access_builder.test.ts
+++ b/packages/backend-storage/src/access_builder.test.ts
@@ -10,16 +10,19 @@ import {
 
 void describe('storageAccessBuilder', () => {
   const resourceAccessAcceptorMock = mock.fn();
-  const groupAccessAcceptorMock = mock.fn();
+  const group1AccessAcceptorMock = mock.fn();
+  const group2AccessAcceptorMock = mock.fn();
 
-  const getResourceAccessAcceptorMock = mock.fn(
-    // allows us to get proper typing on the mock args
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (roleName: string) =>
-      roleName === 'testGroupName'
-        ? groupAccessAcceptorMock
-        : resourceAccessAcceptorMock
-  );
+  const getResourceAccessAcceptorMock = mock.fn((roleName: string) => {
+    switch (roleName) {
+      case 'group1Name':
+        return group1AccessAcceptorMock;
+      case 'group2Name':
+        return group2AccessAcceptorMock;
+      default:
+        return resourceAccessAcceptorMock;
+    }
+  });
 
   const getConstructFactoryMock = mock.fn(
     // this lets us get proper typing on the mock args
@@ -154,9 +157,9 @@ void describe('storageAccessBuilder', () => {
     );
   });
 
-  void it('builds storage access definition for user pool groups', () => {
+  void it('builds storage access definition for multiple user pool groups', () => {
     const accessDefinition = roleAccessBuilder
-      .groups(['testGroupName'])
+      .groups(['group1Name', 'group2Name'])
       .to(['read', 'write']);
 
     assert.deepStrictEqual(accessDefinition.actions, ['read', 'write']);
@@ -166,7 +169,7 @@ void describe('storageAccessBuilder', () => {
         (getResourceAccessAcceptor) =>
           getResourceAccessAcceptor(stubGetInstanceProps)
       ),
-      [groupAccessAcceptorMock]
+      [group1AccessAcceptorMock, group2AccessAcceptorMock]
     );
   });
 });

--- a/packages/backend-storage/src/access_builder.test.ts
+++ b/packages/backend-storage/src/access_builder.test.ts
@@ -55,9 +55,12 @@ void describe('storageAccessBuilder', () => {
       'delete',
     ]);
     assert.equal(accessDefinition.idSubstitution, '*');
-    assert.equal(
-      accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
-      resourceAccessAcceptorMock
+    assert.deepStrictEqual(
+      accessDefinition.getResourceAccessAcceptors.map(
+        (getResourceAccessAcceptor) =>
+          getResourceAccessAcceptor(stubGetInstanceProps)
+      ),
+      [resourceAccessAcceptorMock]
     );
     assert.equal(
       getConstructFactoryMock.mock.calls[0].arguments[0],
@@ -80,9 +83,12 @@ void describe('storageAccessBuilder', () => {
       'delete',
     ]);
     assert.equal(accessDefinition.idSubstitution, '*');
-    assert.equal(
-      accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
-      resourceAccessAcceptorMock
+    assert.deepStrictEqual(
+      accessDefinition.getResourceAccessAcceptors.map(
+        (getResourceAccessAcceptor) =>
+          getResourceAccessAcceptor(stubGetInstanceProps)
+      ),
+      [resourceAccessAcceptorMock]
     );
     assert.equal(
       getConstructFactoryMock.mock.calls[0].arguments[0],
@@ -106,9 +112,12 @@ void describe('storageAccessBuilder', () => {
       accessDefinition.idSubstitution,
       '${cognito-identity.amazonaws.com:sub}'
     );
-    assert.equal(
-      accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
-      resourceAccessAcceptorMock
+    assert.deepStrictEqual(
+      accessDefinition.getResourceAccessAcceptors.map(
+        (getResourceAccessAcceptor) =>
+          getResourceAccessAcceptor(stubGetInstanceProps)
+      ),
+      [resourceAccessAcceptorMock]
     );
     assert.equal(
       getConstructFactoryMock.mock.calls[0].arguments[0],
@@ -136,22 +145,28 @@ void describe('storageAccessBuilder', () => {
       'delete',
     ]);
     assert.equal(accessDefinition.idSubstitution, '*');
-    assert.equal(
-      accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
-      resourceAccessAcceptorMock
+    assert.deepStrictEqual(
+      accessDefinition.getResourceAccessAcceptors.map(
+        (getResourceAccessAcceptor) =>
+          getResourceAccessAcceptor(stubGetInstanceProps)
+      ),
+      [resourceAccessAcceptorMock]
     );
   });
 
   void it('builds storage access definition for user pool groups', () => {
     const accessDefinition = roleAccessBuilder
-      .group('testGroupName')
+      .groups(['testGroupName'])
       .to(['read', 'write']);
 
     assert.deepStrictEqual(accessDefinition.actions, ['read', 'write']);
     assert.equal(accessDefinition.idSubstitution, '*');
-    assert.equal(
-      accessDefinition.getResourceAccessAcceptor(stubGetInstanceProps),
-      groupAccessAcceptorMock
+    assert.deepStrictEqual(
+      accessDefinition.getResourceAccessAcceptors.map(
+        (getResourceAccessAcceptor) =>
+          getResourceAccessAcceptor(stubGetInstanceProps)
+      ),
+      [groupAccessAcceptorMock]
     );
   });
 });

--- a/packages/backend-storage/src/access_builder.ts
+++ b/packages/backend-storage/src/access_builder.ts
@@ -9,37 +9,41 @@ import { StorageAccessBuilder } from './types.js';
 export const roleAccessBuilder: StorageAccessBuilder = {
   authenticated: {
     to: (actions) => ({
-      getResourceAccessAcceptor: getAuthRoleResourceAccessAcceptor,
+      getResourceAccessAcceptors: [getAuthRoleResourceAccessAcceptor],
       actions,
       idSubstitution: '*',
     }),
   },
   guest: {
     to: (actions) => ({
-      getResourceAccessAcceptor: getUnauthRoleResourceAccessAcceptor,
+      getResourceAccessAcceptors: [getUnauthRoleResourceAccessAcceptor],
       actions,
       idSubstitution: '*',
     }),
   },
-  group: (groupName) => ({
+  groups: (groupNames) => ({
     to: (actions) => ({
-      getResourceAccessAcceptor: (getInstanceProps) =>
-        getUserRoleResourceAccessAcceptor(getInstanceProps, groupName),
+      getResourceAccessAcceptors: groupNames.map(
+        (groupName) => (getInstanceProps) =>
+          getUserRoleResourceAccessAcceptor(getInstanceProps, groupName)
+      ),
       actions,
       idSubstitution: '*',
     }),
   }),
   entity: () => ({
     to: (actions) => ({
-      getResourceAccessAcceptor: getAuthRoleResourceAccessAcceptor,
+      getResourceAccessAcceptors: [getAuthRoleResourceAccessAcceptor],
       actions,
       idSubstitution: '${cognito-identity.amazonaws.com:sub}',
     }),
   }),
   resource: (other) => ({
     to: (actions) => ({
-      getResourceAccessAcceptor: (getInstanceProps) =>
-        other.getInstance(getInstanceProps).getResourceAccessAcceptor(),
+      getResourceAccessAcceptors: [
+        (getInstanceProps) =>
+          other.getInstance(getInstanceProps).getResourceAccessAcceptor(),
+      ],
       actions,
       idSubstitution: '*',
     }),

--- a/packages/backend-storage/src/access_builder.ts
+++ b/packages/backend-storage/src/access_builder.ts
@@ -10,6 +10,15 @@ export const roleAccessBuilder: StorageAccessBuilder = {
   authenticated: {
     to: (actions) => ({
       getResourceAccessAcceptors: [getAuthRoleResourceAccessAcceptor],
+      uniqueDefinitionIdValidations: [
+        {
+          uniqueDefinitionId: `authenticated`,
+          validationErrorOptions: {
+            message: `Entity access definition for authenticated users specified multiple times.`,
+            resolution: `Combine all access definitions for authenticated users on a single path into one access rule.`,
+          },
+        },
+      ],
       actions,
       idSubstitution: '*',
     }),
@@ -17,6 +26,15 @@ export const roleAccessBuilder: StorageAccessBuilder = {
   guest: {
     to: (actions) => ({
       getResourceAccessAcceptors: [getUnauthRoleResourceAccessAcceptor],
+      uniqueDefinitionIdValidations: [
+        {
+          uniqueDefinitionId: `guest`,
+          validationErrorOptions: {
+            message: `Entity access definition for guest users specified multiple times.`,
+            resolution: `Combine all access definitions for guest users on a single path into one access rule.`,
+          },
+        },
+      ],
       actions,
       idSubstitution: '*',
     }),
@@ -27,13 +45,29 @@ export const roleAccessBuilder: StorageAccessBuilder = {
         (groupName) => (getInstanceProps) =>
           getUserRoleResourceAccessAcceptor(getInstanceProps, groupName)
       ),
+      uniqueDefinitionIdValidations: groupNames.map((groupName) => ({
+        uniqueDefinitionId: `groups${groupName}`,
+        validationErrorOptions: {
+          message: `Group access definition for ${groupName} specified multiple times.`,
+          resolution: `Combine all access definitions for ${groupName} on a single path into one access rule.`,
+        },
+      })),
       actions,
       idSubstitution: '*',
     }),
   }),
-  entity: () => ({
+  entity: (entityId) => ({
     to: (actions) => ({
       getResourceAccessAcceptors: [getAuthRoleResourceAccessAcceptor],
+      uniqueDefinitionIdValidations: [
+        {
+          uniqueDefinitionId: `entity${entityId}`,
+          validationErrorOptions: {
+            message: `Entity access definition for ${entityId} specified multiple times.`,
+            resolution: `Combine all access definitions for ${entityId} on a single path into one access rule.`,
+          },
+        },
+      ],
       actions,
       idSubstitution: '${cognito-identity.amazonaws.com:sub}',
     }),
@@ -44,6 +78,7 @@ export const roleAccessBuilder: StorageAccessBuilder = {
         (getInstanceProps) =>
           other.getInstance(getInstanceProps).getResourceAccessAcceptor(),
       ],
+      uniqueDefinitionIdValidations: [],
       actions,
       idSubstitution: '*',
     }),

--- a/packages/backend-storage/src/private_types.ts
+++ b/packages/backend-storage/src/private_types.ts
@@ -7,7 +7,9 @@ import { StorageAction } from './types.js';
 /**
  * Storage user error types
  */
-export type StorageError = 'InvalidStorageAccessPathError';
+export type StorageError =
+  | 'InvalidStorageAccessDefinition'
+  | 'InvalidStorageAccessPathError';
 
 /**
  * StorageAction type intended to be used after mapping "read" to "get" and "list"

--- a/packages/backend-storage/src/storage_access_orchestrator.test.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.test.ts
@@ -31,10 +31,12 @@ void describe('StorageAccessOrchestrator', () => {
           'test/prefix/*': [
             {
               actions: ['get', 'write'],
-              getResourceAccessAcceptor: () => ({
-                identifier: 'testResourceAccessAcceptor',
-                acceptResourceAccess: acceptResourceAccessMock,
-              }),
+              getResourceAccessAcceptors: [
+                () => ({
+                  identifier: 'testResourceAccessAcceptor',
+                  acceptResourceAccess: acceptResourceAccessMock,
+                }),
+              ],
               idSubstitution: '*',
             },
           ],
@@ -60,10 +62,12 @@ void describe('StorageAccessOrchestrator', () => {
           'test/prefix/*': [
             {
               actions: ['get', 'write'],
-              getResourceAccessAcceptor: () => ({
-                identifier: 'testResourceAccessAcceptor',
-                acceptResourceAccess: acceptResourceAccessMock,
-              }),
+              getResourceAccessAcceptors: [
+                () => ({
+                  identifier: 'testResourceAccessAcceptor',
+                  acceptResourceAccess: acceptResourceAccessMock,
+                }),
+              ],
               idSubstitution: '*',
             },
           ],
@@ -110,14 +114,14 @@ void describe('StorageAccessOrchestrator', () => {
           'test/prefix/*': [
             {
               actions: ['get', 'write', 'delete'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub],
               idSubstitution: '*',
             },
           ],
           'another/prefix/*': [
             {
               actions: ['get'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub],
               idSubstitution: '*',
             },
           ],
@@ -177,19 +181,19 @@ void describe('StorageAccessOrchestrator', () => {
           'test/prefix/*': [
             {
               actions: ['get', 'write', 'delete'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub1],
               idSubstitution: '*',
             },
             {
               actions: ['get'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub2],
               idSubstitution: '*',
             },
           ],
           'another/prefix/*': [
             {
               actions: ['get', 'delete'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub2],
               idSubstitution: '*',
             },
           ],
@@ -263,10 +267,12 @@ void describe('StorageAccessOrchestrator', () => {
           [`test/${entityIdPathToken}/*`]: [
             {
               actions: ['get', 'write'],
-              getResourceAccessAcceptor: () => ({
-                identifier: 'testResourceAccessAcceptor',
-                acceptResourceAccess: acceptResourceAccessMock,
-              }),
+              getResourceAccessAcceptors: [
+                () => ({
+                  identifier: 'testResourceAccessAcceptor',
+                  acceptResourceAccess: acceptResourceAccessMock,
+                }),
+              ],
               idSubstitution: '{testOwnerSub}',
             },
           ],
@@ -310,20 +316,24 @@ void describe('StorageAccessOrchestrator', () => {
           'foo/*': [
             {
               actions: ['get', 'write'],
-              getResourceAccessAcceptor: () => ({
-                identifier: 'resourceAccessAcceptor1',
-                acceptResourceAccess: acceptResourceAccessMock1,
-              }),
+              getResourceAccessAcceptors: [
+                () => ({
+                  identifier: 'resourceAccessAcceptor1',
+                  acceptResourceAccess: acceptResourceAccessMock1,
+                }),
+              ],
               idSubstitution: '*',
             },
           ],
           'foo/bar/*': [
             {
               actions: ['get'],
-              getResourceAccessAcceptor: () => ({
-                identifier: 'resourceAccessAcceptor2',
-                acceptResourceAccess: acceptResourceAccessMock2,
-              }),
+              getResourceAccessAcceptors: [
+                () => ({
+                  identifier: 'resourceAccessAcceptor2',
+                  acceptResourceAccess: acceptResourceAccessMock2,
+                }),
+              ],
               idSubstitution: '*',
             },
           ],
@@ -396,12 +406,12 @@ void describe('StorageAccessOrchestrator', () => {
           'foo/{entity_id}/*': [
             {
               actions: ['write', 'delete'],
-              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              getResourceAccessAcceptors: [authenticatedResourceAccessAcceptor],
               idSubstitution: '{idSub}',
             },
             {
               actions: ['get'],
-              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              getResourceAccessAcceptors: [authenticatedResourceAccessAcceptor],
               idSubstitution: '*',
             },
           ],
@@ -461,7 +471,7 @@ void describe('StorageAccessOrchestrator', () => {
           'foo/*': [
             {
               actions: ['get', 'write'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub1],
               idSubstitution: '*',
             },
           ],
@@ -470,7 +480,7 @@ void describe('StorageAccessOrchestrator', () => {
           'foo/bar/*': [
             {
               actions: ['get'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub2],
               idSubstitution: '{idSub}',
             },
           ],
@@ -480,7 +490,7 @@ void describe('StorageAccessOrchestrator', () => {
             {
               actions: ['get'],
               idSubstitution: '*',
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub1],
             },
           ],
           // acceptor 1 is denied write on this path (read still allowed)
@@ -488,12 +498,12 @@ void describe('StorageAccessOrchestrator', () => {
           'other/{entity_id}/*': [
             {
               actions: ['get', 'write', 'delete'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub2,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub2],
               idSubstitution: '{idSub}',
             },
             {
               actions: ['get'],
-              getResourceAccessAcceptor: getResourceAccessAcceptorStub1,
+              getResourceAccessAcceptors: [getResourceAccessAcceptorStub1],
               idSubstitution: '*',
             },
           ],
@@ -585,17 +595,17 @@ void describe('StorageAccessOrchestrator', () => {
           'foo/*': [
             {
               actions: ['get'],
-              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              getResourceAccessAcceptors: [authenticatedResourceAccessAcceptor],
               idSubstitution: '*',
             },
             {
               actions: ['write'],
-              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              getResourceAccessAcceptors: [authenticatedResourceAccessAcceptor],
               idSubstitution: '{idSub}',
             },
             {
               actions: ['delete'],
-              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              getResourceAccessAcceptors: [authenticatedResourceAccessAcceptor],
               idSubstitution: '*',
             },
           ],
@@ -648,19 +658,19 @@ void describe('StorageAccessOrchestrator', () => {
           'foo/bar/*': [
             {
               actions: ['read', 'get', 'list'],
-              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              getResourceAccessAcceptors: [authenticatedResourceAccessAcceptor],
               idSubstitution: '*',
             },
             {
               actions: ['list'],
-              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              getResourceAccessAcceptors: [authenticatedResourceAccessAcceptor],
               idSubstitution: '*',
             },
           ],
           'other/baz/*': [
             {
               actions: ['read'],
-              getResourceAccessAcceptor: authenticatedResourceAccessAcceptor,
+              getResourceAccessAcceptors: [authenticatedResourceAccessAcceptor],
               idSubstitution: '*',
             },
           ],

--- a/packages/backend-storage/src/storage_access_orchestrator.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.ts
@@ -93,11 +93,6 @@ export class StorageAccessOrchestrator {
       ([s3Prefix, accessPermissions]) => {
         // iterate over all of the access definitions for a given prefix
         accessPermissions.forEach((permission) => {
-          // get the ResourceAccessAcceptor for the permission and add it to the map if not already present
-          const resourceAccessAcceptor = permission.getResourceAccessAcceptor(
-            this.getInstanceProps
-          );
-
           // make the owner placeholder substitution in the s3 prefix
           const prefix = s3Prefix.replaceAll(
             entityIdPathToken,
@@ -114,11 +109,15 @@ export class StorageAccessOrchestrator {
             new Set(replaceReadWithGetAndList)
           );
 
-          // set an entry that maps this permission to the resource acceptor
-          this.addAccessDefinition(
-            resourceAccessAcceptor,
-            noDuplicateActions,
-            prefix
+          // set an entry that maps this permission to each resource acceptor
+          permission.getResourceAccessAcceptors.forEach(
+            (getResourceAccessAcceptor) => {
+              this.addAccessDefinition(
+                getResourceAccessAcceptor(this.getInstanceProps),
+                noDuplicateActions,
+                prefix
+              );
+            }
           );
         });
       }

--- a/packages/backend-storage/src/storage_access_orchestrator.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.ts
@@ -12,7 +12,8 @@ import { entityIdPathToken } from './constants.js';
 import { StorageAccessPolicyFactory } from './storage_access_policy_factory.js';
 import { validateStorageAccessPaths as _validateStorageAccessPaths } from './validate_storage_access_paths.js';
 import { roleAccessBuilder as _roleAccessBuilder } from './access_builder.js';
-import { InternalStorageAction } from './private_types.js';
+import { InternalStorageAction, StorageError } from './private_types.js';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 /* some types internal to this file to improve readability */
 
@@ -89,10 +90,23 @@ export class StorageAccessOrchestrator {
 
     // iterate over the access definition and group permissions by ResourceAccessAcceptor
     Object.entries(storageAccessDefinition).forEach(
-      // in the access definition, permissions are grouped by storage prefix
       ([s3Prefix, accessPermissions]) => {
+        const uniqueDefinitionIdSet = new Set<string>();
         // iterate over all of the access definitions for a given prefix
         accessPermissions.forEach((permission) => {
+          // iterate over all uniqueDefinitionIdValidations and ensure uniqueness within this path prefix
+          permission.uniqueDefinitionIdValidations.forEach(
+            ({ uniqueDefinitionId, validationErrorOptions }) => {
+              if (uniqueDefinitionIdSet.has(uniqueDefinitionId)) {
+                throw new AmplifyUserError<StorageError>(
+                  'InvalidStorageAccessDefinition',
+                  validationErrorOptions
+                );
+              } else {
+                uniqueDefinitionIdSet.add(uniqueDefinitionId);
+              }
+            }
+          );
           // make the owner placeholder substitution in the s3 prefix
           const prefix = s3Prefix.replaceAll(
             entityIdPathToken,

--- a/packages/backend-storage/src/types.ts
+++ b/packages/backend-storage/src/types.ts
@@ -52,7 +52,7 @@ export type StorageAccessBuilder = {
    * @see https://docs.amplify.aws/gen2/build-a-backend/storage/#user-group-access
    * @param groupName The User Pool group name to configure access for
    */
-  group: (groupName: string) => StorageActionBuilder;
+  groups: (groupNames: string[]) => StorageActionBuilder;
   /**
    * Configure owner-based access. Requires `defineAuth` in the backend definition.
    * @see https://docs.amplify.aws/gen2/build-a-backend/storage/#owner-based-access
@@ -88,9 +88,9 @@ export type StorageAccessRecord = Record<
 >;
 
 export type StorageAccessDefinition = {
-  getResourceAccessAcceptor: (
+  getResourceAccessAcceptors: ((
     getInstanceProps: ConstructFactoryGetInstanceProps
-  ) => ResourceAccessAcceptor;
+  ) => ResourceAccessAcceptor)[];
   /**
    * Actions to grant to this role on a specific prefix
    */

--- a/packages/backend-storage/src/types.ts
+++ b/packages/backend-storage/src/types.ts
@@ -6,6 +6,7 @@ import {
   ResourceProvider,
 } from '@aws-amplify/plugin-types';
 import { AmplifyStorageProps } from './construct.js';
+import { AmplifyUserErrorOptions } from '@aws-amplify/platform-core';
 
 export type AmplifyStorageFactoryProps = Omit<
   AmplifyStorageProps,
@@ -99,6 +100,33 @@ export type StorageAccessDefinition = {
    * The value that will be substituted into the resource string in place of the {owner} token
    */
   idSubstitution: string;
+  /**
+   * Evaluation of the access definition will ensure that all uniqueDefinitionIds occur at most once for a given access path.
+   * This can be used to validate against definitions like
+   *
+   * {
+   *   'foo/*': [
+   *     allow.authenticated.to(['read']),
+   *     allow.authenticated.to(['write'])
+   *   ]
+   * }
+   *
+   * and instead require such a definition to be specified as
+   *
+   * {
+   *   'foo/*': [
+   *     allow.authenticated.to(['read', 'write']),
+   *   ]
+   * }
+   *
+   * The validationErrorMessage will be used to print an error message in case of validation failure
+   *
+   * An empty array means that no uniqueness will be enforced
+   */
+  uniqueDefinitionIdValidations: {
+    uniqueDefinitionId: string;
+    validationErrorOptions: AmplifyUserErrorOptions;
+  }[];
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

When defining storage access for user pool groups, many times multiple groups should have the same access permissions. Our current interface requires specifying separate but duplicate actions for each of these groups.

Additionally, our current access allows the same group (or other entity) to be specified multiple times within the access definition for a single path. This makes it ambiguous how those rules will be combined together.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

To solve the first problem, we are changing `allow.group(name).to([action])` to `allow.groups([name]).to([action])` so that multiple groups can be specified together.

Instead of
```ts
defineStorage({
  access: allow => ({
    'foo/*': [
      allow.group('managers').to(['read']),
      allow.group('auditors').to(['read']),
    ]
  })
})
```
This can now be defined as
```ts
defineStorage({
  access: allow => ({
    'foo/*': [
      allow.groups(['managers', 'auditors']).to(['read']),
    ]
  })
})
```

To solve the second problem, we are adding validation that multiple auth rules for the same `allow.<entity>` on a single path cannot be specified.

The following is not valid:
```ts
defineStorage({
  access: allow => ({
    'foo/*': [
      allow.groups(['managers']).to(['write']),
      allow.groups(['managers', 'auditors']).to(['read']),
    ]
  })
})
```
Instead, manager and auditor permissions must be specified separately:
```ts
defineStorage({
  access: allow => ({
    'foo/*': [
      allow.groups(['managers']).to(['read', 'write']),
      allow.groups(['auditors']).to(['read']),
    ]
  })
})
```

Other types of entities can also only be specified once.

Invalid:
```ts
defineStorage({
  access: allow => ({
    'foo/*': [
      allow.authenticated.to(['read', 'write']),
      allow.authenticated.to(['delete']),
    ]
  })
})
```
Valid:
```ts
defineStorage({
  access: allow => ({
    'foo/*': [
      allow.authenticated.to(['read', 'write', 'delete']),
    ]
  })
})
```

**Corresponding docs PR, if applicable:**
TODO

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Updated / added unit test coverage

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
