### PR TITLE
fix: Domain Name is missing in outputs if name is specified for Auth Stack

### DIFF
--- a/.changeset/purple-spoons-grow.md
+++ b/.changeset/purple-spoons-grow.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct': patch
+---
+
+Fix bug that caused domain name output to be missing if name property is included in props.

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -1056,8 +1056,9 @@ export class AmplifyAuth
 
     output.oauthCognitoDomain = Lazy.string({
       produce: () => {
-        const userPoolDomain =
-          this.resources.userPool.node.tryFindChild('UserPoolDomain');
+        const userPoolDomain = this.resources.userPool.node.tryFindChild(
+          `${this.name}UserPoolDomain`
+        );
         if (!userPoolDomain) {
           return '';
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
If a name is provided to the top level stack, the underlying resource names are affected, which causes 'tryFindChild' to fail. This fix accounts for the 'name' property if it is used.
https://github.com/aws-amplify/amplify-backend/issues/1724

## Changes

Updates the tryFindChild('UserPoolDomain') to tryFindChild(`${this.name}UserPoolDomain`) to account for the optional name property.

## Validation
Tests have been added to check for impact when using 'name' property.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
