### PR TITLE
fix: use correct auth mode in data config for legacy mobile client config

### DIFF
--- a/.changeset/olive-boxes-stare.md
+++ b/.changeset/olive-boxes-stare.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+fix: use correct auth mode in data config for legacy mobile client config

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
@@ -185,14 +185,14 @@ void describe('client config converter', () => {
               data_AWS_IAM: {
                 ApiUrl: 'https://test_api_endpoint.amazon.com',
                 Region: 'test_app_sync_region',
-                AuthMode: 'API_KEY',
+                AuthMode: 'AWS_IAM',
                 ApiKey: 'test_api_key',
                 ClientDatabasePrefix: 'data_AWS_IAM',
               },
               data_AMAZON_COGNITO_USER_POOLS: {
                 ApiUrl: 'https://test_api_endpoint.amazon.com',
                 Region: 'test_app_sync_region',
-                AuthMode: 'API_KEY',
+                AuthMode: 'AMAZON_COGNITO_USER_POOLS',
                 ApiKey: 'test_api_key',
                 ClientDatabasePrefix: 'data_AMAZON_COGNITO_USER_POOLS',
               },

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
@@ -116,7 +116,7 @@ export class ClientConfigMobileConverter {
             ] = {
               ApiUrl: clientConfig.aws_appsync_graphqlEndpoint,
               Region: clientConfig.aws_appsync_region,
-              AuthMode: clientConfig.aws_appsync_authenticationType,
+              AuthMode: additionalAuthenticationType,
               ApiKey: clientConfig.aws_appsync_apiKey,
               ClientDatabasePrefix: `data_${additionalAuthenticationType}`,
             };


### PR DESCRIPTION
## Problem

We were using the wrong auth mode in the additional auth mode configuration. Reference [Gen1 implementation](https://github.com/aws-amplify/amplify-cli/blob/80a596498584d3f9bfeb0ffbde4a0d4256f971eb/packages/amplify-frontend-android/lib/frontend-config-creator.js#L373)

**Issue number, if available:** fixes: https://github.com/aws-amplify/amplify-backend/issues/1547

## Changes

use correct auth mode in data config for legacy mobile client config

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
