### PR TITLE
fix: support connection URI as a shared secret in Amplify console

### DIFF
--- a/.changeset/clean-kiwis-cross.md
+++ b/.changeset/clean-kiwis-cross.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': minor
+---
+
+support connection URI as a shared secret

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.8.0-gen2-release-0418-2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.8.0-gen2-release-0418-2.0.tgz",
-      "integrity": "sha512-fv9p/Lo4pF6h6rkoqzyy0vxRGMoerVQr+w7wa3LKCdOu4JIh2arlGHtAn9hra3nO86OBHVDsjjMeLN4frw5lzg==",
+      "version": "1.8.0-gen2-release-0423.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.8.0-gen2-release-0423.0.tgz",
+      "integrity": "sha512-DTFUVGYJgbOOuaFKA8cYyQotB3Nrxn8KvYjiG/BVLPLdanH0N/160z5PiHOoo5wnyJmVaiuK++FZ9kmGM/OorA==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -755,22 +755,22 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-api-construct": "1.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.12-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer": "1.5.2-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-api-construct": "1.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0423.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.12-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer": "1.5.2-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -779,7 +779,7 @@
         "graceful-fs": "^4.2.11",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
         "is-buffer": "^2.0.5",
@@ -819,18 +819,18 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.5.0-gen2-release-0418-2.0",
+      "version": "3.5.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
@@ -840,35 +840,35 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.4-gen2-release-0418-2.0",
+      "version": "2.3.4-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "1.1.0-gen2-release-0418-2.0",
+      "version": "1.1.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.21-gen2-release-0418-2.0",
+      "version": "2.1.21-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -876,16 +876,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.21-gen2-release-0418-2.0",
+      "version": "2.1.21-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -893,17 +893,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.4.0-gen2-release-0418-2.0",
+      "version": "2.4.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -911,15 +911,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.12-gen2-release-0418-2.0",
+      "version": "3.4.12-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -927,16 +927,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.9.0-gen2-release-0418-2.0",
+      "version": "2.9.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -944,16 +944,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.21-gen2-release-0418-2.0",
+      "version": "2.1.21-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -961,18 +961,18 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.0-gen2-release-0418-2.0",
+      "version": "2.5.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
@@ -981,17 +981,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.7.0-gen2-release-0418-2.0",
+      "version": "2.7.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -999,17 +999,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.3.0-gen2-release-0418-2.0",
+      "version": "0.3.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1017,23 +1017,23 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.5.2-gen2-release-0418-2.0",
+      "version": "1.5.2-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.12-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0"
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0423.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.12-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1041,15 +1041,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.6.1-gen2-release-0418-2.0",
+      "version": "2.7.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -1062,7 +1062,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.7.0-gen2-release-0418-2.0",
+      "version": "3.7.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1154,7 +1154,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/graphql-transformer-common": {
-      "version": "4.30.1-gen2-release-0418-2.0",
+      "version": "4.30.1-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1341,9 +1341,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.9.0-gen2-release-0418-2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.9.0-gen2-release-0418-2.0.tgz",
-      "integrity": "sha512-3rsO8l58yDALR4Xlt0gem5CcvFQfdb/g9l7iPJllwwsk3G75nRMmnaStyaelZ4LjKhgqJQFmReXLXQLAymrjCA==",
+      "version": "1.9.0-gen2-release-0423.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.9.0-gen2-release-0423.0.tgz",
+      "integrity": "sha512-rLL8fQG5VW1E2qQLLrOzCiw4/93hjyK27yDMB0dZ9ni4oXX2jTn0mzDOcpq4Ti8CQP+fqTWtPoPDYa7bIax6lw==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -1387,21 +1387,21 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.12-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer": "1.5.2-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0423.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.12-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer": "1.5.2-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -1410,7 +1410,7 @@
         "graceful-fs": "^4.2.11",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
         "is-buffer": "^2.0.5",
@@ -1450,18 +1450,18 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.5.0-gen2-release-0418-2.0",
+      "version": "3.5.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
@@ -1471,35 +1471,35 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.4-gen2-release-0418-2.0",
+      "version": "2.3.4-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "1.1.0-gen2-release-0418-2.0",
+      "version": "1.1.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.21-gen2-release-0418-2.0",
+      "version": "2.1.21-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1507,16 +1507,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.21-gen2-release-0418-2.0",
+      "version": "2.1.21-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1524,17 +1524,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.4.0-gen2-release-0418-2.0",
+      "version": "2.4.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1542,15 +1542,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.12-gen2-release-0418-2.0",
+      "version": "3.4.12-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1558,16 +1558,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.9.0-gen2-release-0418-2.0",
+      "version": "2.9.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1575,16 +1575,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.21-gen2-release-0418-2.0",
+      "version": "2.1.21-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1592,18 +1592,18 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.0-gen2-release-0418-2.0",
+      "version": "2.5.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
@@ -1612,17 +1612,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.7.0-gen2-release-0418-2.0",
+      "version": "2.7.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1630,17 +1630,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.3.0-gen2-release-0418-2.0",
+      "version": "0.3.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0"
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1648,23 +1648,23 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.5.2-gen2-release-0418-2.0",
+      "version": "1.5.2-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.12-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-core": "2.6.1-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0"
+        "@aws-amplify/graphql-auth-transformer": "3.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.4-gen2-release-0423.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-http-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.12-gen2-release-0423.0",
+        "@aws-amplify/graphql-model-transformer": "2.9.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.21-gen2-release-0423.0",
+        "@aws-amplify/graphql-relational-transformer": "2.5.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-sql-transformer": "0.3.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-core": "2.7.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.80.0",
@@ -1672,15 +1672,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.6.1-gen2-release-0418-2.0",
+      "version": "2.7.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0418-2.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0418-2.0",
+        "@aws-amplify/graphql-directives": "1.1.0-gen2-release-0423.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.7.0-gen2-release-0423.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.30.1-gen2-release-0418-2.0",
+        "graphql-transformer-common": "4.30.1-gen2-release-0423.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -1693,7 +1693,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.7.0-gen2-release-0418-2.0",
+      "version": "3.7.0-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1785,7 +1785,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql-transformer-common": {
-      "version": "4.30.1-gen2-release-0418-2.0",
+      "version": "4.30.1-gen2-release-0423.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -25469,7 +25469,7 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0",
         "@aws-amplify/backend-output-storage": "^0.4.0",
-        "@aws-amplify/data-construct": "1.8.0-gen2-release-0418-2.0",
+        "@aws-amplify/data-construct": "1.8.0-gen2-release-0423.0",
         "@aws-amplify/data-schema-types": "^0.9.0",
         "@aws-amplify/plugin-types": "^0.9.0"
       },

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "^0.4.0",
     "@aws-amplify/backend-output-schemas": "^0.7.0",
-    "@aws-amplify/data-construct": "1.8.0-gen2-release-0418-2.0",
+    "@aws-amplify/data-construct": "1.8.0-gen2-release-0423.0",
     "@aws-amplify/plugin-types": "^0.9.0",
     "@aws-amplify/data-schema-types": "^0.9.0"
   }

--- a/packages/backend-data/src/convert_schema.test.ts
+++ b/packages/backend-data/src/convert_schema.test.ts
@@ -215,8 +215,10 @@ void describe('convertSchemaToCDK', () => {
         // eslint-disable-next-line spellcheck/spell-checker
         name: '00034dcf3444861c3ca5postgresql',
         dbConnectionConfig: {
-          connectionUriSsmPath:
+          connectionUriSsmPath: [
             '/amplify/testBackendId/testBranchName-branch-e482a1c36f/POSTGRES_CONNECTION_STRING',
+            '/amplify/shared/testBackendId/POSTGRES_CONNECTION_STRING',
+          ],
         },
         customSqlStatements: {
           '../test-assets/test-sql-handler/oddList.sql':
@@ -268,8 +270,10 @@ void describe('convertSchemaToCDK', () => {
         // eslint-disable-next-line spellcheck/spell-checker
         name: '00034dcf3444861c3ca5postgresql',
         dbConnectionConfig: {
-          connectionUriSsmPath:
+          connectionUriSsmPath: [
             '/amplify/testBackendId/testBranchName-branch-e482a1c36f/POSTGRES_CONNECTION_STRING',
+            '/amplify/shared/testBackendId/POSTGRES_CONNECTION_STRING',
+          ],
         },
         customSqlStatements: {},
         vpcConfiguration: undefined,
@@ -350,8 +354,10 @@ void describe('convertSchemaToCDK', () => {
         /* eslint-disable spellcheck/spell-checker */
         name: '00034dcf3444861c3ca5mysql',
         dbConnectionConfig: {
-          connectionUriSsmPath:
+          connectionUriSsmPath: [
             '/amplify/testBackendId/testBranchName-branch-e482a1c36f/MYSQL_CONNECTION_STRING',
+            '/amplify/shared/testBackendId/MYSQL_CONNECTION_STRING',
+          ],
         },
         customSqlStatements: {},
         vpcConfiguration: {

--- a/packages/backend-data/src/convert_schema.ts
+++ b/packages/backend-data/src/convert_schema.ts
@@ -172,15 +172,15 @@ const convertDatabaseConfigurationToDataSourceStrategy = (
     customSqlDataSourceStrategies
   );
 
+  const { branchSecretPath, sharedSecretPath } =
+    backendSecretResolver.resolvePath(configuration.connectionUri);
   return {
     dbType,
     name:
       provisionStrategyName +
       (configuration.identifier ?? configuration.engine),
     dbConnectionConfig: {
-      connectionUriSsmPath: backendSecretResolver.resolvePath(
-        configuration.connectionUri
-      ).branchSecretPath,
+      connectionUriSsmPath: [branchSecretPath, sharedSecretPath],
     },
     vpcConfiguration,
     customSqlStatements,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
The customers of Amplify console can have their database connection string stored as a shared secret rather than as a branch specific one. We do not support this today which limits the console customers from using shared database connect secret.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
With this PR, we utilize the updated API that we recently released in the data construct and pass both SSM paths to it. The data construct handles resolution of the secret path by searching in the order of the SSM paths in the list. In this PR, we set the branch specific path followed by shared path in the list that we pass to the data construct, since that is the recommended order.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
