### PR TITLE
Run e2e tests on schedule

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -10,6 +10,8 @@ on:
       - main
       - hotfix
       - feature/**
+  schedule:
+    - cron: '0 12 * * *' # Every day 12:00 UTC
   workflow_dispatch:
 
 jobs:
@@ -133,6 +135,7 @@ jobs:
       run_e2e: ${{ steps.check.outputs.run_e2e }}
     steps:
       # if this workflow is running on a push (ie merge to main), then e2e tests always run
+      # if this workflow is running on a schedule, then e2e tests always run
       # if this workflow is triggered manually, then e2e tests always run
       # if the workflow is running on a pull request, we perform an additional check for the run-e2e label
       # this is not a security measure (that is already handled by the pull_request event behavior) but rather a way for PR authors to easily check e2e test results if they wish
@@ -140,7 +143,7 @@ jobs:
       - name: Check event is push to main or pull request has run-e2e label
         id: check
         run: |
-          if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]] || gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r '.labels[].name' | grep run-e2e --quiet; then
+          if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]] || [[ ${{ github.event_name }} == 'schedule' ]] || gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r '.labels[].name' | grep run-e2e --quiet; then
             echo setting run_e2e to true;
             echo "run_e2e=true" >> "$GITHUB_OUTPUT";
           else
@@ -163,12 +166,19 @@ jobs:
         id: get_baseline_commit_sha
         run: |
           if [[ ${{ github.event_name }} == 'push' ]]; then
-            echo baseline commit sha is ${{ github.event.before }};
-            echo "baseline_commit_sha=${{ github.event.before }}" >> "$GITHUB_OUTPUT";
+            # The SHA of the most recent commit on ref before the push.
+            baseline_commit_sha="${{ github.event.before }}"
           elif [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo baseline commit sha is ${{ github.event.pull_request.base.sha }};
-            echo "baseline_commit_sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT";
+            # The SHA of the HEAD commit on base branch.
+            baseline_commit_sha="${{ github.event.pull_request.base.sha }}"
+          elif [[ ${{ github.event_name }} == 'schedule' ]]; then
+            # The SHA of the parent of HEAD commit on main branch.
+            # This assumes linear history of main branch, i.e. one parent.
+            # The schedule event has only information about HEAD commit, hence the need for lookup.
+            baseline_commit_sha=$(gh search commits --repo ${{ github.repository }} --hash ${{ github.event.workflow_run.head_sha }} --json parents --jq '.[0].parents[0].sha')
           fi
+          echo baseline commit sha is $baseline_commit_sha;
+          echo "baseline_commit_sha=$baseline_commit_sha" >> "$GITHUB_OUTPUT";
       - name: Checkout baseline version
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
         with:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -176,6 +176,9 @@ jobs:
             # This assumes linear history of main branch, i.e. one parent.
             # The schedule event has only information about HEAD commit, hence the need for lookup.
             baseline_commit_sha=$(gh search commits --repo ${{ github.repository }} --hash ${{ github.event.workflow_run.head_sha }} --json parents --jq '.[0].parents[0].sha')
+          else
+            echo Unable to determine baseline commit sha;
+            exit 1;
           fi
           echo baseline commit sha is $baseline_commit_sha;
           echo "baseline_commit_sha=$baseline_commit_sha" >> "$GITHUB_OUTPUT";

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -171,10 +171,10 @@ jobs:
           elif [[ ${{ github.event_name }} == 'pull_request' ]]; then
             # The SHA of the HEAD commit on base branch.
             baseline_commit_sha="${{ github.event.pull_request.base.sha }}"
-          elif [[ ${{ github.event_name }} == 'schedule' ]]; then
+          elif [[ ${{ github.event_name }} == 'schedule' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             # The SHA of the parent of HEAD commit on main branch.
             # This assumes linear history of main branch, i.e. one parent.
-            # The schedule event has only information about HEAD commit, hence the need for lookup.
+            # These events have only information about HEAD commit, hence the need for lookup.
             baseline_commit_sha=$(gh search commits --repo ${{ github.repository }} --hash ${{ github.event.workflow_run.head_sha }} --json parents --jq '.[0].parents[0].sha')
           else
             echo Unable to determine baseline commit sha;


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

We run "shallow canaries" here https://github.com/aws-amplify/amplify-backend/actions/workflows/canary_checks.yml .
But we don't run "deep canaries" out of bound.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

This PR introduces scheduled run of full `health_checks` workflow (minus publish/version PR steps).
This workflow will execute daily and run full suite of e2e tests.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
