### PR TITLE
wrap credential related errors for generate in AmplifyUserError

### DIFF
--- a/.changeset/pink-bees-provide.md
+++ b/.changeset/pink-bees-provide.md
@@ -1,0 +1,8 @@
+---
+'@aws-amplify/deployed-backend-client': minor
+'@aws-amplify/model-generator': patch
+'@aws-amplify/client-config': patch
+'@aws-amplify/backend-cli': patch
+---
+
+wrap credential related errors for generate commands in AmplifyUserError

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
@@ -348,8 +348,8 @@ void describe('generate forms command', () => {
     const fakedBackendOutputClient = {
       getOutput: mock.fn(() => {
         throw new BackendOutputClientError(
-          BackendOutputClientErrorType.EXPIRED_TOKEN,
-          'Unable to get backend outputs with credentials.'
+          BackendOutputClientErrorType.CREDENTIALS_ERROR,
+          'token is expired'
         );
       }),
     };
@@ -370,7 +370,7 @@ void describe('generate forms command', () => {
         assert.strictEqual(error.error.name, 'CredentialsError');
         assert.strictEqual(
           error.error.message,
-          'Unable to get backend outputs with credentials.'
+          'Unable to get backend outputs due to invalid credentials.'
         );
         return true;
       }
@@ -396,7 +396,7 @@ void describe('generate forms command', () => {
       getOutput: mock.fn(() => {
         throw new BackendOutputClientError(
           BackendOutputClientErrorType.ACCESS_DENIED,
-          'Unable to get backend outputs with credentials.'
+          'access is denied'
         );
       }),
     };
@@ -414,10 +414,10 @@ void describe('generate forms command', () => {
     await assert.rejects(
       () => commandRunner.runCommand('forms'),
       (error: TestCommandError) => {
-        assert.strictEqual(error.error.name, 'CredentialsError');
+        assert.strictEqual(error.error.name, 'AccessDenied');
         assert.strictEqual(
           error.error.message,
-          'Unable to get backend outputs with credentials.'
+          'Unable to get backend outputs due to insufficient permissions.'
         );
         return true;
       }

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
@@ -329,4 +329,98 @@ void describe('generate forms command', () => {
       }
     );
   });
+
+  void it('throws user error if credentials are expired when getting backend outputs', async () => {
+    const fakeSandboxId = 'my-fake-app-my-fake-username';
+    const backendIdResolver = {
+      resolve: mock.fn(() =>
+        Promise.resolve({
+          namespace: fakeSandboxId,
+          name: fakeSandboxId,
+          type: 'sandbox',
+        })
+      ),
+    } as BackendIdentifierResolver;
+    const formGenerationHandler = new FormGenerationHandler({
+      awsClientProvider,
+    });
+
+    const fakedBackendOutputClient = {
+      getOutput: mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.EXPIRED_TOKEN,
+          'Unable to get backend outputs with credentials.'
+        );
+      }),
+    };
+
+    const generateFormsCommand = new GenerateFormsCommand(
+      backendIdResolver,
+      () => fakedBackendOutputClient,
+      formGenerationHandler
+    );
+
+    const parser = yargs().command(
+      generateFormsCommand as unknown as CommandModule
+    );
+    const commandRunner = new TestCommandRunner(parser);
+    await assert.rejects(
+      () => commandRunner.runCommand('forms'),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'CredentialsError');
+        assert.strictEqual(
+          error.error.message,
+          'Unable to get backend outputs with credentials.'
+        );
+        return true;
+      }
+    );
+  });
+
+  void it('throws user error if access is denied when getting backend outputs', async () => {
+    const fakeSandboxId = 'my-fake-app-my-fake-username';
+    const backendIdResolver = {
+      resolve: mock.fn(() =>
+        Promise.resolve({
+          namespace: fakeSandboxId,
+          name: fakeSandboxId,
+          type: 'sandbox',
+        })
+      ),
+    } as BackendIdentifierResolver;
+    const formGenerationHandler = new FormGenerationHandler({
+      awsClientProvider,
+    });
+
+    const fakedBackendOutputClient = {
+      getOutput: mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.ACCESS_DENIED,
+          'Unable to get backend outputs with credentials.'
+        );
+      }),
+    };
+
+    const generateFormsCommand = new GenerateFormsCommand(
+      backendIdResolver,
+      () => fakedBackendOutputClient,
+      formGenerationHandler
+    );
+
+    const parser = yargs().command(
+      generateFormsCommand as unknown as CommandModule
+    );
+    const commandRunner = new TestCommandRunner(parser);
+    await assert.rejects(
+      () => commandRunner.runCommand('forms'),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'CredentialsError');
+        assert.strictEqual(
+          error.error.message,
+          'Unable to get backend outputs with credentials.'
+        );
+        return true;
+      }
+    );
+  });
 });

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -72,8 +72,6 @@ export class GenerateFormsCommand
     const backendOutputClient = this.backendOutputClientBuilder();
 
     let output;
-    const credentialsErrorMessage =
-      'Unable to get backend outputs with credentials.';
     try {
       output = await backendOutputClient.getOutput(backendIdentifier);
     } catch (error) {
@@ -106,12 +104,13 @@ export class GenerateFormsCommand
       }
       if (
         error instanceof BackendOutputClientError &&
-        error.code === BackendOutputClientErrorType.EXPIRED_TOKEN
+        error.code === BackendOutputClientErrorType.CREDENTIALS_ERROR
       ) {
         throw new AmplifyUserError(
           'CredentialsError',
           {
-            message: credentialsErrorMessage,
+            message:
+              'Unable to get backend outputs due to invalid credentials.',
             resolution:
               'Ensure your AWS credentials are correctly set and refreshed.',
           },
@@ -123,9 +122,10 @@ export class GenerateFormsCommand
         error.code === BackendOutputClientErrorType.ACCESS_DENIED
       ) {
         throw new AmplifyUserError(
-          'CredentialsError',
+          'AccessDenied',
           {
-            message: credentialsErrorMessage,
+            message:
+              'Unable to get backend outputs due to insufficient permissions.',
             resolution:
               'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
           },

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -72,6 +72,8 @@ export class GenerateFormsCommand
     const backendOutputClient = this.backendOutputClientBuilder();
 
     let output;
+    const credentialsErrorMessage =
+      'Unable to get backend outputs with credentials.';
     try {
       output = await backendOutputClient.getOutput(backendIdentifier);
     } catch (error) {
@@ -102,6 +104,35 @@ export class GenerateFormsCommand
           error
         );
       }
+      if (
+        error instanceof BackendOutputClientError &&
+        error.code === BackendOutputClientErrorType.EXPIRED_TOKEN
+      ) {
+        throw new AmplifyUserError(
+          'CredentialsError',
+          {
+            message: credentialsErrorMessage,
+            resolution:
+              'Ensure your AWS credentials are correctly set and refreshed.',
+          },
+          error
+        );
+      }
+      if (
+        error instanceof BackendOutputClientError &&
+        error.code === BackendOutputClientErrorType.ACCESS_DENIED
+      ) {
+        throw new AmplifyUserError(
+          'CredentialsError',
+          {
+            message: credentialsErrorMessage,
+            resolution:
+              'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
+          },
+          error
+        );
+      }
+
       throw error;
     }
 

--- a/packages/client-config/src/unified_client_config_generator.test.ts
+++ b/packages/client-config/src/unified_client_config_generator.test.ts
@@ -233,5 +233,71 @@ void describe('UnifiedClientConfigGenerator', () => {
         }
       );
     });
+
+    void it('throws user error if credentials are expired when getting backend outputs', async () => {
+      const outputRetrieval = mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.EXPIRED_TOKEN,
+          'unable to get backend outputs with credentials'
+        );
+      });
+      const modelSchemaAdapter = new ModelIntrospectionSchemaAdapter(
+        stubClientProvider
+      );
+
+      const configContributors = new ClientConfigContributorFactory(
+        modelSchemaAdapter
+      ).getContributors('1');
+
+      const clientConfigGenerator = new UnifiedClientConfigGenerator(
+        outputRetrieval,
+        configContributors
+      );
+
+      await assert.rejects(
+        () => clientConfigGenerator.generateClientConfig(),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(
+            error.message,
+            'Unable to get backend outputs with credentials.'
+          );
+          assert.ok(error.resolution);
+          return true;
+        }
+      );
+    });
+
+    void it('throws user error if access is denied when getting backend outputs', async () => {
+      const outputRetrieval = mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.ACCESS_DENIED,
+          'unable to get backend outputs with credentials'
+        );
+      });
+      const modelSchemaAdapter = new ModelIntrospectionSchemaAdapter(
+        stubClientProvider
+      );
+
+      const configContributors = new ClientConfigContributorFactory(
+        modelSchemaAdapter
+      ).getContributors('1');
+
+      const clientConfigGenerator = new UnifiedClientConfigGenerator(
+        outputRetrieval,
+        configContributors
+      );
+
+      await assert.rejects(
+        () => clientConfigGenerator.generateClientConfig(),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(
+            error.message,
+            'Unable to get backend outputs with credentials.'
+          );
+          assert.ok(error.resolution);
+          return true;
+        }
+      );
+    });
   });
 });

--- a/packages/client-config/src/unified_client_config_generator.test.ts
+++ b/packages/client-config/src/unified_client_config_generator.test.ts
@@ -237,8 +237,8 @@ void describe('UnifiedClientConfigGenerator', () => {
     void it('throws user error if credentials are expired when getting backend outputs', async () => {
       const outputRetrieval = mock.fn(() => {
         throw new BackendOutputClientError(
-          BackendOutputClientErrorType.EXPIRED_TOKEN,
-          'unable to get backend outputs with credentials'
+          BackendOutputClientErrorType.CREDENTIALS_ERROR,
+          'token is expired'
         );
       });
       const modelSchemaAdapter = new ModelIntrospectionSchemaAdapter(
@@ -259,7 +259,7 @@ void describe('UnifiedClientConfigGenerator', () => {
         (error: AmplifyUserError) => {
           assert.strictEqual(
             error.message,
-            'Unable to get backend outputs with credentials.'
+            'Unable to get backend outputs due to invalid credentials.'
           );
           assert.ok(error.resolution);
           return true;
@@ -271,7 +271,7 @@ void describe('UnifiedClientConfigGenerator', () => {
       const outputRetrieval = mock.fn(() => {
         throw new BackendOutputClientError(
           BackendOutputClientErrorType.ACCESS_DENIED,
-          'unable to get backend outputs with credentials'
+          'access is denied'
         );
       });
       const modelSchemaAdapter = new ModelIntrospectionSchemaAdapter(
@@ -292,7 +292,7 @@ void describe('UnifiedClientConfigGenerator', () => {
         (error: AmplifyUserError) => {
           assert.strictEqual(
             error.message,
-            'Unable to get backend outputs with credentials.'
+            'Unable to get backend outputs due to insufficient permissions.'
           );
           assert.ok(error.resolution);
           return true;

--- a/packages/client-config/src/unified_client_config_generator.ts
+++ b/packages/client-config/src/unified_client_config_generator.ts
@@ -35,8 +35,6 @@ export class UnifiedClientConfigGenerator implements ClientConfigGenerator {
    * Fetch all backend output, invoke each ClientConfigContributor on the result and merge into a single config object
    */
   generateClientConfig = async (): Promise<ClientConfig> => {
-    const credentialsErrorMessage =
-      'Unable to get backend outputs with credentials.';
     let output;
     try {
       output = await this.fetchOutput();
@@ -70,12 +68,13 @@ export class UnifiedClientConfigGenerator implements ClientConfigGenerator {
       }
       if (
         error instanceof BackendOutputClientError &&
-        error.code === BackendOutputClientErrorType.EXPIRED_TOKEN
+        error.code === BackendOutputClientErrorType.CREDENTIALS_ERROR
       ) {
         throw new AmplifyUserError(
           'CredentialsError',
           {
-            message: credentialsErrorMessage,
+            message:
+              'Unable to get backend outputs due to invalid credentials.',
             resolution:
               'Ensure your AWS credentials are correctly set and refreshed.',
           },
@@ -87,9 +86,10 @@ export class UnifiedClientConfigGenerator implements ClientConfigGenerator {
         error.code === BackendOutputClientErrorType.ACCESS_DENIED
       ) {
         throw new AmplifyUserError(
-          'CredentialsError',
+          'AccessDenied',
           {
-            message: credentialsErrorMessage,
+            message:
+              'Unable to get backend outputs due to insufficient permissions.',
             resolution:
               'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
           },

--- a/packages/client-config/src/unified_client_config_generator.ts
+++ b/packages/client-config/src/unified_client_config_generator.ts
@@ -35,6 +35,8 @@ export class UnifiedClientConfigGenerator implements ClientConfigGenerator {
    * Fetch all backend output, invoke each ClientConfigContributor on the result and merge into a single config object
    */
   generateClientConfig = async (): Promise<ClientConfig> => {
+    const credentialsErrorMessage =
+      'Unable to get backend outputs with credentials.';
     let output;
     try {
       output = await this.fetchOutput();
@@ -66,6 +68,35 @@ export class UnifiedClientConfigGenerator implements ClientConfigGenerator {
           error
         );
       }
+      if (
+        error instanceof BackendOutputClientError &&
+        error.code === BackendOutputClientErrorType.EXPIRED_TOKEN
+      ) {
+        throw new AmplifyUserError(
+          'CredentialsError',
+          {
+            message: credentialsErrorMessage,
+            resolution:
+              'Ensure your AWS credentials are correctly set and refreshed.',
+          },
+          error
+        );
+      }
+      if (
+        error instanceof BackendOutputClientError &&
+        error.code === BackendOutputClientErrorType.ACCESS_DENIED
+      ) {
+        throw new AmplifyUserError(
+          'CredentialsError',
+          {
+            message: credentialsErrorMessage,
+            resolution:
+              'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
+          },
+          error
+        );
+      }
+
       throw error;
     }
     const backendOutput = unifiedBackendOutputSchema.parse(output);

--- a/packages/deployed-backend-client/API.md
+++ b/packages/deployed-backend-client/API.md
@@ -96,9 +96,9 @@ export enum BackendOutputClientErrorType {
     // (undocumented)
     ACCESS_DENIED = "AccessDenied",
     // (undocumented)
-    DEPLOYMENT_IN_PROGRESS = "DeploymentInProgress",
+    CREDENTIALS_ERROR = "CredentialsError",
     // (undocumented)
-    EXPIRED_TOKEN = "ExpiredToken",
+    DEPLOYMENT_IN_PROGRESS = "DeploymentInProgress",
     // (undocumented)
     METADATA_RETRIEVAL_ERROR = "MetadataRetrievalError",
     // (undocumented)

--- a/packages/deployed-backend-client/API.md
+++ b/packages/deployed-backend-client/API.md
@@ -94,7 +94,11 @@ export class BackendOutputClientError extends Error {
 // @public (undocumented)
 export enum BackendOutputClientErrorType {
     // (undocumented)
+    ACCESS_DENIED = "AccessDenied",
+    // (undocumented)
     DEPLOYMENT_IN_PROGRESS = "DeploymentInProgress",
+    // (undocumented)
+    EXPIRED_TOKEN = "ExpiredToken",
     // (undocumented)
     METADATA_RETRIEVAL_ERROR = "MetadataRetrievalError",
     // (undocumented)

--- a/packages/deployed-backend-client/src/backend_output_client_factory.ts
+++ b/packages/deployed-backend-client/src/backend_output_client_factory.ts
@@ -11,6 +11,8 @@ export enum BackendOutputClientErrorType {
   NO_OUTPUTS_FOUND = 'NoOutputsFound',
   DEPLOYMENT_IN_PROGRESS = 'DeploymentInProgress',
   NO_STACK_FOUND = 'NoStackFound',
+  EXPIRED_TOKEN = 'ExpiredToken',
+  ACCESS_DENIED = 'AccessDenied',
 }
 /**
  * Error type for BackendOutputClientError

--- a/packages/deployed-backend-client/src/backend_output_client_factory.ts
+++ b/packages/deployed-backend-client/src/backend_output_client_factory.ts
@@ -11,7 +11,7 @@ export enum BackendOutputClientErrorType {
   NO_OUTPUTS_FOUND = 'NoOutputsFound',
   DEPLOYMENT_IN_PROGRESS = 'DeploymentInProgress',
   NO_STACK_FOUND = 'NoStackFound',
-  EXPIRED_TOKEN = 'ExpiredToken',
+  CREDENTIALS_ERROR = 'CredentialsError',
   ACCESS_DENIED = 'AccessDenied',
 }
 /**

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.test.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.test.ts
@@ -364,7 +364,7 @@ void describe('StackMetadataBackendOutputRetrievalStrategy', () => {
       await assert.rejects(
         retrievalStrategy.fetchBackendOutput(),
         new BackendOutputClientError(
-          BackendOutputClientErrorType.EXPIRED_TOKEN,
+          BackendOutputClientErrorType.CREDENTIALS_ERROR,
           'The security token included in the request is expired'
         )
       );

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
@@ -65,6 +65,24 @@ export class StackMetadataBackendOutputRetrievalStrategy
           `Stack with id ${stackName} does not exist`
         );
       }
+      if (
+        error instanceof CloudFormationServiceException &&
+        error.name === 'ExpiredToken'
+      ) {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.EXPIRED_TOKEN,
+          'The security token included in the request is expired'
+        );
+      }
+      if (
+        error instanceof CloudFormationServiceException &&
+        error.name === 'AccessDenied'
+      ) {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.ACCESS_DENIED,
+          error.message
+        );
+      }
 
       throw error;
     }

--- a/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
+++ b/packages/deployed-backend-client/src/stack_metadata_output_retrieval_strategy.ts
@@ -67,11 +67,11 @@ export class StackMetadataBackendOutputRetrievalStrategy
       }
       if (
         error instanceof CloudFormationServiceException &&
-        error.name === 'ExpiredToken'
+        ['ExpiredToken', 'InvalidClientTokenId'].includes(error.name)
       ) {
         throw new BackendOutputClientError(
-          BackendOutputClientErrorType.EXPIRED_TOKEN,
-          'The security token included in the request is expired'
+          BackendOutputClientErrorType.CREDENTIALS_ERROR,
+          error.message
         );
       }
       if (

--- a/packages/model-generator/src/create_graphql_document_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_document_generator.test.ts
@@ -99,4 +99,66 @@ void describe('model generator factory', () => {
       }
     );
   });
+
+  void it('throws an error if credentials are expired when getting backend outputs', async () => {
+    const fakeBackendOutputClient = {
+      getOutput: mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.EXPIRED_TOKEN,
+          'unable to get backend outputs with credentials'
+        );
+      }),
+    };
+    mock.method(
+      BackendOutputClientFactory,
+      'getInstance',
+      () => fakeBackendOutputClient
+    );
+    const generator = createGraphqlDocumentGenerator({
+      backendIdentifier: { stackName: 'randomStack' },
+      awsClientProvider,
+    });
+    await assert.rejects(
+      () => generator.generateModels({ targetFormat: 'javascript' }),
+      (error: AmplifyUserError) => {
+        assert.strictEqual(
+          error.message,
+          'Unable to get backend outputs with credentials.'
+        );
+        assert.ok(error.resolution);
+        return true;
+      }
+    );
+  });
+
+  void it('throws an error if access is denied when getting backend outputs', async () => {
+    const fakeBackendOutputClient = {
+      getOutput: mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.ACCESS_DENIED,
+          'unable to get backend outputs with credentials'
+        );
+      }),
+    };
+    mock.method(
+      BackendOutputClientFactory,
+      'getInstance',
+      () => fakeBackendOutputClient
+    );
+    const generator = createGraphqlDocumentGenerator({
+      backendIdentifier: { stackName: 'randomStack' },
+      awsClientProvider,
+    });
+    await assert.rejects(
+      () => generator.generateModels({ targetFormat: 'javascript' }),
+      (error: AmplifyUserError) => {
+        assert.strictEqual(
+          error.message,
+          'Unable to get backend outputs with credentials.'
+        );
+        assert.ok(error.resolution);
+        return true;
+      }
+    );
+  });
 });

--- a/packages/model-generator/src/create_graphql_document_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_document_generator.test.ts
@@ -104,8 +104,8 @@ void describe('model generator factory', () => {
     const fakeBackendOutputClient = {
       getOutput: mock.fn(() => {
         throw new BackendOutputClientError(
-          BackendOutputClientErrorType.EXPIRED_TOKEN,
-          'unable to get backend outputs with credentials'
+          BackendOutputClientErrorType.CREDENTIALS_ERROR,
+          'token is expired'
         );
       }),
     };
@@ -123,7 +123,7 @@ void describe('model generator factory', () => {
       (error: AmplifyUserError) => {
         assert.strictEqual(
           error.message,
-          'Unable to get backend outputs with credentials.'
+          'Unable to get backend outputs due to invalid credentials.'
         );
         assert.ok(error.resolution);
         return true;
@@ -136,7 +136,7 @@ void describe('model generator factory', () => {
       getOutput: mock.fn(() => {
         throw new BackendOutputClientError(
           BackendOutputClientErrorType.ACCESS_DENIED,
-          'unable to get backend outputs with credentials'
+          'access is denied'
         );
       }),
     };
@@ -154,7 +154,7 @@ void describe('model generator factory', () => {
       (error: AmplifyUserError) => {
         assert.strictEqual(
           error.message,
-          'Unable to get backend outputs with credentials.'
+          'Unable to get backend outputs due to insufficient permissions.'
         );
         assert.ok(error.resolution);
         return true;

--- a/packages/model-generator/src/create_graphql_models_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_models_generator.test.ts
@@ -109,8 +109,8 @@ void describe('models generator factory', () => {
       const fakeBackendOutputClient = {
         getOutput: mock.fn(() => {
           throw new BackendOutputClientError(
-            BackendOutputClientErrorType.EXPIRED_TOKEN,
-            'unable to get backend outputs with credentials'
+            BackendOutputClientErrorType.CREDENTIALS_ERROR,
+            'token is expired'
           );
         }),
       };
@@ -128,7 +128,7 @@ void describe('models generator factory', () => {
         (error: AmplifyUserError) => {
           assert.strictEqual(
             error.message,
-            'Unable to get backend outputs with credentials.'
+            'Unable to get backend outputs due to invalid credentials.'
           );
           assert.ok(error.resolution);
           return true;
@@ -141,7 +141,7 @@ void describe('models generator factory', () => {
         getOutput: mock.fn(() => {
           throw new BackendOutputClientError(
             BackendOutputClientErrorType.ACCESS_DENIED,
-            'unable to get backend outputs with credentials'
+            'access is denied'
           );
         }),
       };
@@ -159,7 +159,7 @@ void describe('models generator factory', () => {
         (error: AmplifyUserError) => {
           assert.strictEqual(
             error.message,
-            'Unable to get backend outputs with credentials.'
+            'Unable to get backend outputs due to insufficient permissions.'
           );
           assert.ok(error.resolution);
           return true;

--- a/packages/model-generator/src/create_graphql_models_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_models_generator.test.ts
@@ -104,6 +104,68 @@ void describe('models generator factory', () => {
         }
       );
     });
+
+    void it('throws an error if credentials are expired when getting backend outputs', async () => {
+      const fakeBackendOutputClient = {
+        getOutput: mock.fn(() => {
+          throw new BackendOutputClientError(
+            BackendOutputClientErrorType.EXPIRED_TOKEN,
+            'unable to get backend outputs with credentials'
+          );
+        }),
+      };
+      mock.method(
+        BackendOutputClientFactory,
+        'getInstance',
+        () => fakeBackendOutputClient
+      );
+      const generator = createGraphqlModelsGenerator({
+        backendIdentifier: { stackName: 'randomStack' },
+        awsClientProvider,
+      });
+      await assert.rejects(
+        () => generator.generateModels({ target: 'javascript' }),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(
+            error.message,
+            'Unable to get backend outputs with credentials.'
+          );
+          assert.ok(error.resolution);
+          return true;
+        }
+      );
+    });
+
+    void it('throws an error if access is denied when getting backend outputs', async () => {
+      const fakeBackendOutputClient = {
+        getOutput: mock.fn(() => {
+          throw new BackendOutputClientError(
+            BackendOutputClientErrorType.ACCESS_DENIED,
+            'unable to get backend outputs with credentials'
+          );
+        }),
+      };
+      mock.method(
+        BackendOutputClientFactory,
+        'getInstance',
+        () => fakeBackendOutputClient
+      );
+      const generator = createGraphqlModelsGenerator({
+        backendIdentifier: { stackName: 'randomStack' },
+        awsClientProvider,
+      });
+      await assert.rejects(
+        () => generator.generateModels({ target: 'javascript' }),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(
+            error.message,
+            'Unable to get backend outputs with credentials.'
+          );
+          assert.ok(error.resolution);
+          return true;
+        }
+      );
+    });
   });
 
   void describe('createGraphqlModelsFromS3UriGenerator', () => {

--- a/packages/model-generator/src/create_graphql_types_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_types_generator.test.ts
@@ -98,4 +98,66 @@ void describe('types generator factory', () => {
       }
     );
   });
+
+  void it('throws an AmplifyUserError if credentials are expired when getting backend outputs', async () => {
+    const fakeBackendOutputClient = {
+      getOutput: mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.EXPIRED_TOKEN,
+          'unable to get backend outputs with credentials'
+        );
+      }),
+    };
+    mock.method(
+      BackendOutputClientFactory,
+      'getInstance',
+      () => fakeBackendOutputClient
+    );
+    const generator = createGraphqlTypesGenerator({
+      backendIdentifier: { stackName: 'randomStack' },
+      awsClientProvider,
+    });
+    await assert.rejects(
+      () => generator.generateTypes({ target: 'json' }),
+      (error: AmplifyUserError) => {
+        assert.strictEqual(
+          error.message,
+          'Unable to get backend outputs with credentials.'
+        );
+        assert.ok(error.resolution);
+        return true;
+      }
+    );
+  });
+
+  void it('throws an AmplifyUserError if access is denied when getting backend outputs', async () => {
+    const fakeBackendOutputClient = {
+      getOutput: mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.ACCESS_DENIED,
+          'unable to get backend outputs with credentials'
+        );
+      }),
+    };
+    mock.method(
+      BackendOutputClientFactory,
+      'getInstance',
+      () => fakeBackendOutputClient
+    );
+    const generator = createGraphqlTypesGenerator({
+      backendIdentifier: { stackName: 'randomStack' },
+      awsClientProvider,
+    });
+    await assert.rejects(
+      () => generator.generateTypes({ target: 'json' }),
+      (error: AmplifyUserError) => {
+        assert.strictEqual(
+          error.message,
+          'Unable to get backend outputs with credentials.'
+        );
+        assert.ok(error.resolution);
+        return true;
+      }
+    );
+  });
 });

--- a/packages/model-generator/src/create_graphql_types_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_types_generator.test.ts
@@ -103,8 +103,8 @@ void describe('types generator factory', () => {
     const fakeBackendOutputClient = {
       getOutput: mock.fn(() => {
         throw new BackendOutputClientError(
-          BackendOutputClientErrorType.EXPIRED_TOKEN,
-          'unable to get backend outputs with credentials'
+          BackendOutputClientErrorType.CREDENTIALS_ERROR,
+          'token is expired'
         );
       }),
     };
@@ -122,7 +122,7 @@ void describe('types generator factory', () => {
       (error: AmplifyUserError) => {
         assert.strictEqual(
           error.message,
-          'Unable to get backend outputs with credentials.'
+          'Unable to get backend outputs due to invalid credentials.'
         );
         assert.ok(error.resolution);
         return true;
@@ -135,7 +135,7 @@ void describe('types generator factory', () => {
       getOutput: mock.fn(() => {
         throw new BackendOutputClientError(
           BackendOutputClientErrorType.ACCESS_DENIED,
-          'unable to get backend outputs with credentials'
+          'access is denied'
         );
       }),
     };
@@ -153,7 +153,7 @@ void describe('types generator factory', () => {
       (error: AmplifyUserError) => {
         assert.strictEqual(
           error.message,
-          'Unable to get backend outputs with credentials.'
+          'Unable to get backend outputs due to insufficient permissions.'
         );
         assert.ok(error.resolution);
         return true;

--- a/packages/model-generator/src/get_backend_output_with_error_handling.ts
+++ b/packages/model-generator/src/get_backend_output_with_error_handling.ts
@@ -13,6 +13,8 @@ export const getBackendOutputWithErrorHandling = async (
   backendOutputClient: BackendOutputClient,
   backendIdentifier: DeployedBackendIdentifier
 ) => {
+  const credentialsErrorMessage =
+    'Unable to get backend outputs with credentials.';
   try {
     return await backendOutputClient.getOutput(backendIdentifier);
   } catch (error) {
@@ -43,6 +45,35 @@ export const getBackendOutputWithErrorHandling = async (
         error
       );
     }
+    if (
+      error instanceof BackendOutputClientError &&
+      error.code === BackendOutputClientErrorType.EXPIRED_TOKEN
+    ) {
+      throw new AmplifyUserError(
+        'CredentialsError',
+        {
+          message: credentialsErrorMessage,
+          resolution:
+            'Ensure your AWS credentials are correctly set and refreshed.',
+        },
+        error
+      );
+    }
+    if (
+      error instanceof BackendOutputClientError &&
+      error.code === BackendOutputClientErrorType.ACCESS_DENIED
+    ) {
+      throw new AmplifyUserError(
+        'CredentialsError',
+        {
+          message: credentialsErrorMessage,
+          resolution:
+            'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
+        },
+        error
+      );
+    }
+
     throw error;
   }
 };

--- a/packages/model-generator/src/get_backend_output_with_error_handling.ts
+++ b/packages/model-generator/src/get_backend_output_with_error_handling.ts
@@ -13,8 +13,6 @@ export const getBackendOutputWithErrorHandling = async (
   backendOutputClient: BackendOutputClient,
   backendIdentifier: DeployedBackendIdentifier
 ) => {
-  const credentialsErrorMessage =
-    'Unable to get backend outputs with credentials.';
   try {
     return await backendOutputClient.getOutput(backendIdentifier);
   } catch (error) {
@@ -47,12 +45,12 @@ export const getBackendOutputWithErrorHandling = async (
     }
     if (
       error instanceof BackendOutputClientError &&
-      error.code === BackendOutputClientErrorType.EXPIRED_TOKEN
+      error.code === BackendOutputClientErrorType.CREDENTIALS_ERROR
     ) {
       throw new AmplifyUserError(
         'CredentialsError',
         {
-          message: credentialsErrorMessage,
+          message: 'Unable to get backend outputs due to invalid credentials.',
           resolution:
             'Ensure your AWS credentials are correctly set and refreshed.',
         },
@@ -64,9 +62,10 @@ export const getBackendOutputWithErrorHandling = async (
       error.code === BackendOutputClientErrorType.ACCESS_DENIED
     ) {
       throw new AmplifyUserError(
-        'CredentialsError',
+        'AccessDenied',
         {
-          message: credentialsErrorMessage,
+          message:
+            'Unable to get backend outputs due to insufficient permissions.',
           resolution:
             'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
         },


### PR DESCRIPTION
## Problem

Credential errors when running `ampx generate` commands should be wrapped in `AmplifyUserError`.

**Issue number, if available:**

## Changes

Wrap these errors in `AmplifyUserError` with more information on how to fix credentials.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
