### PR TITLE
Show all args in output of `generate graphql-client-code --help`

### DIFF
--- a/.changeset/cyan-dots-film.md
+++ b/.changeset/cyan-dots-film.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Show all options in output of `generate graphql-client-code --help`

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
@@ -162,22 +162,6 @@ void describe('generate graphql-client-code command', () => {
     assert.match(output, /--type-target/);
     assert.match(output, /--model-target/);
     assert.match(output, /--out/);
-    assert.match(output, /--all/);
-  });
-
-  void it('shows all available options in help output', async () => {
-    const output = await commandRunner.runCommand(
-      'graphql-client-code --help --all'
-    );
-    assert.match(output, /--stack/);
-    assert.match(output, /--app-id/);
-    assert.match(output, /--branch/);
-    assert.match(output, /--format/);
-    assert.match(output, /--statement-target/);
-    assert.match(output, /--type-target/);
-    assert.match(output, /--model-target/);
-    assert.match(output, /--out/);
-    assert.match(output, /--all/);
     assert.match(output, /--model-generate-index-rules/);
     assert.match(output, /--model-emit-auth-provider/);
     assert.match(output, /--model-add-timestamp-fields/);

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
@@ -169,63 +169,53 @@ export class GenerateGraphqlClientCodeCommand
         description: 'Adds key/index details to iOS models',
         type: 'boolean',
         array: false,
-        hidden: true,
       })
       .option('model-emit-auth-provider', {
         description: 'Adds auth provider details to iOS models',
         type: 'boolean',
         array: false,
-        hidden: true,
       })
       .option('model-respect-primary-key-attributes-on-connection-field', {
         description:
           'If enabled, Datastore queries will respect the primary + sort key fields, rather than a default id field',
         type: 'boolean',
         array: false,
-        hidden: true,
       })
       .option('model-generate-models-for-lazy-load-and-custom-selection-set', {
         description:
           'Generates lazy model type definitions, required or amplify-js v5+',
         type: 'boolean',
         array: false,
-        hidden: true,
       })
       .option('model-add-timestamp-fields', {
         description: 'Add read-only timestamp fields in modelgen.',
         type: 'boolean',
         array: false,
-        hidden: true,
       })
       .option('model-handle-list-nullability-transparently', {
         description:
           'Configure the nullability of the List and List components in Datastore Models generation',
         type: 'boolean',
         array: false,
-        hidden: true,
       })
       .option('statement-max-depth', {
         description:
           'Determines how deeply nested to generate graphql statements.',
         type: 'number',
         array: false,
-        hidden: true,
       })
       .option('statement-typename-introspection', {
         description:
           'Determines whether to include default __typename for all generated statements',
         type: 'boolean',
         array: false,
-        hidden: true,
       })
       .option('type-multiple-swift-files', {
         description:
           'Determines whether or not to generate a single API.swift, or multiple per-model swift files.',
         type: 'boolean',
         array: false,
-        hidden: true,
-      })
-      .showHidden('all');
+      });
   };
 
   /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Some args of `generate graphql-client-code` were hidden which made discovering these arguments difficult

**Issue number, if available:**
fixes: https://github.com/aws-amplify/amplify-backend/issues/1546

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Unhide all args on the `generate graphql-client-code` command

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Updated unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
