### PR TITLE
prevent ctrl+c handling for pnpm

### DIFF
--- a/.changeset/poor-dodos-compare.md
+++ b/.changeset/poor-dodos-compare.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/cli-core': patch
+---
+
+prevent CTRL+C handling for pnpm

--- a/packages/cli-core/src/package-manager-controller/pnpm_package_manager_controller.ts
+++ b/packages/cli-core/src/package-manager-controller/pnpm_package_manager_controller.ts
@@ -32,4 +32,10 @@ export class PnpmPackageManagerController extends PackageManagerControllerBase {
       existsSync
     );
   }
+
+  /**
+   * Pnpm doesn't handle the node process gracefully during the SIGINT life cycle.
+   * See: https://github.com/pnpm/pnpm/issues/7374
+   */
+  allowsSignalPropagation = () => false;
 }


### PR DESCRIPTION
## Problem

Pnpm doesn't handle the node process gracefully with the SIGINT life cycle.

**Issue number, if available:**

## Changes

Avoid the prompt on SIGINT for pnpm.

**Corresponding docs PR, if applicable:**

## Validation

Before:
<img width="731" alt="Screenshot 2024-08-02 at 2 11 34 PM" src="https://github.com/user-attachments/assets/1cf7606a-8082-4700-b489-dd314a4bb912">

After:
<img width="597" alt="Screenshot 2024-08-02 at 2 10 59 PM" src="https://github.com/user-attachments/assets/f0bd311a-9cd5-47db-b019-5d3009c65934">


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
