### PR TITLE
fix: Only first class supported idp providers should be present in the client config

### DIFF
--- a/.changeset/healthy-monkeys-help.md
+++ b/.changeset/healthy-monkeys-help.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+fix: Only first class supported idp providers should be present in the client config

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.test.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.test.ts
@@ -129,7 +129,7 @@ void describe('auth client config contributor v1', () => {
             oauthRedirectSignIn: 'http://callback.com,http://callback2.com',
             oauthRedirectSignOut: 'http://logout.com,http://logout2.com',
             oauthResponseType: 'code',
-            socialProviders: `["GOOGLE","FACEBOOK"]`,
+            socialProviders: `["GOOGLE","FACEBOOK","SIGN_IN_WITH_APPLE","LOGIN_WITH_AMAZON","GITHUB","DISCORD"]`,
           },
         },
       }),
@@ -152,7 +152,12 @@ void describe('auth client config contributor v1', () => {
           username_attributes: ['email'],
           user_verification_types: ['email', 'phone_number'],
           oauth: {
-            identity_providers: ['GOOGLE', 'FACEBOOK'],
+            identity_providers: [
+              'GOOGLE',
+              'FACEBOOK',
+              'SIGN_IN_WITH_APPLE',
+              'LOGIN_WITH_AMAZON',
+            ], //Only first class supported idp providers
             domain: 'testDomain',
             scopes: ['email', 'profile'],
             redirect_sign_in_uri: [

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
@@ -146,10 +146,14 @@ export class AuthClientConfigContributor implements ClientConfigContributor {
       authOutput.payload.oauthRedirectSignIn &&
       authOutput.payload.oauthRedirectSignOut
     ) {
+      let socialProviders = authOutput.payload.socialProviders
+        ? JSON.parse(authOutput.payload.socialProviders)
+        : [];
+      if (Array.isArray(socialProviders)) {
+        socialProviders = socialProviders.filter(this.isValidIdentityProvider);
+      }
       authClientConfig.auth.oauth = {
-        identity_providers: authOutput.payload.socialProviders
-          ? JSON.parse(authOutput.payload.socialProviders)
-          : [],
+        identity_providers: socialProviders,
         redirect_sign_in_uri: authOutput.payload.oauthRedirectSignIn.split(','),
         redirect_sign_out_uri:
           authOutput.payload.oauthRedirectSignOut.split(','),
@@ -167,6 +171,16 @@ export class AuthClientConfigContributor implements ClientConfigContributor {
     }
 
     return authClientConfig;
+  };
+
+  // Define a type guard function to check if a value is a valid IdentityProvider
+  isValidIdentityProvider = (identityProvider: string): boolean => {
+    return [
+      'GOOGLE',
+      'FACEBOOK',
+      'LOGIN_WITH_AMAZON',
+      'SIGN_IN_WITH_APPLE',
+    ].includes(identityProvider);
   };
 }
 


### PR DESCRIPTION
## Problem

**Issue number, if available:** fixes https://github.com/aws-amplify/amplify-backend/issues/1681

## Changes

Filters OIDC providers out that are not supported out of the box by cognito.

**Corresponding docs PR, if applicable:**

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
