### PR TITLE
chore: fast fail if loginWith phone is enabled but sms mfa is not

### DIFF
--- a/.changeset/wise-dragons-marry.md
+++ b/.changeset/wise-dragons-marry.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct': patch
+---
+
+chore: fast fail if loginWith phone is enabled but sms mfa is not

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -515,6 +515,41 @@ void describe('Auth construct', () => {
     );
   });
 
+  void it('throws error if sms MFA is not enabled with phone login', () => {
+    assert.throws(
+      () =>
+        new AmplifyAuth(new Stack(new App()), 'test', {
+          loginWith: {
+            phone: true,
+          },
+          multifactor: {
+            mode: 'OPTIONAL',
+            totp: true,
+          },
+        }),
+      {
+        message:
+          'Invalid MFA settings. SMS must be enabled in multiFactor if loginWith phone is enabled',
+      }
+    );
+    assert.throws(
+      () =>
+        new AmplifyAuth(new Stack(new App()), 'test', {
+          loginWith: {
+            phone: true,
+          },
+          multifactor: {
+            mode: 'REQUIRED',
+            totp: true,
+          },
+        }),
+      {
+        message:
+          'Invalid MFA settings. SMS must be enabled in multiFactor if loginWith phone is enabled',
+      }
+    );
+  });
+
   void it('requires email attribute if email is enabled', () => {
     const app = new App();
     const stack = new Stack(app);


### PR DESCRIPTION
## Problem

**Issue number, if available:** fixes #1481 

Currently if `loginWith` has `phone` enabled, cdk [auto enables](https://github.com/aws/aws-cdk/blob/4b6dc8c650822bcd0231c8890bd94a934a0cd34d/packages/aws-cdk-lib/aws-cognito/lib/user-pool.ts#L1160) `smsConfiguration` without which cognito would throw error `SMS configuration is required when phone_number is selected for auto verification`

but enabling `smsConfiguration` then requires MFA sms to be turned on, otherwise it fails with error `Can't turn off SMS_MFA when SMS configuration is set for the user pool`

## Changes

This PR adds a fast fail with clear resolution step on how to recover from this error.

**Corresponding docs PR, if applicable:**

## Validation

unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
