### PR TITLE
Discussion: Allow passing in a schema configuration for string based schemas

### DIFF
--- a/.changeset/twenty-pants-own.md
+++ b/.changeset/twenty-pants-own.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': minor
+---
+
+allow passing in a schema configuration for string based SQL schemas

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -1,6 +1,7 @@
 import {
   DerivedCombinedSchema,
   DerivedModelSchema,
+  SchemaConfiguration,
 } from '@aws-amplify/data-schema-types';
 import { AmplifyFunction, ConstructFactory } from '@aws-amplify/plugin-types';
 
@@ -124,6 +125,11 @@ export type DataProps = {
    * Graphql Schema as a string to be passed into the CDK construct.
    */
   schema: DataSchemaInput;
+
+  /**
+   * Schema configuration for non-DynamoDB data sources.
+   */
+  schemaConfiguration?: SchemaConfiguration;
 
   /**
    * Optional name for the generated Api.


### PR DESCRIPTION
I would like to discuss how we could enable users to pass in a SQL based SDL into `defineData` and what the API surface should look like. See github issue for further details.

## Problem

#1705 

## Changes

Added a `SchemaConfiguration` property to `DataProps` to override the default DDB strategy used for string based schemas.

## Validation

N/A

## Checklist

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
