### PR TITLE
major version bump to 1.x

### DIFF
--- a/.changeset/rotten-ducks-invent.md
+++ b/.changeset/rotten-ducks-invent.md
@@ -1,0 +1,26 @@
+---
+'@aws-amplify/auth-construct': major
+'@aws-amplify/backend': major
+'@aws-amplify/backend-auth': major
+'@aws-amplify/backend-data': major
+'@aws-amplify/backend-deployer': major
+'@aws-amplify/backend-function': major
+'@aws-amplify/backend-output-schemas': major
+'@aws-amplify/backend-output-storage': major
+'@aws-amplify/backend-platform-test-stubs': major
+'@aws-amplify/backend-secret': major
+'@aws-amplify/backend-storage': major
+'@aws-amplify/backend-cli': major
+'@aws-amplify/cli-core': major
+'@aws-amplify/client-config': major
+'create-amplify': major
+'@aws-amplify/deployed-backend-client': major
+'@aws-amplify/form-generator': major
+'@aws-amplify/model-generator': major
+'@aws-amplify/platform-core': major
+'@aws-amplify/plugin-types': major
+'@aws-amplify/sandbox': major
+'@aws-amplify/schema-generator': major
+---
+
+Major version bump for all public pacakges.

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -318,6 +318,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # version 3.6.0
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_install_cache
+      - run: npx changeset version
       - run: npm run check:package-versions
 
   update_package_versions:


### PR DESCRIPTION
Major version bump for all public packages in the repo. Except for the `ampx` package which I am leaving at 0.x because it is not intended to be used and we aren't sure how it might evolve at this point.