### PR TITLE
Make conversation response selection set dynamic

### DIFF
--- a/.changeset/lucky-rabbits-decide.md
+++ b/.changeset/lucky-rabbits-decide.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Make conversation response selection set dynamic

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -53,8 +53,11 @@ type ConversationMessageContentBlock = {
 type ConversationTurnEvent = {
     conversationId: string;
     currentMessageId: string;
-    responseMutationName: string;
-    responseMutationInputTypeName: string;
+    responseMutation: {
+        name: string;
+        inputTypeName: string;
+        selectionSet: string;
+    };
     graphqlApiEndpoint: string;
     modelConfiguration: {
         modelId: string;

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.test.ts
@@ -34,8 +34,11 @@ void describe('Bedrock converse adapter', () => {
       systemPrompt: 'testSystemPrompt',
     },
     request: { headers: { authorization: '' } },
-    responseMutationInputTypeName: '',
-    responseMutationName: '',
+    responseMutation: {
+      name: '',
+      inputTypeName: '',
+      selectionSet: '',
+    },
   };
 
   void it('calls bedrock to get conversation response', async () => {

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_executor.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_executor.test.ts
@@ -14,8 +14,11 @@ void describe('Conversation turn executor', () => {
     messages: [],
     modelConfiguration: { modelId: '', systemPrompt: '' },
     request: { headers: { authorization: '' } },
-    responseMutationInputTypeName: '',
-    responseMutationName: '',
+    responseMutation: {
+      name: '',
+      inputTypeName: '',
+      selectionSet: '',
+    },
   };
 
   void it('executes turn successfully', async () => {

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
@@ -13,8 +13,11 @@ void describe('Conversation turn response sender', () => {
     messages: [],
     modelConfiguration: { modelId: '', systemPrompt: '' },
     request: { headers: { authorization: 'testToken' } },
-    responseMutationInputTypeName: 'testResponseMutationInputTypeName',
-    responseMutationName: 'testResponseMutationName',
+    responseMutation: {
+      name: 'testResponseMutationName',
+      inputTypeName: 'testResponseMutationInputTypeName',
+      selectionSet: 'testSelectionSet',
+    },
   };
 
   void it('sends response back to appsync', async () => {
@@ -51,13 +54,7 @@ void describe('Conversation turn response sender', () => {
         '\n' +
         '        mutation PublishModelResponse($input: testResponseMutationInputTypeName!) {\n' +
         '            testResponseMutationName(input: $input) {\n' +
-        '                id\n' +
-        '                conversationId\n' +
-        '                content\n' +
-        '                sender\n' +
-        '                owner\n' +
-        '                createdAt\n' +
-        '                updatedAt\n' +
+        '                testSelectionSet\n' +
         '            }\n' +
         '        }\n' +
         '    ',

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
@@ -47,15 +47,9 @@ export class ConversationTurnResponseSender {
 
   private createMutationRequest = (content: ContentBlock[]) => {
     const query = `
-        mutation PublishModelResponse($input: ${this.event.responseMutationInputTypeName}!) {
-            ${this.event.responseMutationName}(input: $input) {
-                id
-                conversationId
-                content
-                sender
-                owner
-                createdAt
-                updatedAt
+        mutation PublishModelResponse($input: ${this.event.responseMutation.inputTypeName}!) {
+            ${this.event.responseMutation.name}(input: $input) {
+                ${this.event.responseMutation.selectionSet}
             }
         }
     `;

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/event_tools_provider.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/event_tools_provider.test.ts
@@ -14,8 +14,11 @@ void describe('events tool provider', () => {
       messages: [],
       modelConfiguration: { modelId: '', systemPrompt: '' },
       request: { headers: { authorization: '' } },
-      responseMutationInputTypeName: '',
-      responseMutationName: '',
+      responseMutation: {
+        name: '',
+        inputTypeName: '',
+        selectionSet: '',
+      },
     }).getEventTools();
 
     assert.strictEqual(eventTools.length, 0);
@@ -61,8 +64,11 @@ void describe('events tool provider', () => {
       messages: [],
       modelConfiguration: { modelId: '', systemPrompt: '' },
       request: { headers: { authorization: '' } },
-      responseMutationInputTypeName: '',
-      responseMutationName: '',
+      responseMutation: {
+        name: '',
+        inputTypeName: '',
+        selectionSet: '',
+      },
       toolsConfiguration: {
         tools: [toolDefinition1, toolDefinition2],
       },

--- a/packages/ai-constructs/src/conversation/runtime/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/types.ts
@@ -24,8 +24,11 @@ export type ConversationMessageContentBlock = {
 export type ConversationTurnEvent = {
   conversationId: string;
   currentMessageId: string;
-  responseMutationName: string;
-  responseMutationInputTypeName: string;
+  responseMutation: {
+    name: string;
+    inputTypeName: string;
+    selectionSet: string;
+  };
   graphqlApiEndpoint: string;
   modelConfiguration: {
     modelId: string;

--- a/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
+++ b/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
@@ -46,6 +46,26 @@ type ConversationTurnAppSyncResponse = {
   content: string;
 };
 
+const commonEventProperties = {
+  responseMutation: {
+    name: 'createConversationMessageAssistantResponse',
+    inputTypeName: 'CreateConversationMessageAssistantResponseInput',
+    selectionSet: [
+      'id',
+      'conversationId',
+      'content',
+      'sender',
+      'owner',
+      'createdAt',
+      'updatedAt',
+    ].join('\n'),
+  },
+  modelConfiguration: {
+    modelId: bedrockModelId,
+    systemPrompt: 'You are helpful bot.',
+  },
+};
+
 /**
  * Creates conversation handler test project.
  */
@@ -217,13 +237,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
       request: {
         headers: { authorization: accessToken },
       },
-      responseMutationInputTypeName:
-        'CreateConversationMessageAssistantResponseInput',
-      responseMutationName: 'createConversationMessageAssistantResponse',
-      modelConfiguration: {
-        modelId: bedrockModelId,
-        systemPrompt: 'You are helpful bot.',
-      },
+      ...commonEventProperties,
     };
     const response = await this.executeConversationTurn(
       event,
@@ -265,13 +279,6 @@ class ConversationHandlerTestProject extends TestProjectBase {
       request: {
         headers: { authorization: accessToken },
       },
-      responseMutationInputTypeName:
-        'CreateConversationMessageAssistantResponseInput',
-      responseMutationName: 'createConversationMessageAssistantResponse',
-      modelConfiguration: {
-        modelId: bedrockModelId,
-        systemPrompt: 'You are helpful bot.',
-      },
       toolsConfiguration: {
         tools: [
           {
@@ -299,6 +306,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
           },
         ],
       },
+      ...commonEventProperties,
     };
     const response = await this.executeConversationTurn(
       event,
@@ -344,13 +352,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
       request: {
         headers: { authorization: accessToken },
       },
-      responseMutationInputTypeName:
-        'CreateConversationMessageAssistantResponseInput',
-      responseMutationName: 'createConversationMessageAssistantResponse',
-      modelConfiguration: {
-        modelId: bedrockModelId,
-        systemPrompt: 'You are helpful bot.',
-      },
+      ...commonEventProperties,
     };
     const response = await this.executeConversationTurn(
       event,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

When lambda sends final response to AppSync it needs to specify a selection set.
That selection set is important to trigger propagation through subscriptions down the line, but for the lambda it's an opaque value that serves no other purpose than triggering desired behavior upstream.
In other words, lambda doesn't care what selection set is, upstream component does.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

This PR changes event shape to require response selection set to be sent by upstream as opaque string.
Lambda doesn't use it, just makes sure it's in right place.

It is a single opaque string because lambda doesn't really care about the same being requested. This allows flexibility.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
