### PR TITLE
Catch and wrap esbuild error from cdk

### DIFF
--- a/.changeset/ninety-dodos-try.md
+++ b/.changeset/ninety-dodos-try.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+catch and wrap esbuild error from cdk

--- a/package-lock.json
+++ b/package-lock.json
@@ -29816,11 +29816,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.0.0",
-        "@aws-amplify/plugin-types": "^1.0.1",
+        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/plugin-types": "^1.1.0",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -29831,17 +29831,17 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/backend-output-storage": "^1.0.2",
-        "@aws-amplify/plugin-types": "^1.0.1",
+        "@aws-amplify/plugin-types": "^1.1.0",
         "execa": "^8.0.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
-        "@aws-amplify/platform-core": "^1.0.1",
+        "@aws-amplify/platform-core": "^1.0.3",
         "@aws-sdk/client-ssm": "^3.465.0",
         "aws-sdk": "^2.1550.0",
         "uuid": "^9.0.1"
@@ -29929,19 +29929,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.0.1",
+        "@aws-amplify/backend-deployer": "^1.0.2",
         "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/backend-secret": "^1.0.0",
-        "@aws-amplify/cli-core": "^1.1.0",
-        "@aws-amplify/client-config": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/cli-core": "^1.1.1",
+        "@aws-amplify/client-config": "^1.1.1",
+        "@aws-amplify/deployed-backend-client": "^1.1.0",
         "@aws-amplify/form-generator": "^1.0.0",
-        "@aws-amplify/model-generator": "^1.0.1",
-        "@aws-amplify/platform-core": "^1.0.2",
-        "@aws-amplify/sandbox": "^1.1.0",
+        "@aws-amplify/model-generator": "^1.0.2",
+        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/sandbox": "^1.1.1",
         "@aws-amplify/schema-generator": "^1.1.0",
         "@aws-sdk/client-amplify": "^3.465.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
@@ -29975,10 +29975,10 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.0.0",
+        "@aws-amplify/platform-core": "^1.0.3",
         "@inquirer/prompts": "^3.0.0",
         "execa": "^8.0.1",
         "kleur": "^4.1.5"
@@ -30074,13 +30074,13 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.2",
-        "@aws-amplify/model-generator": "^1.0.1",
-        "@aws-amplify/platform-core": "^1.0.1",
+        "@aws-amplify/deployed-backend-client": "^1.1.0",
+        "@aws-amplify/model-generator": "^1.0.2",
+        "@aws-amplify/platform-core": "^1.0.3",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -30095,12 +30095,12 @@
       }
     },
     "packages/create-amplify": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^1.1.0",
-        "@aws-amplify/platform-core": "^1.0.0",
-        "@aws-amplify/plugin-types": "^1.0.1",
+        "@aws-amplify/cli-core": "^1.1.1",
+        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/plugin-types": "^1.1.0",
         "execa": "^8.0.1",
         "kleur": "^4.1.5",
         "yargs": "^17.7.2"
@@ -30202,11 +30202,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/platform-core": "^1.0.0",
+        "@aws-amplify/platform-core": "^1.0.3",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
@@ -30302,14 +30302,14 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.1",
+        "@aws-amplify/deployed-backend-client": "^1.1.0",
         "@aws-amplify/graphql-generator": "^0.4.0",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
-        "@aws-amplify/platform-core": "^1.0.0",
+        "@aws-amplify/platform-core": "^1.0.3",
         "@aws-sdk/client-appsync": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
@@ -30323,10 +30323,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-amplify/plugin-types": "^1.1.0",
         "@aws-sdk/client-sts": "^3.465.0",
         "is-ci": "^3.0.1",
         "lodash.mergewith": "^4.6.2",
@@ -30353,7 +30353,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "execa": "^5.1.1"
@@ -30473,15 +30473,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.0.1",
+        "@aws-amplify/backend-deployer": "^1.0.2",
         "@aws-amplify/backend-secret": "^1.0.0",
-        "@aws-amplify/cli-core": "^1.1.0",
-        "@aws-amplify/client-config": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.0.2",
-        "@aws-amplify/platform-core": "^1.0.2",
+        "@aws-amplify/cli-core": "^1.1.1",
+        "@aws-amplify/client-config": "^1.1.1",
+        "@aws-amplify/deployed-backend-client": "^1.1.0",
+        "@aws-amplify/platform-core": "^1.0.3",
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.465.0",
         "@aws-sdk/client-lambda": "^3.465.0",

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -132,6 +132,15 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: `[esbuild Error]: Expected identifier but found ")"\n      at /Users/user/work-space/amplify-app/amplify/data/resource.ts:16:0`,
   },
   {
+    errorMessage: `Error [TransformError]: Transform failed with 1 error:
+/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Expected "}" but found "email"
+    at failureErrorWithLog (/Users/user/work-space/amplify-app/node_modules/tsx/node_modules/esbuild/lib/main.js:1472:15)`,
+    expectedTopLevelErrorMessage:
+      '/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Expected "}" but found "email"',
+    errorName: 'ESBuildError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
     errorMessage: `some rubbish before
 Error: some cdk synth error
     at lookup (/some_random/path.js:1:3005)

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -164,6 +164,15 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex:
+        /\[TransformError\]: Transform failed with .* error:\n(?<esBuildErrorMessage>.*)/,
+      humanReadableErrorMessage: '{esBuildErrorMessage}',
+      resolutionMessage:
+        'Fix the above mentioned type or syntax error in your backend definition.',
+      errorName: 'ESBuildError',
+      classification: 'ERROR',
+    },
+    {
       errorRegex: /Amplify Backend not found in/,
       humanReadableErrorMessage:
         'Backend definition could not be found in amplify directory.',


### PR DESCRIPTION
## Problem

When customers have either deleted their tsconfig or rendered it useless for TSC to perform type-checks, the syntax and build errors are then caught at the CDK's ESBuild step which is then caught at `stderr`

**Issue number, if available:**

## Changes

catch and wrap the esbuild errors from cdk into AmplifyUserErrors

#### Before
![Screenshot 2024-07-30 at 18 07 36](https://github.com/user-attachments/assets/1b594481-e752-42d0-bf46-02f838250de4)

#### After
![Screenshot 2024-07-30 at 18 06 51](https://github.com/user-attachments/assets/dc8c34d1-be54-44ce-81ce-af3456ded6ab)


**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
