### PR TITLE
defensive logic for undefined function env vars

### DIFF
--- a/.changeset/mighty-owls-impress.md
+++ b/.changeset/mighty-owls-impress.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+Throw helpful error message when function environment variable is undefined

--- a/packages/backend-function/src/function_env_translator.test.ts
+++ b/packages/backend-function/src/function_env_translator.test.ts
@@ -116,6 +116,33 @@ void describe('FunctionEnvironmentTranslator', () => {
     });
   });
 
+  void it('ignores undefined env var entries', () => {
+    const functionEnvProp = {
+      TEST_UNDEFINED: undefined as unknown as string,
+      TEST_DEFINED: 'hello',
+    };
+
+    const testLambda = getTestLambda();
+
+    new FunctionEnvironmentTranslator(
+      testLambda,
+      functionEnvProp,
+      backendResolver,
+      new FunctionEnvironmentTypeGenerator(testLambdaName)
+    );
+
+    const template = Template.fromStack(Stack.of(testLambda));
+
+    template.resourceCountIs('AWS::Lambda::Function', 1);
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Environment: {
+        Variables: {
+          TEST_DEFINED: 'hello',
+        },
+      },
+    });
+  });
+
   void it('throws if function prop contains a reserved env name', () => {
     const functionEnvProp = {
       AMPLIFY_SSM_ENV_CONFIG: 'test',

--- a/packages/backend-function/src/function_env_translator.test.ts
+++ b/packages/backend-function/src/function_env_translator.test.ts
@@ -116,7 +116,7 @@ void describe('FunctionEnvironmentTranslator', () => {
     });
   });
 
-  void it('ignores undefined env var entries', () => {
+  void it('throws on undefined env var entries', () => {
     const functionEnvProp = {
       TEST_UNDEFINED: undefined as unknown as string,
       TEST_DEFINED: 'hello',
@@ -124,23 +124,19 @@ void describe('FunctionEnvironmentTranslator', () => {
 
     const testLambda = getTestLambda();
 
-    new FunctionEnvironmentTranslator(
-      testLambda,
-      functionEnvProp,
-      backendResolver,
-      new FunctionEnvironmentTypeGenerator(testLambdaName)
-    );
-
-    const template = Template.fromStack(Stack.of(testLambda));
-
-    template.resourceCountIs('AWS::Lambda::Function', 1);
-    template.hasResourceProperties('AWS::Lambda::Function', {
-      Environment: {
-        Variables: {
-          TEST_DEFINED: 'hello',
-        },
+    assert.throws(
+      () => {
+        new FunctionEnvironmentTranslator(
+          testLambda,
+          functionEnvProp,
+          backendResolver,
+          new FunctionEnvironmentTypeGenerator(testLambdaName)
+        );
       },
-    });
+      {
+        name: 'InvalidFunctionConfiguration',
+      }
+    );
   });
 
   void it('throws if function prop contains a reserved env name', () => {

--- a/packages/backend-function/src/function_env_translator.ts
+++ b/packages/backend-function/src/function_env_translator.ts
@@ -4,6 +4,7 @@ import { FunctionProps } from './factory.js';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { FunctionEnvironmentTypeGenerator } from './function_env_type_generator.js';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 /**
  * Translates function environment props into appropriate environment records and builds a policy statement
@@ -36,7 +37,10 @@ export class FunctionEnvironmentTranslator {
         );
       }
       if (typeof value === 'undefined') {
-        continue;
+        throw new AmplifyUserError('InvalidFunctionConfiguration', {
+          message: `The value of environment variable ${key} is undefined.`,
+          resolution: `Ensure that all defineFunction environment variables are defined.`,
+        });
       } else if (typeof value === 'string') {
         this.lambda.addEnvironment(key, value);
       } else {

--- a/packages/backend-function/src/function_env_translator.ts
+++ b/packages/backend-function/src/function_env_translator.ts
@@ -35,7 +35,11 @@ export class FunctionEnvironmentTranslator {
           `${this.amplifySsmEnvConfigKey} is a reserved environment variable name`
         );
       }
-      if (typeof value !== 'string') {
+      if (typeof value === 'undefined') {
+        continue;
+      } else if (typeof value === 'string') {
+        this.lambda.addEnvironment(key, value);
+      } else {
         const { branchSecretPath, sharedSecretPath } =
           this.backendSecretResolver.resolvePath(value);
         this.lambda.addEnvironment(key, this.ssmValuePlaceholderText);
@@ -44,8 +48,6 @@ export class FunctionEnvironmentTranslator {
           sharedPath: sharedSecretPath,
         };
         this.ssmPaths.push(branchSecretPath, sharedSecretPath);
-      } else {
-        this.lambda.addEnvironment(key, value);
       }
       this.amplifyBackendEnvVarNames.push(key);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

If an undefined value is passed as a function env var to `defineFunction`, the existing logic would try to treat it like a BackendSecret and error out.

**Issue number, if available:**
fixes: https://github.com/aws-amplify/amplify-backend/issues/1460
## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Add defensive logic to check for undefined environment variable values and throw a clear error message.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Added a unit test

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
