### PR TITLE
chore: add success messaging when setting and removing sandbox secrets

### DIFF
--- a/.changeset/chilly-onions-look.md
+++ b/.changeset/chilly-onions-look.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+chore: add success messaging when setting and removing sandbox secrets

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.test.ts
@@ -5,6 +5,7 @@ import assert from 'node:assert';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { getSecretClient } from '@aws-amplify/backend-secret';
 import { SandboxSecretRemoveCommand } from './sandbox_secret_remove_command.js';
+import { printer } from '@aws-amplify/cli-core';
 
 const testSecretName = 'testSecretName';
 const testBackendId = 'testBackendId';
@@ -17,6 +18,7 @@ void describe('sandbox secret remove command', () => {
     'removeSecret',
     (): Promise<void> => Promise.resolve()
   );
+  const printMock = mock.method(printer, 'print');
 
   const sandboxIdResolver: SandboxBackendIdResolver = {
     resolve: (identifier?: string) =>
@@ -40,6 +42,7 @@ void describe('sandbox secret remove command', () => {
 
   beforeEach(async () => {
     secretRemoveMock.mock.resetCalls();
+    printMock.mock.resetCalls();
   });
 
   void it('remove a secret', async () => {
@@ -53,6 +56,10 @@ void describe('sandbox secret remove command', () => {
       },
       testSecretName,
     ]);
+    assert.equal(
+      printMock.mock.calls[0].arguments,
+      `Successfully removed secret ${testSecretName}`
+    );
   });
 
   void it('removes secret from named sandbox', async () => {

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.ts
@@ -3,6 +3,7 @@ import { SecretClient } from '@aws-amplify/backend-secret';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
 import { SandboxCommandGlobalOptions } from '../option_types.js';
+import { printer } from '@aws-amplify/cli-core';
 
 /**
  * Command to remove sandbox secret.
@@ -44,6 +45,8 @@ export class SandboxSecretRemoveCommand
       sandboxBackendIdentifier,
       args.secretName
     );
+
+    printer.print(`Successfully removed secret ${args.secretName}`);
   };
 
   /**

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, mock } from 'node:test';
-import { AmplifyPrompter } from '@aws-amplify/cli-core';
+import { AmplifyPrompter, printer } from '@aws-amplify/cli-core';
 import yargs, { CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
@@ -26,6 +26,7 @@ void describe('sandbox secret set command', () => {
     'setSecret',
     (): Promise<SecretIdentifier> => Promise.resolve(testSecretIdentifier)
   );
+  const printMock = mock.method(printer, 'print');
 
   const sandboxIdResolver: SandboxBackendIdResolver = {
     resolve: (identifier?: string) =>
@@ -53,6 +54,7 @@ void describe('sandbox secret set command', () => {
 
   beforeEach(async () => {
     secretSetMock.mock.resetCalls();
+    printMock.mock.resetCalls();
   });
 
   void it('sets a secret', async (contextual) => {
@@ -75,6 +77,10 @@ void describe('sandbox secret set command', () => {
       testSecretName,
       testSecretValue,
     ]);
+    assert.equal(
+      printMock.mock.calls[0].arguments[0],
+      `Successfully created version ${testSecretIdentifier.version} of secret ${testSecretIdentifier.name}`
+    );
   });
 
   void it('sets a secret in a named sandbox', async (contextual) => {

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.ts
@@ -1,7 +1,7 @@
 import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { AmplifyPrompter } from '@aws-amplify/cli-core';
+import { AmplifyPrompter, printer } from '@aws-amplify/cli-core';
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
 import { SandboxCommandGlobalOptions } from '../option_types.js';
 import { once } from 'events';
@@ -43,10 +43,13 @@ export class SandboxSecretSetCommand
   ): Promise<void> => {
     const secretValue = await this.readSecretValue();
 
-    await this.secretClient.setSecret(
+    const secretIdentifier = await this.secretClient.setSecret(
       await this.sandboxIdResolver.resolve(args.identifier),
       args.secretName,
       secretValue
+    );
+    printer.print(
+      `Successfully created version ${secretIdentifier.version} of secret ${secretIdentifier.name}`
     );
   };
 


### PR DESCRIPTION
## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:** fixes https://github.com/aws-amplify/amplify-backend/issues/1480

## Changes

Better messaging to let users know that the secret command was successful.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
