### PR TITLE
allow custom ssl certificate to generate schema-from-database command

### DIFF
--- a/.changeset/strange-moose-hide.md
+++ b/.changeset/strange-moose-hide.md
@@ -1,6 +1,6 @@
 ---
-'@aws-amplify/schema-generator': patch
-'@aws-amplify/backend-cli': patch
+'@aws-amplify/schema-generator': minor
+'@aws-amplify/backend-cli': minor
 ---
 
 Add custom SSL certificate support to generate SQL schema command.

--- a/.changeset/strange-moose-hide.md
+++ b/.changeset/strange-moose-hide.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/schema-generator': patch
+'@aws-amplify/backend-cli': patch
+---
+
+Add custom SSL certificate support to generate SQL schema command.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,12 +1944,12 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@aws-amplify/graphql-schema-generator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-schema-generator/-/graphql-schema-generator-0.8.3.tgz",
-      "integrity": "sha512-3aFPmYiCZxdc4+ECqe6KWMKftpGti5xSEG3mIeLpVGrC6yoOSNSuUoDsjiei87dUllKYKgnWYRviHXYktDMeNQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-schema-generator/-/graphql-schema-generator-0.9.0.tgz",
+      "integrity": "sha512-TDco+WuNv76QqNCaP/W3OjlAGgToptmFRq/0yThqLlW2p8mV6KHpmqAHIJnxNl/fI8R+wbscOmM/0Q1oYzPwAg==",
       "dependencies": {
-        "@aws-amplify/graphql-transformer-core": "2.7.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.9.0",
         "@aws-sdk/client-ec2": "3.338.0",
         "@aws-sdk/client-iam": "3.338.0",
         "@aws-sdk/client-lambda": "3.338.0",
@@ -1957,9 +1957,9 @@
         "csv-parse": "^5.5.2",
         "fs-extra": "11.1.1",
         "graphql": "^15.5.0",
-        "graphql-transformer-common": "4.30.1",
+        "graphql-transformer-common": "4.31.0",
         "knex": "~2.4.0",
-        "mysql2": "~3.9.4",
+        "mysql2": "~3.9.7",
         "ora": "^4.0.3",
         "pg": "~8.11.3",
         "pluralize": "^8.0.0",
@@ -2511,16 +2511,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-2.7.0.tgz",
-      "integrity": "sha512-JDt/rjWEFimcrVNtc2e1pYmr08D5nUO1UIBGU+frSrhI452TSTSCREsZfquleNPD89dmLb5hjVP7smK3brw+cw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-2.9.0.tgz",
+      "integrity": "sha512-aIS4seXV+hxHpjnrQ9eA8FQYdzNxeuAtneshmBApDC4RvNaeTEwLv7qSsT//ZMkbW+ngK38hEmVOf14Ua2ZdEg==",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.7.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.9.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
-        "graphql-transformer-common": "4.30.1",
+        "graphql-transformer-common": "4.31.0",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -2570,9 +2570,9 @@
       }
     },
     "node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.7.0.tgz",
-      "integrity": "sha512-fHGc8D78C3sIBNqKbS5KjGu2xDACSFdyS0YdwZiQu+MMMs7IWGnip8aogSFFgeCQ3kSHqrMUd+1CdI7Zh015Rg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.9.0.tgz",
+      "integrity": "sha512-MlO+jABhnRlxWtgqrg+V++JQOU0HwP+s7WOFKIsQuzoj6137DEyPYoY6rXm8mlUFzpdcq8gTob866d/SDWPCYQ==",
       "dependencies": {
         "graphql": "^15.5.0"
       },
@@ -18629,9 +18629,9 @@
       }
     },
     "node_modules/graphql-transformer-common": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.30.1.tgz",
-      "integrity": "sha512-SPitc4dEtWdyy+xe3FJSsvqw64ScMkl5mBpHK+P/iEMJEp9YE6H+s+9GAcewBhDSTDZibDHE+dT04a91FYN27w==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.31.0.tgz",
+      "integrity": "sha512-y5VUlFIz/tI8xyRrUmHWpbjMyP4FFrZd1hEncUtttho4mNuauaQh98m2d8oCvSdTU/JnxNHkwIJ2plu9jHzVig==",
       "dependencies": {
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
@@ -26256,7 +26256,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-schema-generator": "^0.8.3",
+        "@aws-amplify/graphql-schema-generator": "^0.9.0",
         "@aws-amplify/platform-core": "^1.0.0"
       }
     }

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
@@ -54,7 +54,7 @@ void describe('generate graphql-client-code command', () => {
   secretClientGetSecret.mock.mockImplementation(() => {
     return Promise.resolve({
       name: 'CONN_STRING',
-      value: 'FAKE_CONN_STRING_VALUE',
+      value: 'FAKE_SECRET_VALUE',
       lastUpdated: new Date(),
       version: '1',
     });
@@ -77,6 +77,44 @@ void describe('generate graphql-client-code command', () => {
     );
 
     assert.equal(schemaGeneratorGenerateMethod.mock.calls.length, 1);
+    assert.deepStrictEqual(
+      schemaGeneratorGenerateMethod.mock.calls[0].arguments[0],
+      {
+        connectionUri: {
+          secretName: 'CONN_STRING',
+          value: 'FAKE_SECRET_VALUE',
+        },
+        out: 'schema.rds.ts',
+      }
+    );
+  });
+
+  void it('uses sandbox by default with custom ssl certificate', async () => {
+    await commandRunner.runCommand(
+      'schema-from-database --connection-uri-secret CONN_STRING --out schema.rds.ts --ssl-cert-secret SSL_CERT'
+    );
+
+    assert.equal(
+      (secretClientGetSecret.mock.calls[0].arguments[0] as BackendIdentifier)
+        .name,
+      fakeSandboxId
+    );
+
+    assert.equal(schemaGeneratorGenerateMethod.mock.calls.length, 1);
+    assert.deepStrictEqual(
+      schemaGeneratorGenerateMethod.mock.calls[0].arguments[0],
+      {
+        connectionUri: {
+          secretName: 'CONN_STRING',
+          value: 'FAKE_SECRET_VALUE',
+        },
+        sslCert: {
+          secretName: 'SSL_CERT',
+          value: 'FAKE_SECRET_VALUE',
+        },
+        out: 'schema.rds.ts',
+      }
+    );
   });
 
   void it('generates and writes schema for stack', async () => {
@@ -88,7 +126,7 @@ void describe('generate graphql-client-code command', () => {
     assert.deepEqual(schemaGeneratorGenerateMethod.mock.calls[0].arguments[0], {
       connectionUri: {
         secretName: 'CONN_STRING',
-        value: 'FAKE_CONN_STRING_VALUE',
+        value: 'FAKE_SECRET_VALUE',
       },
       out: 'schema.rds.ts',
     });
@@ -103,7 +141,7 @@ void describe('generate graphql-client-code command', () => {
     assert.deepEqual(schemaGeneratorGenerateMethod.mock.calls[0].arguments[0], {
       connectionUri: {
         secretName: 'CONN_STRING',
-        value: 'FAKE_CONN_STRING_VALUE',
+        value: 'FAKE_SECRET_VALUE',
       },
       out: 'schema.rds.ts',
     });

--- a/packages/schema-generator/API.md
+++ b/packages/schema-generator/API.md
@@ -16,6 +16,10 @@ export type SchemaGeneratorConfig = {
         secretName: string;
         value: string;
     };
+    sslCert?: {
+        secretName: string;
+        value: string;
+    };
     out: string;
 };
 

--- a/packages/schema-generator/package.json
+++ b/packages/schema-generator/package.json
@@ -17,7 +17,7 @@
     "update:api": "api-extractor run --local"
   },
   "dependencies": {
-    "@aws-amplify/graphql-schema-generator": "^0.8.3",
+    "@aws-amplify/graphql-schema-generator": "^0.9.0",
     "@aws-amplify/platform-core": "^1.0.0"
   },
   "license": "Apache-2.0"

--- a/packages/schema-generator/src/generate_schema.ts
+++ b/packages/schema-generator/src/generate_schema.ts
@@ -7,6 +7,10 @@ export type SchemaGeneratorConfig = {
     secretName: string;
     value: string;
   };
+  sslCert?: {
+    secretName: string;
+    value: string;
+  };
   out: string;
 };
 
@@ -25,6 +29,11 @@ export class SchemaGenerator {
       const schema = await TypescriptDataSchemaGenerator.generate({
         ...dbConfig,
         connectionUriSecretName: props.connectionUri.secretName,
+        ...(props.sslCert &&
+          props.sslCert.secretName && {
+            sslCertificateSecretName: props.sslCert.secretName,
+            sslCertificate: props.sslCert.value,
+          }),
       });
       await fs.writeFile(props.out, schema);
     } catch (err) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Add support to pass a custom SSL certificate to connect to the SQL database for `generate schema-from-database` command.

**Issue number, if available:**
NA

## Changes
Adds new option `ssl-cert-secret` to the `generate schema-from-database` to specify the secret which contains the SSL certificate to be used to connect to the SQL database.

The new option is optional. If not provided, the command will use the default bundled certificate.

**Corresponding docs PR, if applicable:**
Docs update will be released later.

## Validation

- New unit tests
- Manual testing

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
