### PR TITLE
chore: Add oauth client config even if no external provider is configured

### DIFF
--- a/.changeset/hip-taxis-design.md
+++ b/.changeset/hip-taxis-design.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-auth': minor
+'@aws-amplify/auth-construct-alpha': patch
+'@aws-amplify/backend-cli': patch
+---
+
+Add oauth client config even if no external provider is configured

--- a/packages/backend-auth/API.md
+++ b/packages/backend-auth/API.md
@@ -88,7 +88,7 @@ export type Expand<T> = T extends infer O ? {
 } : never;
 
 // @public
-export type ExternalProviderGeneralFactoryProps = Omit<ExternalProviderOptions, 'signInWithApple' | 'loginWithAmazon' | 'facebook' | 'oidc' | 'google'>;
+export type ExternalProviderGeneralFactoryProps = Omit<ExternalProviderOptions, 'signInWithApple' | 'loginWithAmazon' | 'facebook' | 'oidc' | 'google' | 'domainPrefix'>;
 
 // @public
 export type ExternalProviderSpecificFactoryProps = ExternalProviderGeneralFactoryProps & {

--- a/packages/backend-auth/src/types.ts
+++ b/packages/backend-auth/src/types.ts
@@ -140,7 +140,12 @@ export type OidcProviderFactoryProps = Omit<
  */
 export type ExternalProviderGeneralFactoryProps = Omit<
   ExternalProviderOptions,
-  'signInWithApple' | 'loginWithAmazon' | 'facebook' | 'oidc' | 'google'
+  | 'signInWithApple'
+  | 'loginWithAmazon'
+  | 'facebook'
+  | 'oidc'
+  | 'google'
+  | 'domainPrefix'
 >;
 
 /**

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.test.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.test.ts
@@ -166,6 +166,69 @@ void describe('auth client config contributor v1', () => {
       } as Partial<clientConfigTypesV1.AWSAmplifyBackendOutputs>
     );
   });
+
+  void it('returns translated config when output has oauth settings but no social providers', () => {
+    const contributor = new AuthClientConfigContributor();
+    assert.deepStrictEqual(
+      contributor.contribute({
+        [authOutputKey]: {
+          version: '1',
+          payload: {
+            identityPoolId: 'testIdentityPoolId',
+            userPoolId: 'testUserPoolId',
+            webClientId: 'testWebClientId',
+            authRegion: 'testRegion',
+            passwordPolicyMinLength: '15',
+            passwordPolicyRequirements:
+              '["REQUIRES_NUMBERS","REQUIRES_LOWERCASE","REQUIRES_UPPERCASE"]',
+            mfaTypes: '["SMS","TOTP"]',
+            mfaConfiguration: 'OPTIONAL',
+            verificationMechanisms: '["email","phone_number"]',
+            usernameAttributes: '["email"]',
+            signupAttributes: '["email"]',
+            allowUnauthenticatedIdentities: 'true',
+            oauthClientId: 'testWebClientId', // same as webClientId
+            oauthCognitoDomain: 'testDomain',
+            oauthScope: '["email","profile"]',
+            oauthRedirectSignIn: 'http://callback.com,http://callback2.com',
+            oauthRedirectSignOut: 'http://logout.com,http://logout2.com',
+            oauthResponseType: 'code',
+          },
+        },
+      }),
+      {
+        auth: {
+          user_pool_id: 'testUserPoolId',
+          user_pool_client_id: 'testWebClientId',
+          aws_region: 'testRegion',
+          identity_pool_id: 'testIdentityPoolId',
+          unauthenticated_identities_enabled: true,
+          mfa_configuration: 'OPTIONAL',
+          mfa_methods: ['SMS', 'TOTP'],
+          password_policy: {
+            require_lowercase: true,
+            require_numbers: true,
+            require_uppercase: true,
+            min_length: 15,
+          },
+          standard_required_attributes: ['email'],
+          username_attributes: ['email'],
+          user_verification_types: ['email', 'phone_number'],
+          oauth: {
+            identity_providers: [],
+            domain: 'testDomain',
+            scopes: ['email', 'profile'],
+            redirect_sign_in_uri: [
+              'http://callback.com',
+              'http://callback2.com',
+            ],
+            redirect_sign_out_uri: ['http://logout.com', 'http://logout2.com'],
+            response_type: 'code',
+          },
+        },
+      } as Partial<clientConfigTypesV1.AWSAmplifyBackendOutputs>
+    );
+  });
 });
 
 void describe('data client config contributor v1', () => {


### PR DESCRIPTION
## Problem

Setting up non-social hosted provider was broken. Current logic required that oauth settings to be only surfaced in the client config if one of the external providers are configured. 

However, cognito's hosted UI can still be used without specifying an external provider.

## Changes

Surface oauth settings regardless if external provider is configured or not.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
