### PR TITLE
Remove "Gen 2" wording from telemetry message

### DIFF
--- a/.changeset/curvy-lamps-swim.md
+++ b/.changeset/curvy-lamps-swim.md
@@ -1,0 +1,5 @@
+---
+'create-amplify': patch
+---
+
+Remove "Gen 2" wording from telemetry message

--- a/packages/create-amplify/src/amplify_project_creator.test.ts
+++ b/packages/create-amplify/src/amplify_project_creator.test.ts
@@ -92,10 +92,10 @@ void describe('AmplifyProjectCreator', () => {
     assert.equal(
       logSpy.mock.calls[14].arguments[0],
       grey(
-        `Amplify Gen 2 collects anonymous telemetry data about general usage of the CLI. Participation is optional, and you may opt-out by using ${cyan(
+        `Amplify collects anonymous telemetry data about general usage of the CLI. Participation is optional, and you may opt-out by using ${cyan(
           'npx ampx configure telemetry disable'
         )}. To learn more about telemetry, visit ${underline(
-          blue('https://docs.amplify.aws/gen2/reference/telemetry')
+          blue('https://docs.amplify.aws/react/reference/telemetry')
         )}`
       )
     );
@@ -137,10 +137,10 @@ void describe('AmplifyProjectCreator', () => {
     assert.equal(
       logSpy.mock.calls[14].arguments[0],
       grey(
-        `Amplify Gen 2 collects anonymous telemetry data about general usage of the CLI. Participation is optional, and you may opt-out by using ${cyan(
+        `Amplify collects anonymous telemetry data about general usage of the CLI. Participation is optional, and you may opt-out by using ${cyan(
           'npx ampx configure telemetry disable'
         )}. To learn more about telemetry, visit ${underline(
-          blue('https://docs.amplify.aws/gen2/reference/telemetry')
+          blue('https://docs.amplify.aws/react/reference/telemetry')
         )}`
       )
     );

--- a/packages/create-amplify/src/amplify_project_creator.ts
+++ b/packages/create-amplify/src/amplify_project_creator.ts
@@ -6,7 +6,7 @@ import { GitIgnoreInitializer } from './gitignore_initializer.js';
 import { InitialProjectFileGenerator } from './initial_project_file_generator.js';
 
 const LEARN_MORE_USAGE_DATA_TRACKING_LINK =
-  'https://docs.amplify.aws/gen2/reference/telemetry';
+  'https://docs.amplify.aws/react/reference/telemetry';
 
 /**
  * Orchestration class that sets up a new Amplify project
@@ -106,7 +106,7 @@ export class AmplifyProjectCreator {
 
     printer.log(
       format.note(
-        `Amplify Gen 2 collects anonymous telemetry data about general usage of the CLI. Participation is optional, and you may opt-out by using ${format.normalizeAmpxCommand(
+        `Amplify collects anonymous telemetry data about general usage of the CLI. Participation is optional, and you may opt-out by using ${format.normalizeAmpxCommand(
           'configure telemetry disable'
         )}. To learn more about telemetry, visit ${format.link(
           LEARN_MORE_USAGE_DATA_TRACKING_LINK


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

There's "Gen 2" in telemetry message.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

"Gen 2" is removed now.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

1. Unit test amended.
2. Manually verified that changed http link works as expected.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
