### PR TITLE
fix error message formatting when amplify outputs cannot be generated

### DIFF
--- a/.changeset/flat-toys-love.md
+++ b/.changeset/flat-toys-love.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+fix error message formatting when amplify outputs cannot be generated

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.test.ts
@@ -174,12 +174,9 @@ void describe('sandbox_event_handler_factory', () => {
 
     assert.deepStrictEqual(
       printMock.mock.calls[0].arguments[0],
-      format.error('Amplify configuration could not be generated.')
-    );
-
-    assert.deepStrictEqual(
-      printMock.mock.calls[1].arguments[0],
-      format.error(new Error('test error message'))
+      `${format.error(
+        'Amplify outputs could not be generated.'
+      )} ${format.error(new Error('test error message'))}`
     );
 
     assert.deepEqual(generateClientConfigMock.mock.calls[0].arguments, [

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.ts
@@ -45,9 +45,10 @@ export class SandboxEventHandlerFactory {
           } catch (error) {
             // Don't crash sandbox if config cannot be generated, but print the error message
             printer.print(
-              format.error('Amplify configuration could not be generated.')
+              `${format.error(
+                'Amplify outputs could not be generated.'
+              )} ${format.error(error)}`
             );
-            printer.print(format.error(error));
           }
         },
       ],


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Fixes https://github.com/aws-amplify/amplify-backend/issues/964 .

## Changes

1. Improves spacing
2. It changes wording from `configuration` to `outputs` to align with rest of the code.

## Out of scope

The GH issue asked to include region in error message. However, that error message is coming from CFN service via SDK call and we don't have control over it. Region messaging should be handled differently.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
