### PR TITLE
fix: Correctly generate Gen1 social provider config form Gen2

### DIFF
--- a/.changeset/tidy-dancers-march.md
+++ b/.changeset/tidy-dancers-march.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+Correctly generate Gen1 social provider config form Gen2

--- a/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.test.ts
@@ -59,7 +59,12 @@ void describe('ClientConfigLegacyConverter', () => {
           redirect_sign_in_uri: ['http://callback.com', 'http://callback2.com'],
           redirect_sign_out_uri: ['http://logout.com', 'http://logout2.com'],
           response_type: 'code',
-          identity_providers: ['GOOGLE', 'FACEBOOK'],
+          identity_providers: [
+            'GOOGLE',
+            'FACEBOOK',
+            'LOGIN_WITH_AMAZON',
+            'SIGN_IN_WITH_APPLE',
+          ],
         },
       },
     };
@@ -91,7 +96,7 @@ void describe('ClientConfigLegacyConverter', () => {
         redirectSignOut: 'http://logout.com,http://logout2.com',
         responseType: 'code',
       },
-      aws_cognito_social_providers: ['GOOGLE', 'FACEBOOK'],
+      aws_cognito_social_providers: ['GOOGLE', 'FACEBOOK', 'AMAZON', 'APPLE'],
     };
 
     assert.deepStrictEqual(

--- a/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.ts
@@ -112,7 +112,15 @@ export class ClientConfigLegacyConverter {
       if (clientConfig.auth.oauth) {
         authClientConfig.oauth = {};
         authClientConfig.aws_cognito_social_providers =
-          clientConfig.auth.oauth.identity_providers;
+          clientConfig.auth.oauth.identity_providers.map((provider) => {
+            if (provider === 'SIGN_IN_WITH_APPLE') {
+              return 'APPLE';
+            }
+            if (provider === 'LOGIN_WITH_AMAZON') {
+              return 'AMAZON';
+            }
+            return provider;
+          });
         authClientConfig.oauth.domain = clientConfig.auth.oauth.domain;
         authClientConfig.oauth.scope = clientConfig.auth.oauth.scopes;
         authClientConfig.oauth.redirectSignIn =


### PR DESCRIPTION
Follow up from https://github.com/aws-amplify/amplify-backend/pull/1507

## Changes

Gen1/Legacy config [contains social providers](https://github.com/aws-amplify/amplify-js/blob/24a76474853b8e8d03a27b501fa5462b47f07968/packages/core/src/singleton/Auth/types.ts#L185) as `APPLE` and `AMAZON` while Gen2 is `LOGIN_WITH_AMAZON` and `SIGN_IN_WITH_APPLE`.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
