### PR TITLE
refactor run e2e check; when running on hotfix, only run on version package commits

### DIFF
--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -62,6 +62,7 @@
   "graphql",
   "grey",
   "homedir",
+  "hotfix",
   "hotswap",
   "hotswapped",
   "iamv2",

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -131,7 +131,7 @@ jobs:
       # This is required so that the step can read the labels on the pull request
       pull-requests: read
     env:
-      # The gh cli expects the token at this environment variable
+      # The do_include_e2e script needs to query pull request labels
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       run_e2e: ${{ steps.check.outputs.run_e2e }}

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -138,6 +138,7 @@ jobs:
       - name: Check if E2E tests should run
         id: check
         run: echo "run_e2e=$(npx tsx scripts/do_include_e2e.ts)" >> "$GITHUB_OUTPUT"
+      - run: echo run_e2e set to ${{ steps.check.outputs.run_e2e }}
   e2e_iam_access_drift:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -130,7 +130,7 @@ jobs:
       pull-requests: read
     env:
       # The gh cli expects the token at this environment variable
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       run_e2e: ${{ steps.check.outputs.run_e2e }}
     steps:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -122,6 +122,8 @@ jobs:
           mkdir api-validation-projects
           npx tsx scripts/check_api_changes.ts base-branch-content api-validation-projects
   do_include_e2e:
+    needs:
+      - install
     runs-on: ubuntu-latest
     permissions:
       # This is required so that the step can read the labels on the pull request
@@ -132,21 +134,10 @@ jobs:
     outputs:
       run_e2e: ${{ steps.check.outputs.run_e2e }}
     steps:
-      # if this workflow is running on a push (ie merge to main), then e2e tests always run
-      # if this workflow is triggered manually, then e2e tests always run
-      # if the workflow is running on a pull request, we perform an additional check for the run-e2e label
-      # this is not a security measure (that is already handled by the pull_request event behavior) but rather a way for PR authors to easily check e2e test results if they wish
-      # the reason it doesn't run all the time is because it will always fail for external contributor PRs (they don't have access to repo secrets) and we don't want to waste resources running e2e on every PR commit
-      - name: Check event is push to main or pull request has run-e2e label
+      - uses: ./.github/actions/restore_install_cache
+      - name: Check if E2E tests should run
         id: check
-        run: |
-          if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]] || gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r '.labels[].name' | grep run-e2e --quiet; then
-            echo setting run_e2e to true;
-            echo "run_e2e=true" >> "$GITHUB_OUTPUT";
-          else
-            echo setting run_e2e to false;
-            echo "run_e2e=false" >> "$GITHUB_OUTPUT";
-          fi
+        run: echo "run_e2e=$(npx tsx scripts/do_include_e2e.ts)" >> "$GITHUB_OUTPUT"
   e2e_iam_access_drift:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
@@ -422,7 +413,7 @@ jobs:
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_install_cache
       - id: is_version_packages_commit
-        run: npx tsx scripts/is_version_packages_commit.ts "$GITHUB_EVENT_PATH" >> "$GITHUB_OUTPUT"
+        run: echo "is_version_packages_commit=$(npx tsx scripts/is_version_packages_commit.ts)" >> "$GITHUB_OUTPUT"
       - name: Create or update Version Packages PR
         # if this push is NOT merging a version packages PR, then we update/create the version packages PR
         if: ${{ steps.is_version_packages_commit.outputs.is_version_packages_commit == 'false' }}
@@ -448,7 +439,7 @@ jobs:
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
       - id: is_version_packages_commit
-        run: npx tsx scripts/is_version_packages_commit.ts "$GITHUB_EVENT_PATH" >> "$GITHUB_OUTPUT"
+        run: echo "is_version_packages_commit=$(npx tsx scripts/is_version_packages_commit.ts)" >> "$GITHUB_OUTPUT"
       - name: Publish packages
         # if this push is merging a version packages PR, then we publish the new versions
         if: ${{ steps.is_version_packages_commit.outputs.is_version_packages_commit == 'true' }}

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -134,6 +134,8 @@ jobs:
     outputs:
       run_e2e: ${{ steps.check.outputs.run_e2e }}
     steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
+      - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_install_cache
       - name: Check if E2E tests should run
         id: check

--- a/scripts/components/github_client.ts
+++ b/scripts/components/github_client.ts
@@ -49,6 +49,14 @@ export class GithubClient {
       pullRequestNumber: prResult.data.number,
     };
   };
+
+  fetchPullRequest = async (pullRequestNumber: number) => {
+    const response = await this.ghClient.pulls.get({
+      pull_number: pullRequestNumber,
+      ...ghContext.repo,
+    });
+    return response.data;
+  };
 }
 
 /**

--- a/scripts/components/is_version_packages_commit.ts
+++ b/scripts/components/is_version_packages_commit.ts
@@ -1,0 +1,23 @@
+import { PushEvent } from '@octokit/webhooks-types';
+import { readFile } from 'fs/promises';
+
+/**
+ * Reads the GitHub event using the GITHUB_EVENT_PATH environment variable.
+ * Expects the event payload to be a PushEvent.
+ * Returns true if the push event is a version packages commit, false otherwise.
+ *
+ * See https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+ */
+export const isVersionPackagesCommit = async () => {
+  const githubPushEventPayload = JSON.parse(
+    await readFile(process.env.GITHUB_EVENT_PATH!, 'utf-8')
+  ) as PushEvent;
+
+  const isVersionPackagesCommit =
+    githubPushEventPayload.commits.length === 1 &&
+    githubPushEventPayload.commits[0].author.name.includes(
+      'github-actions[bot]'
+    ) &&
+    githubPushEventPayload.commits[0].message.includes('Version Packages');
+  return isVersionPackagesCommit;
+};

--- a/scripts/do_include_e2e.ts
+++ b/scripts/do_include_e2e.ts
@@ -20,18 +20,21 @@ const prHasRunE2ELabel = async () => {
   return hasRunE2ELabel;
 };
 
-// e2e tests run if...
+const isPushToBranchBesidesHotfix =
+  eventName === 'push' && refName !== 'hotfix';
+const isVersionPackagesPushToHotfix =
+  eventName === 'push' && refName === 'hotfix' && isVersionPackagesCommit();
+
+const isWorkflowTriggeredManually = eventName === 'workflow_dispatch';
+const isWorkflowTriggeredBySchedule = eventName == 'schedule';
+const isPullRequestWithRunE2ELabel = await prHasRunE2ELabel();
+
 const doIncludeE2e =
-  await // this workflow is running on a push to a branch besides hotfix
-  ((eventName === 'push' && refName !== 'hotfix') ||
-    // this workflow is running on a version packages push to hotfix
-    (eventName === 'push' &&
-      refName === 'hotfix' &&
-      isVersionPackagesCommit()) ||
-    // this workflow was triggered manually
-    eventName === 'workflow_dispatch' ||
-    // this workflow is running on a PR with the 'run-e2e' label
-    (await prHasRunE2ELabel()));
+  isPushToBranchBesidesHotfix ||
+  isVersionPackagesPushToHotfix ||
+  isWorkflowTriggeredManually ||
+  isWorkflowTriggeredBySchedule ||
+  isPullRequestWithRunE2ELabel;
 
 // print a true/false of whether e2e tests should run
 console.log(doIncludeE2e);

--- a/scripts/do_include_e2e.ts
+++ b/scripts/do_include_e2e.ts
@@ -1,0 +1,37 @@
+import { context as ghContext } from '@actions/github';
+import { isVersionPackagesCommit } from './components/is_version_packages_commit.js';
+import { GithubClient } from './components/github_client.js';
+
+const { GITHUB_EVENT_NAME: eventName, GITHUB_REF_NAME: refName } = process.env;
+
+const gitHubClient = new GithubClient();
+
+const prHasRunE2ELabel = async () => {
+  if (!ghContext.payload.pull_request) {
+    // event is not a pull request
+    return false;
+  }
+  const prInfo = await gitHubClient.fetchPullRequest(
+    ghContext.payload.pull_request.number
+  );
+  const hasRunE2ELabel = prInfo.labels.some(
+    (label) => label.name === 'run-e2e'
+  );
+  return hasRunE2ELabel;
+};
+
+// e2e tests run if...
+const doIncludeE2e =
+  await // this workflow is running on a push to a branch besides hotfix
+  ((eventName === 'push' && refName !== 'hotfix') ||
+    // this workflow is running on a version packages commit to hotfix
+    (eventName === 'push' &&
+      refName === 'hotfix' &&
+      isVersionPackagesCommit()) ||
+    // this workflow was triggered manually
+    eventName === 'workflow_dispatch' ||
+    // this workflow is running on a PR with the 'run-e2e' label
+    (await prHasRunE2ELabel()));
+
+// print a true/false of whether e2e tests should run
+console.log(doIncludeE2e);

--- a/scripts/do_include_e2e.ts
+++ b/scripts/do_include_e2e.ts
@@ -24,7 +24,7 @@ const prHasRunE2ELabel = async () => {
 const doIncludeE2e =
   await // this workflow is running on a push to a branch besides hotfix
   ((eventName === 'push' && refName !== 'hotfix') ||
-    // this workflow is running on a version packages commit to hotfix
+    // this workflow is running on a version packages push to hotfix
     (eventName === 'push' &&
       refName === 'hotfix' &&
       isVersionPackagesCommit()) ||

--- a/scripts/is_version_packages_commit.ts
+++ b/scripts/is_version_packages_commit.ts
@@ -1,7 +1,4 @@
 import { isVersionPackagesCommit } from './components/is_version_packages_commit.js';
 
-/*
-Prints a true/false of whether the push event is a version packages commit
-*/
-
+// print whether the push event is a version packages commit
 console.log(await isVersionPackagesCommit());

--- a/scripts/is_version_packages_commit.ts
+++ b/scripts/is_version_packages_commit.ts
@@ -1,24 +1,7 @@
-import { readFile } from 'fs/promises';
-import { PushEvent } from '@octokit/webhooks-types';
+import { isVersionPackagesCommit } from './components/is_version_packages_commit.js';
 
 /*
-Reads the GitHub webhook event payload from the specified file path
-Returns a true/false of whether the push event contains one and only one version bump commit
-The result is returned in a form that is intended to be piped to GITHUB_OUTPUT
-See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+Prints a true/false of whether the push event is a version packages commit
 */
 
-const githubPushEventPayloadPath = process.argv[2];
-
-const githubPushEventPayload = JSON.parse(
-  await readFile(githubPushEventPayloadPath, 'utf-8')
-) as PushEvent;
-
-const isVersionPackagesCommit =
-  githubPushEventPayload.commits.length === 1 &&
-  githubPushEventPayload.commits[0].author.name.includes(
-    'github-actions[bot]'
-  ) &&
-  githubPushEventPayload.commits[0].message.includes('Version Packages');
-
-console.log(`is_version_packages_commit=${isVersionPackagesCommit}`);
+console.log(await isVersionPackagesCommit());


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

When releasing from the hotfix branch, we want to be able to get releases out as fast as possible without compromising safety checks. We are currently running e2e tests on all merges to the hotfix branch. This means that for a patch, e2e tests run at least twice: once when the patch is merged and a second time when the version packages PR is merged.

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

To shorten this time, we can update the workflow to only run e2e tests on hotfix version packages merges. This ensures that e2e is still run on any hotfix release payload but doesn't run automatically on the patch merge itself. E2E can still be triggered on the patch PR by applying the `run-e2e` label.

While making this change, I also refactored the run e2e check from bash to TS so that the bash conditional didn't get out of hand

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Will run e2e on this PR to ensure the check still works

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
