### PR TITLE
chore: lint ignore test-projects directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,6 +9,7 @@ API.md
 examples
 verdaccio-cache
 expected-cdk-out
+test-projects
 
 #auto generated files
 packages/client-config/src/client-config-schema


### PR DESCRIPTION
## Problem
Running linter scripts fail for local test projects created by `npm run setup:test-project`

**Issue number, if available:**

## Changes
The local projects are not tracked or part of this repo. No need to run linter for external code.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->


## Validation
Confirmed that linter ignored files under test-projects.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
