### PR TITLE
Update changeset to honor auth-construct package rename

### DIFF
--- a/.changeset/dull-colts-march.md
+++ b/.changeset/dull-colts-march.md
@@ -1,6 +1,6 @@
 ---
 '@aws-amplify/backend-auth': minor
-'@aws-amplify/auth-construct-alpha': patch
+'@aws-amplify/auth-construct': patch
 '@aws-amplify/client-config': patch
 ---
 


### PR DESCRIPTION
## Problem

https://github.com/aws-amplify/amplify-backend/actions/runs/8850930224/job/24306472182#step:7:84

```console
  error Error: "hip-taxis-design" changeset mentions a release for a package "@aws-amplify/auth-construct-alpha" but such a package could not be found.
```

## Changes

Update changeset

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
