### PR TITLE
update cdk error mapper to catch all deployment errors

### DIFF
--- a/.changeset/long-chairs-march.md
+++ b/.changeset/long-chairs-march.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Update cdk error mapper to catch all deployment errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -29777,7 +29777,7 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/auth-construct": "^1.1.5",
@@ -29786,7 +29786,7 @@
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
-        "@aws-amplify/platform-core": "^1.0.0"
+        "@aws-amplify/platform-core": "^1.0.4"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.132.0",
@@ -29816,10 +29816,10 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/platform-core": "^1.0.4",
         "@aws-amplify/plugin-types": "^1.1.0",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
@@ -29929,18 +29929,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.0.2",
+        "@aws-amplify/backend-deployer": "^1.0.3",
         "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/backend-secret": "^1.0.0",
         "@aws-amplify/cli-core": "^1.1.1",
-        "@aws-amplify/client-config": "^1.1.1",
-        "@aws-amplify/deployed-backend-client": "^1.1.0",
+        "@aws-amplify/client-config": "^1.1.2",
+        "@aws-amplify/deployed-backend-client": "^1.2.0",
         "@aws-amplify/form-generator": "^1.0.0",
-        "@aws-amplify/model-generator": "^1.0.2",
-        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/model-generator": "^1.0.3",
+        "@aws-amplify/platform-core": "^1.0.4",
         "@aws-amplify/sandbox": "^1.1.1",
         "@aws-amplify/schema-generator": "^1.1.0",
         "@aws-sdk/client-amplify": "^3.465.0",
@@ -30074,13 +30074,13 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.1.0",
-        "@aws-amplify/model-generator": "^1.0.2",
-        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/deployed-backend-client": "^1.2.0",
+        "@aws-amplify/model-generator": "^1.0.3",
+        "@aws-amplify/platform-core": "^1.0.4",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -30202,11 +30202,11 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/platform-core": "^1.0.4",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
@@ -30302,14 +30302,14 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.1.0",
+        "@aws-amplify/deployed-backend-client": "^1.2.0",
         "@aws-amplify/graphql-generator": "^0.4.0",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
-        "@aws-amplify/platform-core": "^1.0.3",
+        "@aws-amplify/platform-core": "^1.0.4",
         "@aws-sdk/client-appsync": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",
         "@aws-sdk/credential-providers": "^3.465.0",
@@ -30323,7 +30323,7 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.1.0",

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -91,7 +91,16 @@ const testErrorMappings = [
       ` and after`,
     expectedTopLevelErrorMessage: 'The CloudFormation deployment has failed.',
     errorName: 'CloudFormationDeploymentError',
-    expectedDownstreamErrorMessage: `❌ Deployment failed: something bad happened${EOL}`,
+    expectedDownstreamErrorMessage: `Deployment failed: something bad happened${EOL}`,
+  },
+  {
+    errorMessage:
+      `[31m  Deployment failed: Error: The stack named something-fancy failed creation, it may need to be manually deleted from the AWS console: ROLLBACK_COMPLETE: Illegal character in authority at index 8: https://bedrock-runtime.us- east-1.amazonaws.com (Service: AWSAppSync; Status Code: 400; Error Code: BadRequestException;)` +
+      EOL +
+      ` and after`,
+    expectedTopLevelErrorMessage: 'The CloudFormation deployment has failed.',
+    errorName: 'CloudFormationDeploymentError',
+    expectedDownstreamErrorMessage: `Deployment failed: Error: The stack named something-fancy failed creation, it may need to be manually deleted from the AWS console: ROLLBACK_COMPLETE: Illegal character in authority at index 8: https://bedrock-runtime.us- east-1.amazonaws.com (Service: AWSAppSync; Status Code: 400; Error Code: BadRequestException;)${EOL}`,
   },
   {
     errorMessage: `Received response status [FAILED] from custom resource. Message returned: Failed to retrieve backend secret 'non-existent-secret' for 'project-name'. Reason: {"cause":{"name":"ParameterNotFound","$fault":"client"},"__type":"ParameterNotFound","message":"UnknownError"},"httpStatusCode":400,"name":"SecretError"}`,

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -248,7 +248,7 @@ export class CdkErrorMapper {
     },
     {
       // Note that the order matters, this should be the last as it captures generic CFN error
-      errorRegex: new RegExp(`❌ Deployment failed: (.*)${EOL}`),
+      errorRegex: new RegExp(`Deployment failed: (.*)${EOL}`),
       humanReadableErrorMessage: 'The CloudFormation deployment has failed.',
       resolutionMessage:
         'Find more information in the CloudFormation AWS Console for this stack.',


### PR DESCRIPTION
## Problem

When cfn deployments are failed because of custom resource failures, cdk was printing a slightly different message. 

**Issue number, if available:**

## Changes

The error mapper has been updated to catch this type of deployment failure as well.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
