### PR TITLE
Adding an `ai` subpath under `backend` package to place ai functions

### DIFF
--- a/.changeset/proud-drinks-drop.md
+++ b/.changeset/proud-drinks-drop.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-ai': minor
+'@aws-amplify/backend': minor
+---
+
+Added ai subpath under backend for ai functions

--- a/.changeset/smart-forks-pay.md
+++ b/.changeset/smart-forks-pay.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-ai': minor
+'@aws-amplify/backend': minor
+---
+
+Added ai subpath under backend directory for ai functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -440,6 +440,10 @@
       "resolved": "packages/backend",
       "link": true
     },
+    "node_modules/@aws-amplify/backend-ai": {
+      "resolved": "packages/backend-ai",
+      "link": true
+    },
     "node_modules/@aws-amplify/backend-auth": {
       "resolved": "packages/backend-auth",
       "link": true
@@ -27733,12 +27737,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.0.1",
-        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-amplify/backend-output-storage": "^1.0.2",
+        "@aws-amplify/plugin-types": "^1.0.1",
         "@aws-sdk/util-arn-parser": "^3.465.0"
       },
       "peerDependencies": {
@@ -27748,20 +27752,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^1.0.2",
-        "@aws-amplify/backend-data": "^1.0.2",
-        "@aws-amplify/backend-function": "^1.0.3",
+        "@aws-amplify/backend-auth": "^1.1.0",
+        "@aws-amplify/backend-data": "^1.0.3",
+        "@aws-amplify/backend-function": "^1.1.0",
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.0.1",
+        "@aws-amplify/backend-output-storage": "^1.0.2",
         "@aws-amplify/backend-secret": "^1.0.0",
-        "@aws-amplify/backend-storage": "^1.0.2",
-        "@aws-amplify/client-config": "^1.0.3",
+        "@aws-amplify/backend-storage": "^1.0.4",
+        "@aws-amplify/client-config": "^1.0.5",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^1.0.1",
-        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-amplify/plugin-types": "^1.0.1",
         "@aws-sdk/client-amplify": "^3.465.0",
         "lodash.snakecase": "^4.1.1"
       },
@@ -27775,14 +27779,18 @@
         "constructs": "^10.0.0"
       }
     },
+    "packages/backend-ai": {
+      "version": "0.1.0",
+      "license": "Apache-2.0"
+    },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct": "^1.1.1",
-        "@aws-amplify/backend-output-storage": "^1.0.1",
-        "@aws-amplify/plugin-types": "^1.0.0"
+        "@aws-amplify/auth-construct": "^1.1.5",
+        "@aws-amplify/backend-output-storage": "^1.0.2",
+        "@aws-amplify/plugin-types": "^1.0.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
@@ -27795,14 +27803,14 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.0.1",
+        "@aws-amplify/backend-output-storage": "^1.0.2",
         "@aws-amplify/data-construct": "^1.8.0",
         "@aws-amplify/data-schema-types": "^1.0.0",
-        "@aws-amplify/plugin-types": "^1.0.0"
+        "@aws-amplify/plugin-types": "^1.0.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
@@ -27816,11 +27824,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.0",
-        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-amplify/plugin-types": "^1.0.1",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -27831,12 +27839,12 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.0.1",
-        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-amplify/backend-output-storage": "^1.0.2",
+        "@aws-amplify/plugin-types": "^1.0.1",
         "execa": "^8.0.1"
       },
       "devDependencies": {
@@ -27877,7 +27885,7 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -27911,12 +27919,12 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.0.1",
-        "@aws-amplify/plugin-types": "^1.0.0"
+        "@aws-amplify/backend-output-storage": "^1.0.2",
+        "@aws-amplify/plugin-types": "^1.0.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
@@ -27929,20 +27937,20 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.0.0",
+        "@aws-amplify/backend-deployer": "^1.0.1",
         "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/backend-secret": "^1.0.0",
         "@aws-amplify/cli-core": "^1.0.0",
-        "@aws-amplify/client-config": "^1.0.3",
+        "@aws-amplify/client-config": "^1.0.5",
         "@aws-amplify/deployed-backend-client": "^1.0.1",
         "@aws-amplify/form-generator": "^1.0.0",
         "@aws-amplify/model-generator": "^1.0.1",
         "@aws-amplify/platform-core": "^1.0.1",
-        "@aws-amplify/sandbox": "^1.0.3",
-        "@aws-amplify/schema-generator": "^1.0.0",
+        "@aws-amplify/sandbox": "^1.0.5",
+        "@aws-amplify/schema-generator": "^1.1.0",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
@@ -28074,7 +28082,7 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -28095,12 +28103,12 @@
       }
     },
     "packages/create-amplify": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/cli-core": "^1.0.0",
         "@aws-amplify/platform-core": "^1.0.0",
-        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-amplify/plugin-types": "^1.0.1",
         "execa": "^8.0.1",
         "kleur": "^4.1.5",
         "yargs": "^17.7.2"
@@ -28351,7 +28359,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "execa": "^5.1.1"
@@ -28471,13 +28479,13 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.0.0",
+        "@aws-amplify/backend-deployer": "^1.0.1",
         "@aws-amplify/backend-secret": "^1.0.0",
         "@aws-amplify/cli-core": "^1.0.0",
-        "@aws-amplify/client-config": "^1.0.4",
+        "@aws-amplify/client-config": "^1.0.5",
         "@aws-amplify/deployed-backend-client": "^1.0.2",
         "@aws-amplify/platform-core": "^1.0.1",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -28500,7 +28508,7 @@
     },
     "packages/schema-generator": {
       "name": "@aws-amplify/schema-generator",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-schema-generator": "^0.9.0",

--- a/packages/backend-ai/.npmignore
+++ b/packages/backend-ai/.npmignore
@@ -1,0 +1,14 @@
+# Be very careful editing this file. It is crafted to work around [this issue](https://github.com/npm/npm/issues/4479)
+
+# First ignore everything
+**/*
+
+# Then add back in transpiled js and ts declaration files
+!lib/**/*.js
+!lib/**/*.d.ts
+
+# Then ignore test js and ts declaration files
+*.test.js
+*.test.d.ts
+
+# This leaves us with including only js and ts declaration files of functional code

--- a/packages/backend-ai/README.md
+++ b/packages/backend-ai/README.md
@@ -1,0 +1,5 @@
+# Description
+
+This package provides ergonomic functions integrating AI capabilities into their Amplify backend, specifically for building custom Lambda handlers that leverage AI services in the cloud.
+
+It contains high-level abstractions and utilities for interacting with AI models, simplifying the process of incorporating AI functionality into Amplify projects.

--- a/packages/backend-ai/api-extractor.json
+++ b/packages/backend-ai/api-extractor.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../api-extractor.base.json"
+}

--- a/packages/backend-ai/package.json
+++ b/packages/backend-ai/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@aws-amplify/backend-ai",
+  "version": "1.0.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js",
+      "require": "./lib/index.js"
+    }
+  },
+  "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.602.0"
+  },
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "update:api": "api-extractor run --local"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/backend-ai/tsconfig.json
+++ b/packages/backend-ai/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  }
+}

--- a/packages/backend-ai/tsconfig.json
+++ b/packages/backend-ai/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
-  }
+  "compilerOptions": { "rootDir": "src", "outDir": "lib" },
+  "references": []
 }

--- a/packages/backend-ai/typedoc.json
+++ b/packages/backend-ai/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,6 +13,11 @@
     },
     "./types/platform": {
       "types": "./lib/types/platform.d.ts"
+    },
+    "./ai": {
+      "types": "./lib/ai.d.ts",
+      "import": "./lib/ai.js",
+      "require": "./lib/ai.js"
     }
   },
   "imports": {
@@ -24,6 +29,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-amplify/backend-ai": "^1.0.0",
     "@aws-amplify/data-schema": "^1.0.0",
     "@aws-amplify/backend-auth": "^1.1.0",
     "@aws-amplify/backend-function": "^1.1.0",

--- a/packages/backend/src/at.ts
+++ b/packages/backend/src/at.ts
@@ -1,0 +1,1 @@
+export * from '@aws-amplify/backend-ai';

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
   "references": [
+    { "path": "../backend-ai" },
     { "path": "../backend-auth" },
     { "path": "../backend-function" },
     { "path": "../backend-data" },


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

- Adding an `ai` subpath under `backend` package to place ai functions
- allow exports from `backend-ai` under `backend`

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
