### PR TITLE
fix: gracefully fail on usage data emit failure

### DIFF
--- a/.changeset/six-deers-sin.md
+++ b/.changeset/six-deers-sin.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+gracefully exit on usage data emit failure

--- a/packages/cli/src/error_handler.ts
+++ b/packages/cli/src/error_handler.ts
@@ -112,38 +112,23 @@ const handleError = async ({
   printMessagePreamble?.();
 
   if (error instanceof AmplifyError) {
-    try {
-      await usageDataEmitter?.emitFailure(error, {
-        command: command ?? 'UnknownCommand',
-      });
-    } finally {
-      printer.print(format.error(`${error.name}: ${error.message}`));
+    printer.print(format.error(`${error.name}: ${error.message}`));
 
-      if (error.resolution) {
-        printer.print(`Resolution: ${error.resolution}`);
-      }
-      if (error.details) {
-        printer.print(`Details: ${error.details}`);
-      }
-      if (errorHasCauseMessage(error)) {
-        printer.print(`Cause: ${error.cause.message}`);
-      }
+    if (error.resolution) {
+      printer.print(`Resolution: ${error.resolution}`);
+    }
+    if (error.details) {
+      printer.print(`Details: ${error.details}`);
+    }
+    if (errorHasCauseMessage(error)) {
+      printer.print(`Cause: ${error.cause.message}`);
     }
   } else {
     // non-Amplify Error object
-    try {
-      await usageDataEmitter?.emitFailure(
-        AmplifyError.fromError(
-          error && error instanceof Error ? error : new Error(message)
-        ),
-        { command: command ?? 'UnknownCommand' }
-      );
-    } finally {
-      printer.print(format.error(message || String(error)));
+    printer.print(format.error(message || String(error)));
 
-      if (errorHasCauseMessage(error)) {
-        printer.print(`Cause: ${error.cause.message}`);
-      }
+    if (errorHasCauseMessage(error)) {
+      printer.print(`Cause: ${error.cause.message}`);
     }
   }
 
@@ -154,6 +139,15 @@ const handleError = async ({
   if (errorHasCauseStackTrace(error)) {
     printer.log(error.cause.stack, LogLevel.DEBUG);
   }
+
+  await usageDataEmitter?.emitFailure(
+    error instanceof AmplifyError
+      ? error
+      : AmplifyError.fromError(
+          error && error instanceof Error ? error : new Error(message)
+        ),
+    { command: command ?? 'UnknownCommand' }
+  );
 };
 
 const isUserForceClosePromptError = (err?: Error): boolean => {

--- a/packages/cli/src/error_handler.ts
+++ b/packages/cli/src/error_handler.ts
@@ -112,32 +112,38 @@ const handleError = async ({
   printMessagePreamble?.();
 
   if (error instanceof AmplifyError) {
-    await usageDataEmitter?.emitFailure(error, {
-      command: command ?? 'UnknownCommand',
-    });
-    printer.print(format.error(`${error.name}: ${error.message}`));
+    try {
+      await usageDataEmitter?.emitFailure(error, {
+        command: command ?? 'UnknownCommand',
+      });
+    } finally {
+      printer.print(format.error(`${error.name}: ${error.message}`));
 
-    if (error.resolution) {
-      printer.print(`Resolution: ${error.resolution}`);
-    }
-    if (error.details) {
-      printer.print(`Details: ${error.details}`);
-    }
-    if (errorHasCauseMessage(error)) {
-      printer.print(`Cause: ${error.cause.message}`);
+      if (error.resolution) {
+        printer.print(`Resolution: ${error.resolution}`);
+      }
+      if (error.details) {
+        printer.print(`Details: ${error.details}`);
+      }
+      if (errorHasCauseMessage(error)) {
+        printer.print(`Cause: ${error.cause.message}`);
+      }
     }
   } else {
     // non-Amplify Error object
-    await usageDataEmitter?.emitFailure(
-      AmplifyError.fromError(
-        error && error instanceof Error ? error : new Error(message)
-      ),
-      { command: command ?? 'UnknownCommand' }
-    );
-    printer.print(format.error(message || String(error)));
+    try {
+      await usageDataEmitter?.emitFailure(
+        AmplifyError.fromError(
+          error && error instanceof Error ? error : new Error(message)
+        ),
+        { command: command ?? 'UnknownCommand' }
+      );
+    } finally {
+      printer.print(format.error(message || String(error)));
 
-    if (errorHasCauseMessage(error)) {
-      printer.print(`Cause: ${error.cause.message}`);
+      if (errorHasCauseMessage(error)) {
+        printer.print(`Cause: ${error.cause.message}`);
+      }
     }
   }
 

--- a/packages/platform-core/src/usage-data/usage_data_emitter.ts
+++ b/packages/platform-core/src/usage-data/usage_data_emitter.ts
@@ -55,7 +55,6 @@ export class DefaultUsageDataEmitter implements UsageDataEmitter {
     dimensions?: Record<string, string>;
     error?: AmplifyError;
   }) => {
-    
     return {
       accountId: await this.accountIdFetcher.fetch(),
       sessionUuid: this.sessionUuid,

--- a/packages/platform-core/src/usage-data/usage_data_emitter.ts
+++ b/packages/platform-core/src/usage-data/usage_data_emitter.ts
@@ -55,6 +55,7 @@ export class DefaultUsageDataEmitter implements UsageDataEmitter {
     dimensions?: Record<string, string>;
     error?: AmplifyError;
   }) => {
+    
     return {
       accountId: await this.accountIdFetcher.fetch(),
       sessionUuid: this.sessionUuid,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
UsageDataEmitter needs credential to emit metrics and will throw. This is resulting in an infinite loop

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes
Gracefully handle the emit failure.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
