### PR TITLE
fix: error mapping regex for host specific newline characters

### DIFF
--- a/.changeset/mighty-donuts-check.md
+++ b/.changeset/mighty-donuts-check.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+fix error mapping regex for host specific newline characters

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -13,6 +13,7 @@ import {
   PackageManagerController,
 } from '@aws-amplify/plugin-types';
 import { BackendDeployerOutputFormatter } from './types.js';
+import { EOL } from 'os';
 
 const formatterStub: BackendDeployerOutputFormatter = {
   normalizeAmpxCommand: () => 'test command',
@@ -518,10 +519,14 @@ void describe('invokeCDKCommand', () => {
 
   void it('throws the original synth error if the synth failed but tsc succeeded', async () => {
     // simulate first execa call for synth as throwing error
-    const stderr = `some rubbish before
-Error: some cdk synth error
-    at lookup (/some_random/path.js:1:3005)
-    at lookup2 (/some_random/path2.js:2:3005)`;
+    const stderr =
+      `some rubbish before` +
+      EOL +
+      `Error: some cdk synth error` +
+      EOL +
+      `    at lookup (/some_random/path.js:1:3005)` +
+      EOL +
+      `    at lookup2 (/some_random/path2.js:2:3005)`;
     executeCommandMock.mock.mockImplementation((commandArgs: string[]) => {
       if (commandArgs.includes('synth')) {
         return Promise.reject(new Error(stderr));
@@ -541,8 +546,11 @@ Error: some cdk synth error
           resolution:
             'Check your backend definition in the `amplify` folder for syntax and type errors.',
         },
-        new Error(`Error: some cdk synth error
-    at lookup (/some_random/path.js:1:3005)`)
+        new Error(
+          `Error: some cdk synth error` +
+            EOL +
+            `    at lookup (/some_random/path.js:1:3005)`
+        )
       )
     );
     assert.strictEqual(executeCommandMock.mock.callCount(), 3);

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -30,13 +30,17 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: 'Access Denied',
   },
   {
-    errorMessage: `ReferenceError: var is not defined
-    at lookup(/some_random/path.js: 1: 3005)`,
+    errorMessage:
+      `ReferenceError: var is not defined` +
+      EOL +
+      `    at lookup(/some_random/path.js: 1: 3005)`,
     expectedTopLevelErrorMessage:
       'Unable to build the Amplify backend definition.',
     errorName: 'SyntaxError',
-    expectedDownstreamErrorMessage: `ReferenceError: var is not defined
-    at lookup(/some_random/path.js: 1: 3005)`,
+    expectedDownstreamErrorMessage:
+      `ReferenceError: var is not defined` +
+      EOL +
+      `    at lookup(/some_random/path.js: 1: 3005)`,
   },
   {
     errorMessage:

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { CdkErrorMapper } from './cdk_error_mapper.js';
 import { BackendDeployerOutputFormatter } from './types.js';
+import { EOL } from 'os';
 
 const formatterStub: BackendDeployerOutputFormatter = {
   normalizeAmpxCommand: () => 'test command',
@@ -38,13 +39,17 @@ const testErrorMappings = [
     at lookup(/some_random/path.js: 1: 3005)`,
   },
   {
-    errorMessage: `TypeError: Cannot read properties of undefined (reading 'post')
-    at lookup(/some_random/path.js: 1: 3005)`,
+    errorMessage:
+      `TypeError: Cannot read properties of undefined (reading 'post')` +
+      EOL +
+      `    at lookup(/some_random/path.js: 1: 3005)`,
     expectedTopLevelErrorMessage:
       'Unable to build the Amplify backend definition.',
     errorName: 'SyntaxError',
-    expectedDownstreamErrorMessage: `TypeError: Cannot read properties of undefined (reading 'post')
-    at lookup(/some_random/path.js: 1: 3005)`,
+    expectedDownstreamErrorMessage:
+      `TypeError: Cannot read properties of undefined (reading 'post')` +
+      EOL +
+      `    at lookup(/some_random/path.js: 1: 3005)`,
   },
   {
     errorMessage: 'Has the environment been bootstrapped',
@@ -77,11 +82,12 @@ const testErrorMappings = [
   },
   {
     errorMessage:
-      'Overall error message had other stuff before ❌ Deployment failed: something bad happened\n and after',
+      `Overall error message had other stuff before ❌ Deployment failed: something bad happened` +
+      EOL +
+      ` and after`,
     expectedTopLevelErrorMessage: 'The CloudFormation deployment has failed.',
     errorName: 'CloudFormationDeploymentError',
-    expectedDownstreamErrorMessage:
-      '❌ Deployment failed: something bad happened\n',
+    expectedDownstreamErrorMessage: `❌ Deployment failed: something bad happened${EOL}`,
   },
   {
     errorMessage: `Received response status [FAILED] from custom resource. Message returned: Failed to retrieve backend secret 'non-existent-secret' for 'project-name'. Reason: {"cause":{"name":"ParameterNotFound","$fault":"client"},"__type":"ParameterNotFound","message":"UnknownError"},"httpStatusCode":400,"name":"SecretError"}`,
@@ -124,57 +130,89 @@ const testErrorMappings = [
       'Other CLIs (PID=68436) are currently reading from .amplify/artifacts/cdk.out. ',
   },
   {
-    errorMessage: `[esbuild Error]: Expected identifier but found ")"
-      at /Users/user/work-space/amplify-app/amplify/data/resource.ts:16:0`,
+    errorMessage:
+      `[esbuild Error]: Expected identifier but found ")"` +
+      EOL +
+      `      at /Users/user/work-space/amplify-app/amplify/data/resource.ts:16:0`,
     expectedTopLevelErrorMessage:
       'Unable to build the Amplify backend definition.',
     errorName: 'ESBuildError',
-    expectedDownstreamErrorMessage: `[esbuild Error]: Expected identifier but found ")"\n      at /Users/user/work-space/amplify-app/amplify/data/resource.ts:16:0`,
+    expectedDownstreamErrorMessage:
+      `[esbuild Error]: Expected identifier but found ")"` +
+      EOL +
+      `      at /Users/user/work-space/amplify-app/amplify/data/resource.ts:16:0`,
   },
   {
-    errorMessage: `Error [TransformError]: Transform failed with 1 error:
-/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Expected "}" but found "email"
-    at failureErrorWithLog (/Users/user/work-space/amplify-app/node_modules/tsx/node_modules/esbuild/lib/main.js:1472:15)`,
+    errorMessage:
+      `Error [TransformError]: Transform failed with 1 error:` +
+      EOL +
+      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Expected "}" but found "email"` +
+      EOL +
+      `    at failureErrorWithLog (/Users/user/work-space/amplify-app/node_modules/tsx/node_modules/esbuild/lib/main.js:1472:15)`,
     expectedTopLevelErrorMessage:
       '/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Expected "}" but found "email"',
     errorName: 'ESBuildError',
     expectedDownstreamErrorMessage: undefined,
   },
   {
-    errorMessage: `some rubbish before
-Error: some cdk synth error
-    at lookup (/some_random/path.js:1:3005)
-    at lookup2 (/some_random/path2.js:2:3005)`,
+    errorMessage:
+      `some rubbish before` +
+      EOL +
+      `Error: some cdk synth error` +
+      EOL +
+      `    at lookup (/some_random/path.js:1:3005)` +
+      EOL +
+      `    at lookup2 (/some_random/path2.js:2:3005)`,
     expectedTopLevelErrorMessage:
       'Unable to build the Amplify backend definition.',
     errorName: 'BackendSynthError',
-    expectedDownstreamErrorMessage: `Error: some cdk synth error
-    at lookup (/some_random/path.js:1:3005)`,
+    expectedDownstreamErrorMessage:
+      'Error: some cdk synth error' +
+      EOL +
+      '    at lookup (/some_random/path.js:1:3005)',
   },
   {
-    errorMessage: `Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/user/work-space/shared_secret.js' imported from /Users/user/work-space/amplify-app/amplify/function.ts
-      at __node_internal_captureLargerStackTrace (node:internal/errors:496:5)
-      at new NodeError (node:internal/errors:405:5) {
-    url: 'file:///Users/user/work-space/shared_secret.js',
-    code: 'ERR_MODULE_NOT_FOUND'
-  }
-  
-  Node.js v18.19.0`,
+    errorMessage:
+      `Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/user/work-space/shared_secret.js' imported from /Users/user/work-space/amplify-app/amplify/function.ts` +
+      EOL +
+      `      at __node_internal_captureLargerStackTrace (node:internal/errors:496:5)` +
+      EOL +
+      `      at new NodeError (node:internal/errors:405:5) {` +
+      EOL +
+      `    url: 'file:///Users/user/work-space/shared_secret.js',` +
+      EOL +
+      `    code: 'ERR_MODULE_NOT_FOUND'` +
+      EOL +
+      `  }` +
+      EOL +
+      `  ` +
+      EOL +
+      `  Node.js v18.19.0`,
     expectedTopLevelErrorMessage: 'Cannot find module',
     errorName: 'ModuleNotFoundError',
-    expectedDownstreamErrorMessage: `[ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/user/work-space/shared_secret.js' imported from /Users/user/work-space/amplify-app/amplify/function.ts\n`,
+    expectedDownstreamErrorMessage: `[ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/user/work-space/shared_secret.js' imported from /Users/user/work-space/amplify-app/amplify/function.ts${EOL}`,
   },
   {
-    errorMessage: `Error: node:internal/modules/cjs/loader:1098
-    const err = new Error('Cannot find module ');
-                ^
-  
-  Error: Cannot find module '/Users/user/work-space/amplify/resources/module.ts'
-      at createEsmNotFoundErr (node:internal/modules/cjs/loader:1098:15)
-    code: 'MODULE_NOT_FOUND',
-  }
-  
-  Node.js v18.17.1`,
+    errorMessage:
+      `Error: node:internal/modules/cjs/loader:1098` +
+      EOL +
+      `    const err = new Error('Cannot find module ');` +
+      EOL +
+      `                ^` +
+      EOL +
+      `  ` +
+      EOL +
+      `  Error: Cannot find module '/Users/user/work-space/amplify/resources/module.ts'` +
+      EOL +
+      `      at createEsmNotFoundErr (node:internal/modules/cjs/loader:1098:15)` +
+      EOL +
+      `    code: 'MODULE_NOT_FOUND',` +
+      EOL +
+      `  }` +
+      EOL +
+      `  ` +
+      EOL +
+      `  Node.js v18.17.1`,
     expectedTopLevelErrorMessage: 'Cannot find module',
     errorName: 'ModuleNotFoundError',
     expectedDownstreamErrorMessage: `Error: Cannot find module '/Users/user/work-space/amplify/resources/module.ts'`,

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -5,6 +5,7 @@ import {
   AmplifyUserError,
 } from '@aws-amplify/platform-core';
 import { BackendDeployerOutputFormatter } from './types.js';
+import { EOL } from 'os';
 
 /**
  * Transforms CDK error messages to human readable ones
@@ -109,7 +110,9 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex: /(SyntaxError|ReferenceError|TypeError):((?:.|\n)*?at .*)/,
+      errorRegex: new RegExp(
+        `(SyntaxError|ReferenceError|TypeError):((?:.|${EOL})*?at .*)`
+      ),
       humanReadableErrorMessage:
         'Unable to build the Amplify backend definition.',
       resolutionMessage:
@@ -135,8 +138,9 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex:
-        /\[ERR_MODULE_NOT_FOUND\]:(.*)\n|Error: Cannot find module (.*)/,
+      errorRegex: new RegExp(
+        `\\[ERR_MODULE_NOT_FOUND\\]:(.*)${EOL}|Error: Cannot find module (.*)`
+      ),
       humanReadableErrorMessage: 'Cannot find module',
       resolutionMessage:
         'Check your backend definition in the `amplify` folder for missing file or package imports. Try installing them with your package manager.',
@@ -155,7 +159,7 @@ export class CdkErrorMapper {
     },
     {
       // Also extracts the first line in the stack where the error happened
-      errorRegex: /\[esbuild Error\]: ((?:.|\n)*?at .*)/,
+      errorRegex: new RegExp(`\\[esbuild Error\\]: ((?:.|${EOL})*?at .*)`),
       humanReadableErrorMessage:
         'Unable to build the Amplify backend definition.',
       resolutionMessage:
@@ -164,8 +168,9 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex:
-        /\[TransformError\]: Transform failed with .* error:\n(?<esBuildErrorMessage>.*)/,
+      errorRegex: new RegExp(
+        `\\[TransformError\\]: Transform failed with .* error:${EOL}(?<esBuildErrorMessage>.*)`
+      ),
       humanReadableErrorMessage: '{esBuildErrorMessage}',
       resolutionMessage:
         'Fix the above mentioned type or syntax error in your backend definition.',
@@ -213,7 +218,7 @@ export class CdkErrorMapper {
     {
       // Error: .* is printed to stderr during cdk synth
       // Also extracts the first line in the stack where the error happened
-      errorRegex: /^Error: (.*\n.*at.*)/m,
+      errorRegex: new RegExp(`^Error: (.*${EOL}.*at.*)`, 'm'),
       humanReadableErrorMessage:
         'Unable to build the Amplify backend definition.',
       resolutionMessage:
@@ -243,7 +248,7 @@ export class CdkErrorMapper {
     },
     {
       // Note that the order matters, this should be the last as it captures generic CFN error
-      errorRegex: /❌ Deployment failed: (.*)\n/,
+      errorRegex: new RegExp(`❌ Deployment failed: (.*)${EOL}`),
       humanReadableErrorMessage: 'The CloudFormation deployment has failed.',
       resolutionMessage:
         'Find more information in the CloudFormation AWS Console for this stack.',


### PR DESCRIPTION
## Problem

Current error mapping regexes were using hard coded line feeds `\n` which doesn't work on some OS.

**Issue number, if available:**

## Changes

Parameterize those regex to include os specific line feed.
1. Change explicit `\n` to `os.EOL`
2. Change implicit new line to `os.EOL`  and simple line concatenation in tests.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
