### PR TITLE
chore: change generate config command to generate outputs

### DIFF
--- a/.changeset/angry-wasps-marry.md
+++ b/.changeset/angry-wasps-marry.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+change generate config command to generate outputs

--- a/.changeset/angry-wasps-marry.md
+++ b/.changeset/angry-wasps-marry.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/backend-cli': patch
+'@aws-amplify/backend-cli': minor
 ---
 
 change generate config command to generate outputs

--- a/package-lock.json
+++ b/package-lock.json
@@ -25417,7 +25417,7 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^0.6.0",
@@ -25426,8 +25426,8 @@
         "@aws-amplify/backend-output-schemas": "^0.7.0",
         "@aws-amplify/backend-output-storage": "^0.4.0",
         "@aws-amplify/backend-secret": "^0.4.5",
-        "@aws-amplify/backend-storage": "^0.6.0",
-        "@aws-amplify/client-config": "^0.9.1",
+        "@aws-amplify/backend-storage": "^0.7.0",
+        "@aws-amplify/client-config": "^0.9.2",
         "@aws-amplify/data-schema": "^0.16.0",
         "@aws-amplify/platform-core": "^0.5.0",
         "@aws-amplify/plugin-types": "^0.9.0",
@@ -25577,7 +25577,7 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0",
@@ -25595,19 +25595,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1",
         "@aws-amplify/backend-output-schemas": "^0.7.0",
         "@aws-amplify/backend-secret": "^0.4.5",
         "@aws-amplify/cli-core": "^0.5.0",
-        "@aws-amplify/client-config": "^0.9.1",
-        "@aws-amplify/deployed-backend-client": "^0.4.0",
+        "@aws-amplify/client-config": "^0.9.2",
+        "@aws-amplify/deployed-backend-client": "^0.4.1",
         "@aws-amplify/form-generator": "^0.9.0",
-        "@aws-amplify/model-generator": "^0.6.0",
+        "@aws-amplify/model-generator": "^0.6.1",
         "@aws-amplify/platform-core": "^0.5.0",
-        "@aws-amplify/sandbox": "^0.5.3",
+        "@aws-amplify/sandbox": "^0.5.4",
         "@aws-amplify/schema-generator": "^0.1.0",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -25762,12 +25762,12 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0",
-        "@aws-amplify/deployed-backend-client": "^0.4.0",
-        "@aws-amplify/model-generator": "^0.6.0",
+        "@aws-amplify/deployed-backend-client": "^0.4.1",
+        "@aws-amplify/model-generator": "^0.6.1",
         "@aws-amplify/platform-core": "^0.5.0",
         "zod": "^3.22.2"
       },
@@ -25912,7 +25912,7 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0",
@@ -25963,9 +25963,9 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/auth-construct-alpha": "^0.6.1",
-        "@aws-amplify/backend": "^0.13.1",
+        "@aws-amplify/backend": "^0.13.2",
         "@aws-amplify/backend-secret": "^0.4.5",
-        "@aws-amplify/client-config": "^0.9.1",
+        "@aws-amplify/client-config": "^0.9.2",
         "@aws-amplify/data-schema": "^0.16.0",
         "@aws-amplify/platform-core": "^0.5.0",
         "@aws-sdk/client-amplify": "^3.465.0",
@@ -25989,11 +25989,11 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0",
-        "@aws-amplify/deployed-backend-client": "^0.4.0",
+        "@aws-amplify/deployed-backend-client": "^0.4.1",
         "@aws-amplify/graphql-generator": "0.4.0-gen2-release-0416.0",
         "@aws-amplify/graphql-types-generator": "3.6.0-gen2-release-0416.0",
         "@aws-amplify/platform-core": "^0.5.0",
@@ -26550,14 +26550,14 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.5.1",
         "@aws-amplify/backend-secret": "^0.4.5",
         "@aws-amplify/cli-core": "^0.5.0",
-        "@aws-amplify/client-config": "^0.9.1",
-        "@aws-amplify/deployed-backend-client": "^0.4.0",
+        "@aws-amplify/client-config": "^0.9.2",
+        "@aws-amplify/deployed-backend-client": "^0.4.1",
         "@aws-amplify/platform-core": "^0.5.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",

--- a/packages/cli/src/commands/generate/generate_command.ts
+++ b/packages/cli/src/commands/generate/generate_command.ts
@@ -1,5 +1,5 @@
 import { Argv, CommandModule } from 'yargs';
-import { GenerateConfigCommand } from './config/generate_config_command.js';
+import { GenerateOutputsCommand } from './outputs/generate_outputs_command.js';
 import { GenerateFormsCommand } from './forms/generate_forms_command.js';
 import { GenerateGraphqlClientCodeCommand } from './graphql-client-code/generate_graphql_client_code_command.js';
 import { CommandMiddleware } from '../../command_middleware.js';
@@ -23,7 +23,7 @@ export class GenerateCommand implements CommandModule {
    * Creates top level entry point for generate command.
    */
   constructor(
-    private readonly generateConfigCommand: GenerateConfigCommand,
+    private readonly generateOutputsCommand: GenerateOutputsCommand,
     private readonly generateFormsCommand: GenerateFormsCommand,
     private readonly generateGraphqlClientCodeCommand: GenerateGraphqlClientCodeCommand,
     private readonly generateSchemaCommand: GenerateSchemaCommand,
@@ -48,7 +48,7 @@ export class GenerateCommand implements CommandModule {
       yargs
         .version(false)
         // Cast to erase options types used in internal sub command implementation. Otherwise, compiler fails here.
-        .command(this.generateConfigCommand as unknown as CommandModule)
+        .command(this.generateOutputsCommand as unknown as CommandModule)
         .command(this.generateFormsCommand as unknown as CommandModule)
         .command(
           this.generateGraphqlClientCodeCommand as unknown as CommandModule

--- a/packages/cli/src/commands/generate/generate_command_factory.test.ts
+++ b/packages/cli/src/commands/generate/generate_command_factory.test.ts
@@ -16,7 +16,7 @@ void describe('top level generate command', () => {
   void it('includes generate subcommands in help output', async () => {
     const output = await commandRunner.runCommand('generate --help');
     assert.match(output, /Commands:/);
-    assert.match(output, /generate config\W*Generates client config/);
+    assert.match(output, /generate outputs\W*Generates amplify outputs/);
     assert.match(
       output,
       /generate graphql-client-code\W*Generates graphql API code/

--- a/packages/cli/src/commands/generate/generate_command_factory.ts
+++ b/packages/cli/src/commands/generate/generate_command_factory.ts
@@ -1,6 +1,6 @@
 import { CommandModule } from 'yargs';
 import { GenerateCommand } from './generate_command.js';
-import { GenerateConfigCommand } from './config/generate_config_command.js';
+import { GenerateOutputsCommand } from './outputs/generate_outputs_command.js';
 import { GenerateFormsCommand } from './forms/generate_forms_command.js';
 import { PackageJsonReader } from '@aws-amplify/platform-core';
 import { GenerateGraphqlClientCodeCommand } from './graphql-client-code/generate_graphql_client_code_command.js';
@@ -47,7 +47,7 @@ export const createGenerateCommand = (): CommandModule => {
     new SandboxBackendIdResolver(namespaceResolver)
   );
 
-  const generateConfigCommand = new GenerateConfigCommand(
+  const generateOutputsCommand = new GenerateOutputsCommand(
     clientConfigGenerator,
     backendIdentifierResolver
   );
@@ -74,7 +74,7 @@ export const createGenerateCommand = (): CommandModule => {
   const commandMiddleware = new CommandMiddleware(printer);
 
   return new GenerateCommand(
-    generateConfigCommand,
+    generateOutputsCommand,
     generateFormsCommand,
     generateGraphqlClientCodeCommand,
     generateSchemaCommand,

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, mock } from 'node:test';
-import { GenerateConfigCommand } from './generate_config_command.js';
+import { GenerateOutputsCommand } from './generate_outputs_command.js';
 import { ClientConfigFormat } from '@aws-amplify/client-config';
 import yargs, { CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
@@ -12,7 +12,7 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 
-void describe('generate config command', () => {
+void describe('generate outputs command', () => {
   const clientConfigGeneratorAdapter = new ClientConfigGeneratorAdapter({
     getS3Client: () => new S3Client(),
     getAmplifyClient: () => new AmplifyClient(),
@@ -41,12 +41,12 @@ void describe('generate config command', () => {
     sandboxIdResolver
   );
 
-  const generateConfigCommand = new GenerateConfigCommand(
+  const generateOutputsCommand = new GenerateOutputsCommand(
     clientConfigGeneratorAdapter,
     backendIdResolver
   );
   const parser = yargs().command(
-    generateConfigCommand as unknown as CommandModule
+    generateOutputsCommand as unknown as CommandModule
   );
   const commandRunner = new TestCommandRunner(parser);
 
@@ -59,14 +59,14 @@ void describe('generate config command', () => {
       clientConfigGeneratorAdapter,
       'generateClientConfigToFile'
     );
-    await commandRunner.runCommand('config');
+    await commandRunner.runCommand('outputs');
 
     assert.equal(handlerSpy.mock.calls[0].arguments[0], fakeSandboxId);
   });
 
   void it('generates and writes config for stack', async () => {
     await commandRunner.runCommand(
-      'config --stack stack_name --out-dir /foo/bar --format ts'
+      'outputs --stack stack_name --out-dir /foo/bar --format ts'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepEqual(generateClientConfigMock.mock.calls[0].arguments[0], {
@@ -89,7 +89,7 @@ void describe('generate config command', () => {
 
   void it('generates and writes config for branch', async () => {
     await commandRunner.runCommand(
-      'config --branch branch_name --out-dir /foo/bar --format ts'
+      'outputs --branch branch_name --out-dir /foo/bar --format ts'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepEqual(generateClientConfigMock.mock.calls[0].arguments[0], {
@@ -116,7 +116,7 @@ void describe('generate config command', () => {
 
   void it('generates and writes config for appID and branch', async () => {
     await commandRunner.runCommand(
-      'config --branch branch_name --app-id app_id --out-dir /foo/bar --format mjs'
+      'outputs --branch branch_name --app-id app_id --out-dir /foo/bar --format mjs'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -136,7 +136,7 @@ void describe('generate config command', () => {
 
   void it('can generate to custom absolute path', async () => {
     await commandRunner.runCommand(
-      'config --stack stack_name --out-dir /foo/bar --format ts'
+      'outputs --stack stack_name --out-dir /foo/bar --format ts'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -154,7 +154,7 @@ void describe('generate config command', () => {
 
   void it('can generate to custom relative path', async () => {
     await commandRunner.runCommand(
-      'config --stack stack_name --out-dir foo/bar --format mjs'
+      'outputs --stack stack_name --out-dir foo/bar --format mjs'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -170,9 +170,9 @@ void describe('generate config command', () => {
     );
   });
 
-  void it('can generate config in dart format', async () => {
+  void it('can generate outputs in dart format', async () => {
     await commandRunner.runCommand(
-      'config --stack stack_name --out-dir foo/bar --format dart'
+      'outputs --stack stack_name --out-dir foo/bar --format dart'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -188,9 +188,9 @@ void describe('generate config command', () => {
     );
   });
 
-  void it('can generate config in json mobile format', async () => {
+  void it('can generate outputs in json mobile format', async () => {
     await commandRunner.runCommand(
-      'config --stack stack_name --out-dir foo/bar --format json-mobile'
+      'outputs --stack stack_name --out-dir foo/bar --format json-mobile'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -206,9 +206,9 @@ void describe('generate config command', () => {
     );
   });
 
-  void it('can generate config in with a different version', async () => {
+  void it('can generate outputs in with a different version', async () => {
     await commandRunner.runCommand(
-      'config --stack stack_name --config-version 1 --out-dir foo/bar --format json-mobile'
+      'outputs --stack stack_name --config-version 1 --out-dir foo/bar --format json-mobile'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -225,7 +225,7 @@ void describe('generate config command', () => {
   });
 
   void it('shows available options in help output', async () => {
-    const output = await commandRunner.runCommand('config --help');
+    const output = await commandRunner.runCommand('outputs --help');
     assert.match(output, /--stack/);
     assert.match(output, /--app-id/);
     assert.match(output, /--branch/);
@@ -235,7 +235,7 @@ void describe('generate config command', () => {
 
   void it('fails if both stack and branch are present', async () => {
     const output = await commandRunner.runCommand(
-      'config --stack foo --branch baz'
+      'outputs --stack foo --branch baz'
     );
     assert.match(output, /Arguments .* mutually exclusive/);
   });

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -9,10 +9,10 @@ import { BackendIdentifierResolver } from '../../../backend-identifier/backend_i
 import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
 
-export type GenerateConfigCommandOptions =
-  ArgumentsKebabCase<GenerateConfigCommandOptionsCamelCase>;
+export type GenerateOutputsCommandOptions =
+  ArgumentsKebabCase<GenerateOutputsCommandOptionsCamelCase>;
 
-type GenerateConfigCommandOptionsCamelCase = {
+type GenerateOutputsCommandOptionsCamelCase = {
   stack: string | undefined;
   appId: string | undefined;
   branch: string | undefined;
@@ -22,10 +22,10 @@ type GenerateConfigCommandOptionsCamelCase = {
 };
 
 /**
- * Command that generates client config.
+ * Command that generates client config aka amplify_outputs.
  */
-export class GenerateConfigCommand
-  implements CommandModule<object, GenerateConfigCommandOptions>
+export class GenerateOutputsCommand
+  implements CommandModule<object, GenerateOutputsCommandOptions>
 {
   /**
    * @inheritDoc
@@ -38,21 +38,21 @@ export class GenerateConfigCommand
   readonly describe: string;
 
   /**
-   * Creates client config generation command.
+   * Creates client config (amplify-outputs.json) generation command.
    */
   constructor(
     private readonly clientConfigGenerator: ClientConfigGeneratorAdapter,
     private readonly backendIdentifierResolver: BackendIdentifierResolver
   ) {
-    this.command = 'config';
-    this.describe = 'Generates client config';
+    this.command = 'outputs';
+    this.describe = 'Generates amplify outputs';
   }
 
   /**
    * @inheritDoc
    */
   handler = async (
-    args: ArgumentsCamelCase<GenerateConfigCommandOptions>
+    args: ArgumentsCamelCase<GenerateOutputsCommandOptions>
   ): Promise<void> => {
     const backendIdentifier = await this.backendIdentifierResolver.resolve(
       args
@@ -73,7 +73,7 @@ export class GenerateConfigCommand
   /**
    * @inheritDoc
    */
-  builder = (yargs: Argv): Argv<GenerateConfigCommandOptions> => {
+  builder = (yargs: Argv): Argv<GenerateOutputsCommandOptions> => {
     return yargs
       .option('stack', {
         conflicts: ['app-id', 'branch'],
@@ -111,7 +111,7 @@ export class GenerateConfigCommand
       })
       .option('config-version', {
         describe:
-          'Version of the client config. Version 0 represents classic amplify-cli client config amplify-configuration (Default) and 1 represents new unified client config amplify_outputs',
+          'Version of the configuration. Version 0 represents classic amplify-cli config file amplify-configuration and 1 represents newer config file amplify_outputs',
         type: 'string',
         array: false,
         choices: Object.values(ClientConfigVersionOption),

--- a/packages/integration-tests/src/test-e2e/deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment.test.ts
@@ -88,7 +88,7 @@ void describe('deployment tests', { concurrency: testConcurrencyLevel }, () => {
             await amplifyCli(
               [
                 'generate',
-                'config',
+                'outputs',
                 '--branch',
                 testBranch.branchName,
                 '--app-id',


### PR DESCRIPTION
Now that we have new configuration file name `amplify_outputs.json`, rename the command name to reflect that as well.

`npx amplify generate config` --> `npx amplify generate outputs`

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
