### PR TITLE
Default name cleanup

### DIFF
--- a/.changeset/empty-poets-approve.md
+++ b/.changeset/empty-poets-approve.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-function': minor
+'@aws-amplify/backend-auth': minor
+'@aws-amplify/backend-data': minor
+---
+
+Standardize name validation across storage, functions, auth, and data

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -94,12 +94,16 @@ export class AmplifyAuthFactory implements ConstructFactory<BackendAuth> {
   getInstance = (
     getInstanceProps: ConstructFactoryGetInstanceProps
   ): BackendAuth => {
-    const { constructContainer, importPathVerifier } = getInstanceProps;
+    const { constructContainer, importPathVerifier, resourceNameValidator } =
+      getInstanceProps;
     importPathVerifier?.verify(
       this.importStack,
       path.join('amplify', 'auth', 'resource'),
       'Amplify Auth must be defined in amplify/auth/resource.ts'
     );
+    if (this.props.name) {
+      resourceNameValidator?.validate(this.props.name);
+    }
     if (!this.generator) {
       this.generator = new AmplifyAuthGenerator(this.props, getInstanceProps);
     }
@@ -109,14 +113,16 @@ export class AmplifyAuthFactory implements ConstructFactory<BackendAuth> {
 
 class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
   readonly resourceGroupName = 'auth';
-  private readonly defaultName = 'amplifyAuth';
+  private readonly name: string;
 
   constructor(
     private readonly props: AmplifyAuthProps,
     private readonly getInstanceProps: ConstructFactoryGetInstanceProps,
     private readonly authAccessBuilder = _authAccessBuilder,
     private readonly authAccessPolicyArbiterFactory = new AuthAccessPolicyArbiterFactory()
-  ) {}
+  ) {
+    this.name = props.name ?? 'amplifyAuth';
+  }
 
   generateContainerEntry = ({
     scope,
@@ -139,7 +145,7 @@ class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
 
     let authConstruct: AmplifyAuth;
     try {
-      authConstruct = new AmplifyAuth(scope, this.defaultName, authProps);
+      authConstruct = new AmplifyAuth(scope, this.name, authProps);
     } catch (error) {
       throw new AmplifyUserError(
         'AmplifyAuthConstructInitializationError',
@@ -151,10 +157,7 @@ class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
       );
     }
 
-    Tags.of(authConstruct).add(
-      TagName.FRIENDLY_NAME,
-      this.props.name ?? this.defaultName
-    );
+    Tags.of(authConstruct).add(TagName.FRIENDLY_NAME, this.name);
 
     Object.entries(this.props.triggers || {}).forEach(
       ([triggerEvent, handlerFactory]) => {
@@ -199,7 +202,7 @@ class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
 
     const ssmEnvironmentEntries =
       ssmEnvironmentEntriesGenerator.generateSsmEnvironmentEntries({
-        [`${this.props.name ?? this.defaultName}_USERPOOL_ID`]:
+        [`${this.name}_USERPOOL_ID`]:
           authConstructMixin.resources.userPool.userPoolId,
       });
 

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -1,10 +1,14 @@
-import { beforeEach, describe, it } from 'node:test';
+import { beforeEach, describe, it, mock } from 'node:test';
 import { App, Stack } from 'aws-cdk-lib';
-import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
+import {
+  ConstructFactoryGetInstanceProps,
+  ResourceNameValidator,
+} from '@aws-amplify/plugin-types';
 import assert from 'node:assert';
 import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
 import {
   ConstructContainerStub,
+  ResourceNameValidatorStub,
   StackResolverStub,
 } from '@aws-amplify/backend-platform-test-stubs';
 import { defaultLambda } from './test-assets/default-lambda/resource.js';
@@ -26,6 +30,7 @@ const createStackAndSetContext = (): Stack => {
 void describe('AmplifyFunctionFactory', () => {
   let rootStack: Stack;
   let getInstanceProps: ConstructFactoryGetInstanceProps;
+  let resourceNameValidator: ResourceNameValidator;
 
   beforeEach(() => {
     rootStack = createStackAndSetContext();
@@ -38,9 +43,12 @@ void describe('AmplifyFunctionFactory', () => {
       rootStack
     );
 
+    resourceNameValidator = new ResourceNameValidatorStub();
+
     getInstanceProps = {
       constructContainer,
       outputStorageStrategy,
+      resourceNameValidator,
     };
   });
 
@@ -109,6 +117,21 @@ void describe('AmplifyFunctionFactory', () => {
     template.resourceCountIs('AWS::Lambda::Function', 1);
     template.hasResourceProperties('AWS::Lambda::Function', {
       Tags: [{ Key: 'amplify:friendly-name', Value: 'myCoolLambda' }],
+    });
+  });
+
+  void it('throws on invalid name', () => {
+    mock
+      .method(resourceNameValidator, 'validate')
+      .mock.mockImplementationOnce(() => {
+        throw new Error('test validation error');
+      });
+    const functionFactory = defineFunction({
+      entry: './test-assets/default-lambda/handler.ts',
+      name: 'this!is@wrong',
+    });
+    assert.throws(() => functionFactory.getInstance(getInstanceProps), {
+      message: 'test validation error',
     });
   });
 

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -8,6 +8,7 @@ import {
   FunctionResources,
   GenerateContainerEntryProps,
   ResourceAccessAcceptorFactory,
+  ResourceNameValidator,
   ResourceProvider,
   SsmEnvironmentEntry,
 } from '@aws-amplify/plugin-types';
@@ -107,19 +108,24 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
   getInstance = ({
     constructContainer,
     outputStorageStrategy,
+    resourceNameValidator,
   }: ConstructFactoryGetInstanceProps): AmplifyFunction => {
     if (!this.generator) {
       this.generator = new FunctionGenerator(
-        this.hydrateDefaults(),
+        this.hydrateDefaults(resourceNameValidator),
         outputStorageStrategy
       );
     }
     return constructContainer.getOrCompute(this.generator) as AmplifyFunction;
   };
 
-  private hydrateDefaults = (): HydratedFunctionProps => {
+  private hydrateDefaults = (
+    resourceNameValidator?: ResourceNameValidator
+  ): HydratedFunctionProps => {
+    const name = this.resolveName();
+    resourceNameValidator?.validate(name);
     return {
-      name: this.resolveName(),
+      name,
       entry: this.resolveEntry(),
       timeoutSeconds: this.resolveTimeout(),
       memoryMB: this.resolveMemory(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

https://github.com/aws-amplify/amplify-backend/pull/1330 introduced validation for the `name` prop in `defineStorage`. This applies the same validation to the `name` prop of the other `define*` functions for consistency

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Added unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
