### PR TITLE
pass valid props to root stack

### DIFF
--- a/.changeset/chatty-gifts-bathe.md
+++ b/.changeset/chatty-gifts-bathe.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': minor
+---
+
+Allow StackProps to be passed from defineBackend down to AmplifyStack for root Stack configuration

--- a/packages/backend/API.md
+++ b/packages/backend/API.md
@@ -31,6 +31,7 @@ import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { SsmEnvironmentEntriesGenerator } from '@aws-amplify/plugin-types';
 import { SsmEnvironmentEntry } from '@aws-amplify/plugin-types';
 import { Stack } from 'aws-cdk-lib';
+import { StackProps } from 'aws-cdk-lib';
 
 export { a }
 
@@ -70,7 +71,7 @@ export { ConstructFactoryGetInstanceProps }
 export { defineAuth }
 
 // @public
-export const defineBackend: <T extends DefineBackendProps>(constructFactories: T) => Backend<T>;
+export const defineBackend: <T extends DefineBackendProps>(constructFactories: T, mainStackProps?: MainStackProps) => Backend<T>;
 
 // @public (undocumented)
 export type DefineBackendProps = Record<string, ConstructFactory<ResourceProvider & Partial<ResourceAccessAcceptorFactory<never>>>> & {
@@ -88,6 +89,9 @@ export { FunctionResources }
 export { GenerateContainerEntryProps }
 
 export { ImportPathVerifier }
+
+// @public
+export type MainStackProps = Pick<StackProps, 'description' | 'env' | 'tags' | 'analyticsReporting' | 'crossRegionReferences' | 'suppressTemplateIndentation'>;
 
 export { ResourceProvider }
 

--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -27,6 +27,7 @@ import {
 import { CustomOutputsAccumulator } from './engine/custom_outputs_accumulator.js';
 import { ObjectAccumulator } from '@aws-amplify/platform-core';
 import { DefaultResourceNameValidator } from './engine/validations/default_resource_name_validator.js';
+import { MainStackProps } from './engine/amplify_stack.js';
 
 // Be very careful editing this value. It is the value used in the BI metrics to attribute stacks as Amplify root stacks
 const rootStackTypeIdentifier = 'root';
@@ -55,7 +56,15 @@ export class BackendFactory<
    * Initialize an Amplify backend with the given construct factories and in the given CDK App.
    * If no CDK App is specified a new one is created
    */
-  constructor(constructFactories: T, stack: Stack = createDefaultStack()) {
+  constructor(
+    constructFactories: T,
+    stack?: Stack,
+    mainStackProps?: MainStackProps
+  ) {
+    if (stack === undefined) {
+      stack = createDefaultStack(undefined, mainStackProps);
+    }
+
     new AttributionMetadataStorage().storeAttributionMetadata(
       stack,
       rootStackTypeIdentifier,
@@ -150,9 +159,14 @@ export class BackendFactory<
  * @param constructFactories - list of backend factories such as those created by `defineAuth` or `defineData`
  */
 export const defineBackend = <T extends DefineBackendProps>(
-  constructFactories: T
+  constructFactories: T,
+  mainStackProps?: MainStackProps
 ): Backend<T> => {
-  const backend = new BackendFactory(constructFactories);
+  const backend = new BackendFactory(
+    constructFactories,
+    undefined,
+    mainStackProps
+  );
   return {
     ...backend.resources,
     createStack: backend.createStack,

--- a/packages/backend/src/default_stack_factory.ts
+++ b/packages/backend/src/default_stack_factory.ts
@@ -1,14 +1,21 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { ProjectEnvironmentMainStackCreator } from './project_environment_main_stack_creator.js';
 import { getBackendIdentifier } from './backend_identifier.js';
+import { MainStackProps } from './engine/amplify_stack.js';
 
 /**
  * Creates a default CDK scope for the Amplify backend to use if no scope is provided to the constructor
  */
-export const createDefaultStack = (app = new App()): Stack => {
+export const createDefaultStack = (
+  app?: App,
+  props?: MainStackProps
+): Stack => {
+  if (app === undefined) {
+    app = new App();
+  }
   const mainStackCreator = new ProjectEnvironmentMainStackCreator(
     app,
     getBackendIdentifier(app)
   );
-  return mainStackCreator.getOrCreateMainStack();
+  return mainStackCreator.getOrCreateMainStack(props);
 };

--- a/packages/backend/src/engine/amplify_stack.ts
+++ b/packages/backend/src/engine/amplify_stack.ts
@@ -1,7 +1,38 @@
 import { AmplifyFault } from '@aws-amplify/platform-core';
-import { Aspects, CfnElement, IAspect, Stack } from 'aws-cdk-lib';
+import { Aspects, CfnElement, IAspect, Stack, StackProps } from 'aws-cdk-lib';
 import { Role } from 'aws-cdk-lib/aws-iam';
 import { Construct, IConstruct } from 'constructs';
+
+/**
+ * Props for root CDK Stack
+ * @see {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.StackProps.html | AWS documentation for aws-cdk-lib.StackProps}
+ *
+ * Props are picked to ensure explicit addition of new StackProps is required.
+ * Props incompatible with Amplify's intended Stack hierarchy, build or deployment processes are ommited:
+ * - stackName: Conflicts with dynamic resource naming.
+ * - synthesizer: Conflicts with managed deployments and resource references.
+ * - terminationProtection: Conflicts with sandbox/app delete.
+ * - permissionsBoundary: Conflicts with single root Stack ethos (i.e. Unable to create Role prior to `defineBackend`).
+ *
+ * Props are passed down from `defineBackend`:
+ * @example <caption>Set explicit region (e.g. for `new cloudfront.experimental.EdgeFunction`)</caption>
+ * ```
+ * defineBackend({}, {
+ *   env:
+ *     region: 'us-east-1' // Any valid AWS region
+ *   }
+ * })
+ * ```
+ */
+export type MainStackProps = Pick<
+  StackProps,
+  | 'description'
+  | 'env'
+  | 'tags'
+  | 'analyticsReporting'
+  | 'crossRegionReferences'
+  | 'suppressTemplateIndentation'
+>;
 
 /**
  * Amplify-specific Stack implementation to handle cross-cutting concerns for all Amplify stacks
@@ -10,8 +41,8 @@ export class AmplifyStack extends Stack {
   /**
    * Default constructor
    */
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: MainStackProps) {
+    super(scope, id, props);
     Aspects.of(this).add(new CognitoRoleTrustPolicyValidator());
   }
   /**

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,3 +1,4 @@
+export { type MainStackProps } from './engine/amplify_stack.js';
 export { defineBackend } from './backend_factory.js';
 export * from './backend.js';
 export * from './secret.js';

--- a/packages/backend/src/project_environment_main_stack_creator.ts
+++ b/packages/backend/src/project_environment_main_stack_creator.ts
@@ -1,7 +1,7 @@
 import { BackendIdentifier, MainStackCreator } from '@aws-amplify/plugin-types';
 import { Construct } from 'constructs';
 import { Stack, Tags } from 'aws-cdk-lib';
-import { AmplifyStack } from './engine/amplify_stack.js';
+import { AmplifyStack, MainStackProps } from './engine/amplify_stack.js';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 
 /**
@@ -20,11 +20,12 @@ export class ProjectEnvironmentMainStackCreator implements MainStackCreator {
   /**
    * Get a stack for this environment in the provided CDK scope
    */
-  getOrCreateMainStack = (): Stack => {
+  getOrCreateMainStack = (props?: MainStackProps): Stack => {
     if (this.mainStack === undefined) {
       this.mainStack = new AmplifyStack(
         this.scope,
-        BackendIdentifierConversions.toStackName(this.backendId)
+        BackendIdentifierConversions.toStackName(this.backendId),
+        props
       );
     }
 


### PR DESCRIPTION
## Problem

Currently, it is not possible to pass instantiation props to the Amplify root CDK Stack, and, by convention, any Nested Stack created through `backend.createStack`. This prevents certain resource deployments: An EdgeFunction for instance requires the region to be explicitly set. Furthermore, while Nested Stacks inherit their region from their parent stack, Amplify has a single root node convention, so multiple root stacks are not an option. Evaluation in CDK appears to be strict so the only way to do deploy an EdgeFunction from an Amplify project looks to be at instantiation of the root Stack.

Note: I used 'main' instead of 'root' because that is the naming convention used in the [current code](https://github.com/aws-amplify/amplify-backend/blob/1f4c6e0c298e8ee087000d0efd3eb25f18eec433/packages/backend/src/default_stack_factory.ts#L9). 
 
See **#1663** for more information on trying to deploy an EdgeFunction with current version. 

## Changes

This implementation specifically avoids breaking changes, but does require argument mutation. The relevant args are not typed as `const` so this may be fine, but if it goes against an established convention, let me know as I can update it easily enough. This was needed because the relevant calls are being made as default argument values in both [BackendFactory constructor](https://github.com/aws-amplify/amplify-backend/blob/1f4c6e0c298e8ee087000d0efd3eb25f18eec433/packages/backend/src/backend_factory.ts#L58) and [createDefaultStack](https://github.com/aws-amplify/amplify-backend/blob/1f4c6e0c298e8ee087000d0efd3eb25f18eec433/packages/backend/src/default_stack_factory.ts#L8C14-L8C33) respectively.

This PR introduces a `mainStackProps` argument to the `defineBackend` function. This gets passed down the callstack and used to define the root Stack in the `AmplifyStack` class.

### Props for root CDK Stack

[AWS documentation for aws-cdk-lib.StackProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.StackProps.html)

- Props are picked to ensure explicit addition of new StackProps is required.
  - description?: string
  - env?: Environment
  - tags?: { [key: string]: string }
  - analyticsReporting?: boolean
  - crossRegionReferences?: boolean
  - suppressTemplateIndentation?: boolean

- StackProps incompatible with Amplify's intended hierarchy, build or deployment processes are omitted:
  - stackName: Conflicts with dynamic resource naming.
  - synthesizer: Conflicts with managed deployments and resource references.
  - terminationProtection: Conflicts with sandbox/app delete.
  - permissionsBoundary: Conflicts with single root Stack ethos (i.e. Unable to create Role prior to `defineBackend`).

Props are passed down from `defineBackend`. e.g:

```
defineBackend({
  auth,
  storage,
}, {
  description: 'test-description',
  env: {
    region: 'us-east-1',
    account: '[YOUR_ACCOUNT_ID]'
  },
  tags: {
    'test-tag': 'test-tag-value',
  },
  analyticsReporting: true,
  crossRegionReferences: true,
  suppressTemplateIndentation: true,
})
```

## Validation

All existing unit, e2e and deployment tests pass. Coverage is unchanged. 

Using the npm proxy, I have fully deployed and tested the EdgeFunction case with various configurations.   

This change simply passes props tested in [aws-cdk-lib/core/test/stack.test.ts](https://github.com/aws/aws-cdk/blob/3b95777ee5dae32fd41481d81922d07c804a2c6b/packages/aws-cdk-lib/core/test/stack.test.ts). i.e It already follows defined convention. As such, I am not sure what automated testing would actually be useful. I did try though, so please let me know if you would like me to some tests back in?

I started out writing unit tests, but struggled to find a way to validate anything useful there. I could potentially check that `${AWS::Region}` does not exist in the generated Stack Template but that seems like a stretch. 

I wrote e2e and deployment tests, but they don't really do much to actually test anything in scope and they add a lot of unnecessary overhead. The deployment tests for instance, requires that I update the test stack generation process and/or write the tests without following the conventions established by the existing test structure. Again, if you would prefer these be in, I can put them back. 

## Checklist

A point on the below: The PROJECT_ARCHITECTURE.md readme doesn't exist. 

- [] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR. 
- [] If this PR requires a docs update, I have linked to that docs PR above.
- [] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
