### PR TITLE
chore: rename config generation options as outputs generation options

### DIFF
--- a/.changeset/four-oranges-brake.md
+++ b/.changeset/four-oranges-brake.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+rename config generation options as outputs generation options

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,11 +192,11 @@
       }
     },
     "node_modules/@ardatan/relay-compiler/node_modules/@babel/generator": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
-      "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
       "dependencies": {
-        "@babel/types": "^7.24.0",
+        "@babel/types": "^7.24.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -206,12 +206,12 @@
       }
     },
     "node_modules/@ardatan/relay-compiler/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -245,11 +245,11 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@ardatan/relay-compiler/node_modules/minimatch": {
@@ -305,9 +305,9 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.28.tgz",
-      "integrity": "sha512-hfzRVyKhseiizpnYz61mT78xyfPMeTp4I0lMvffBA7HTfh1tNhO9iDZqOZJmFBfxpEG/kEc0fXYl/X8u+Z8U9w==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.29.tgz",
+      "integrity": "sha512-P5ULdwdMfDF0URJvHfgyXTuAWN08jWc8L/YhO3gQxLRVfbrI5D2G+0TFLaPfmdymlj3B4JzzC7i9m8qsoL2Atg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/client-firehose": "3.398.0",
@@ -334,41 +334,30 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.0.30",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.30.tgz",
-      "integrity": "sha512-T/1+5oN5SKle0aXoBOjEdZoDl6uDrhQDfD1ob7zOuDtwC4CZIc4FrzK6wDsxICGXQ2dUeswnX/HpqTnftZMd/g==",
+      "version": "6.0.31",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.31.tgz",
+      "integrity": "sha512-QzYpJfFLAG/C4rRkS2b+wCsVVZP9Ata7zJpooBpIY83I0MxcV9AT2Zw/eD/g5jDOg+QqkGLKjJzLXPyzW9yTHA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.0.30",
-        "@aws-amplify/api-rest": "4.0.28",
+        "@aws-amplify/api-graphql": "4.1.0",
+        "@aws-amplify/api-rest": "4.0.29",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.0.30.tgz",
-      "integrity": "sha512-P6H6a2cI7e8HcEVkydAp8WsXSIVvmB/TijGXfy3ErEnT0HW8Butl1K6jK2Yxe8qD7SBaYjcyewDOiOfUkYkk/g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.1.0.tgz",
+      "integrity": "sha512-YBbvWfDKGMaC2/uMJij3F6hqTBzopMlCBAqtOTajR1p3fHqtdNFnxz5GBHOnvNPK+IJr7DUc27HjYgTzbvuLRw==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/api-rest": "4.0.28",
-        "@aws-amplify/core": "6.0.28",
-        "@aws-amplify/data-schema": "^0.17.0",
+        "@aws-amplify/api-rest": "4.0.29",
+        "@aws-amplify/core": "6.1.0",
+        "@aws-amplify/data-schema": "^1.0.0",
         "@aws-sdk/types": "3.387.0",
         "graphql": "15.8.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.5.0",
         "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/api-graphql/node_modules/@aws-amplify/data-schema": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-0.17.1.tgz",
-      "integrity": "sha512-E9Iq68arbBCjtVg1vIrjQ7/WQ6cg4EzulPAJPBFHEFlF23p9XDT1gX2kSkm4u+X0Nptb3EaMdjYzpMz4WcO3Dg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-amplify/data-schema-types": "*",
-        "@types/aws-lambda": "^8.10.134",
-        "rxjs": "^7.8.1"
       }
     },
     "node_modules/@aws-amplify/api-graphql/node_modules/@aws-sdk/types": {
@@ -398,9 +387,9 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "4.0.28",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.28.tgz",
-      "integrity": "sha512-X02Lbe9+7razFLZBi09GjP1Sb8vr2Ii4DOL8dk+G/CN4QyeWCYXs+2dcfHiouoSJNWIaPCMG4R0RgmWHUrgnVg==",
+      "version": "4.0.29",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.29.tgz",
+      "integrity": "sha512-3MUU14f21TYlAvPzYVi1Ga3D8BBC7XHKNzb8JrSZ6MP+8qd2xd6dC7Q+vfm9dtj72y7lPrJee4DkZtMu7HapiQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -410,9 +399,9 @@
       }
     },
     "node_modules/@aws-amplify/appsync-modelgen-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.11.0.tgz",
-      "integrity": "sha512-I2g6r1lmYo1trN2xfhvpuO1c55bbcsj63y4hHKeBdBTHDiHiuKL6bHNJtCc368L+IbZOvKdEG999HczpUAnN6w==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.12.0.tgz",
+      "integrity": "sha512-SHafjmo6JoYMVp8hgfhY/b7o0JROcyLd8Sc7YCLPZA0koMDtmsyUta8WCVk9VlsjZuokiBegN4pDDjNEs6GXUA==",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^1.18.8",
         "@graphql-codegen/visitor-plugin-common": "^1.22.0",
@@ -430,9 +419,9 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.2.1.tgz",
-      "integrity": "sha512-LvLVHCIu0w6bReD4l28AWQ9ZCXVKwPQ2cIyP3KQ+uRRgemL5O+7X2HJEeoe5rNwoa1VRTDEZiuBhJlkQVtnYsA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.2.2.tgz",
+      "integrity": "sha512-lx/pZPYaGZrB4UV/FNNeUaEUWVrC2ayJJx/0mnZrOceH5OdGUMp1mdZz0epDaShtGanTcq7JOlVuu/1LC6eI7g==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -550,9 +539,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.0.28",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.0.28.tgz",
-      "integrity": "sha512-bjp/MgIkFmB7JleBRhFQ9C7tD+Y294F+XXKkpvxGnR1WlPdz2h1P51fCk0j3kpKJRVeo7VyVMTAY21QiWHBS6g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-r3ErH/aa5iO7sQjYASduPr2L4YiRX3VBUHjFYlvoCgZTh1RXDjcntBFQ9suQTIsQe4dtk5Z2MqhepqfjUH7zWw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1201,9 +1190,9 @@
       }
     },
     "node_modules/@aws-amplify/data-schema": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.0.0.tgz",
-      "integrity": "sha512-pvXko9gDnBqyNshXwrkAer3CbFGkwtlMI35wJk48+N1rxLXKLYElADZj6kWwZXmBbI67uD4ZJ3s62Qzsb6lZZA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.0.1.tgz",
+      "integrity": "sha512-DV45EdLKLy1ZJCZatUNGteZw+SMIi2Ygzd2lN8ZiLXR0lEmK87l/yvpj9eahLxvynVJaz7bVsu5k8yI/GrtMvA==",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
         "@types/aws-lambda": "^8.10.134",
@@ -1220,12 +1209,12 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.30",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.30.tgz",
-      "integrity": "sha512-VIFTCMQa0bjxk/F/ZCFVfXsv75c31o/xOgp77JZy3oPuan3XlQ0IBKoBYfld9xzxu5Xd3TON7dnyQNAUE/ynuw==",
+      "version": "5.0.31",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.31.tgz",
+      "integrity": "sha512-JCRU9ZjXjiye7CKO91DHkIkF4SxHN7M0gvcuD4y4p9rIXVerSUbb5Jilbk6zLC8hmDm4E/iyxYBhULgzCMNBMg==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/api": "6.0.30",
+        "@aws-amplify/api": "6.0.31",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -1837,11 +1826,11 @@
       }
     },
     "node_modules/@aws-amplify/graphql-generator": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.0.tgz",
-      "integrity": "sha512-3EPwNIQNspgjjk4m9lg6ix9tXoyjwhnRZ3C6a1xASPmav/Q6rqP+eTVlB1iAHuQDXCMDR1kgc/McXTKZkyzOfg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.1.tgz",
+      "integrity": "sha512-dY8NhtFZFfjXlM/rODQnj5lg6f7Uj47j7Uh+d/X9mYUMBDygISiEQK8bxKfsLcQW8MIIiAPP8w/BOZOsO35NlQ==",
       "dependencies": {
-        "@aws-amplify/appsync-modelgen-plugin": "2.11.0",
+        "@aws-amplify/appsync-modelgen-plugin": "2.12.0",
         "@aws-amplify/graphql-directives": "^1.0.1",
         "@aws-amplify/graphql-docs-generator": "4.2.1",
         "@aws-amplify/graphql-types-generator": "3.6.0",
@@ -2711,9 +2700,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.28.tgz",
-      "integrity": "sha512-XnB1/V4lQxtk46iJsD6EhXXwVmz08IZYQne/JAK8+3k1GDFVvjZlpSMITqh0y8QrrrPzQCAGdffme5XK0ERXrQ==",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.29.tgz",
+      "integrity": "sha512-OZZiFRFgNSZga0EcEE+u10CibWuZl/zaL2JuBg20FMdSrMMORqzjE9ce846tlasROjERBTfJUE0fd/IfSj5aWQ==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
@@ -2740,9 +2729,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.3.1.tgz",
-      "integrity": "sha512-k8W89ySzzoXCCl3Vn2DZPj7bXEJkBUS8GTPKG7kvD/Cn6IQRupINqzDWSw9P47XE0tJzbp6evyn7NMVd1W5Hbg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.4.0.tgz",
+      "integrity": "sha512-FAbw+CM2nOtU/RJpUP3/hGBNJv6V2IvdbbEb1Xit8AIJm7b8CpaYQN24t86tstF5mlFrJRbo+BETuNo2EVzCEA==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
@@ -2943,14 +2932,14 @@
       }
     },
     "node_modules/@aws-sdk/client-amplify": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplify/-/client-amplify-3.564.0.tgz",
-      "integrity": "sha512-uvMmuquDlCsWjV2bbPpkXPBRixvGC36PkJo/cgn/BioDWpuQLji4yEllmFGB7uVWpyM6mMo3arPiSYDEjhVWyg==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplify/-/client-amplify-3.565.0.tgz",
+      "integrity": "sha512-cyBN7FKCqQmUb0vqj2p5y7G8bou21mKMLO62RHibHERWLSUZr/SupyxkvA8px1WBWIEfBThdGnOAt/9WZxoxrg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -2992,14 +2981,14 @@
       }
     },
     "node_modules/@aws-sdk/client-amplifyuibuilder": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplifyuibuilder/-/client-amplifyuibuilder-3.564.0.tgz",
-      "integrity": "sha512-UyfXnznxZpeBtqzKNlHVttEw6wVsECDmZPkEoZc5Cabchx+96IsYhR9PJ0D7KmGrSAvawbYQB7RFlorE6Gyy6Q==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplifyuibuilder/-/client-amplifyuibuilder-3.565.0.tgz",
+      "integrity": "sha512-PnL1K+0/WAYlBDY1kxMQK8+iOc29S7rkr5vw+ZayNqEWYYYLh9US0UlRpGfb3u9PSM/jhF5J4oNRE0fmcWs5oQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -3054,14 +3043,14 @@
       }
     },
     "node_modules/@aws-sdk/client-appsync": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.564.0.tgz",
-      "integrity": "sha512-8RbN2Djk7NGRPBcleBuBvgBh/WXCdRkmbc45Uu4lH1F0U2pnL67TVPxQGUajKe+VFmSZc6tIMBvk+jj7SzRyHA==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.565.0.tgz",
+      "integrity": "sha512-mCeWRZWtHpYgZvi7GgpAUHf5ie7mg8DVAjmemxJV30joJiX90zq2DHFIX4bvy+ZZh0sDYrdI1EHaFGKGYzDPCQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -3104,14 +3093,14 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.564.0.tgz",
-      "integrity": "sha512-yO2Ac78rkMgTpF3OboHWklX9Ju4ut2EFEOOQqPb8DAgg5unhkh7063x6GPHPNJrmRWkJTr0HbVb8tdK5nExmJQ==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.565.0.tgz",
+      "integrity": "sha512-U1PYFfKS7RZ7PNwJGllFeYMUQuE2YGm0yYI7/BJ0V8P8hABJ8jg5+Xu+Qnnocd7DnsUfgofYiBJ9DgnmKr9sRw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -3167,14 +3156,14 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.564.0.tgz",
-      "integrity": "sha512-AJGd0RXAyycNqb8RBySVkIrzNOd8JzI4sVVC/7pA41t4EeUGM6b2tcsOlt1eVqcNxR1hvn2ZbwnNI8e3OlEnhQ==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.565.0.tgz",
+      "integrity": "sha512-g3CycpQTqw4YW9BbX/0Z7cXO3v5x4s0SUDmYu5qEE3ziUmeTxqQc0aJN5wPjuKbF0UuQ4oEnTiMV/yZQrcMEIQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -3216,15 +3205,15 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.564.0.tgz",
-      "integrity": "sha512-Fo9GO4uMRoj2QfKYMjcyQa0iSYIo3iA4D6YEglIlO1Yutg7Y5BoY5wdDdSb/Glz37fsFtbkyOZyyTgcmeLfibg==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.565.0.tgz",
+      "integrity": "sha512-3hVg0CSCIAGNVXiRen7Br0+hH77/OTmN7TCICclUbiXOtpA+fJA+mz+lRhsVDdWT3rBcfqiiUIe0v1QDKyHaUA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -3266,15 +3255,15 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.564.0.tgz",
-      "integrity": "sha512-2jz7nDEXvdHofxYQ16V2yFxKTeYwM+7o0RmM6KP2HCghTlRpS5L/TUw2fptqpxj+kx+nf2M7o85guJwLDbQu/g==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.565.0.tgz",
+      "integrity": "sha512-3qZz65ULWL8q1ytxXNfwPvdKw9WBNYX/5q1qJ1Oa3rLg/gsrNdj1faWWQL3jH8L5k7bPTZM2oART16p0SIkVDw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-endpoint-discovery": "3.535.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
@@ -4242,15 +4231,15 @@
       }
     },
     "node_modules/@aws-sdk/client-iam": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.564.0.tgz",
-      "integrity": "sha512-ENLELTEPk+VTVaMj8Pw5uS1t82nRGTsiEWoz2MjPFG89g3uWYPEH4iIN8Egts/UzDcbuWTBf4P1/zpWUZbXn2w==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.565.0.tgz",
+      "integrity": "sha512-DK+qBDEdopf4du8CGmfUzdOxfolBj9fU2vK/BJlT6jK8bcYw8oWkTKhl9m3pa40vBWMIkkZ3S48Yl+zD4tI4mQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -4741,15 +4730,15 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.564.0.tgz",
-      "integrity": "sha512-2n7fNWrQroIRXoN0VucijYieM7bLMq8/l1pWkrYKdd8DG1lLPTKK57axRe6DEqaCguWOR63pHPEzNUgTf5CU+w==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.565.0.tgz",
+      "integrity": "sha512-+FXfr6lBcEFXnM8P7nyoS9dSJYzLjrSyd52xlztxdOd4RGDNxA9b/VnqWVUqp8tQ0OCtt5uVi9x3ket1yRRhbg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -5705,15 +5694,15 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.564.0.tgz",
-      "integrity": "sha512-QvTjjQWC7LB18X7BRvYK6Rc1oK1nToht4KOBR+zXmz4R1TEtMpyC9xgZzzVzp2aocXV1/WuDlg8Mvssx8UmUuQ==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.565.0.tgz",
+      "integrity": "sha512-e5ioE9XBV6bJTrCClvCpK9vGP+Dp69y/LcC4ENfPcEM+BniQau2StCWcNkFuvVXyuKuk0drS+ZLnP+tefNEJ4A==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.535.0",
         "@aws-sdk/middleware-expect-continue": "3.535.0",
         "@aws-sdk/middleware-flexible-checksums": "3.535.0",
@@ -5771,14 +5760,14 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.564.0.tgz",
-      "integrity": "sha512-52YWBKEd6g7z5L+bMYow2jZplGqmBy1LgJ++GqvA2EbGY0qNGklMMX7R5NhQ424ofrJ7NhiPuQWt57LnCNzcIg==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.565.0.tgz",
+      "integrity": "sha512-wVtU39/CCPU+IHj7bwvY9FJAbZN1G5aPLhf1ESdTj8AWrRlEQdMFjd42OFJQH+jpl0YLOUWngfSPLSM+hWUCVg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -5882,13 +5871,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.564.0.tgz",
-      "integrity": "sha512-LWBXiwA0qlGhpJx3fbFQagVEyVPoecGtJh3+5hoc+CTVnT00J7T0jLe3kgemvEI9kjhIyDW+MFkq1jCttrGNJw==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.565.0.tgz",
+      "integrity": "sha512-uMdjTRa8cPGo+7JPjEkesh6jNEZG8uJS44cWeskTHTVhHWcdwXvjSwQWmeXlkYVhHQSwG9Ps3pq12Vpw9oFrxg==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -5927,19 +5918,17 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-provider-node": "^3.564.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.556.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.556.0.tgz",
-      "integrity": "sha512-TsK3js7Suh9xEmC886aY+bv0KdLLYtzrcmVt6sJ/W6EnDXYQhBuKYFhp03NrN2+vSvMGpqJwR62DyfKe1G0QzQ==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.565.0.tgz",
+      "integrity": "sha512-c2T20tz+Akn9uBgmZPPK3VLpgzYGVuHxKNisLwGtGL5NdQSoZZ6HNT08PY3KB12Ou8VcZLv8cvUz2Nivqhg4RA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.556.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/middleware-host-header": "3.535.0",
         "@aws-sdk/middleware-logger": "3.535.0",
         "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -5978,9 +5967,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-provider-node": "^3.556.0"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
@@ -6026,11 +6012,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.564.0.tgz",
-      "integrity": "sha512-rjpj+VR9NbF9hg2H0gfuhbQL+6WlRVEBBxI8rweSsSm5r5exENqP+xmEdL6mmFCyM/EjDQswNs0td2tVSc/onw==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.565.0.tgz",
+      "integrity": "sha512-nOI0RYE0aHByaDI8w5Eu855fGOwGuAPEeCUgu8AIhExvDUZ5bmiwMN4TxHJW/+CEgQB8uZcPYCDEUMzqr0yh5w==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.564.0",
+        "@aws-sdk/client-cognito-identity": "3.565.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/types": "^2.12.0",
@@ -6100,15 +6086,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.564.0.tgz",
-      "integrity": "sha512-kiEfBoKRcbX7I/rjhVGJrTUQ0895ANhPu6KE1GRZW7wc1gIGgKGJ+0tvAqRtQjYX0U9pivEDb0dh16OF9PBFFw==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.565.0.tgz",
+      "integrity": "sha512-H9+etKKjeQot3vKzuE/osTb1xMzYW0UNQZSLSt1T4fZYSMdEgnOFXRwT0kw8yGMtSQuWMYZcXYHv0jMYetho4A==",
       "dependencies": {
-        "@aws-sdk/client-sts": "3.556.0",
         "@aws-sdk/credential-provider-env": "3.535.0",
         "@aws-sdk/credential-provider-process": "3.535.0",
-        "@aws-sdk/credential-provider-sso": "3.564.0",
-        "@aws-sdk/credential-provider-web-identity": "3.556.0",
+        "@aws-sdk/credential-provider-sso": "3.565.0",
+        "@aws-sdk/credential-provider-web-identity": "3.565.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/credential-provider-imds": "^2.3.0",
         "@smithy/property-provider": "^2.2.0",
@@ -6118,19 +6103,22 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.565.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.564.0.tgz",
-      "integrity": "sha512-HXD5ZCXzfcd6cJ/pW8frh8DuYlKaCd/JKmwzuCRUxgxZwbLEeNmyRYvF+D7osETJJZ4VIwgVbpEw1yLqRz1onw==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.565.0.tgz",
+      "integrity": "sha512-d9xlnyd6Ba7DMJNTy0hoAHexFTOx8LWn1XPWbHZqgyRb+0YDIOhPN2ADYxE4Zq+Dc03MLTqq15zWOUhIqAPLuQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.535.0",
         "@aws-sdk/credential-provider-http": "3.552.0",
-        "@aws-sdk/credential-provider-ini": "3.564.0",
+        "@aws-sdk/credential-provider-ini": "3.565.0",
         "@aws-sdk/credential-provider-process": "3.535.0",
-        "@aws-sdk/credential-provider-sso": "3.564.0",
-        "@aws-sdk/credential-provider-web-identity": "3.556.0",
+        "@aws-sdk/credential-provider-sso": "3.565.0",
+        "@aws-sdk/credential-provider-web-identity": "3.565.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/credential-provider-imds": "^2.3.0",
         "@smithy/property-provider": "^2.2.0",
@@ -6158,12 +6146,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.564.0.tgz",
-      "integrity": "sha512-Wv0NV8tDwtydEpsp/kVZ22Z+40bsSBDYgYZ1Uxx+KR8a1PvT6B5FnEtccWTJ371sQG/uqLum7dXSbJq1Qqze1w==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.565.0.tgz",
+      "integrity": "sha512-MWefgFWt5BvVMlbjS0mxolxJPA8BKSnzfbdgGCoyEImuHa3GzVArYDQru4oWk6lD+naZFVHzPjHzEDYMag2KGw==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.556.0",
-        "@aws-sdk/token-providers": "3.564.0",
+        "@aws-sdk/token-providers": "3.565.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/shared-ini-file-loader": "^2.4.0",
@@ -6175,11 +6163,10 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.556.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.556.0.tgz",
-      "integrity": "sha512-R/YAL8Uh8i+dzVjzMnbcWLIGeeRi2mioHVGnVF+minmaIkCiQMZg2HPrdlKm49El+RljT28Nl5YHRuiqzEIwMA==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.565.0.tgz",
+      "integrity": "sha512-+MWMp3jxn93Ol2E2gjjXjqoZDNMao03OErGmGoDKMIlu322jNHTvYZo5W0WBy+615mnDKahbX55MmVBge/FwDg==",
       "dependencies": {
-        "@aws-sdk/client-sts": "3.556.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/types": "^2.12.0",
@@ -6187,24 +6174,27 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.565.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.564.0.tgz",
-      "integrity": "sha512-QQrVTPuRRK37IEtCqzGpStfvr5fZMqxlCQFNJ6mDpHOkL1oyrYIrBpWCB4N95dJyoyLsogleDoFZelfjM9HIzQ==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.565.0.tgz",
+      "integrity": "sha512-heCRN2Qrje8Nu8TKo+EMM5ToIRECIuCLfHKf2hvkl9iWUs/a7ailNTWUqhE4gqZKGDvFO9dbvqxwKRKi5YXfiA==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.564.0",
+        "@aws-sdk/client-cognito-identity": "3.565.0",
         "@aws-sdk/client-sso": "3.556.0",
-        "@aws-sdk/client-sts": "3.556.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.564.0",
+        "@aws-sdk/client-sts": "3.565.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.565.0",
         "@aws-sdk/credential-provider-env": "3.535.0",
         "@aws-sdk/credential-provider-http": "3.552.0",
-        "@aws-sdk/credential-provider-ini": "3.564.0",
-        "@aws-sdk/credential-provider-node": "3.564.0",
+        "@aws-sdk/credential-provider-ini": "3.565.0",
+        "@aws-sdk/credential-provider-node": "3.565.0",
         "@aws-sdk/credential-provider-process": "3.535.0",
-        "@aws-sdk/credential-provider-sso": "3.564.0",
-        "@aws-sdk/credential-provider-web-identity": "3.556.0",
+        "@aws-sdk/credential-provider-sso": "3.565.0",
+        "@aws-sdk/credential-provider-web-identity": "3.565.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/credential-provider-imds": "^2.3.0",
         "@smithy/property-provider": "^2.2.0",
@@ -7116,11 +7106,10 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.564.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.564.0.tgz",
-      "integrity": "sha512-Kk5ixcl9HjqwzfBJZGQAtsqwKa7Z8P7Mdug837BG8zCJbhf7wwNsmItzXTiAlpVrDZyT8P1yWIxsLOS1YUtmow==",
+      "version": "3.565.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.565.0.tgz",
+      "integrity": "sha512-QPoQUTWijvFZD+7yqu9oJORG6FxqUseD4uhV3iZKVZsj7/Rlpvlh8oEZVCrcnsZ17vKzy+RMUVlnj3vf7Pwp8Q==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.564.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/shared-ini-file-loader": "^2.4.0",
@@ -7129,6 +7118,9 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.565.0"
       }
     },
     "node_modules/@aws-sdk/types": {
@@ -7514,20 +7506,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
-      "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
+      "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.4",
+        "@babel/generator": "^7.24.5",
         "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.24.4",
-        "@babel/parser": "^7.24.4",
+        "@babel/helper-module-transforms": "^7.24.5",
+        "@babel/helpers": "^7.24.5",
+        "@babel/parser": "^7.24.5",
         "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.1",
-        "@babel/types": "^7.24.0",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -7543,11 +7535,11 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/generator": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
-      "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
       "dependencies": {
-        "@babel/types": "^7.24.0",
+        "@babel/types": "^7.24.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -7557,12 +7549,12 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7578,9 +7570,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.1.tgz",
-      "integrity": "sha512-d5guuzMlPeDfZIbpQ8+g1NaCNuAGBBGNECh0HVqz1sjOeVLh2CEaifuOysCH18URW6R7pqXINvf5PaR/dC6jLQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.5.tgz",
+      "integrity": "sha512-gsUcqS/fPlgAw1kOtpss7uhY6E9SFFANQ6EFX5GTvzUwaV0+sGaZWk6xq22MOdeT9wfxyokW3ceCUvOiRtZciQ==",
       "dev": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -7592,7 +7584,7 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/@babel/eslint-parser/node_modules/semver": {
@@ -7605,9 +7597,9 @@
       }
     },
     "node_modules/@babel/eslint-plugin": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.23.5.tgz",
-      "integrity": "sha512-03+E/58Hoo/ui69gR+beFdGpplpoVK0BSIdke2iw4/Bz7eGN0ssRenNlnU4nmbkowNQOPCStKSwFr8H6DiY49g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.24.5.tgz",
+      "integrity": "sha512-5n3K9Zv13VOa9SG2ZiX0WV7A0ddApRn6vsV8zBojCsxnCbYKLjCDvzDfVxS7C4STmjQDOXU1uk/ppxxDTC860w==",
       "dev": true,
       "dependencies": {
         "eslint-rule-composer": "^0.3.0"
@@ -7617,7 +7609,7 @@
       },
       "peerDependencies": {
         "@babel/eslint-parser": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -7644,12 +7636,12 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7680,18 +7672,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz",
-      "integrity": "sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.5.tgz",
+      "integrity": "sha512-uRc4Cv8UQWnE4NXlYTIIdM7wfFkOqlFztcC/gVXDKohKoVB3OyonfelUBaJzSwpBntZ2KYGF/9S7asCHsXwW6g==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-member-expression-to-functions": "^7.23.0",
+        "@babel/helper-member-expression-to-functions": "^7.24.5",
         "@babel/helper-optimise-call-expression": "^7.22.5",
         "@babel/helper-replace-supers": "^7.24.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-split-export-declaration": "^7.24.5",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -7730,12 +7722,12 @@
       }
     },
     "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7754,12 +7746,12 @@
       }
     },
     "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7767,23 +7759,23 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
-      "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.5.tgz",
+      "integrity": "sha512-4owRteeihKWKamtqg4JmWSsEZU445xpFRXPEwp44HbgbxdWlUV1b4Agg4lkA806Lil5XM/e+FJyS0vj5T6vmcA==",
       "dependencies": {
-        "@babel/types": "^7.23.0"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7802,12 +7794,12 @@
       }
     },
     "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7815,15 +7807,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
+      "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
+        "@babel/helper-module-imports": "^7.24.3",
+        "@babel/helper-simple-access": "^7.24.5",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/helper-validator-identifier": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7844,12 +7836,12 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7857,9 +7849,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
-      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+      "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -7881,23 +7873,23 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
+      "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7916,12 +7908,12 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7929,23 +7921,23 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+      "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -7961,9 +7953,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -7977,25 +7969,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
-      "integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
+      "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
       "dependencies": {
         "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.1",
-        "@babel/types": "^7.24.0"
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -8003,11 +7995,11 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -8081,9 +8073,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
-      "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -8205,11 +8197,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.4.tgz",
-      "integrity": "sha512-nIFUZIpGKDf9O9ttyRXpHFpKC+X3Y5mtshZONuEUYBomAKoM4y029Jr+uB1bHGPhNmK8YXHevDtKDOLmtRrp6g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.5.tgz",
+      "integrity": "sha512-sMfBc3OxghjC95BkYrYocHL3NaOplrcaunblzwXhGmlPwpmfsxr4vK+mBBt49r+S240vahmv+kUxkeKgs+haCw==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8219,17 +8211,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.1.tgz",
-      "integrity": "sha512-ZTIe3W7UejJd3/3R4p7ScyyOoafetUShSf4kCqV0O7F/RiHxVj/wRaRnQlrGwflvcehNA8M42HkAiEDYZu2F1Q==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.5.tgz",
+      "integrity": "sha512-gWkLP25DFj2dwe9Ck8uwMOpko4YsqyfZJrOmqqcegeDYEbp7rmn4U6UQZNj08UF6MaX39XenSpKRCvpDRBtZ7Q==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-plugin-utils": "^7.24.0",
+        "@babel/helper-plugin-utils": "^7.24.5",
         "@babel/helper-replace-supers": "^7.24.1",
-        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-split-export-declaration": "^7.24.5",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -8255,11 +8247,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.1.tgz",
-      "integrity": "sha512-ow8jciWqNxR3RYbSNVuF4U2Jx130nwnBnhRw6N6h1bOejNkABmcI5X5oz29K4alWX7vf1C+o6gtKXikzRKkVdw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.5.tgz",
+      "integrity": "sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8374,11 +8366,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.1.tgz",
-      "integrity": "sha512-8Jl6V24g+Uw5OGPeWNKrKqXPDw2YDjLc53ojwfMcKwlEoETKU9rU0mHUtcg9JntWI/QYzGAXNWEcVHZ+fR+XXg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.5.tgz",
+      "integrity": "sha512-9Co00MqZ2aoky+4j2jhofErthm6QVLKbpQrvz20c3CH9KQCLHyNB+t2ya4/UrRpQGR+Wrwjg9foopoeSdnHOkA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8434,12 +8426,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -8490,9 +8482,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -8514,12 +8506,12 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -8527,18 +8519,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
-      "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
       "dependencies": {
-        "@babel/code-frame": "^7.24.1",
-        "@babel/generator": "^7.24.1",
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.24.1",
-        "@babel/types": "^7.24.0",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -8547,11 +8539,11 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/generator": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
-      "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
       "dependencies": {
-        "@babel/types": "^7.24.0",
+        "@babel/types": "^7.24.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -8561,12 +8553,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -9867,9 +9859,9 @@
       }
     },
     "node_modules/@graphql-codegen/core/node_modules/@graphql-tools/utils": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.1.3.tgz",
-      "integrity": "sha512-loco2ctrrMQzdpSHbcOo6+Ecp21BV67cQ2pNGhuVKAexruu01RdLn3LgtK47B9BpLz3cUD6U0u1R0rur7xMOOg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.0.tgz",
+      "integrity": "sha512-HYV7dO6pNA2nGKawygaBpk8y+vXOUjjzzO43W/Kb7EPRmXUEQKjHxPYRvQbiF72u1N3XxwGK5jnnFk9WVhUwYw==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-inspect": "1.0.0",
@@ -10146,9 +10138,9 @@
       }
     },
     "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@graphql-tools/utils": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.1.3.tgz",
-      "integrity": "sha512-loco2ctrrMQzdpSHbcOo6+Ecp21BV67cQ2pNGhuVKAexruu01RdLn3LgtK47B9BpLz3cUD6U0u1R0rur7xMOOg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.0.tgz",
+      "integrity": "sha512-HYV7dO6pNA2nGKawygaBpk8y+vXOUjjzzO43W/Kb7EPRmXUEQKjHxPYRvQbiF72u1N3XxwGK5jnnFk9WVhUwYw==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-inspect": "1.0.0",
@@ -10163,9 +10155,9 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.3.tgz",
-      "integrity": "sha512-FeKv9lKLMwqDu0pQjPpF59GY3HReUkWXKsMIuMuJQOKh9BETu7zPEFUELvcw8w+lwZkl4ileJsHXC9+AnsT2Lw==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.4.tgz",
+      "integrity": "sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==",
       "dependencies": {
         "@graphql-tools/utils": "^10.0.13",
         "tslib": "^2.4.0"
@@ -10178,9 +10170,9 @@
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.1.3.tgz",
-      "integrity": "sha512-loco2ctrrMQzdpSHbcOo6+Ecp21BV67cQ2pNGhuVKAexruu01RdLn3LgtK47B9BpLz3cUD6U0u1R0rur7xMOOg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.0.tgz",
+      "integrity": "sha512-HYV7dO6pNA2nGKawygaBpk8y+vXOUjjzzO43W/Kb7EPRmXUEQKjHxPYRvQbiF72u1N3XxwGK5jnnFk9WVhUwYw==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-inspect": "1.0.0",
@@ -10248,9 +10240,9 @@
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.1.3.tgz",
-      "integrity": "sha512-loco2ctrrMQzdpSHbcOo6+Ecp21BV67cQ2pNGhuVKAexruu01RdLn3LgtK47B9BpLz3cUD6U0u1R0rur7xMOOg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.0.tgz",
+      "integrity": "sha512-HYV7dO6pNA2nGKawygaBpk8y+vXOUjjzzO43W/Kb7EPRmXUEQKjHxPYRvQbiF72u1N3XxwGK5jnnFk9WVhUwYw==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-inspect": "1.0.0",
@@ -11280,9 +11272,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
-      "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
@@ -11375,12 +11367,12 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
-      "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+      "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
       "dev": true,
       "dependencies": {
-        "@octokit/openapi-types": "^22.1.0"
+        "@octokit/openapi-types": "^22.2.0"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -14040,18 +14032,18 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.1.4.tgz",
-      "integrity": "sha512-FA+BVYbb9Pej4Md6vNiuUiXA9VZpQs4u5pzOhzfWgpsBZRE6Z0RMfMFg6tcW2dvSxjk2DX1s6l8v+9gqqKsA5Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.2.0.tgz",
+      "integrity": "sha512-mpQN+J5Dd1hC8lolPo1KuHST7mRwtNiEd821c9whgf46gr5gpkE+yP9ta4YUYzN+hv60n7c0cAbu/2e6nSLtOA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/analytics": "7.0.28",
-        "@aws-amplify/api": "6.0.30",
-        "@aws-amplify/auth": "6.2.1",
-        "@aws-amplify/core": "6.0.28",
-        "@aws-amplify/datastore": "5.0.30",
-        "@aws-amplify/notifications": "2.0.28",
-        "@aws-amplify/storage": "6.3.1",
+        "@aws-amplify/analytics": "7.0.29",
+        "@aws-amplify/api": "6.0.31",
+        "@aws-amplify/auth": "6.2.2",
+        "@aws-amplify/core": "6.1.0",
+        "@aws-amplify/datastore": "5.0.31",
+        "@aws-amplify/notifications": "2.0.29",
+        "@aws-amplify/storage": "6.4.0",
         "tslib": "^2.5.0"
       }
     },
@@ -14114,9 +14106,9 @@
       "dev": true
     },
     "node_modules/aws-cdk": {
-      "version": "2.139.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.139.0.tgz",
-      "integrity": "sha512-MjMsySQbhR5yTWCphnuVQuS15UdGMV6v4XIM+C8SN7/eUOfv7BFr7QgYMUm5WXCG/f66RnY0zjJbOLRxvcjCrQ==",
+      "version": "2.139.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.139.1.tgz",
+      "integrity": "sha512-EKnhoF02puYbZFKmj3oZrzOKIi3nplH6pOfg0h0ICUBBg5wY45C8nDqTUm34YGcgQS42mLywnPn4BW9HO7aKWw==",
       "peer": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -14129,9 +14121,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.139.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.139.0.tgz",
-      "integrity": "sha512-G9yoc+VFwF10kpgf4omtrAVmUNPeAP708oF5fc7XlRTzoTXMmAdUJW9cRGOMtAkFY83SxiJP0wm8n5Z9tjAdUA==",
+      "version": "2.139.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.139.1.tgz",
+      "integrity": "sha512-Nn2VUpVY1zh5ipV3QEyAIZ9lSXF1p7mnB1mqEffWxYnrX6TUQs/eJY7IrqAEnCaVFAhJpGJzTw/wRXTtBjWObg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -14525,9 +14517,9 @@
       "dev": true
     },
     "node_modules/aws-sdk": {
-      "version": "2.1608.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1608.0.tgz",
-      "integrity": "sha512-qqmKS6PRNTRO+O3ZVp9+tvB6asy5uRYDpR6AhSrnhu46JtDpI47aB/O9vyykqQf3JsFu0loinDJjl2hxQoal9A==",
+      "version": "2.1609.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1609.0.tgz",
+      "integrity": "sha512-l5RiTld8f0AtxgSN2hXkuM/PPD04UHm4yfnJR6NpuQ+VSCl9RQfdNFUlnnVrJPd2hcoq/qz/gQiBVPjFqGAZwQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -15298,9 +15290,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001612",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
-      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
+      "version": "1.0.30001614",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001614.tgz",
+      "integrity": "sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==",
       "funding": [
         {
           "type": "opencollective",
@@ -15503,6 +15495,9 @@
       "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.1.tgz",
       "integrity": "sha512-dYFdjLb7y1ajfxQopN05mylEpK9ZX0sO1/RfMXdfmwjlIsPkbh4p7A682x++zFPLDCo1x3p82dtljHf5cW2LKA==",
       "dev": true,
+      "workspaces": [
+        "website"
+      ],
       "dependencies": {
         "typanion": "^3.8.0"
       },
@@ -16351,9 +16346,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.750",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.750.tgz",
-      "integrity": "sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA=="
+      "version": "1.4.751",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.751.tgz",
+      "integrity": "sha512-2DEPi++qa89SMGRhufWTiLmzqyuGmNF3SK4+PQetW1JKiZdEpF4XQonJXJCzyuYSA6mauiMhbyVhqYAP45Hvfw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -16392,9 +16387,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.12.0.tgz",
-      "integrity": "sha512-Iw9rQJBGpJRd3rwXm9ft/JiGoAZmLxxJZELYDQoPRZ4USVhkKtIcNBPw6U+/K2mBpaqM25JSV6Yl4Az9vO2wJg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
+      "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
       "bin": {
         "envinfo": "dist/cli.js"
       },
@@ -18227,7 +18222,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -18474,11 +18468,12 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dependencies": {
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18842,7 +18837,6 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -20624,7 +20618,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -20633,7 +20626,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -21570,9 +21562,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.1.tgz",
-      "integrity": "sha512-tS24spDe/zXhWbNPErCHs/AGOzbKGHT+ybSBqmdLm8WZ1xXLWvH8Qn71QPAlqVhd0qUTWjy+Kl9JmISgDdEjsA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -23929,9 +23921,9 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
@@ -24258,7 +24250,10 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
       "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
-      "dev": true
+      "dev": true,
+      "workspaces": [
+        "website"
+      ]
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -25256,7 +25251,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
       "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -25403,9 +25397,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.4.tgz",
-      "integrity": "sha512-/AtWOKbBgjzEYYQRNfoGKHObgfAZag6qUJX1VbHo2PRBgS+wfWagEY2mizjfyAPcGesrJOcx/wcl0L9WnVrHFw==",
+      "version": "3.23.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.5.tgz",
+      "integrity": "sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -25431,17 +25425,17 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^0.7.0",
-        "@aws-amplify/backend-data": "^0.13.0",
+        "@aws-amplify/backend-data": "^0.14.0",
         "@aws-amplify/backend-function": "^0.9.1",
         "@aws-amplify/backend-output-schemas": "^0.7.0",
         "@aws-amplify/backend-output-storage": "^0.4.1",
         "@aws-amplify/backend-secret": "^0.4.6",
         "@aws-amplify/backend-storage": "^0.7.1",
-        "@aws-amplify/client-config": "^0.9.5",
+        "@aws-amplify/client-config": "^0.9.6",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^0.5.1",
         "@aws-amplify/plugin-types": "^0.10.0",
@@ -25478,7 +25472,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0",
@@ -25612,19 +25606,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.6.0",
         "@aws-amplify/backend-output-schemas": "^0.7.0",
         "@aws-amplify/backend-secret": "^0.4.6",
         "@aws-amplify/cli-core": "^0.6.0",
-        "@aws-amplify/client-config": "^0.9.5",
+        "@aws-amplify/client-config": "^0.9.6",
         "@aws-amplify/deployed-backend-client": "^0.4.2",
         "@aws-amplify/form-generator": "^0.10.0",
         "@aws-amplify/model-generator": "^0.7.1",
         "@aws-amplify/platform-core": "^0.5.1",
-        "@aws-amplify/sandbox": "^0.6.1",
+        "@aws-amplify/sandbox": "^0.6.2",
         "@aws-amplify/schema-generator": "^0.2.1",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -25642,8 +25636,8 @@
         "zod": "^3.22.2"
       },
       "bin": {
-        "amplify": "lib/backend.js",
-        "ampx": "lib/backend.js"
+        "amplify": "lib/ampx.js",
+        "ampx": "lib/ampx.js"
       },
       "devDependencies": {
         "@types/envinfo": "^7.8.3",
@@ -25757,7 +25751,7 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.7.0",
@@ -25932,14 +25926,14 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
         "@aws-amplify/auth-construct": "^0.7.1",
-        "@aws-amplify/backend": "^0.14.0",
+        "@aws-amplify/backend": "^0.15.0",
         "@aws-amplify/backend-secret": "^0.4.6",
-        "@aws-amplify/client-config": "^0.9.5",
+        "@aws-amplify/client-config": "^0.9.6",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^0.5.1",
         "@aws-sdk/client-amplify": "^3.465.0",
@@ -26152,13 +26146,13 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^0.6.0",
         "@aws-amplify/backend-secret": "^0.4.6",
         "@aws-amplify/cli-core": "^0.6.0",
-        "@aws-amplify/client-config": "^0.9.5",
+        "@aws-amplify/client-config": "^0.9.6",
         "@aws-amplify/deployed-backend-client": "^0.4.2",
         "@aws-amplify/platform-core": "^0.5.1",
         "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -19,7 +19,7 @@ type GenerateFormsCommandOptionsCamelCase = {
 };
 
 /**
- * Command that generates client config.
+ * Command that generates UI forms.
  */
 export class GenerateFormsCommand
   implements CommandModule<object, GenerateFormsCommandOptions>
@@ -35,7 +35,7 @@ export class GenerateFormsCommand
   readonly describe: string;
 
   /**
-   * Creates client config generation command.
+   * Creates UI forms generation command.
    */
   constructor(
     private readonly backendIdentifierResolver: BackendIdentifierResolver,

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
@@ -57,7 +57,7 @@ const DEFAULT_TYPE_TARGET_FOR_STATEMENT_TARGET: Record<
 };
 
 /**
- * Command that generates client config.
+ * Command that generates graphql client code.
  */
 export class GenerateGraphqlClientCodeCommand
   implements CommandModule<object, GenerateGraphqlClientCodeCommandOptions>

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -182,7 +182,7 @@ void describe('generate outputs command', () => {
 
   void it('can generate legacy config in json mobile format', async () => {
     await commandRunner.runCommand(
-      'outputs --stack stack_name --config-version 0 --out-dir foo/bar --format json-mobile'
+      'outputs --stack stack_name --outputs-version 0 --out-dir foo/bar --format json-mobile'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -200,7 +200,7 @@ void describe('generate outputs command', () => {
 
   void it('can generate legacy config in ts format', async () => {
     await commandRunner.runCommand(
-      'outputs --stack stack_name --config-version 0 --out-dir foo/bar --format ts'
+      'outputs --stack stack_name --outputs-version 0 --out-dir foo/bar --format ts'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -218,7 +218,7 @@ void describe('generate outputs command', () => {
 
   void it('can generate legacy config in mjs format', async () => {
     await commandRunner.runCommand(
-      'outputs --stack stack_name --config-version 0 --out-dir foo/bar --format mjs'
+      'outputs --stack stack_name --outputs-version 0 --out-dir foo/bar --format mjs'
     );
     assert.equal(generateClientConfigMock.mock.callCount(), 1);
     assert.deepStrictEqual(

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -18,7 +18,7 @@ type GenerateOutputsCommandOptionsCamelCase = {
   branch: string | undefined;
   format: ClientConfigFormat | undefined;
   outDir: string | undefined;
-  configVersion: string;
+  outputsVersion: string;
 };
 
 /**
@@ -64,7 +64,7 @@ export class GenerateOutputsCommand
 
     await this.clientConfigGenerator.generateClientConfigToFile(
       backendIdentifier,
-      args.configVersion as ClientConfigVersion,
+      args.outputsVersion as ClientConfigVersion,
       args.outDir,
       args.format
     );
@@ -109,7 +109,7 @@ export class GenerateOutputsCommand
         type: 'string',
         array: false,
       })
-      .option('config-version', {
+      .option('outputs-version', {
         describe:
           'Version of the configuration. Version 0 represents classic amplify-cli config file amplify-configuration and 1 represents newer config file amplify_outputs',
         type: 'string',

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -16,8 +16,8 @@ export type PipelineDeployCommandOptions =
 type PipelineDeployCommandOptionsCamelCase = {
   branch: string;
   appId: string;
-  configVersion: string;
-  configOutDir?: string;
+  outputsVersion: string;
+  outputsOutDir?: string;
 };
 
 /**
@@ -71,8 +71,8 @@ export class PipelineDeployCommand
     });
     await this.clientConfigGenerator.generateClientConfigToFile(
       backendId,
-      args.configVersion as ClientConfigVersion,
-      args.configOutDir
+      args.outputsVersion as ClientConfigVersion,
+      args.outputsOutDir
     );
   };
 
@@ -91,15 +91,15 @@ export class PipelineDeployCommand
         type: 'string',
         array: false,
       })
-      .option('config-out-dir', {
+      .option('outputs-out-dir', {
         describe:
-          'A path to directory where config is written. If not provided defaults to current process working directory.',
+          'A path to directory where amplify_outputs is written. If not provided defaults to current process working directory.',
         type: 'string',
         array: false,
       })
-      .option('config-version', {
+      .option('outputs-version', {
         describe:
-          'Version of the client config. Version 0 represents classic amplify-cli client config (Default)',
+          'Version of the configuration. Version 0 represents classic amplify-cli config file amplify-configuration and 1 represents newer config file amplify_outputs',
         type: 'string',
         array: false,
         choices: Object.values(ClientConfigVersionOption),

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -115,8 +115,8 @@ void describe('sandbox command', () => {
     assert.match(output, /--identifier/);
     assert.match(output, /--dir-to-watch/);
     assert.match(output, /--exclude/);
-    assert.match(output, /--config-format/);
-    assert.match(output, /--config-out-dir/);
+    assert.match(output, /--outputs-format/);
+    assert.match(output, /--outputs-out-dir/);
     assert.match(output, /--once/);
     assert.equal(mockHandleProfile.mock.callCount(), 0);
   });
@@ -280,7 +280,7 @@ void describe('sandbox command', () => {
   void it('starts sandbox if a value containing "." is provided for config-out-dir', async () => {
     // this is a valid case to maintain consistency with behaviors of ampx generate graphql-client-code/forms
     await commandRunner.runCommand(
-      'sandbox --config-out-dir existentFile.json'
+      'sandbox --outputs-out-dir existentFile.json'
     );
     assert.equal(sandboxStartMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -294,7 +294,7 @@ void describe('sandbox command', () => {
       isDirectory: () => true,
     }));
     await commandRunner.runCommand(
-      'sandbox --config-out-dir existentDir --config-format dart'
+      'sandbox --outputs-out-dir existentDir --outputs-format dart'
     );
     assert.equal(sandboxStartMock.mock.callCount(), 1);
     assert.deepStrictEqual(
@@ -306,7 +306,7 @@ void describe('sandbox command', () => {
   void it('sandbox creates an empty client config file if one does not already exist for version 0', async (contextual) => {
     contextual.mock.method(fs, 'existsSync', () => false);
     const writeFileMock = contextual.mock.method(fsp, 'writeFile', () => true);
-    await commandRunner.runCommand('sandbox --config-version 0');
+    await commandRunner.runCommand('sandbox --outputs-version 0');
     assert.equal(sandboxStartMock.mock.callCount(), 1);
     assert.equal(writeFileMock.mock.callCount(), 1);
     assert.deepStrictEqual(writeFileMock.mock.calls[0].arguments[1], '{}');
@@ -319,7 +319,7 @@ void describe('sandbox command', () => {
   void it('sandbox creates an empty client config file if one does not already exist for version 1', async (contextual) => {
     contextual.mock.method(fs, 'existsSync', () => false);
     const writeFileMock = contextual.mock.method(fsp, 'writeFile', () => true);
-    await commandRunner.runCommand('sandbox --config-version 1');
+    await commandRunner.runCommand('sandbox --outputs-version 1');
     assert.equal(sandboxStartMock.mock.callCount(), 1);
     assert.equal(writeFileMock.mock.callCount(), 1);
     assert.deepStrictEqual(

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -22,9 +22,9 @@ export type SandboxCommandOptionsKebabCase = ArgumentsKebabCase<
   {
     dirToWatch: string | undefined;
     exclude: string[] | undefined;
-    configFormat: ClientConfigFormat | undefined;
-    configOutDir: string | undefined;
-    configVersion: string;
+    outputsFormat: ClientConfigFormat | undefined;
+    outputsOutDir: string | undefined;
+    outputsVersion: string;
     once: boolean | undefined;
   } & SandboxCommandGlobalOptions
 >;
@@ -91,9 +91,9 @@ export class SandboxCommand
     // attaching event handlers
     const clientConfigLifecycleHandler = new ClientConfigLifecycleHandler(
       this.clientConfigGeneratorAdapter,
-      args.configVersion as ClientConfigVersion,
-      args.configOutDir,
-      args.configFormat
+      args.outputsVersion as ClientConfigVersion,
+      args.outputsOutDir,
+      args.outputsFormat
     );
     const eventHandlers = this.sandboxEventHandlerCreator?.({
       sandboxIdentifier: this.sandboxIdentifier,
@@ -106,19 +106,19 @@ export class SandboxCommand
     }
     const watchExclusions = args.exclude ?? [];
     const fileName = getClientConfigFileName(
-      args.configVersion as ClientConfigVersion
+      args.outputsVersion as ClientConfigVersion
     );
     const clientConfigWritePath = await getClientConfigPath(
       fileName,
-      args.configOutDir,
-      args.configFormat
+      args.outputsOutDir,
+      args.outputsFormat
     );
 
     if (!fs.existsSync(clientConfigWritePath)) {
       await generateEmptyClientConfigToFile(
-        args.configVersion as ClientConfigVersion,
-        args.configOutDir,
-        args.configFormat
+        args.outputsVersion as ClientConfigVersion,
+        args.outputsOutDir,
+        args.outputsFormat
       );
     }
 
@@ -162,24 +162,25 @@ export class SandboxCommand
           type: 'string',
           array: false,
         })
-        .option('config-format', {
-          describe: 'Client config output format',
+        .option('outputs-format', {
+          describe: 'amplify_outputs file format',
           type: 'string',
           array: false,
           choices: Object.values(ClientConfigFormat),
           global: false,
         })
-        .option('config-version', {
-          describe: 'Client config format version',
+        .option('outputs-version', {
+          describe:
+            'Version of the configuration. Version 0 represents classic amplify-cli config file amplify-configuration and 1 represents newer config file amplify_outputs',
           type: 'string',
           array: false,
           choices: Object.values(ClientConfigVersionOption),
           global: false,
           default: DEFAULT_CLIENT_CONFIG_VERSION,
         })
-        .option('config-out-dir', {
+        .option('outputs-out-dir', {
           describe:
-            'A path to directory where config is written. If not provided defaults to current process working directory.',
+            'A path to directory where amplify_outputs is written. If not provided defaults to current process working directory.',
           type: 'string',
           array: false,
           global: false,


### PR DESCRIPTION
Rename all the config generation options to have `outputs` instead of `config` in it.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
