### PR TITLE
fix: disallow Gen 1 Patterns in GraphQL SDL schema.

### DIFF
--- a/.changeset/unlucky-otters-hide.md
+++ b/.changeset/unlucky-otters-hide.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': patch
+---
+
+Disallow Gen 1 Patterns in GraphQL SDL schema.

--- a/.changeset/unlucky-otters-hide.md
+++ b/.changeset/unlucky-otters-hide.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/backend-data': patch
+'@aws-amplify/backend-data': minor
 ---
 
 Disallow Gen 1 Patterns in GraphQL SDL schema.

--- a/package-lock.json
+++ b/package-lock.json
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.9.1.tgz",
-      "integrity": "sha512-xnL5zZBJ1EYCoqG8Y1BnGJ24sutBWcchxd1NflNiM4Dk9o1m47GNxnJOdIUp7c5pewKSTvGXk37lTesHPIcuvw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.9.2.tgz",
+      "integrity": "sha512-r5PCfKOHKdfcSbliR0fWrvV+CVXfPZb2IBhAPIUdIeuu1VIYrbUUdle/cEBu1j9ThmlRWLM0OPzJByAX3lHSjw==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -666,22 +666,22 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-api-construct": "1.11.1",
-        "@aws-amplify/graphql-auth-transformer": "3.6.2",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.10",
+        "@aws-amplify/graphql-api-construct": "1.11.2",
+        "@aws-amplify/graphql-auth-transformer": "3.6.3",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.11",
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.25",
-        "@aws-amplify/graphql-http-transformer": "2.1.25",
-        "@aws-amplify/graphql-index-transformer": "2.4.6",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.20",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.25",
-        "@aws-amplify/graphql-relational-transformer": "2.5.8",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.6",
-        "@aws-amplify/graphql-sql-transformer": "0.3.6",
-        "@aws-amplify/graphql-transformer": "1.6.2",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.26",
+        "@aws-amplify/graphql-http-transformer": "2.1.26",
+        "@aws-amplify/graphql-index-transformer": "2.4.7",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.21",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.26",
+        "@aws-amplify/graphql-relational-transformer": "2.5.9",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.7",
+        "@aws-amplify/graphql-sql-transformer": "0.3.7",
+        "@aws-amplify/graphql-transformer": "1.6.3",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -705,8 +705,8 @@
         "zod": "^3.22.3"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-schemas": {
@@ -730,15 +730,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.6.2",
+      "version": "3.6.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-relational-transformer": "2.5.8",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-relational-transformer": "2.5.9",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1",
@@ -746,18 +746,18 @@
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.10",
+      "version": "2.3.11",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1",
@@ -770,194 +770,194 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.25",
+      "version": "2.1.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.25",
+      "version": "2.1.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.4.6",
+      "version": "2.4.7",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.20",
+      "version": "3.4.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.11.1",
+      "version": "2.11.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.25",
+      "version": "2.1.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.8",
+      "version": "2.5.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.6",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.7",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.7.6",
+      "version": "2.7.7",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.3.6",
+      "version": "0.3.7",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.6.2",
+      "version": "1.6.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.6.2",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.10",
-        "@aws-amplify/graphql-function-transformer": "2.1.25",
-        "@aws-amplify/graphql-http-transformer": "2.1.25",
-        "@aws-amplify/graphql-index-transformer": "2.4.6",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.20",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.25",
-        "@aws-amplify/graphql-relational-transformer": "2.5.8",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.6",
-        "@aws-amplify/graphql-sql-transformer": "0.3.6",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0"
+        "@aws-amplify/graphql-auth-transformer": "3.6.3",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.11",
+        "@aws-amplify/graphql-function-transformer": "2.1.26",
+        "@aws-amplify/graphql-http-transformer": "2.1.26",
+        "@aws-amplify/graphql-index-transformer": "2.4.7",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.21",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.26",
+        "@aws-amplify/graphql-relational-transformer": "2.5.9",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.7",
+        "@aws-amplify/graphql-sql-transformer": "0.3.7",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.9.2",
+      "version": "2.9.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
@@ -969,20 +969,20 @@
         "ts-dedent": "^2.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.10.0",
+      "version": "3.10.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "graphql": "^15.5.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core": {
@@ -1236,9 +1236,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.11.1.tgz",
-      "integrity": "sha512-FMTPU4yPOM10f1eM9ZwEOlyfHJBRrCVZoC/1DC9KVHxjt27lcpHYH8U227IBGEecqWxBjI6e7Vopd9ibjroFdA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.11.2.tgz",
+      "integrity": "sha512-0Xp32hm+3DPchxYjmyqT+ry+ZrQgPntGpPs0hgHFmVMdOLBlwlmcyLv6qiUsPuuQkY5cA0K9UMGUStEoV6nxmg==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
@@ -1282,21 +1282,21 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^0.4.0",
         "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-auth-transformer": "3.6.2",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.10",
+        "@aws-amplify/graphql-auth-transformer": "3.6.3",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.11",
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-function-transformer": "2.1.25",
-        "@aws-amplify/graphql-http-transformer": "2.1.25",
-        "@aws-amplify/graphql-index-transformer": "2.4.6",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.20",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.25",
-        "@aws-amplify/graphql-relational-transformer": "2.5.8",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.6",
-        "@aws-amplify/graphql-sql-transformer": "0.3.6",
-        "@aws-amplify/graphql-transformer": "1.6.2",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-function-transformer": "2.1.26",
+        "@aws-amplify/graphql-http-transformer": "2.1.26",
+        "@aws-amplify/graphql-index-transformer": "2.4.7",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.21",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.26",
+        "@aws-amplify/graphql-relational-transformer": "2.5.9",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.7",
+        "@aws-amplify/graphql-sql-transformer": "0.3.7",
+        "@aws-amplify/graphql-transformer": "1.6.3",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "@aws-amplify/platform-core": "^0.2.0",
         "@aws-amplify/plugin-types": "^0.4.1",
         "charenc": "^0.0.2",
@@ -1320,8 +1320,8 @@
         "zod": "^3.22.3"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-schemas": {
@@ -1345,15 +1345,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "3.6.2",
+      "version": "3.6.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-relational-transformer": "2.5.8",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-relational-transformer": "2.5.9",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1",
@@ -1361,18 +1361,18 @@
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "2.3.10",
+      "version": "2.3.11",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1",
@@ -1385,194 +1385,194 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "2.1.25",
+      "version": "2.1.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "2.1.25",
+      "version": "2.1.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "2.4.6",
+      "version": "2.4.7",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "3.4.20",
+      "version": "3.4.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "2.11.1",
+      "version": "2.11.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "2.1.25",
+      "version": "2.1.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "2.5.8",
+      "version": "2.5.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-index-transformer": "2.4.6",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-index-transformer": "2.4.7",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "2.7.6",
+      "version": "2.7.7",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.3.6",
+      "version": "0.3.7",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
         "graphql-transformer-common": "4.31.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "1.6.2",
+      "version": "1.6.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "3.6.2",
-        "@aws-amplify/graphql-default-value-transformer": "2.3.10",
-        "@aws-amplify/graphql-function-transformer": "2.1.25",
-        "@aws-amplify/graphql-http-transformer": "2.1.25",
-        "@aws-amplify/graphql-index-transformer": "2.4.6",
-        "@aws-amplify/graphql-maps-to-transformer": "3.4.20",
-        "@aws-amplify/graphql-model-transformer": "2.11.1",
-        "@aws-amplify/graphql-predictions-transformer": "2.1.25",
-        "@aws-amplify/graphql-relational-transformer": "2.5.8",
-        "@aws-amplify/graphql-searchable-transformer": "2.7.6",
-        "@aws-amplify/graphql-sql-transformer": "0.3.6",
-        "@aws-amplify/graphql-transformer-core": "2.9.2",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0"
+        "@aws-amplify/graphql-auth-transformer": "3.6.3",
+        "@aws-amplify/graphql-default-value-transformer": "2.3.11",
+        "@aws-amplify/graphql-function-transformer": "2.1.26",
+        "@aws-amplify/graphql-http-transformer": "2.1.26",
+        "@aws-amplify/graphql-index-transformer": "2.4.7",
+        "@aws-amplify/graphql-maps-to-transformer": "3.4.21",
+        "@aws-amplify/graphql-model-transformer": "2.11.2",
+        "@aws-amplify/graphql-predictions-transformer": "2.1.26",
+        "@aws-amplify/graphql-relational-transformer": "2.5.9",
+        "@aws-amplify/graphql-searchable-transformer": "2.7.7",
+        "@aws-amplify/graphql-sql-transformer": "0.3.7",
+        "@aws-amplify/graphql-transformer-core": "2.9.3",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "2.9.2",
+      "version": "2.9.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "1.1.0",
-        "@aws-amplify/graphql-transformer-interfaces": "3.10.0",
+        "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.16",
@@ -1584,20 +1584,20 @@
         "ts-dedent": "^2.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "3.10.0",
+      "version": "3.10.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "graphql": "^15.5.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.80.0",
-        "constructs": "^10.0.5"
+        "aws-cdk-lib": "^2.129.0",
+        "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core": {
@@ -20540,7 +20540,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -21156,7 +21155,6 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -27733,7 +27731,7 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -27800,7 +27798,7 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/backend-output-storage": "^1.0.2",
-        "@aws-amplify/data-construct": "^1.9.1",
+        "@aws-amplify/data-construct": "^1.9.2",
         "@aws-amplify/data-schema-types": "^1.1.1",
         "@aws-amplify/plugin-types": "^1.0.1"
       },
@@ -27929,7 +27927,7 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.0.1",
@@ -27940,8 +27938,8 @@
         "@aws-amplify/deployed-backend-client": "^1.0.1",
         "@aws-amplify/form-generator": "^1.0.0",
         "@aws-amplify/model-generator": "^1.0.1",
-        "@aws-amplify/platform-core": "^1.0.1",
-        "@aws-amplify/sandbox": "^1.0.5",
+        "@aws-amplify/platform-core": "^1.0.2",
+        "@aws-amplify/sandbox": "^1.0.6",
         "@aws-amplify/schema-generator": "^1.1.0",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -28322,7 +28320,7 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.0.0",
@@ -28472,7 +28470,7 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.0.1",
@@ -28480,7 +28478,7 @@
         "@aws-amplify/cli-core": "^1.0.0",
         "@aws-amplify/client-config": "^1.0.5",
         "@aws-amplify/deployed-backend-client": "^1.0.2",
-        "@aws-amplify/platform-core": "^1.0.1",
+        "@aws-amplify/platform-core": "^1.0.2",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-ssm": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "^1.0.2",
     "@aws-amplify/backend-output-schemas": "^1.1.0",
-    "@aws-amplify/data-construct": "^1.9.1",
+    "@aws-amplify/data-construct": "^1.9.2",
     "@aws-amplify/plugin-types": "^1.0.1",
     "@aws-amplify/data-schema-types": "^1.1.1"
   }

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -470,6 +470,26 @@ void describe('DataFactory', () => {
     );
   });
 
+  void it('throws on gen 1 patterns', () => {
+    resetFactoryCount();
+    const schema = `
+      type Profile @model {
+        author: Author @belongsTo
+      }
+      type Author @model {
+        profileID: ID
+        profile: Profile @hasOne(fields: ["profileID"])
+      }
+    `;
+    const dataFactory = defineData({
+      schema,
+    });
+    assert.throws(() => dataFactory.getInstance(getInstanceProps), {
+      message:
+        'fields argument on @hasOne is disallowed. Modify Author.profile to use references instead.',
+    });
+  });
+
   void describe('function access', () => {
     beforeEach(() => {
       resetFactoryCount();

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -485,8 +485,7 @@ void describe('DataFactory', () => {
       schema,
     });
     assert.throws(() => dataFactory.getInstance(getInstanceProps), {
-      message:
-        'fields argument on @hasOne is disallowed. Modify Author.profile to use references instead.',
+      message: 'Failed to instantiate data construct',
     });
   });
 

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -484,9 +484,18 @@ void describe('DataFactory', () => {
     const dataFactory = defineData({
       schema,
     });
-    assert.throws(() => dataFactory.getInstance(getInstanceProps), {
-      message: 'Failed to instantiate data construct',
-    });
+    assert.throws(
+      () => dataFactory.getInstance(getInstanceProps),
+      (err: AmplifyUserError<AmplifyDataError>) => {
+        assert.strictEqual(err.message, 'Failed to instantiate data construct');
+        assert.ok(err.cause);
+        assert.strictEqual(
+          err.cause.message,
+          'fields argument on @hasOne is disallowed. Modify Author.profile to use references instead.'
+        );
+        return true;
+      }
+    );
   });
 
   void describe('function access', () => {

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -246,6 +246,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
            * The CI/CD check should take the responsibility to validate if any tables are being replaced and determine whether to execute the changeset
            */
           allowDestructiveGraphqlSchemaUpdates: true,
+          _allowGen1Patterns: false,
         },
       });
     } catch (error) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

Customers can use Gen 1 patterns in GraphQL SDL string schema. This is not intentional.

**Issue number, if available:** N/A

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Disallows usage of specific gen 1 patterns. See https://github.com/aws-amplify/amplify-category-api/pull/2670 for list.

**Corresponding docs PR, if applicable:** https://github.com/aws-amplify/docs/pull/7793

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

* Unit testing

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
