### PR TITLE
add support to input secret value using redirection

### DIFF
--- a/.changeset/tasty-cougars-visit.md
+++ b/.changeset/tasty-cougars-visit.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Add support to input secret value using redirection

--- a/.changeset/tasty-cougars-visit.md
+++ b/.changeset/tasty-cougars-visit.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/backend-cli': patch
+'@aws-amplify/backend-cli': minor
 ---
 
 Add support to input secret value using redirection

--- a/package-lock.json
+++ b/package-lock.json
@@ -25487,7 +25487,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -25665,7 +25665,7 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -25828,11 +25828,11 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/deployed-backend-client": "^1.0.2",
         "@aws-amplify/model-generator": "^1.0.1",
         "@aws-amplify/platform-core": "^1.0.1",
         "zod": "^3.22.2"
@@ -25956,7 +25956,7 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -26224,14 +26224,14 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.0.0",
         "@aws-amplify/backend-secret": "^1.0.0",
         "@aws-amplify/cli-core": "^1.0.0",
-        "@aws-amplify/client-config": "^1.0.3",
-        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/client-config": "^1.0.4",
+        "@aws-amplify/deployed-backend-client": "^1.0.2",
         "@aws-amplify/platform-core": "^1.0.1",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
@@ -36,12 +36,13 @@ void describe('sandbox secret set command', () => {
       }),
   } as SandboxBackendIdResolver;
 
-  const mockReadStream = new ReadStream(0); // ReadStream(fd=0) defaults 'isTTY' to true.
+  const mockReadStream = new PassThrough();
+  (mockReadStream as unknown as ReadStream).isTTY = true; // Fake a TTY in tests
 
   const sandboxSecretSetCmd = new SandboxSecretSetCommand(
     sandboxIdResolver,
     secretClient,
-    mockReadStream
+    mockReadStream as unknown as ReadStream
   );
 
   const parser = yargs().command(

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
@@ -36,9 +36,12 @@ void describe('sandbox secret set command', () => {
       }),
   } as SandboxBackendIdResolver;
 
+  const mockReadStream = new ReadStream(0); // ReadStream(fd=0) defaults 'isTTY' to true.
+
   const sandboxSecretSetCmd = new SandboxSecretSetCommand(
     sandboxIdResolver,
-    secretClient
+    secretClient,
+    mockReadStream
   );
 
   const parser = yargs().command(
@@ -49,8 +52,6 @@ void describe('sandbox secret set command', () => {
 
   beforeEach(async () => {
     secretSetMock.mock.resetCalls();
-    // Fake a TTY in tests
-    process.stdin.isTTY = true;
   });
 
   void it('sets a secret', async (contextual) => {
@@ -100,7 +101,7 @@ void describe('sandbox secret set command', () => {
   });
 
   void it('sets a secret using redirection', async () => {
-    const readStream = new PassThrough();
+    const readStream = new PassThrough(); // 'isTTY' flag doesn't exist on PassThrough stream.
 
     const sandboxSecretSetCmdWithStream = new SandboxSecretSetCommand(
       sandboxIdResolver,

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
@@ -100,7 +100,6 @@ void describe('sandbox secret set command', () => {
   });
 
   void it('sets a secret using redirection', async () => {
-    process.stdin.isTTY = false; // Override isTTY to false
     const readStream = new PassThrough();
 
     const sandboxSecretSetCmdWithStream = new SandboxSecretSetCommand(

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
@@ -2,9 +2,9 @@ import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { AmplifyPrompter } from '@aws-amplify/cli-core';
-
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
 import { SandboxCommandGlobalOptions } from '../option_types.js';
+import { once } from 'events';
 
 /**
  * Command to set sandbox secret.
@@ -39,11 +39,12 @@ export class SandboxSecretSetCommand
   handler = async (
     args: ArgumentsCamelCase<SecretSetCommandOptionsKebabCase>
   ): Promise<void> => {
-    const secretVal = await AmplifyPrompter.secretValue();
+    const secretValue = await this.readSecretValue();
+
     await this.secretClient.setSecret(
       await this.sandboxIdResolver.resolve(args.identifier),
       args.secretName,
-      secretVal
+      secretValue
     );
   };
 
@@ -56,6 +57,28 @@ export class SandboxSecretSetCommand
       type: 'string',
       demandOption: true,
     });
+  };
+
+  /**
+   * Prompt (or) read secret value from stdin based on terminal interactive mode
+   */
+  private readSecretValue = async (): Promise<string> => {
+    let secretValue = '';
+    if (process.stdin.isTTY) {
+      // This input is for interactive mode.
+      secretValue = await AmplifyPrompter.secretValue();
+    } else {
+      // This allows to accept secret value from redirected input `|` and `>`.
+      process.stdin.on('readable', () => {
+        const chunk = process.stdin.read();
+        if (chunk !== null) {
+          secretValue += chunk;
+        }
+      });
+      // Wait for the end of the input.
+      await once(process.stdin, 'end');
+    }
+    return secretValue;
   };
 }
 


### PR DESCRIPTION
**Issue number, if available:**
NA

## Changes

Add support to pass secret value using redirections like `|` or `<`.

**Usage:**
```sh
$ pbpaste | npx ampx sandbox secret set SECRET_NAME
(or)
$ npx ampx sandbox secret set SECRET_NAME < SECRET.TXT
```

**Corresponding docs PR, if applicable:**
Docs will be updated as part of SQL custom SSL certificate support documentation.

## Validation

- New unit tests
- Manual testing

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
