### PR TITLE
fix: add oauth client config for legacy mobile config

### DIFF
--- a/.changeset/few-needles-fix.md
+++ b/.changeset/few-needles-fix.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+fix: add oauth client config for legacy mobile config

--- a/package-lock.json
+++ b/package-lock.json
@@ -25487,7 +25487,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -25585,7 +25585,7 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -32,6 +32,16 @@ export type ClientConfigMobileAppsyncAuth = {
   ClientDatabasePrefix: string | undefined;
 };
 
+// Reference: https://github.com/aws-amplify/amplify-cli/blob/80a596498584d3f9bfeb0ffbde4a0d4256f971eb/packages/amplify-frontend-ios/lib/frontend-config-creator.js#L243-L255
+// Note that AppClientSecret is not here since we don't collect it in Gen2
+export type ClientConfigMobileAuthOAuthConfig = {
+  WebDomain: string | undefined;
+  Scopes: Array<string> | undefined;
+  SignInRedirectURI: string | undefined;
+  SignOutRedirectURI: string | undefined;
+  AppClientId: string | undefined;
+};
+
 export type ClientConfigMobileAuth = {
   plugins: {
     awsCognitoAuthPlugin: {
@@ -64,6 +74,7 @@ export type ClientConfigMobileAuth = {
           signupAttributes: Array<string>;
           usernameAttributes: Array<string>;
           verificationMechanisms: Array<string>;
+          OAuth?: ClientConfigMobileAuthOAuthConfig;
         };
       };
       AppSync?: {

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
@@ -37,6 +37,14 @@ void describe('client config converter', () => {
       ],
       aws_cognito_mfa_configuration: 'test_mfa_configuration',
       aws_cognito_mfa_types: ['test_mfa_type_1', 'test_mfa_type_2'],
+
+      oauth: {
+        clientId: 'test_client_id',
+        domain: 'test_domain',
+        scope: ['test_scope_1', 'test_scope_2'],
+        redirectSignIn: 'test_redirect_sign_in',
+        redirectSignOut: 'test_redirect_sign_out',
+      },
     };
     const expectedMobileConfig: ClientConfigMobile = {
       UserAgent: expectedUserAgent,
@@ -82,6 +90,13 @@ void describe('client config converter', () => {
                   'test_verification_mechanism_1',
                   'test_verification_mechanism_2',
                 ],
+                OAuth: {
+                  WebDomain: 'test_domain',
+                  AppClientId: 'test_client_id',
+                  Scopes: ['test_scope_1', 'test_scope_2'],
+                  SignInRedirectURI: 'test_redirect_sign_in',
+                  SignOutRedirectURI: 'test_redirect_sign_out',
+                },
               },
             },
           },

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
@@ -74,6 +74,17 @@ export class ClientConfigMobileConverter {
           },
         },
       };
+      let oauth;
+      if (clientConfig.oauth) {
+        oauth = {
+          WebDomain: clientConfig.oauth.domain,
+          Scopes: clientConfig.oauth.scope,
+          SignInRedirectURI: clientConfig.oauth.redirectSignIn,
+          SignOutRedirectURI: clientConfig.oauth.redirectSignOut,
+          AppClientId: clientConfig.oauth.clientId,
+        };
+        authConfig.plugins.awsCognitoAuthPlugin.Auth.Default.OAuth = oauth;
+      }
       mobileConfig.auth = authConfig;
     }
 


### PR DESCRIPTION
## Problem

oauth client config was missing from the mobile client config.

**Issue number, if available:** https://github.com/aws-amplify/amplify-backend/issues/1551

## Changes

add oauth client config for legacy mobile config

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
