### PR TITLE
fix: disable implicit grant oauth flows by default

### DIFF
--- a/.changeset/cool-falcons-begin.md
+++ b/.changeset/cool-falcons-begin.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct-alpha': patch
+---
+
+Disable implicit grant oauth flows by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18243,6 +18243,7 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -18855,6 +18856,7 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -967,6 +967,24 @@ void describe('Auth construct', () => {
       });
     });
 
+    void it('disables implicit grant OAUTH flow by default', () => {
+      const app = new App();
+      const stack = new Stack(app);
+      new AmplifyAuth(stack, 'test');
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::Cognito::UserPool', {
+        Policies: {
+          PasswordPolicy: {
+            MinimumLength: 8,
+            RequireLowercase: true,
+            RequireNumbers: true,
+            RequireSymbols: true,
+            RequireUppercase: true,
+          },
+        },
+      });
+    });
+
     void it('creates a default client with cognito provider', () => {
       const app = new App();
       const stack = new Stack(app);

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -972,16 +972,31 @@ void describe('Auth construct', () => {
       const stack = new Stack(app);
       new AmplifyAuth(stack, 'test');
       const template = Template.fromStack(stack);
-      template.hasResourceProperties('AWS::Cognito::UserPool', {
-        Policies: {
-          PasswordPolicy: {
-            MinimumLength: 8,
-            RequireLowercase: true,
-            RequireNumbers: true,
-            RequireSymbols: true,
-            RequireUppercase: true,
+      template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+        AllowedOAuthFlows: ['code'],
+      });
+    });
+
+    void it('disables implicit grant OAUTH flow by default when oauth providers are used', () => {
+      const app = new App();
+      const stack = new Stack(app);
+      new AmplifyAuth(stack, 'test', {
+        loginWith: {
+          email: true,
+          externalProviders: {
+            google: {
+              clientId: googleClientId,
+              clientSecret: new SecretValue(googleClientSecret),
+            },
+            callbackUrls: ['https://callback.com'],
+            logoutUrls: ['https://logout.com'],
+            domainPrefix: 'test',
           },
         },
+      });
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+        AllowedOAuthFlows: ['code'],
       });
     });
 

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -573,7 +573,9 @@ export class AmplifyAuth
     const result: IdentityProviderSetupResult = {
       oAuthMappings: {},
       providersList: [],
-      oAuthSettings: undefined,
+      oAuthSettings: {
+        flows: DEFAULTS.OAUTH_FLOWS,
+      },
     };
     // external providers
     const external = loginOptions.externalProviders;

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -770,9 +770,7 @@ export class AmplifyAuth
       scopes: external.scopes
         ? this.getOAuthScopes(external.scopes)
         : DEFAULT_OAUTH_SCOPES,
-      flows: {
-        authorizationCodeGrant: true,
-      },
+      flows: DEFAULTS.OAUTH_FLOWS,
     };
 
     return result;

--- a/packages/auth-construct/src/defaults.ts
+++ b/packages/auth-construct/src/defaults.ts
@@ -46,6 +46,13 @@ export const DEFAULTS = {
     custom: true,
   },
   /**
+   * Default OAUTH flows for the UserPool
+   */
+  OAUTH_FLOWS: {
+    authorizationCodeGrant: true,
+    implicitCodeGrant: false,
+  },
+  /**
    * Specifies if attributes are required for signup/login, may depend on which settings are enabled.
    */
   IS_REQUIRED_ATTRIBUTE: {


### PR DESCRIPTION


## Problem
A bug in the setupExternalProviders would return undefined for the 'oAuthSettings' value if external providers were not configured.
[The undefined value led to enabling both implicit grant and token oauth flows.](https://github.com/aws/aws-cdk/blob/91246acde1ab0512ea6b375f66c283516cb6f2b0/packages/aws-cdk-lib/aws-cognito/lib/user-pool-client.ts#L388)

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation
Tests updated/added to ensure that implicit grant flow is disabled, even if external providers are not configured.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
