### PR TITLE
fix: add `socialProvider` and `AppClientId` to lagecy config

### DIFF
--- a/.changeset/tiny-worms-confess.md
+++ b/.changeset/tiny-worms-confess.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+add AppClientId to OAuth lagecy config

--- a/package-lock.json
+++ b/package-lock.json
@@ -25487,7 +25487,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -25665,7 +25665,7 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -25828,11 +25828,11 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/deployed-backend-client": "^1.0.2",
         "@aws-amplify/model-generator": "^1.0.1",
         "@aws-amplify/platform-core": "^1.0.1",
         "zod": "^3.22.2"
@@ -25956,7 +25956,7 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -26224,14 +26224,14 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.0.0",
         "@aws-amplify/backend-secret": "^1.0.0",
         "@aws-amplify/cli-core": "^1.0.0",
-        "@aws-amplify/client-config": "^1.0.3",
-        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/client-config": "^1.0.4",
+        "@aws-amplify/deployed-backend-client": "^1.0.2",
         "@aws-amplify/platform-core": "^1.0.1",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -72,6 +72,7 @@ export type ClientConfigMobileAuth = {
             passwordPolicyCharacters: Array<string>;
           };
           signupAttributes: Array<string>;
+          socialProviders: Array<string>;
           usernameAttributes: Array<string>;
           verificationMechanisms: Array<string>;
           OAuth?: ClientConfigMobileAuthOAuthConfig;

--- a/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
+++ b/packages/client-config/src/client-config-types/mobile/client_config_mobile_types.ts
@@ -72,7 +72,7 @@ export type ClientConfigMobileAuth = {
             passwordPolicyCharacters: Array<string>;
           };
           signupAttributes: Array<string>;
-          socialProviders: Array<string>;
+          socialProviders: Array<string> | undefined;
           usernameAttributes: Array<string>;
           verificationMechanisms: Array<string>;
           OAuth?: ClientConfigMobileAuthOAuthConfig;

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
@@ -77,6 +77,7 @@ void describe('client config converter', () => {
                   'test_signup_attribute_1',
                   'test_signup_attribute_2',
                 ],
+                socialProviders: [],
                 usernameAttributes: [
                   'test_username_attribute_1',
                   'test_username_attribute_2',
@@ -180,6 +181,7 @@ void describe('client config converter', () => {
                 mfaConfiguration: undefined,
                 mfaTypes: undefined,
                 signupAttributes: [],
+                socialProviders: [],
                 usernameAttributes: [],
                 passwordProtectionSettings: {
                   passwordPolicyCharacters: [],

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
@@ -40,6 +40,7 @@ void describe('client config converter', () => {
       aws_cognito_social_providers: ['GOOGLE', 'FACEBOOK', 'AMAZON', 'APPLE'],
 
       oauth: {
+        clientId: '',
         domain: 'test_domain',
         scope: ['test_scope_1', 'test_scope_2'],
         redirectSignIn: 'test_redirect_sign_in',

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
@@ -77,7 +77,7 @@ void describe('client config converter', () => {
                   'test_signup_attribute_1',
                   'test_signup_attribute_2',
                 ],
-                socialProviders: [],
+                socialProviders: ['GOOGLE', 'FACEBOOK', 'AMAZON', 'APPLE'],
                 usernameAttributes: [
                   'test_username_attribute_1',
                   'test_username_attribute_2',

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
@@ -37,6 +37,7 @@ void describe('client config converter', () => {
       ],
       aws_cognito_mfa_configuration: 'test_mfa_configuration',
       aws_cognito_mfa_types: ['test_mfa_type_1', 'test_mfa_type_2'],
+      aws_cognito_social_providers: ['GOOGLE', 'FACEBOOK', 'AMAZON', 'APPLE'],
 
       oauth: {
         domain: 'test_domain',
@@ -151,6 +152,7 @@ void describe('client config converter', () => {
       aws_appsync_authenticationType: 'API_KEY',
       aws_appsync_additionalAuthenticationTypes:
         'AMAZON_COGNITO_USER_POOLS,AWS_IAM',
+      aws_cognito_social_providers: ['GOOGLE', 'FACEBOOK', 'AMAZON', 'APPLE'],
     };
     const expectedMobileConfig: ClientConfigMobile = {
       UserAgent: expectedUserAgent,
@@ -181,7 +183,7 @@ void describe('client config converter', () => {
                 mfaConfiguration: undefined,
                 mfaTypes: undefined,
                 signupAttributes: [],
-                socialProviders: [],
+                socialProviders: ['GOOGLE', 'FACEBOOK', 'AMAZON', 'APPLE'],
                 usernameAttributes: [],
                 passwordProtectionSettings: {
                   passwordPolicyCharacters: [],

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.test.ts
@@ -39,7 +39,6 @@ void describe('client config converter', () => {
       aws_cognito_mfa_types: ['test_mfa_type_1', 'test_mfa_type_2'],
 
       oauth: {
-        clientId: 'test_client_id',
         domain: 'test_domain',
         scope: ['test_scope_1', 'test_scope_2'],
         redirectSignIn: 'test_redirect_sign_in',
@@ -92,7 +91,7 @@ void describe('client config converter', () => {
                 ],
                 OAuth: {
                   WebDomain: 'test_domain',
-                  AppClientId: 'test_client_id',
+                  AppClientId: 'test_user_pool_app_client_id',
                   Scopes: ['test_scope_1', 'test_scope_2'],
                   SignInRedirectURI: 'test_redirect_sign_in',
                   SignOutRedirectURI: 'test_redirect_sign_out',

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
@@ -69,6 +69,8 @@ export class ClientConfigMobileConverter {
                   clientConfig.aws_cognito_username_attributes ?? [],
                 verificationMechanisms:
                   clientConfig.aws_cognito_verification_mechanisms ?? [],
+                socialProviders:
+                  clientConfig.aws_cognito_social_providers ?? [],
               },
             },
           },

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
@@ -82,7 +82,9 @@ export class ClientConfigMobileConverter {
           Scopes: clientConfig.oauth.scope,
           SignInRedirectURI: clientConfig.oauth.redirectSignIn,
           SignOutRedirectURI: clientConfig.oauth.redirectSignOut,
-          AppClientId: clientConfig.aws_user_pools_web_client_id,
+          AppClientId:
+            clientConfig.oauth.clientId ||
+            clientConfig.aws_user_pools_web_client_id,
         };
       }
       mobileConfig.auth = authConfig;

--- a/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_mobile_legacy_converter.ts
@@ -80,7 +80,7 @@ export class ClientConfigMobileConverter {
           Scopes: clientConfig.oauth.scope,
           SignInRedirectURI: clientConfig.oauth.redirectSignIn,
           SignOutRedirectURI: clientConfig.oauth.redirectSignOut,
-          AppClientId: clientConfig.oauth.clientId,
+          AppClientId: clientConfig.aws_user_pools_web_client_id,
         };
       }
       mobileConfig.auth = authConfig;


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

`socialProvider` and `AppClientId` are missing in the lagecy config when running `npx ampx generate outputs --format dart --out-dir lib --outputs-version 0` or `npx ampx sandbox --outputs-format dart --outputs-out-dir lib --outputs-version 0 `. 

This PR is to add `socialProvider` and `AppClientId` and modify the unit tests.

**Issue number, if available:**
https://github.com/aws-amplify/amplify-backend/issues/1551

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

Added unit tests and tested on local app.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
