### PR TITLE
Handle nested namespaces in api check

### DIFF
--- a/scripts/components/api-changes-validator/api_changes_validator.test.ts
+++ b/scripts/components/api-changes-validator/api_changes_validator.test.ts
@@ -52,7 +52,7 @@ void describe('Api changes validator', { concurrency: true }, () => {
           'utf-8'
         )
       ).trim();
-      await execa('tsc', ['--build'], { cwd: latestPackagePath });
+      await execa('npx', ['tsc', '--build'], { cwd: latestPackagePath });
       const baselinePackageApiReportPath = path.join(
         latestPackagePath,
         'API.md'
@@ -83,7 +83,7 @@ void describe('Api changes validator', { concurrency: true }, () => {
         testProjectsWithoutBreaksPath,
         testProject
       );
-      await execa('tsc', ['--build'], { cwd: latestPackagePath });
+      await execa('npx', ['tsc', '--build'], { cwd: latestPackagePath });
       const baselinePackageApiReportPath = path.join(
         latestPackagePath,
         'API.md'

--- a/scripts/components/api-changes-validator/api_usage_generator.test.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.test.ts
@@ -302,9 +302,20 @@ export type SomeTypeUnderNamespace = {
   someProperty: string;
 }
 
+type SomeTypeUnderSubNamespace = {
+  someOtherProperty: string;
+}
+
+declare namespace someSubNamespace {
+  export {
+    SomeTypeUnderSubNamespace
+  }
+}
+
 declare namespace someNamespace {
   export {
-    SomeTypeUnderNamespace
+    SomeTypeUnderNamespace,
+    someSubNamespace
   }
 }
     `,
@@ -316,6 +327,13 @@ type SomeTypeUnderNamespaceBaseline = {
 }
 const someTypeUnderNamespaceUsageFunction = (someTypeUnderNamespaceFunctionParameter: SomeTypeUnderNamespaceBaseline) => {
   const someTypeUnderNamespace: someNamespace.SomeTypeUnderNamespace = someTypeUnderNamespaceFunctionParameter;
+}
+
+type SomeTypeUnderSubNamespaceBaseline = {
+  someOtherProperty: string;
+}
+const someTypeUnderSubNamespaceUsageFunction = (someTypeUnderSubNamespaceFunctionParameter: SomeTypeUnderSubNamespaceBaseline) => {
+  const someTypeUnderSubNamespace: someNamespace.someSubNamespace.SomeTypeUnderSubNamespace = someTypeUnderSubNamespaceFunctionParameter;
 }
     `,
   },

--- a/scripts/components/api-changes-validator/api_usage_statements_generators.ts
+++ b/scripts/components/api-changes-validator/api_usage_statements_generators.ts
@@ -142,9 +142,17 @@ export class TypeUsageStatementsGenerator implements UsageStatementsGenerator {
     let importStatement: string | undefined;
     let typeNameWithNamespace: string;
     if (this.namespaceDefinitions.namespaceBySymbol.has(typeName)) {
-      typeNameWithNamespace = `${this.namespaceDefinitions.namespaceBySymbol.get(
-        typeName
-      )}.${typeName}`;
+      let currentSymbolName: string | undefined = typeName;
+      const namespaceHierarchy: Array<string> = [];
+      do {
+        currentSymbolName =
+          this.namespaceDefinitions.namespaceBySymbol.get(currentSymbolName);
+        if (currentSymbolName) {
+          namespaceHierarchy.unshift(currentSymbolName);
+        }
+      } while (currentSymbolName);
+
+      typeNameWithNamespace = `${namespaceHierarchy.join('.')}.${typeName}`;
     } else {
       importStatement = `import { ${typeName} } from '${this.packageName}';`;
       typeNameWithNamespace = typeName;

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
@@ -4,9 +4,20 @@ export type SomeTypeUnderNamespace = {
   someProperty: string;
 }
 
+type SomeTypeUnderSubNamespace = {
+  someOtherProperty: string;
+}
+
+declare namespace someSubNamespace {
+  export {
+    SomeTypeUnderSubNamespace
+  }
+}
+
 declare namespace someNamespace {
   export {
-    SomeTypeUnderNamespace
+    SomeTypeUnderNamespace,
+    someSubNamespace
   }
 }
 

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
@@ -1,3 +1,7 @@
+import * as someSubNamespace from './some_sub_namespace.js';
+
 export type SomeTypeUnderNamespace = {
   someProperty: string;
 };
+
+export { someSubNamespace };

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_sub_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_sub_namespace.ts
@@ -1,0 +1,3 @@
+export type SomeTypeUnderSubNamespace = {
+  someOtherProperty: string;
+};

--- a/scripts/components/api-changes-validator/types.ts
+++ b/scripts/components/api-changes-validator/types.ts
@@ -11,6 +11,7 @@ export type UsageStatementsGenerator = {
 };
 
 export type NamespaceDefinitions = {
-  namespaceNames: Array<string>;
+  topLevelNamespaces: Set<string>;
+  namespaceNames: Set<string>;
   namespaceBySymbol: Map<string, string>;
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

While working on feature branch I noticed that api check is not handling nested properties correctly.
See https://github.com/aws-amplify/amplify-backend/actions/runs/10325487544/job/28587278238?pr=1830 

```
AggregateError: Breaking API changes detected. See below for details.
    If these changes are intentional, this is okay.
    Otherwise, update the PR to remove the unintentional breaks
    at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:87:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  [errors]: [
    Error: Validation of @aws-amplify/ai-constructs failed, compiler output:
    index.ts(4,10): error TS2305: Module '"@aws-amplify/ai-constructs"' has no exported member 'ConversationHandlerFunction'.
    index.ts(5,10): error TS2305: Module '"@aws-amplify/ai-constructs"' has no exported member 'handleConversationTurnEvent'.
    index.ts(7,10): error TS2305: Module '"@aws-amplify/ai-constructs"' has no exported member 'runtime'.
    index.ts(9,99): error TS2552: Cannot find name 'ConversationHandlerFunctionProps'. Did you mean 'ConversationHandlerFunctionPropsBaseline'?
    index.ts(35,20): error TS2552: Cannot find name 'ConversationMessageContentBlock'. Did you mean 'ConversationMessageContentBlockBaseline'?
    index.ts(64,21): error TS2304: Cannot find name 'ConversationMessage'.
    index.ts(70,58): error TS2304: Cannot find name 'ConversationTurnEvent'.
        at ApiChangesValidator.validate (/home/runner/work/amplify-backend/amplify-backend/scripts/components/api-changes-validator/api_changes_validator.ts:61:13)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:70:5)
        at async Promise.allSettled (index 25)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:50:27)
  ]
}
```

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Fix logic in such a way that:
1. Top level namespaces are detected (as those without parents).
2. Namespace hierarchy is rendered if type is nested.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

Added tests.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
