### PR TITLE
chore: disambiguate url imports and import from node:url explicitly

### DIFF
--- a/.changeset/light-pets-behave.md
+++ b/.changeset/light-pets-behave.md
@@ -1,0 +1,12 @@
+---
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend-storage': patch
+'@aws-amplify/client-config': patch
+'@aws-amplify/platform-core': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/backend': patch
+'@aws-amplify/backend-cli': patch
+---
+
+chore: disambiguate url imports and import from node:url explicitly

--- a/packages/backend-data/src/convert_js_resolvers.ts
+++ b/packages/backend-data/src/convert_js_resolvers.ts
@@ -3,7 +3,7 @@ import { AmplifyData } from '@aws-amplify/data-construct';
 import { CfnFunctionConfiguration, CfnResolver } from 'aws-cdk-lib/aws-appsync';
 import { JsResolver } from '@aws-amplify/data-schema-types';
 import { resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { Asset } from 'aws-cdk-lib/aws-s3-assets';
 import { resolveEntryPath } from './resolve_entry_path.js';
 

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -29,7 +29,7 @@ import {
 } from '@aws-amplify/backend-output-schemas';
 import { FunctionEnvironmentTypeGenerator } from './function_env_type_generator.js';
 import { AttributionMetadataStorage } from '@aws-amplify/backend-output-storage';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { AmplifyUserError, TagName } from '@aws-amplify/platform-core';
 
 const functionStackType = 'function-Lambda';

--- a/packages/backend-storage/src/construct.ts
+++ b/packages/backend-storage/src/construct.ts
@@ -22,7 +22,7 @@ import {
   AttributionMetadataStorage,
   StackMetadataBackendOutputStorageStrategy,
 } from '@aws-amplify/backend-output-storage';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { S3EventSourceV2 } from 'aws-cdk-lib/aws-lambda-event-sources';
 

--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -17,7 +17,7 @@ import {
 import { createDefaultStack } from './default_stack_factory.js';
 import { getBackendIdentifier } from './backend_identifier.js';
 import { platformOutputKey } from '@aws-amplify/backend-output-schemas';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { Backend, DefineBackendProps } from './backend.js';
 import { AmplifyBranchLinkerConstruct } from './engine/branch-linker/branch_linker_construct.js';
 import {

--- a/packages/backend/src/engine/backend-secret/backend_secret_fetcher_provider_factory.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_fetcher_provider_factory.ts
@@ -5,7 +5,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as path from 'path';
 import { Runtime as LambdaRuntime } from 'aws-cdk-lib/aws-lambda';
 import { Provider } from 'aws-cdk-lib/custom-resources';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { ParameterPathConversions } from '@aws-amplify/platform-core';
 

--- a/packages/backend/src/engine/branch-linker/branch_linker_construct.ts
+++ b/packages/backend/src/engine/branch-linker/branch_linker_construct.ts
@@ -2,7 +2,7 @@ import { Construct } from 'constructs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Runtime as LambdaRuntime } from 'aws-cdk-lib/aws-lambda';
 import { CustomResource, Duration } from 'aws-cdk-lib';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { AmplifyBranchLinkerCustomResourceProps } from './lambda/branch_linker_types.js';

--- a/packages/backend/src/engine/nested_stack_resolver.ts
+++ b/packages/backend/src/engine/nested_stack_resolver.ts
@@ -1,6 +1,6 @@
 import { NestedStack, Stack } from 'aws-cdk-lib';
 import { AttributionMetadataStorage } from '@aws-amplify/backend-output-storage';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Vends stacks for a resource grouping

--- a/packages/cli/src/commands/sandbox/sandbox_command_factory.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command_factory.ts
@@ -1,5 +1,5 @@
 import { CommandModule } from 'yargs';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import {
   SandboxCommand,
   SandboxCommandOptionsKebabCase,

--- a/packages/client-config/src/write_client_config_to_file.ts
+++ b/packages/client-config/src/write_client_config_to_file.ts
@@ -8,7 +8,7 @@ import {
 } from './client-config-types/client_config.js';
 import { getClientConfigPath } from './paths/index.js';
 import { ClientConfigMobileConverter } from './client-config-writer/client_config_to_mobile_legacy_converter.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import * as fsp from 'fs/promises';
 import { ClientConfigFormatterLegacy } from './client-config-writer/client_config_formatter_legacy.js';
 import { ClientConfigFormatterDefault } from './client-config-writer/client_config_formatter_default.js';

--- a/packages/integration-tests/src/cdk_version_finder.ts
+++ b/packages/integration-tests/src/cdk_version_finder.ts
@@ -1,5 +1,5 @@
 import fsp from 'fs/promises';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import semver from 'semver';
 
 /**

--- a/packages/integration-tests/src/setup_test_directory.ts
+++ b/packages/integration-tests/src/setup_test_directory.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Root test directory.

--- a/packages/integration-tests/src/test-project-setup/cdk/test_cdk_project_creator.ts
+++ b/packages/integration-tests/src/test-project-setup/cdk/test_cdk_project_creator.ts
@@ -2,7 +2,7 @@ import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { e2eToolingClientConfig } from '../../e2e_tooling_client_config.js';
 import { TestCdkProjectBase } from './test_cdk_project_base.js';
 import { AuthTestCdkProjectCreator } from './auth_cdk_project.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import { DeployedResourcesFinder } from '../../find_deployed_resource.js';
 

--- a/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
+++ b/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
@@ -4,7 +4,7 @@ import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { createEmptyAmplifyProject } from './create_empty_amplify_project.js';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { TestProjectBase, TestProjectUpdate } from './test_project_base.js';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import path from 'path';
 import { TestProjectCreator } from './test_project_creator.js';
 import { DeployedResourcesFinder } from '../find_deployed_resource.js';

--- a/packages/platform-core/src/extract_file_path_from_stack_trace_line.ts
+++ b/packages/platform-core/src/extract_file_path_from_stack_trace_line.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Regex that pulls out the path from a stack trace line. Works for both unix and windows paths and cjs and esm loaders

--- a/packages/platform-core/src/usage-data/get_usage_data_url.ts
+++ b/packages/platform-core/src/usage-data/get_usage_data_url.ts
@@ -1,4 +1,4 @@
-import url, { UrlWithStringQuery } from 'url';
+import url, { UrlWithStringQuery } from 'node:url';
 import { latestApiVersion } from './constants.js';
 
 let cachedUrl: UrlWithStringQuery;


### PR DESCRIPTION
## Problem

![image](https://github.com/aws-amplify/amplify-backend/assets/51211245/80e25e52-4de9-4ee5-9eba-b5e0c14bc4e1)

**Issue number, if available:**

## Changes

disambiguate `url` imports and change to `import from 'node:url'` explicitly

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
