### PR TITLE
wrap yargs validation errors in AmplifyUserError

### DIFF
--- a/.changeset/lazy-teachers-fold.md
+++ b/.changeset/lazy-teachers-fold.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+wrap yargs validation errors in AmplifyUserError

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -21,7 +21,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     // (undocumented)
     readonly details?: string;
     // (undocumented)
-    static fromError: (error: unknown) => AmplifyError<'UnknownFault' | 'CredentialsError'>;
+    static fromError: (error: unknown) => AmplifyError<'UnknownFault' | 'CredentialsError' | 'InvalidCommandInputError'>;
     // (undocumented)
     static fromStderr: (_stderr: string) => AmplifyError | undefined;
     // (undocumented)

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -148,3 +148,25 @@ and some after the error message
     assert.deepStrictEqual(actual?.resolution, 'test resolution');
   });
 });
+
+void describe('AmplifyError.fromError', async () => {
+  void it('wraps Yargs validation errors in AmplifyUserError', () => {
+    const yargsErrors = [
+      new Error('Unknown command: asd'),
+      new Error('Unknown arguments: a,b,c'),
+      new Error('Missing required argument: d'),
+      new Error('Did you mean sandbox'),
+      new Error('Not enough non-option arguments: got 2, need at least 4'),
+      new Error('Invalid values: Arguments: a, Given: n, Choices: [b, c, d]'),
+      new Error('Arguments a and b are mutually exclusive'),
+    ];
+    yargsErrors.forEach((error) => {
+      const actual = AmplifyError.fromError(error);
+      assert.ok(
+        actual instanceof AmplifyError &&
+          actual.name === 'InvalidCommandInputError',
+        `Failed the test for error ${error.message}`
+      );
+    });
+  });
+});

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -114,7 +114,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
         {
           message: errorMessage,
           resolution:
-            'Ensure your AWS credentials are correctly set and if required refreshed.',
+            'Ensure your AWS credentials are correctly set and refreshed.',
         },
         error
       );


### PR DESCRIPTION
## Problem

Yargs validation errors are currently reported as unknown faults

**Issue number, if available:**

## Changes

wrap yargs validation errors in AmplifyUserError.

No UX change, the error is wrapped before sending to telemetry

**Corresponding docs PR, if applicable:**

## Validation

Unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
