### PR TITLE
correctly classify credentials related errors while making sdk calls to SSM

### DIFF
--- a/.changeset/few-beans-tan.md
+++ b/.changeset/few-beans-tan.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+Correctly classify credentials related errors while making sdk calls to SSM

--- a/packages/sandbox/src/sandbox_executor.test.ts
+++ b/packages/sandbox/src/sandbox_executor.test.ts
@@ -133,7 +133,7 @@ void describe('Sandbox executor', () => {
   });
 
   void it('throws AmplifyUserError if listSecrets fails due to CredentialsProviderError', async () => {
-    const credentialsError = new Error('creds error');
+    const credentialsError = new Error('credentials error');
     credentialsError.name = 'CredentialsProviderError';
     const secretsError = SecretError.createInstance(credentialsError);
     listSecretMock.mock.mockImplementationOnce(() => {

--- a/packages/sandbox/src/sandbox_executor.test.ts
+++ b/packages/sandbox/src/sandbox_executor.test.ts
@@ -101,7 +101,7 @@ void describe('Sandbox executor', () => {
     assert.strictEqual(validateAppSourcesProvider.mock.callCount(), 1);
   });
 
-  void it('throws AmplifyUserError if listSecrets fails due to expired credentials', async () => {
+  void it('throws AmplifyUserError if listSecrets fails due to ExpiredTokenException', async () => {
     const ssmError = new SSMServiceException({
       name: 'ExpiredTokenException',
       $fault: 'client',
@@ -132,8 +132,37 @@ void describe('Sandbox executor', () => {
     );
   });
 
-  void it('throws AmplifyFault if listSecrets fails due to exception other than expired credentials', async () => {
-    const secretError = new SecretError('some secret error');
+  void it('throws AmplifyUserError if listSecrets fails due to CredentialsProviderError', async () => {
+    const credentialsError = new Error('creds error');
+    credentialsError.name = 'CredentialsProviderError';
+    const secretsError = SecretError.createInstance(credentialsError);
+    listSecretMock.mock.mockImplementationOnce(() => {
+      throw secretsError;
+    });
+    await assert.rejects(
+      () =>
+        sandboxExecutor.deploy(
+          {
+            namespace: 'testSandboxId',
+            name: 'testSandboxName',
+            type: 'sandbox',
+          },
+          validateAppSourcesProvider
+        ),
+      new AmplifyUserError(
+        'SecretsExpiredTokenError',
+        {
+          message: 'Fetching the list of secrets failed due to expired tokens',
+          resolution: 'Please refresh your credentials and try again',
+        },
+        secretsError
+      )
+    );
+  });
+
+  void it('throws AmplifyFault if listSecrets fails due to a non-SSM exception other than expired credentials', async () => {
+    const underlyingError = new Error('some secret error');
+    const secretError = SecretError.createInstance(underlyingError);
     listSecretMock.mock.mockImplementationOnce(() => {
       throw secretError;
     });
@@ -152,7 +181,37 @@ void describe('Sandbox executor', () => {
         {
           message: 'Fetching the list of secrets failed',
         },
-        secretError
+        underlyingError // If it's not an SSM exception, we use the original error instead of secrets error
+      )
+    );
+  });
+
+  void it('throws AmplifyFault if listSecrets fails due to an SSM exception other than expired credentials', async () => {
+    const underlyingError = new SSMServiceException({
+      name: 'SomeException',
+      $fault: 'client',
+      $metadata: {},
+    });
+    const secretError = SecretError.createInstance(underlyingError);
+    listSecretMock.mock.mockImplementationOnce(() => {
+      throw secretError;
+    });
+    await assert.rejects(
+      () =>
+        sandboxExecutor.deploy(
+          {
+            namespace: 'testSandboxId',
+            name: 'testSandboxName',
+            type: 'sandbox',
+          },
+          validateAppSourcesProvider
+        ),
+      new AmplifyFault(
+        'ListSecretsFailedFault',
+        {
+          message: 'Fetching the list of secrets failed',
+        },
+        secretError // If it's an SSM exception, we use the wrapper secret error
       )
     );
   });


### PR DESCRIPTION
## Problem

Currently token refresh errors are currently wrapped by SecretsErrors which then gets wrapped under `ListSecretsFault`

**Issue number, if available:**

## Changes

correctly classify credentials related errors while making sdk calls to SSM

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
