### PR TITLE
add cfnBucket to storage resource

### DIFF
--- a/.changeset/neat-hotels-thank.md
+++ b/.changeset/neat-hotels-thank.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': patch
+---
+
+Add cfnBucket to storage resource

--- a/.changeset/neat-hotels-thank.md
+++ b/.changeset/neat-hotels-thank.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/backend-storage': patch
+'@aws-amplify/backend-storage': minor
 ---
 
 Add cfnBucket to storage resource

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -6,6 +6,7 @@
 
 import { AmplifyUserErrorOptions } from '@aws-amplify/platform-core';
 import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
+import { CfnBucket } from 'aws-cdk-lib/aws-s3';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
 import { FunctionResources } from '@aws-amplify/plugin-types';
@@ -77,6 +78,9 @@ export type StoragePath = `${string}/*`;
 // @public (undocumented)
 export type StorageResources = {
     bucket: IBucket;
+    cfnResources: {
+        cfnBucket: CfnBucket;
+    };
 };
 
 // (No @packageDocumentation comment for this package)

--- a/packages/backend-storage/src/construct.test.ts
+++ b/packages/backend-storage/src/construct.test.ts
@@ -140,4 +140,23 @@ void describe('AmplifyStorage', () => {
       });
     });
   });
+
+  void describe('storage overrides', () => {
+    void it('can override bucket properties', () => {
+      const app = new App();
+      const stack = new Stack(app);
+
+      const bucket = new AmplifyStorage(stack, 'test', { name: 'testName' });
+      bucket.resources.cfnResources.cfnBucket.accelerateConfiguration = {
+        accelerationStatus: 'Enabled',
+      };
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        AccelerateConfiguration: {
+          AccelerationStatus: 'Enabled',
+        },
+      });
+    });
+  });
 });

--- a/packages/backend-storage/src/construct.ts
+++ b/packages/backend-storage/src/construct.ts
@@ -2,6 +2,7 @@ import { Construct } from 'constructs';
 import {
   Bucket,
   BucketProps,
+  CfnBucket,
   EventType,
   HttpMethods,
   IBucket,
@@ -64,6 +65,9 @@ export type AmplifyStorageProps = {
 
 export type StorageResources = {
   bucket: IBucket;
+  cfnResources: {
+    cfnBucket: CfnBucket;
+  };
 };
 
 /**
@@ -107,8 +111,14 @@ export class AmplifyStorage
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
     };
+
+    const bucket = new Bucket(this, 'Bucket', bucketProps);
+
     this.resources = {
-      bucket: new Bucket(this, 'Bucket', bucketProps),
+      bucket,
+      cfnResources: {
+        cfnBucket: bucket.node.findChild('Resource') as CfnBucket,
+      },
     };
 
     this.storeOutput(props.outputStorageStrategy);


### PR DESCRIPTION
## Problem

In order to provide a better DX and maintain consistency with other categories, we want to provide access to the L1 bucket to the customer. This way they have access to the S3 resource and can further customize the bucket using CDK.

**Issue number, if available:**
Fixes #1249 

## Changes

Add `cfnResources` to storage resource to provide access to L1 `cfnBucket`.

**Corresponding docs PR, if applicable:**
TODO

## Validation

Unit tests and locally:

<img width="811" alt="Screenshot 2024-04-18 at 3 19 56 PM" src="https://github.com/aws-amplify/amplify-backend/assets/23459628/dab5007d-32c7-4b38-b97f-47d410bd9434">

<img width="565" alt="Screenshot 2024-04-18 at 3 17 32 PM" src="https://github.com/aws-amplify/amplify-backend/assets/23459628/ce6baf1d-f0b3-4895-bafd-c37776ae0501">


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
