### PR TITLE
chore: bump data-schema deps to latest

### DIFF
--- a/.changeset/ninety-beds-tan.md
+++ b/.changeset/ninety-beds-tan.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-data': minor
+'@aws-amplify/backend': minor
+---
+
+use latest data-schema

--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,9 +1201,9 @@
       }
     },
     "node_modules/@aws-amplify/data-schema": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.16.2.tgz",
-      "integrity": "sha512-Ij9Lig1L+JCxWe1hX9MqSqbAGUpYnV+H7321dZlD2gBEPhnyzjm78bCXThvadM77EiMzE4DDn93q+fk5Dm8++Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.0.0.tgz",
+      "integrity": "sha512-pvXko9gDnBqyNshXwrkAer3CbFGkwtlMI35wJk48+N1rxLXKLYElADZj6kWwZXmBbI67uD4ZJ3s62Qzsb6lZZA==",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
         "@types/aws-lambda": "^8.10.134",
@@ -25411,7 +25411,7 @@
       }
     },
     "packages/ampx": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0"
     },
     "packages/auth-construct": {
@@ -25442,7 +25442,7 @@
         "@aws-amplify/backend-secret": "^0.4.6",
         "@aws-amplify/backend-storage": "^0.7.1",
         "@aws-amplify/client-config": "^0.9.4",
-        "@aws-amplify/data-schema": "^0.16.0",
+        "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^0.5.1",
         "@aws-amplify/plugin-types": "^0.10.0",
         "@aws-sdk/client-amplify": "^3.465.0",
@@ -25484,35 +25484,15 @@
         "@aws-amplify/backend-output-schemas": "^0.7.0",
         "@aws-amplify/backend-output-storage": "^0.4.1",
         "@aws-amplify/data-construct": "^1.8.0",
-        "@aws-amplify/data-schema-types": "^0.9.0",
+        "@aws-amplify/data-schema-types": "^1.0.0",
         "@aws-amplify/plugin-types": "^0.10.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
-        "@aws-amplify/data-schema": "^0.16.0",
+        "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^0.5.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.127.0",
-        "constructs": "^10.0.0"
-      }
-    },
-    "packages/backend-data/node_modules/@aws-amplify/data-schema-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.9.0.tgz",
-      "integrity": "sha512-hA5M6D+4ET25h9y9+VZ4VRbh/KGdtpm8/skyMvhvAwPmE//kYpuP1x3JDl5A8RiAhqZiYLVK/ckNRnWMYSeyfg==",
-      "dependencies": {
-        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
-        "graphql": "15.8.0",
-        "rxjs": "^7.8.1"
-      }
-    },
-    "packages/backend-data/node_modules/@aws-amplify/data-schema-types/node_modules/@aws-amplify/plugin-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-0.9.0.tgz",
-      "integrity": "sha512-dOwuyjRWKHvKSxcCwycdBTb6clRr2/soW1hL+HaXyTN69+dQanQegpS6ylmVwbPPiy9q2LCbqaw+5Np7bacLgw==",
-      "peerDependencies": {
-        "@aws-sdk/types": "^3.465.0",
         "aws-cdk-lib": "^2.127.0",
         "constructs": "^10.0.0"
       }
@@ -25960,7 +25940,7 @@
         "@aws-amplify/backend": "^0.13.4",
         "@aws-amplify/backend-secret": "^0.4.6",
         "@aws-amplify/client-config": "^0.9.4",
-        "@aws-amplify/data-schema": "^0.16.0",
+        "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^0.5.1",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-amplify/data-schema": "^0.16.0",
+    "@aws-amplify/data-schema": "^1.0.0",
     "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
     "@aws-amplify/platform-core": "^0.5.1"
   },
@@ -31,6 +31,6 @@
     "@aws-amplify/backend-output-schemas": "^0.7.0",
     "@aws-amplify/data-construct": "^1.8.0",
     "@aws-amplify/plugin-types": "^0.10.0",
-    "@aws-amplify/data-schema-types": "^0.9.0"
+    "@aws-amplify/data-schema-types": "^1.0.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-amplify/data-schema": "^0.16.0",
+    "@aws-amplify/data-schema": "^1.0.0",
     "@aws-amplify/backend-auth": "^0.7.0",
     "@aws-amplify/backend-function": "^0.9.1",
     "@aws-amplify/backend-data": "^0.12.1",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -9,7 +9,7 @@
     "@aws-amplify/backend": "^0.13.4",
     "@aws-amplify/backend-secret": "^0.4.6",
     "@aws-amplify/client-config": "^0.9.4",
-    "@aws-amplify/data-schema": "^0.16.0",
+    "@aws-amplify/data-schema": "^1.0.0",
     "@aws-amplify/platform-core": "^0.5.1",
     "@aws-sdk/client-amplify": "^3.465.0",
     "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/integration-tests/src/test-projects/access-testing-project/amplify/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/access-testing-project/amplify/data/resource.ts
@@ -10,7 +10,7 @@ const schema = a.schema({
     .model({
       content: a.string(),
     })
-    .authorization((allow) => [allow.authenticated('iam')]),
+    .authorization((allow) => [allow.authenticated('identityPool')]),
 }) as never; // Not 100% sure why TS is complaining here. The error I'm getting is "The inferred type of 'schema' references an inaccessible 'unique symbol' type. A type annotation is necessary."
 
 // ^ appears to be caused by these 2 rules in tsconfig.base.json: https://github.com/aws-amplify/amplify-backend/blob/8d9a7a4c3033c474b0fc78379cdd4c1854d890ce/tsconfig.base.json#L7-L8


### PR DESCRIPTION
## Changes

* bumps `data-schema` and `data-schema-types` deps to latest

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

* build/tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
