### PR TITLE
add `backend` command name

### DIFF
--- a/.changeset/yellow-toes-smile.md
+++ b/.changeset/yellow-toes-smile.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+add 'backend' as valid CLI command name

--- a/package-lock.json
+++ b/package-lock.json
@@ -25625,7 +25625,8 @@
         "zod": "^3.22.2"
       },
       "bin": {
-        "amplify": "lib/amplify.js"
+        "amplify": "lib/amplify.js",
+        "backend": "lib/amplify.js"
       },
       "devDependencies": {
         "@types/envinfo": "^7.8.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,8 @@
   "version": "0.12.1",
   "description": "Command line interface for various Amplify tools",
   "bin": {
-    "amplify": "lib/amplify.js"
+    "amplify": "lib/amplify.js",
+    "backend": "lib/amplify.js"
   },
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Adds `backend` as a valid command name for executing the Gen 2 CLI.

Intentionally not updating any of the other references to the `amplify` command in the codebase at this time.