### PR TITLE
add possibility to specify output format in pipeline-deploy command

### DIFF
--- a/.changeset/selfish-pumpkins-sparkle.md
+++ b/.changeset/selfish-pumpkins-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+add possibility to specify output format in pipeline-deploy command

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@aws-amplify/cli-core';
 import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
 import {
+  ClientConfigFormat,
   ClientConfigVersionOption,
   DEFAULT_CLIENT_CONFIG_VERSION,
 } from '@aws-amplify/client-config';
@@ -156,6 +157,7 @@ void describe('deploy command', () => {
       },
       DEFAULT_CLIENT_CONFIG_VERSION,
       'src',
+      undefined,
     ]);
   });
 
@@ -192,6 +194,44 @@ void describe('deploy command', () => {
       },
       ClientConfigVersionOption.V0,
       undefined,
+      undefined,
+    ]);
+  });
+
+  void it('allows --outputs-format argument', async () => {
+    const backendDeployerFactory = new BackendDeployerFactory(
+      packageManagerControllerFactory.getPackageManagerController(),
+      formatterStub
+    );
+    const mockDeploy = mock.method(
+      backendDeployerFactory.getInstance(),
+      'deploy',
+      () => Promise.resolve()
+    );
+    await getCommandRunner(true).runCommand(
+      'pipeline-deploy --app-id abc --branch test-branch --outputs-format dart'
+    );
+    assert.strictEqual(mockDeploy.mock.callCount(), 1);
+    assert.deepStrictEqual(mockDeploy.mock.calls[0].arguments, [
+      {
+        name: 'test-branch',
+        namespace: 'abc',
+        type: 'branch',
+      },
+      {
+        validateAppSources: true,
+      },
+    ]);
+    assert.equal(generateClientConfigMock.mock.callCount(), 1);
+    assert.deepStrictEqual(generateClientConfigMock.mock.calls[0].arguments, [
+      {
+        name: 'test-branch',
+        namespace: 'abc',
+        type: 'branch',
+      },
+      DEFAULT_CLIENT_CONFIG_VERSION,
+      undefined,
+      ClientConfigFormat.DART,
     ]);
   });
 });

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -5,6 +5,7 @@ import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_
 import { ArgumentsKebabCase } from '../../kebab_case.js';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import {
+  ClientConfigFormat,
   ClientConfigVersion,
   ClientConfigVersionOption,
   DEFAULT_CLIENT_CONFIG_VERSION,
@@ -16,6 +17,7 @@ export type PipelineDeployCommandOptions =
 type PipelineDeployCommandOptionsCamelCase = {
   branch: string;
   appId: string;
+  outputsFormat: ClientConfigFormat | undefined;
   outputsVersion: string;
   outputsOutDir?: string;
 };
@@ -72,7 +74,8 @@ export class PipelineDeployCommand
     await this.clientConfigGenerator.generateClientConfigToFile(
       backendId,
       args.outputsVersion as ClientConfigVersion,
-      args.outputsOutDir
+      args.outputsOutDir,
+      args.outputsFormat
     );
   };
 
@@ -104,6 +107,12 @@ export class PipelineDeployCommand
         array: false,
         choices: Object.values(ClientConfigVersionOption),
         default: DEFAULT_CLIENT_CONFIG_VERSION,
+      })
+      .option('outputs-format', {
+        describe: 'amplify_outputs file format',
+        type: 'string',
+        array: false,
+        choices: Object.values(ClientConfigFormat),
       });
   };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

`pipeline-deploy` command can't render same outputs as `sandbox` command. This impacts DX of non-JS projects.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**
https://github.com/aws-amplify/amplify-backend/issues/1612

## Changes

Introduce `--outputs-format` parameter for pipeline deploy command by pattern matching sandbox.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

Unit test added.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
