### PR TITLE
Fix a case where default password policy are not populated

### DIFF
--- a/.changeset/healthy-crabs-breathe.md
+++ b/.changeset/healthy-crabs-breathe.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/client-config': patch
+'@aws-amplify/client-config': minor
 ---
 
 Fix a case where auth password policies could not be parsed by upstream frontend components due to absent defaults.

--- a/.changeset/healthy-crabs-breathe.md
+++ b/.changeset/healthy-crabs-breathe.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+Fix a case where auth password policies could not be parsed by upstream frontend components due to absent defaults.

--- a/packages/client-config/API.md
+++ b/packages/client-config/API.md
@@ -76,11 +76,11 @@ interface AWSAmplifyBackendOutputs {
         user_pool_client_id: string;
         identity_pool_id?: string;
         password_policy?: {
-            min_length?: number;
-            require_numbers?: boolean;
-            require_lowercase?: boolean;
-            require_uppercase?: boolean;
-            require_symbols?: boolean;
+            min_length: number;
+            require_numbers: boolean;
+            require_lowercase: boolean;
+            require_uppercase: boolean;
+            require_symbols: boolean;
         };
         oauth?: {
             identity_providers: ('GOOGLE' | 'FACEBOOK' | 'LOGIN_WITH_AMAZON' | 'SIGN_IN_WITH_APPLE')[];

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.test.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.test.ts
@@ -103,6 +103,73 @@ void describe('auth client config contributor v1', () => {
     );
   });
 
+  void it('returns default password length if not specified but other policies are provided', () => {
+    const contributor = new AuthClientConfigContributor();
+    assert.deepStrictEqual(
+      contributor.contribute({
+        [authOutputKey]: {
+          version: '1',
+          payload: {
+            identityPoolId: 'testIdentityPoolId',
+            userPoolId: 'testUserPoolId',
+            webClientId: 'testWebClientId',
+            authRegion: 'testRegion',
+            passwordPolicyRequirements:
+              '["REQUIRES_NUMBERS","REQUIRES_LOWERCASE","REQUIRES_SYMBOLS","REQUIRES_UPPERCASE"]',
+          },
+        },
+      }),
+      {
+        auth: {
+          user_pool_id: 'testUserPoolId',
+          user_pool_client_id: 'testWebClientId',
+          aws_region: 'testRegion',
+          identity_pool_id: 'testIdentityPoolId',
+          password_policy: {
+            min_length: 8,
+            require_lowercase: true,
+            require_numbers: true,
+            require_symbols: true,
+            require_uppercase: true,
+          },
+        },
+      } as Partial<clientConfigTypesV1.AWSAmplifyBackendOutputs>
+    );
+  });
+
+  void it('returns default password policies if only password length policy is provided', () => {
+    const contributor = new AuthClientConfigContributor();
+    assert.deepStrictEqual(
+      contributor.contribute({
+        [authOutputKey]: {
+          version: '1',
+          payload: {
+            identityPoolId: 'testIdentityPoolId',
+            userPoolId: 'testUserPoolId',
+            webClientId: 'testWebClientId',
+            authRegion: 'testRegion',
+            passwordPolicyMinLength: '42',
+          },
+        },
+      }),
+      {
+        auth: {
+          user_pool_id: 'testUserPoolId',
+          user_pool_client_id: 'testWebClientId',
+          aws_region: 'testRegion',
+          identity_pool_id: 'testIdentityPoolId',
+          password_policy: {
+            min_length: 42,
+            require_lowercase: false,
+            require_numbers: false,
+            require_symbols: false,
+            require_uppercase: false,
+          },
+        },
+      } as Partial<clientConfigTypesV1.AWSAmplifyBackendOutputs>
+    );
+  });
+
   void it('returns translated config when output has auth with zero-config attributes', () => {
     const contributor = new AuthClientConfigContributor();
     assert.deepStrictEqual(
@@ -145,6 +212,7 @@ void describe('auth client config contributor v1', () => {
           password_policy: {
             require_lowercase: true,
             require_numbers: true,
+            require_symbols: false,
             require_uppercase: true,
             min_length: 15,
           },
@@ -213,6 +281,7 @@ void describe('auth client config contributor v1', () => {
           password_policy: {
             require_lowercase: true,
             require_numbers: true,
+            require_symbols: false,
             require_uppercase: true,
             min_length: 15,
           },
@@ -273,6 +342,7 @@ void describe('auth client config contributor v1', () => {
         password_policy: {
           require_lowercase: true,
           require_numbers: true,
+          require_symbols: false,
           require_uppercase: true,
           min_length: 15,
         },

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
@@ -112,7 +112,13 @@ export class AuthClientConfigContributor implements ClientConfigContributor {
       authOutput.payload.passwordPolicyMinLength ||
       authOutput.payload.passwordPolicyRequirements
     ) {
-      authClientConfig.auth.password_policy = {};
+      authClientConfig.auth.password_policy = {
+        min_length: 8, // This is the default.
+        require_lowercase: false,
+        require_numbers: false,
+        require_symbols: false,
+        require_uppercase: false,
+      };
       if (authOutput.payload.passwordPolicyMinLength) {
         authClientConfig.auth.password_policy.min_length = Number.parseInt(
           authOutput.payload.passwordPolicyMinLength

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
@@ -113,7 +113,9 @@ export class AuthClientConfigContributor implements ClientConfigContributor {
       authOutput.payload.passwordPolicyRequirements
     ) {
       authClientConfig.auth.password_policy = {
-        min_length: 8, // This is the default.
+        min_length: 8, // This is the default that is matching what construct defines.
+        // Values below are set to false instead of being undefined as libraries expect defined values.
+        // They are overridden below with construct outputs (default or not) if applicable.
         require_lowercase: false,
         require_numbers: false,
         require_symbols: false,

--- a/packages/client-config/src/client-config-schema/client_config_v1.ts
+++ b/packages/client-config/src/client-config-schema/client_config_v1.ts
@@ -91,11 +91,11 @@ export interface AWSAmplifyBackendOutputs {
      * Cognito User Pool password policy
      */
     password_policy?: {
-      min_length?: number;
-      require_numbers?: boolean;
-      require_lowercase?: boolean;
-      require_uppercase?: boolean;
-      require_symbols?: boolean;
+      min_length: number;
+      require_numbers: boolean;
+      require_lowercase: boolean;
+      require_uppercase: boolean;
+      require_symbols: boolean;
     };
     oauth?: {
       /**

--- a/packages/client-config/src/client-config-schema/schema_v1.json
+++ b/packages/client-config/src/client-config-schema/schema_v1.json
@@ -78,7 +78,14 @@
             "require_symbols": {
               "type": "boolean"
             }
-          }
+          },
+          "required": [
+            "min_length",
+            "require_numbers",
+            "require_lowercase",
+            "require_uppercase",
+            "require_symbols"
+          ]
         },
         "oauth": {
           "type": "object",

--- a/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_to_legacy_converter.test.ts
@@ -45,6 +45,7 @@ void describe('ClientConfigLegacyConverter', () => {
           min_length: 15,
           require_lowercase: true,
           require_numbers: true,
+          require_symbols: false,
           require_uppercase: true,
         },
         mfa_methods: ['SMS', 'TOTP'],

--- a/packages/client-config/src/unified_client_config_generator.test.ts
+++ b/packages/client-config/src/unified_client_config_generator.test.ts
@@ -97,6 +97,7 @@ void describe('UnifiedClientConfigGenerator', () => {
             min_length: 8,
             require_lowercase: true,
             require_numbers: true,
+            require_symbols: false,
             require_uppercase: true,
           },
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Upstream components expect defaults in password policies shape even if they have not been specified.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**
https://github.com/aws-amplify/amplify-backend/issues/1749

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

1. Make properties of password policy shape mandatory in schema.
2. Adjust code to render defaults if needed.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests added.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
