### PR TITLE
Sanitize backend type inference

### DIFF
--- a/.changeset/tiny-drinks-melt.md
+++ b/.changeset/tiny-drinks-melt.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': minor
+---
+
+omit "getResourceAccessAcceptor" method from resources on defineBackend object

--- a/packages/backend/API.md
+++ b/packages/backend/API.md
@@ -26,6 +26,7 @@ import { defineStorage } from '@aws-amplify/backend-storage';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { GenerateContainerEntryProps } from '@aws-amplify/plugin-types';
 import { ImportPathVerifier } from '@aws-amplify/plugin-types';
+import { ResourceAccessAcceptorFactory } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { SsmEnvironmentEntriesGenerator } from '@aws-amplify/plugin-types';
 import { SsmEnvironmentEntry } from '@aws-amplify/plugin-types';
@@ -41,7 +42,7 @@ export { AuthRoleName }
 
 // @public
 export type Backend<T extends DefineBackendProps> = BackendBase & {
-    [K in keyof T]: ReturnType<T[K]['getInstance']>;
+    [K in keyof T]: Omit<ReturnType<T[K]['getInstance']>, keyof ResourceAccessAcceptorFactory>;
 };
 
 // @public (undocumented)
@@ -72,7 +73,7 @@ export { defineAuth }
 export const defineBackend: <T extends DefineBackendProps>(constructFactories: T) => Backend<T>;
 
 // @public (undocumented)
-export type DefineBackendProps = Record<string, ConstructFactory<ResourceProvider>> & {
+export type DefineBackendProps = Record<string, ConstructFactory<ResourceProvider & Partial<ResourceAccessAcceptorFactory<never>>>> & {
     [K in keyof BackendBase]?: never;
 };
 

--- a/packages/backend/src/backend.ts
+++ b/packages/backend/src/backend.ts
@@ -1,6 +1,7 @@
 import {
   ConstructFactory,
   DeepPartial,
+  ResourceAccessAcceptorFactory,
   ResourceProvider,
 } from '@aws-amplify/plugin-types';
 import { Stack } from 'aws-cdk-lib';
@@ -14,7 +15,9 @@ export type BackendBase = {
 // Type that allows construct factories to be defined using any keys except those used in BackendHelpers
 export type DefineBackendProps = Record<
   string,
-  ConstructFactory<ResourceProvider>
+  ConstructFactory<
+    ResourceProvider & Partial<ResourceAccessAcceptorFactory<never>>
+  >
 > & { [K in keyof BackendBase]?: never };
 
 /**
@@ -23,5 +26,8 @@ export type DefineBackendProps = Record<
  * It also has dynamic properties based on the resources passed into `defineBackend`
  */
 export type Backend<T extends DefineBackendProps> = BackendBase & {
-  [K in keyof T]: ReturnType<T[K]['getInstance']>;
+  [K in keyof T]: Omit<
+    ReturnType<T[K]['getInstance']>,
+    keyof ResourceAccessAcceptorFactory
+  >;
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

The `getResourceAccessAcceptor` method that is used internally for wiring resource access is exposed on the `defineBackend` type. While this method is part of our package interface, we don't intend for customers to use it directly in normal circumstances.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Hides the `getResourceAccessAcceptor` method on backend resources.

Before:
![Screenshot 2024-04-18 at 10 07 25](https://github.com/aws-amplify/amplify-backend/assets/19419978/12ede9c7-e583-4720-b0b5-ef5debeced03)

After:
![Screenshot 2024-04-18 at 10 08 03](https://github.com/aws-amplify/amplify-backend/assets/19419978/e3f5ec3f-e52d-4373-ab28-158df94096d1)

Note that it is still possible to find this method if you inspect the return value of `defineFunction` or `defineAuth` directly. We can't hide this type as it is required for proper type inferences when passing references of these objects in the backend definition.


**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Manually validated that editor tooltips are working as expected and all existing test cases build

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
