### PR TITLE
chore: minor client config updates

### DIFF
--- a/.changeset/lovely-pugs-know.md
+++ b/.changeset/lovely-pugs-know.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+minor client config updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -18243,6 +18243,7 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -18855,6 +18856,7 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"

--- a/packages/client-config/API.md
+++ b/packages/client-config/API.md
@@ -72,7 +72,6 @@ interface AWSAmplifyBackendOutputs {
     };
     auth?: {
         aws_region: AwsRegion;
-        authentication_flow_type?: 'USER_SRP_AUTH' | 'CUSTOM_AUTH';
         user_pool_id: string;
         user_pool_client_id: string;
         identity_pool_id?: string;
@@ -85,8 +84,7 @@ interface AWSAmplifyBackendOutputs {
         };
         oauth?: {
             identity_providers: ('GOOGLE' | 'FACEBOOK' | 'LOGIN_WITH_AMAZON' | 'SIGN_IN_WITH_APPLE')[];
-            cognito_domain: string;
-            custom_domain?: string;
+            domain: string;
             scopes: string[];
             redirect_sign_in_uri: string[];
             redirect_sign_out_uri: string[];
@@ -286,13 +284,7 @@ export type NotificationsClientConfig = {
                 region: string;
             };
         };
-        APNS?: {
-            AWSPinpoint: {
-                appId: string;
-                region: string;
-            };
-        };
-        FCM?: {
+        Push?: {
             AWSPinpoint: {
                 appId: string;
                 region: string;

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.test.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.test.ts
@@ -153,7 +153,7 @@ void describe('auth client config contributor v1', () => {
           user_verification_types: ['email', 'phone_number'],
           oauth: {
             identity_providers: ['GOOGLE', 'FACEBOOK'],
-            cognito_domain: 'testDomain',
+            domain: 'testDomain',
             scopes: ['email', 'profile'],
             redirect_sign_in_uri: [
               'http://callback.com',

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
@@ -160,7 +160,7 @@ export class AuthClientConfigContributor implements ClientConfigContributor {
           authOutput.payload.oauthRedirectSignOut.split(','),
         response_type: authOutput.payload.oauthResponseType as 'code' | 'token',
         scopes: JSON.parse(authOutput.payload.oauthScope),
-        cognito_domain: authOutput.payload.oauthCognitoDomain,
+        domain: authOutput.payload.oauthCognitoDomain,
       };
     }
 

--- a/packages/client-config/src/client-config-schema/client_config_v1.ts
+++ b/packages/client-config/src/client-config-schema/client_config_v1.ts
@@ -76,10 +76,6 @@ export interface AWSAmplifyBackendOutputs {
      */
     aws_region: AwsRegion;
     /**
-     * Authentication flow types
-     */
-    authentication_flow_type?: 'USER_SRP_AUTH' | 'CUSTOM_AUTH';
-    /**
      * Cognito User Pool ID
      */
     user_pool_id: string;
@@ -114,13 +110,9 @@ export interface AWSAmplifyBackendOutputs {
         | 'SIGN_IN_WITH_APPLE'
       )[];
       /**
-       * Auto generated cognito domain used for identity providers
+       * Domain used for identity providers
        */
-      cognito_domain: string;
-      /**
-       * Custom Domain used for identity providers
-       */
-      custom_domain?: string;
+      domain: string;
       /**
        * @minItems 0
        */

--- a/packages/client-config/src/client-config-schema/schema_v1.json
+++ b/packages/client-config/src/client-config-schema/schema_v1.json
@@ -44,12 +44,6 @@
           "description": "AWS Region of Amazon Cognito resources",
           "$ref": "#/$defs/aws_region"
         },
-        "authentication_flow_type": {
-          "description": "Authentication flow types",
-          "type": "string",
-          "enum": ["USER_SRP_AUTH", "CUSTOM_AUTH"],
-          "default": "USER_SRP_AUTH"
-        },
         "user_pool_id": {
           "description": "Cognito User Pool ID",
           "type": "string"
@@ -105,12 +99,8 @@
               "minItems": 0,
               "uniqueItems": true
             },
-            "cognito_domain": {
-              "description": "Auto generated cognito domain used for identity providers",
-              "type": "string"
-            },
-            "custom_domain": {
-              "description": "Custom Domain used for identity providers",
+            "domain": {
+              "description": "Domain used for identity providers",
               "type": "string"
             },
             "scopes": {

--- a/packages/client-config/src/client-config-types/notifications_client_config.ts
+++ b/packages/client-config/src/client-config-types/notifications_client_config.ts
@@ -12,13 +12,9 @@ export type NotificationsClientConfig = {
         region: string;
       };
     };
-    APNS?: {
-      AWSPinpoint: {
-        appId: string;
-        region: string;
-      };
-    };
-    FCM?: {
+    // APNS and FCM maps to Push
+    // https://github.com/aws-amplify/amplify-cli/blob/1da5de70c57b15a76f02c92364af4889d1585229/packages/amplify-frontend-javascript/lib/frontend-config-creator.js#L587-L588
+    Push?: {
       AWSPinpoint: {
         appId: string;
         region: string;

--- a/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.test.ts
@@ -54,7 +54,7 @@ void describe('ClientConfigLegacyConverter', () => {
         standard_required_attributes: ['email'],
         unauthenticated_identities_enabled: true,
         oauth: {
-          cognito_domain: 'testDomain',
+          domain: 'testDomain',
           scopes: ['email', 'profile'],
           redirect_sign_in_uri: ['http://callback.com', 'http://callback2.com'],
           redirect_sign_out_uri: ['http://logout.com', 'http://logout2.com'],
@@ -379,16 +379,16 @@ void describe('ClientConfigLegacyConverter', () => {
   void it('returns translated legacy config for notifications', () => {
     const converter = new ClientConfigLegacyConverter();
 
-    const v1Config: ClientConfig = {
+    let v1Config: ClientConfig = {
       version: ClientConfigVersionOption.V1,
       notifications: {
         amazon_pinpoint_app_id: 'testAppId',
         aws_region: 'testRegion',
-        channels: ['APNS', 'EMAIL', 'FCM', 'IN_APP_MESSAGING', 'SMS'],
+        channels: ['EMAIL', 'FCM', 'IN_APP_MESSAGING', 'SMS'],
       },
     };
 
-    const expectedLegacyConfig: NotificationsClientConfig = {
+    let expectedLegacyConfig: NotificationsClientConfig = {
       Notifications: {
         InAppMessaging: {
           AWSPinpoint: {
@@ -396,7 +396,7 @@ void describe('ClientConfigLegacyConverter', () => {
             region: 'testRegion',
           },
         },
-        APNS: {
+        Push: {
           AWSPinpoint: {
             appId: 'testAppId',
             region: 'testRegion',
@@ -408,13 +408,32 @@ void describe('ClientConfigLegacyConverter', () => {
             region: 'testRegion',
           },
         },
-        FCM: {
+        SMS: {
           AWSPinpoint: {
             appId: 'testAppId',
             region: 'testRegion',
           },
         },
-        SMS: {
+      },
+    };
+    assert.deepStrictEqual(
+      converter.convertToLegacyConfig(v1Config),
+      expectedLegacyConfig
+    );
+
+    // both APNS and FCM cannot be specified together as they both map to Push.
+    v1Config = {
+      version: ClientConfigVersionOption.V1,
+      notifications: {
+        amazon_pinpoint_app_id: 'testAppId',
+        aws_region: 'testRegion',
+        channels: ['APNS'],
+      },
+    };
+
+    expectedLegacyConfig = {
+      Notifications: {
+        Push: {
           AWSPinpoint: {
             appId: 'testAppId',
             region: 'testRegion',

--- a/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.ts
@@ -113,7 +113,7 @@ export class ClientConfigLegacyConverter {
         authClientConfig.oauth = {};
         authClientConfig.aws_cognito_social_providers =
           clientConfig.auth.oauth.identity_providers;
-        authClientConfig.oauth.domain = clientConfig.auth.oauth.cognito_domain;
+        authClientConfig.oauth.domain = clientConfig.auth.oauth.domain;
         authClientConfig.oauth.scope = clientConfig.auth.oauth.scopes;
         authClientConfig.oauth.redirectSignIn =
           clientConfig.auth.oauth.redirect_sign_in_uri.join(',');
@@ -228,10 +228,11 @@ export class ClientConfigLegacyConverter {
             notificationConfig.Notifications.InAppMessaging = pinPointConfig;
             break;
           case 'FCM':
-            notificationConfig.Notifications.FCM = pinPointConfig;
+            notificationConfig.Notifications.Push = pinPointConfig;
             break;
           case 'APNS':
-            notificationConfig.Notifications.APNS = pinPointConfig;
+            // It's fine to overwrite APNS over FCM since they are the exact same config.
+            notificationConfig.Notifications.Push = pinPointConfig;
             break;
           case 'EMAIL':
             notificationConfig.Notifications.EMAIL = pinPointConfig;

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
@@ -352,13 +352,7 @@ void describe('client config converter', () => {
             region: 'email_region',
           },
         },
-        FCM: {
-          AWSPinpoint: {
-            appId: 'push_app_id',
-            region: 'push_region',
-          },
-        },
-        APNS: {
+        Push: {
           AWSPinpoint: {
             appId: 'push_app_id',
             region: 'push_region',
@@ -403,10 +397,10 @@ void describe('client config converter', () => {
     assert.deepStrictEqual(expectedMobileConfig, actualMobileConfig);
   });
 
-  void it('converts apn notifications config', () => {
+  void it('converts push notifications config', () => {
     const clientConfig: ClientConfigLegacy = {
       Notifications: {
-        APNS: {
+        Push: {
           AWSPinpoint: {
             appId: 'push_app_id',
             region: 'push_region',
@@ -431,65 +425,5 @@ void describe('client config converter', () => {
     const actualMobileConfig = converter.convertToMobileConfig(clientConfig);
 
     assert.deepStrictEqual(expectedMobileConfig, actualMobileConfig);
-  });
-
-  void it('converts fcm notifications config', () => {
-    const clientConfig: ClientConfigLegacy = {
-      Notifications: {
-        FCM: {
-          AWSPinpoint: {
-            appId: 'push_app_id',
-            region: 'push_region',
-          },
-        },
-      },
-    };
-
-    const expectedMobileConfig: ClientConfigMobile = {
-      UserAgent: 'test_package_name/test_package_version;',
-      Version: '1.0',
-      notifications: {
-        plugins: {
-          awsPinpointPushNotificationsPlugin: {
-            appId: 'push_app_id',
-            region: 'push_region',
-          },
-        },
-      },
-    };
-
-    const actualMobileConfig = converter.convertToMobileConfig(clientConfig);
-
-    assert.deepStrictEqual(expectedMobileConfig, actualMobileConfig);
-  });
-
-  void it('throw on ambiguous push config', () => {
-    const clientConfig: ClientConfigLegacy = {
-      Notifications: {
-        FCM: {
-          AWSPinpoint: {
-            appId: 'push_app_id_1',
-            region: 'push_region',
-          },
-        },
-        APNS: {
-          AWSPinpoint: {
-            appId: 'push_app_id_2',
-            region: 'push_region',
-          },
-        },
-      },
-    };
-
-    assert.throws(
-      () => converter.convertToMobileConfig(clientConfig),
-      (error: Error) => {
-        assert.strictEqual(
-          error.message,
-          'Cannot convert client config to mobile config if both FCM and APNS are defined with different AWS Pinpoint instance'
-        );
-        return true;
-      }
-    );
   });
 });

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
@@ -164,21 +164,6 @@ export class ClientConfigMobileConverter {
     }
 
     if (clientConfig.Notifications) {
-      // APNS and FCM are mapped to the same awsPinpointPushNotificationsPlugin
-      // Throw if they're both present but defined differently
-      // as this is ambiguous situation
-      const fcm = clientConfig.Notifications.FCM;
-      const apns = clientConfig.Notifications.APNS;
-      if (
-        fcm &&
-        apns &&
-        (fcm.AWSPinpoint.appId !== apns.AWSPinpoint.appId ||
-          fcm.AWSPinpoint.region !== apns.AWSPinpoint.region)
-      ) {
-        throw new Error(
-          'Cannot convert client config to mobile config if both FCM and APNS are defined with different AWS Pinpoint instance'
-        );
-      }
       mobileConfig.notifications = {
         plugins: {},
       };
@@ -194,14 +179,9 @@ export class ClientConfigMobileConverter {
         mobileConfig.notifications.plugins.awsPinpointInAppMessagingNotificationsPlugin =
           clientConfig.Notifications.InAppMessaging.AWSPinpoint;
       }
-      // It's fine to overwrite FCM and APNS given validation above.
-      if (clientConfig.Notifications.FCM) {
+      if (clientConfig.Notifications.Push) {
         mobileConfig.notifications.plugins.awsPinpointPushNotificationsPlugin =
-          clientConfig.Notifications.FCM.AWSPinpoint;
-      }
-      if (clientConfig.Notifications.APNS) {
-        mobileConfig.notifications.plugins.awsPinpointPushNotificationsPlugin =
-          clientConfig.Notifications.APNS.AWSPinpoint;
+          clientConfig.Notifications.Push.AWSPinpoint;
       }
     }
 


### PR DESCRIPTION
## Changes

1. Revert splitting `oauth.domain` to `oauth.cognito_domain` and `oauth.custom_domain`. Custom domain config will be configured in the customs section until we have first class support.
2. Remove `authentication_flow_type`
3. Fix the notifications config. APNS and FCM maps to `Push` config key in all libraries, including [javascript](https://github.com/aws-amplify/amplify-cli/blob/1da5de70c57b15a76f02c92364af4889d1585229/packages/amplify-frontend-javascript/lib/frontend-config-creator.js#L587-L588)

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
