### PR TITLE
lazy load ssm

### DIFF
--- a/.changeset/afraid-cameras-walk.md
+++ b/.changeset/afraid-cameras-walk.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+fix: lazy load ssm client in backend function banner

--- a/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
+++ b/packages/integration-tests/src/test-in-memory/data_storage_auth_with_triggers.test.ts
@@ -52,6 +52,7 @@ void it('data storage auth with triggers', () => {
   assertExpectedLogicalIds(templates.defaultNodeFunc, 'AWS::Lambda::Function', [
     'defaultNodeFunctionlambda5C194062',
     'echoFunclambdaE17DCA46',
+    'funcWithSsmlambda6A8824A1',
     'handler2lambda1B9C7EFF',
     'node16Functionlambda97ECC775',
     'onUploadlambdaA252C959',

--- a/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
+++ b/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
@@ -194,8 +194,15 @@ class DataStorageAuthWithTriggerTestProject extends TestProjectBase {
       (name) => name.includes('node16Function')
     );
 
+    const funcWithSsm = await this.resourceFinder.findByBackendIdentifier(
+      backendId,
+      'AWS::Lambda::Function',
+      (name) => name.includes('funcWithSsm')
+    );
+
     assert.equal(defaultNodeLambda.length, 1);
     assert.equal(node16Lambda.length, 1);
+    assert.equal(funcWithSsm.length, 1);
 
     const expectedResponse = {
       s3TestContent: 'this is some test content',
@@ -206,6 +213,7 @@ class DataStorageAuthWithTriggerTestProject extends TestProjectBase {
 
     await this.checkLambdaResponse(defaultNodeLambda[0], expectedResponse);
     await this.checkLambdaResponse(node16Lambda[0], expectedResponse);
+    await this.checkLambdaResponse(funcWithSsm[0], 'It is working');
 
     const bucketName = await this.resourceFinder.findByBackendIdentifier(
       backendId,

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/handler_with_ssm.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/handler_with_ssm.ts
@@ -1,0 +1,10 @@
+import { SSM } from '@aws-sdk/client-ssm';
+
+/**
+ * This function asserts that customer can import and use SSM client.
+ * I.e. asserts that the banner we inject doesn't prevent that use case.
+ */
+export const handler = async () => {
+  new SSM();
+  return 'It is working';
+};

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/function.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/function.ts
@@ -34,3 +34,8 @@ export const onUpload = defineFunction({
   name: 'onUpload',
   entry: './func-src/handler.ts',
 });
+
+export const funcWithSsm = defineFunction({
+  name: 'funcWithSsm',
+  entry: './func-src/handler_with_ssm.ts',
+});

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/test_factories.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/test_factories.ts
@@ -1,5 +1,5 @@
 import { data } from './data/resource.js';
-import { defaultNodeFunc, node16Func } from './function.js';
+import { defaultNodeFunc, funcWithSsm, node16Func } from './function.js';
 import { storage } from './storage/resource.js';
 import { auth } from './auth/resource.js';
 
@@ -9,4 +9,5 @@ export const dataStorageAuthWithTriggers = {
   defaultNodeFunc,
   data,
   node16Func,
+  funcWithSsm,
 };

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/hotswap-update-files/function.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/hotswap-update-files/function.ts
@@ -36,3 +36,8 @@ export const onUpload = defineFunction({
   name: 'onUpload',
   entry: './func-src/handler.ts',
 });
+
+export const funcWithSsm = defineFunction({
+  name: 'funcWithSsm',
+  entry: './func-src/handler_with_ssm.ts',
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

There are two problems:
1. Customers can't use SSM in lambdas, as described here https://github.com/aws-amplify/amplify-backend/issues/1520 .
2. AWS SSM client is loaded eagerly even if unused impacting cold start performance.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

This PR attempts to solve these two problems by removing eager import from header.

## Alternatives considered

I was looking at possibility of not rendering a banner conditionally at synthesis time but I hit a problem that SSM entries are processed lazily as well which demanded lazy rendering of banner.
Then it appeared that lazy rendering banner makes esbuild fail, as apparently esbuild runs before CDK tokens are resolved, see screenshot:
![image](https://github.com/aws-amplify/amplify-backend/assets/5849952/4d395077-085a-4ed5-8b45-b861d2879990)


<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
