### PR TITLE
chore: update plugin-types changeset

### DIFF
--- a/.changeset/nine-oranges-eat.md
+++ b/.changeset/nine-oranges-eat.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/plugin-types': patch
+---
+
+update plugin-types for https://github.com/aws-amplify/amplify-backend/pull/1288

--- a/.changeset/nine-oranges-eat.md
+++ b/.changeset/nine-oranges-eat.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/plugin-types': patch
+'@aws-amplify/plugin-types': minor
 ---
 
-update plugin-types for https://github.com/aws-amplify/amplify-backend/pull/1288
+add AWSClientProvider type


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-backend/pull/1288 should have updated plugin-types changeset but overlooked it. This PR creates the missing changeset.