### PR TITLE
fix: emit `NONE` instead of `OFF` into outputs when MFA is not enabled

### DIFF
--- a/.changeset/ten-falcons-train.md
+++ b/.changeset/ten-falcons-train.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct': patch
+---
+
+fix: emit `NONE` instead of `OFF` into outputs when MFA is not enabled

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -647,7 +647,7 @@ void describe('Auth construct', () => {
       );
       assert.equal(outputs['mfaTypes']['Value'], '[]');
 
-      assert.equal(outputs['mfaConfiguration']['Value'], 'OFF');
+      assert.equal(outputs['mfaConfiguration']['Value'], 'NONE');
       assert.equal(
         outputs['passwordPolicyMinLength']['Value'],
         DEFAULTS.PASSWORD_POLICY.minLength.toString()
@@ -659,6 +659,21 @@ void describe('Auth construct', () => {
       assert.equal(outputs['signupAttributes']['Value'], '["email"]');
       assert.equal(outputs['usernameAttributes']['Value'], '["email"]');
       assert.equal(outputs['verificationMechanisms']['Value'], '["email"]');
+    });
+
+    void it('outputs NONE when mfa is explicitly disabled', () => {
+      new AmplifyAuth(stack, 'test', {
+        loginWith: {
+          email: true,
+        },
+        multifactor: {
+          mode: 'OFF',
+        },
+      });
+      const template = Template.fromStack(stack);
+      const outputs = template.findOutputs('*');
+      assert.equal(outputs['mfaTypes']['Value'], '[]');
+      assert.equal(outputs['mfaConfiguration']['Value'], 'NONE');
     });
 
     void it('updates signupAttributes when userAttributes prop is used', () => {

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -993,7 +993,13 @@ export class AmplifyAuth
     // extract the MFA configuration setting from the UserPool resource
     output.mfaConfiguration = Lazy.string({
       produce: () => {
-        return cfnUserPool.mfaConfiguration ?? 'OFF';
+        switch (cfnUserPool.mfaConfiguration) {
+          case undefined:
+          case 'OFF':
+            return 'NONE';
+          default:
+            return cfnUserPool.mfaConfiguration;
+        }
       },
     });
     // extract the MFA types from the UserPool resource


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

Auth construct emit unexpected `OFF` into outputs. The expected value is `NONE`.

**Issue number, if available:**
https://github.com/aws-amplify/amplify-backend/issues/1644

## Changes

This PR changes the emitted output to `NONE` when mfa is explicitly disabled or not enabled.

## Alternatives considered

The a mapping from `OFF` to `NONE` could as well reside in `client-config`.
It is questionable if the fix for this should go into `client-config` or `auth-construct`. 
Stack outputs are considered implementation detail, hence fix could go into `auth-construct` without break.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
