### PR TITLE
use ssm parameter to detect CDK boostrap

### DIFF
--- a/.changeset/proud-clouds-cross.md
+++ b/.changeset/proud-clouds-cross.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+use ssm parameter to detect CDK boostrap

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import path from 'path';
 import watcher from '@parcel/watcher';
 import {
-  CDK_BOOTSTRAP_STACK_NAME,
-  CDK_BOOTSTRAP_VERSION_KEY,
+  CDK_BOOTSTRAP_VERSION_PARAMETER_PREFIX,
+  CDK_BOOTSTRAP_VERSION_PARAMETER_SUFFIX,
   FileWatchingSandbox,
   getBootstrapUrl,
 } from './file_watching_sandbox.js';
@@ -15,7 +15,6 @@ import {
 } from '@aws-amplify/backend-deployer';
 import fs from 'fs';
 import parseGitIgnore from 'parse-gitignore';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import _open from 'open';
 import { SecretListItem, getSecretClient } from '@aws-amplify/backend-secret';
 import { Sandbox, SandboxOptions } from './sandbox.js';
@@ -29,6 +28,8 @@ import {
 import { fileURLToPath } from 'url';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
+import { SSMClient } from '@aws-sdk/client-ssm';
+import { randomUUID } from 'node:crypto';
 
 // Watcher mocks
 const unsubscribeMockFn = mock.fn();
@@ -85,22 +86,15 @@ const backendDeployerDestroyMock = mock.method(backendDeployer, 'destroy', () =>
   Promise.resolve()
 );
 const region = 'test-region';
-const cfnClientMock = new CloudFormationClient({ region });
-const cfnClientSendMock = mock.fn();
-mock.method(cfnClientMock, 'send', cfnClientSendMock);
-cfnClientSendMock.mock.mockImplementation(() =>
+const ssmClientMock = new SSMClient({ region });
+const ssmClientSendMock = mock.fn();
+mock.method(ssmClientMock, 'send', ssmClientSendMock);
+ssmClientSendMock.mock.mockImplementation(() =>
   Promise.resolve({
-    Stacks: [
+    Parameters: [
       {
-        Name: CDK_BOOTSTRAP_STACK_NAME,
-        Outputs: [
-          {
-            Description:
-              'The version of the bootstrap resources that are currently mastered in this stack',
-            OutputKey: CDK_BOOTSTRAP_VERSION_KEY,
-            OutputValue: '18',
-          },
-        ],
+        Name: `${CDK_BOOTSTRAP_VERSION_PARAMETER_PREFIX}${randomUUID()}${CDK_BOOTSTRAP_VERSION_PARAMETER_SUFFIX}`,
+        Value: '18',
       },
     ],
   })
@@ -140,19 +134,19 @@ void describe('Sandbox to check if region is bootstrapped', () => {
     sandboxInstance = new FileWatchingSandbox(
       async () => testSandboxBackendId,
       sandboxExecutor,
-      cfnClientMock,
+      ssmClientMock,
       printer as unknown as Printer,
       openMock as never
     );
 
-    cfnClientSendMock.mock.resetCalls();
+    ssmClientSendMock.mock.resetCalls();
     openMock.mock.resetCalls();
     backendDeployerDestroyMock.mock.resetCalls();
     backendDeployerDeployMock.mock.resetCalls();
   });
 
   afterEach(async () => {
-    cfnClientSendMock.mock.resetCalls();
+    ssmClientSendMock.mock.resetCalls();
     openMock.mock.resetCalls();
     backendDeployerDestroyMock.mock.resetCalls();
     backendDeployerDeployMock.mock.resetCalls();
@@ -164,7 +158,7 @@ void describe('Sandbox to check if region is bootstrapped', () => {
   });
 
   void it('when region has not bootstrapped, then opens console to initiate bootstrap', async () => {
-    cfnClientSendMock.mock.mockImplementationOnce(() => {
+    ssmClientSendMock.mock.mockImplementationOnce(() => {
       throw new Error('Stack with id CDKToolkit does not exist');
     });
 
@@ -173,7 +167,7 @@ void describe('Sandbox to check if region is bootstrapped', () => {
       exclude: ['exclude1', 'exclude2'],
     });
 
-    assert.strictEqual(cfnClientSendMock.mock.callCount(), 1);
+    assert.strictEqual(ssmClientSendMock.mock.callCount(), 1);
     assert.strictEqual(openMock.mock.callCount(), 1);
     assert.strictEqual(
       openMock.mock.calls[0].arguments[0],
@@ -182,19 +176,12 @@ void describe('Sandbox to check if region is bootstrapped', () => {
   });
 
   void it('when region has bootstrapped, but with a version lower than the minimum (6), then opens console to initiate bootstrap', async () => {
-    cfnClientSendMock.mock.mockImplementationOnce(() =>
+    ssmClientSendMock.mock.mockImplementationOnce(() =>
       Promise.resolve({
-        Stacks: [
+        Parameters: [
           {
-            Name: CDK_BOOTSTRAP_STACK_NAME,
-            Outputs: [
-              {
-                Description:
-                  'The version of the bootstrap resources that are currently mastered in this stack',
-                OutputKey: CDK_BOOTSTRAP_VERSION_KEY,
-                OutputValue: '5',
-              },
-            ],
+            Name: `${CDK_BOOTSTRAP_VERSION_PARAMETER_PREFIX}${randomUUID()}${CDK_BOOTSTRAP_VERSION_PARAMETER_SUFFIX}`,
+            Value: '5',
           },
         ],
       })
@@ -205,7 +192,7 @@ void describe('Sandbox to check if region is bootstrapped', () => {
       exclude: ['exclude1', 'exclude2'],
     });
 
-    assert.strictEqual(cfnClientSendMock.mock.callCount(), 1);
+    assert.strictEqual(ssmClientSendMock.mock.callCount(), 1);
     assert.strictEqual(openMock.mock.callCount(), 1);
     assert.strictEqual(
       openMock.mock.calls[0].arguments[0],
@@ -219,7 +206,7 @@ void describe('Sandbox to check if region is bootstrapped', () => {
       exclude: ['exclude1', 'exclude2'],
     });
 
-    assert.strictEqual(cfnClientSendMock.mock.callCount(), 1);
+    assert.strictEqual(ssmClientSendMock.mock.callCount(), 1);
     assert.strictEqual(openMock.mock.callCount(), 0);
   });
 });
@@ -244,7 +231,7 @@ void describe('Sandbox using local project name resolver', () => {
     backendDeployerDestroyMock.mock.resetCalls();
     backendDeployerDeployMock.mock.resetCalls();
     subscribeMock.mock.resetCalls();
-    cfnClientSendMock.mock.resetCalls();
+    ssmClientSendMock.mock.resetCalls();
     await sandboxInstance.stop();
 
     // Printer mocks are reset after the sandbox stop to reset the "Shutting down" call as well.
@@ -256,7 +243,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       undefined,
       false
@@ -279,7 +266,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       {
         // imaginary dir does not have any ts files
@@ -309,7 +296,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       {
         dir: testDir,
@@ -335,7 +322,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       {
         dir: 'testDir',
@@ -364,13 +351,13 @@ void describe('Sandbox using local project name resolver', () => {
         validateAppSources: true,
       },
     ]);
-    assert.strictEqual(cfnClientSendMock.mock.callCount(), 0);
+    assert.strictEqual(ssmClientSendMock.mock.callCount(), 0);
   });
 
   void it('calls watcher subscribe with the default "./amplify" if no `dir` specified', async () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     await fileChangeEventCallback(null, [
       { type: 'update', path: 'foo/test1.ts' },
@@ -383,7 +370,7 @@ void describe('Sandbox using local project name resolver', () => {
   void it('calls BackendDeployer only once when multiple file changes are present', async () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     await fileChangeEventCallback(null, [
       { type: 'update', path: 'foo/test2.ts' },
@@ -403,7 +390,7 @@ void describe('Sandbox using local project name resolver', () => {
   void it('skips type checking if no typescript change is detected', async () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     await fileChangeEventCallback(null, [
       { type: 'update', path: 'foo/test2.txt' },
@@ -423,7 +410,7 @@ void describe('Sandbox using local project name resolver', () => {
   void it('calls BackendDeployer once when multiple file changes are within few milliseconds (debounce)', async () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     // Not awaiting for this file event to be processed and submitting another one right away
     const firstFileChange = fileChangeEventCallback(null, [
@@ -449,7 +436,7 @@ void describe('Sandbox using local project name resolver', () => {
   void it('waits for file changes after completing a deployment and deploys again', async () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     await fileChangeEventCallback(null, [
       { type: 'update', path: 'foo/test5.ts' },
@@ -479,7 +466,7 @@ void describe('Sandbox using local project name resolver', () => {
   void it('queues deployment if a file change is detected during an ongoing deployment', async () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     // Mimic BackendDeployer taking 200 ms.
     backendDeployerDeployMock.mock.mockImplementationOnce(async () => {
@@ -524,7 +511,7 @@ void describe('Sandbox using local project name resolver', () => {
   void it('calls BackendDeployer destroy when delete is called', async () => {
     ({ sandboxInstance } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     await sandboxInstance.delete({});
 
@@ -541,7 +528,7 @@ void describe('Sandbox using local project name resolver', () => {
     const mockListener = mock.fn();
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     sandboxInstance.on('successfulDeployment', mockListener);
     const contextualBackendDeployerMock = contextual.mock.method(
@@ -578,7 +565,7 @@ void describe('Sandbox using local project name resolver', () => {
   void it('handles UpdateNotSupported error while deploying and offers to reset sandbox and customer says yes', async (contextual) => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     const contextualBackendDeployerMock = contextual.mock.method(
       backendDeployer,
@@ -621,7 +608,7 @@ void describe('Sandbox using local project name resolver', () => {
   void it('handles UpdateNotSupported error while deploying and offers to reset sandbox and customer says no, continues running sandbox', async (contextual) => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
     const contextualBackendDeployerMock = contextual.mock.method(
       backendDeployer,
@@ -669,7 +656,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       {
         dir: 'testDir',
@@ -694,7 +681,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       { identifier: 'customSandboxName' }
     ));
@@ -724,7 +711,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       { identifier: 'customSandboxName' }
     ));
@@ -759,7 +746,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       {
         exclude: ['customer_exclude1', 'customer_exclude2'],
@@ -804,7 +791,7 @@ void describe('Sandbox using local project name resolver', () => {
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       {
         exclude: ['customer_exclude1', 'customer_exclude2'],
@@ -836,7 +823,7 @@ void describe('Sandbox using local project name resolver', () => {
     const mockListener = mock.fn();
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
 
     sandboxInstance.on('successfulDeployment', mockListener);
@@ -852,7 +839,7 @@ void describe('Sandbox using local project name resolver', () => {
     const mockListener = mock.fn();
     ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
       executor: sandboxExecutor,
-      cfnClient: cfnClientMock,
+      ssmClient: ssmClientMock,
     }));
 
     sandboxInstance.on('successfulDeletion', mockListener);
@@ -866,7 +853,7 @@ void describe('Sandbox using local project name resolver', () => {
     await setupAndStartSandbox(
       {
         executor: sandboxExecutor,
-        cfnClient: cfnClientMock,
+        ssmClient: ssmClientMock,
       },
       { watchForChanges: false }
     );
@@ -894,7 +881,7 @@ const setupAndStartSandbox = async (
       type: 'sandbox',
     }),
     testData.executor,
-    testData.cfnClient,
+    testData.ssmClient,
     printer as unknown as Printer,
     testData.open ?? _open
   );
@@ -909,7 +896,7 @@ const setupAndStartSandbox = async (
     // Reset all the calls to avoid extra startup call
     backendDeployerDestroyMock.mock.resetCalls();
     backendDeployerDeployMock.mock.resetCalls();
-    cfnClientSendMock.mock.resetCalls();
+    ssmClientSendMock.mock.resetCalls();
     listSecretMock.mock.resetCalls();
   }
 
@@ -946,6 +933,6 @@ type SandboxTestData = {
   // To instantiate sandbox
   sandboxName?: string;
   executor: AmplifySandboxExecutor;
-  cfnClient: CloudFormationClient;
+  ssmClient: SSMClient;
   open?: typeof _open;
 };

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -2,8 +2,7 @@ import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import path from 'path';
 import watcher from '@parcel/watcher';
 import {
-  CDK_BOOTSTRAP_VERSION_PARAMETER_PREFIX,
-  CDK_BOOTSTRAP_VERSION_PARAMETER_SUFFIX,
+  CDK_DEFAULT_BOOTSTRAP_VERSION_PARAMETER_NAME,
   FileWatchingSandbox,
   getBootstrapUrl,
 } from './file_watching_sandbox.js';
@@ -29,7 +28,6 @@ import { fileURLToPath } from 'url';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
 import { SSMClient } from '@aws-sdk/client-ssm';
-import { randomUUID } from 'node:crypto';
 
 // Watcher mocks
 const unsubscribeMockFn = mock.fn();
@@ -91,12 +89,10 @@ const ssmClientSendMock = mock.fn();
 mock.method(ssmClientMock, 'send', ssmClientSendMock);
 ssmClientSendMock.mock.mockImplementation(() =>
   Promise.resolve({
-    Parameters: [
-      {
-        Name: `${CDK_BOOTSTRAP_VERSION_PARAMETER_PREFIX}${randomUUID()}${CDK_BOOTSTRAP_VERSION_PARAMETER_SUFFIX}`,
-        Value: '18',
-      },
-    ],
+    Parameter: {
+      Name: CDK_DEFAULT_BOOTSTRAP_VERSION_PARAMETER_NAME,
+      Value: '18',
+    },
   })
 );
 const openMock = mock.fn(_open, (url: string) => Promise.resolve(url));
@@ -178,12 +174,10 @@ void describe('Sandbox to check if region is bootstrapped', () => {
   void it('when region has bootstrapped, but with a version lower than the minimum (6), then opens console to initiate bootstrap', async () => {
     ssmClientSendMock.mock.mockImplementationOnce(() =>
       Promise.resolve({
-        Parameters: [
-          {
-            Name: `${CDK_BOOTSTRAP_VERSION_PARAMETER_PREFIX}${randomUUID()}${CDK_BOOTSTRAP_VERSION_PARAMETER_SUFFIX}`,
-            Value: '5',
-          },
-        ],
+        Parameter: {
+          Name: CDK_DEFAULT_BOOTSTRAP_VERSION_PARAMETER_NAME,
+          Value: '5',
+        },
       })
     );
 

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -299,6 +299,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       const { Parameters: parameters } = await this.ssmClient.send(
         new GetParametersByPathCommand({
           Path: CDK_BOOTSTRAP_VERSION_PARAMETER_PREFIX,
+          Recursive: true,
         })
       );
 

--- a/packages/sandbox/src/sandbox_singleton_factory.ts
+++ b/packages/sandbox/src/sandbox_singleton_factory.ts
@@ -7,7 +7,7 @@ import { FileWatchingSandbox } from './file_watching_sandbox.js';
 import { BackendIdSandboxResolver, Sandbox } from './sandbox.js';
 import { BackendDeployerFactory } from '@aws-amplify/backend-deployer';
 import { AmplifySandboxExecutor } from './sandbox_executor.js';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { SSMClient } from '@aws-sdk/client-ssm';
 import { getSecretClient } from '@aws-amplify/backend-secret';
 
 /**
@@ -42,7 +42,7 @@ export class SandboxSingletonFactory {
           getSecretClient(),
           this.printer
         ),
-        new CloudFormationClient(),
+        new SSMClient(),
         this.printer
       );
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

CDK can be bootstrapped in a region using custom stack name. I.e. other than `CDKToolkit`

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**
https://github.com/aws-amplify/amplify-backend/issues/1510

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

This PR changes detection logic to use SSM parameter that contains version.

SSM access is already required for other functionalities to work.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
