### PR TITLE
chore: add missing dependent arguments error in the yargs validations

### DIFF
--- a/.changeset/real-dragons-trade.md
+++ b/.changeset/real-dragons-trade.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+Add missing dependent arguments error in the yargs validations

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -159,6 +159,7 @@ void describe('AmplifyError.fromError', async () => {
       new Error('Not enough non-option arguments: got 2, need at least 4'),
       new Error('Invalid values: Arguments: a, Given: n, Choices: [b, c, d]'),
       new Error('Arguments a and b are mutually exclusive'),
+      new Error('Missing dependent arguments: branch -> appId'),
     ];
     yargsErrors.forEach((error) => {
       const actual = AmplifyError.fromError(error);

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -160,6 +160,7 @@ void describe('AmplifyError.fromError', async () => {
       new Error('Invalid values: Arguments: a, Given: n, Choices: [b, c, d]'),
       new Error('Arguments a and b are mutually exclusive'),
       new Error('Missing dependent arguments: branch -> appId'),
+      new Error('Implications failed:\n app-id -> branch'),
     ];
     yargsErrors.forEach((error) => {
       const actual = AmplifyError.fromError(error);

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -155,6 +155,7 @@ const isYargsValidationError = (err?: Error): boolean => {
       'Too many non-option arguments',
       'Missing required argument',
       'Invalid values:',
+      'Missing dependent arguments',
     ].some((message) => err.message.startsWith(message)) ||
       err.message.endsWith('are mutually exclusive'))
   );

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -156,6 +156,7 @@ const isYargsValidationError = (err?: Error): boolean => {
       'Missing required argument',
       'Invalid values:',
       'Missing dependent arguments',
+      'Implications failed',
     ].some((message) => err.message.startsWith(message)) ||
       err.message.endsWith('are mutually exclusive'))
   );


### PR DESCRIPTION
## Problem

Yargs error when a dependent argument is not provided by the customer was still missing from the error map.

**Issue number, if available:**

## Changes

add missing dependent arguments error in the yargs validations

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
