### PR TITLE
test: update health-checks cron

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -11,10 +11,12 @@ on:
       - hotfix
       - feature/**
   schedule:
-    # Every day at 00:00 and 12:00 UTC.
+    # Every day at At minute 0 past hour 0, 6, 12, and 18 UTC.
     # This is to make sure that there is at least one workflow run every 24 hours
-    # taking into account that scheduled runs may not fire at exact prescribed time.
-    - cron: '0 0,12 * * *'
+    # taking into account that
+    # 1) scheduled runs may not fire at exact prescribed time;
+    # 2) transient failures may happen and auto recover;
+    - cron: '0 0,6,12,18 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

We run health check twice per day, so if there's one failure, and the other one gets delayed, an alarm would be triggered. 

In this PR, we add 1 more test, so that we have 3 data points within a 24 hours period to avoid the false alarm. 

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
