### PR TITLE
remove changeset

### DIFF
--- a/.changeset/spotty-llamas-jump.md
+++ b/.changeset/spotty-llamas-jump.md
@@ -1,6 +1,0 @@
----
-'@aws-amplify/integration-tests': patch
-'@aws-amplify/backend-storage': patch
----
-
-Revert "fix: remove name validation on defineStorage"


### PR DESCRIPTION
removes changeset introduced with https://github.com/aws-amplify/amplify-backend/pull/1327

Since this revert was never part of a release it shouldn't appear in the changelog