### PR TITLE
UI tools

### DIFF
--- a/.changeset/fifty-bags-type.md
+++ b/.changeset/fifty-bags-type.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Add client tools

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -83,10 +83,7 @@ type ConversationTurnEvent = {
 };
 
 // @public (undocumented)
-type ExecutableTool = {
-    name: string;
-    description: string;
-    inputSchema: ToolInputSchema;
+type ExecutableTool = ToolDefinition & {
     execute: (input: DocumentType | undefined) => Promise<ToolResultContentBlock>;
 };
 
@@ -101,13 +98,17 @@ declare namespace runtime {
         ConversationMessageContentBlock,
         ConversationTurnEvent,
         ExecutableTool,
-        handleConversationTurnEvent
+        handleConversationTurnEvent,
+        ToolDefinition
     }
 }
 
-// Warnings were encountered during analysis:
-//
-// src/conversation/runtime/types.ts:48:5 - (ae-forgotten-export) The symbol "ToolDefinition" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+type ToolDefinition = {
+    name: string;
+    description: string;
+    inputSchema: ToolInputSchema;
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -68,16 +68,14 @@ type ConversationTurnEvent = {
     };
     messages: Array<ConversationMessage>;
     toolsConfiguration?: {
-        tools: Array<{
-            name: string;
-            description: string;
-            inputSchema: ToolInputSchema;
+        dataTools?: Array<ToolDefinition & {
             graphqlRequestInputDescriptor: {
                 queryName: string;
                 selectionSet: string[];
                 propertyTypes: Record<string, string>;
             };
         }>;
+        clientTools?: Array<ToolDefinition>;
     };
 };
 
@@ -103,6 +101,10 @@ declare namespace runtime {
         handleConversationTurnEvent
     }
 }
+
+// Warnings were encountered during analysis:
+//
+// src/conversation/runtime/types.ts:48:5 - (ae-forgotten-export) The symbol "ToolDefinition" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
@@ -8,7 +8,11 @@ import {
   Tool,
   ToolConfiguration,
 } from '@aws-sdk/client-bedrock-runtime';
-import { ConversationTurnEvent, ExecutableTool } from './types.js';
+import {
+  ConversationTurnEvent,
+  ExecutableTool,
+  ToolDefinition,
+} from './types.js';
 import { ConversationTurnEventToolsProvider } from './event-tools-provider';
 
 /**
@@ -16,8 +20,12 @@ import { ConversationTurnEventToolsProvider } from './event-tools-provider';
  * in order to produce final response that can be sent back to caller.
  */
 export class BedrockConverseAdapter {
-  private readonly allTools: Array<ExecutableTool>;
-  private readonly toolByName: Map<string, ExecutableTool> = new Map();
+  private readonly allTools: Array<ToolDefinition>;
+  private readonly allExecutableTools: Array<ExecutableTool>;
+  private readonly clientTools: Array<ToolDefinition>;
+  private readonly executableToolByName: Map<string, ExecutableTool> =
+    new Map();
+  private readonly clientToolByName: Map<string, ToolDefinition> = new Map();
 
   /**
    * Creates Bedrock Converse Adapter.
@@ -30,13 +38,27 @@ export class BedrockConverseAdapter {
     ),
     eventToolsProvider = new ConversationTurnEventToolsProvider(event)
   ) {
-    this.allTools = [...eventToolsProvider.getEventTools(), ...additionalTools];
+    this.allExecutableTools = [
+      ...eventToolsProvider.getEventTools(),
+      ...additionalTools,
+    ];
+    this.clientTools = this.event.toolsConfiguration?.clientTools ?? [];
+    this.allTools = [...this.allExecutableTools, ...this.clientTools];
     const duplicateTools = new Set<string>();
-    this.allTools.forEach((t) => {
-      if (this.toolByName.has(t.name)) {
+    this.allExecutableTools.forEach((t) => {
+      if (this.executableToolByName.has(t.name)) {
         duplicateTools.add(t.name);
       }
-      this.toolByName.set(t.name, t);
+      this.executableToolByName.set(t.name, t);
+    });
+    this.clientTools.forEach((t) => {
+      if (this.executableToolByName.has(t.name)) {
+        duplicateTools.add(t.name);
+      }
+      if (this.clientToolByName.has(t.name)) {
+        duplicateTools.add(t.name);
+      }
+      this.clientToolByName.set(t.name, t);
     });
     if (duplicateTools.size > 0) {
       throw new Error(
@@ -74,13 +96,24 @@ export class BedrockConverseAdapter {
       if (bedrockResponse.stopReason === 'tool_use') {
         const responseContentBlocks =
           bedrockResponse.output?.message?.content ?? [];
-        for (const responseContentBlock of responseContentBlocks) {
-          if ('toolUse' in responseContentBlock) {
-            const toolUseBlock =
-              responseContentBlock as ContentBlock.ToolUseMember;
-            const toolMessage = await this.executeTool(toolUseBlock);
-            messages.push(toolMessage);
-          }
+        const toolUseBlocks = responseContentBlocks.filter(
+          (block) => 'toolUse' in block
+        ) as Array<ContentBlock.ToolUseMember>;
+        const clientToolUseBlocks = responseContentBlocks.filter(
+          (block) =>
+            block.toolUse?.name &&
+            this.clientToolByName.has(block.toolUse?.name)
+        );
+        if (clientToolUseBlocks.length > 0) {
+          // For now if any of client tools is used we ignore executable tools
+          // and propagate result back to client.
+          return clientToolUseBlocks;
+        }
+        for (const responseContentBlock of toolUseBlocks) {
+          const toolUseBlock =
+            responseContentBlock as ContentBlock.ToolUseMember;
+          const toolMessage = await this.executeTool(toolUseBlock);
+          messages.push(toolMessage);
         }
       }
     } while (bedrockResponse.stopReason === 'tool_use');
@@ -89,7 +122,7 @@ export class BedrockConverseAdapter {
   };
 
   private createToolConfiguration = (): ToolConfiguration | undefined => {
-    if (this.allTools.length === 0) {
+    if (this.allExecutableTools.length === 0) {
       return undefined;
     }
 
@@ -112,7 +145,7 @@ export class BedrockConverseAdapter {
     if (!toolUseBlock.toolUse.name) {
       throw Error('Bedrock tool use response is missing a tool name');
     }
-    const tool = this.toolByName.get(toolUseBlock.toolUse.name);
+    const tool = this.executableToolByName.get(toolUseBlock.toolUse.name);
     if (!tool) {
       throw Error(
         `Bedrock tool use response contains unknown tool '${toolUseBlock.toolUse.name}'`

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
@@ -21,7 +21,7 @@ import { ConversationTurnEventToolsProvider } from './event-tools-provider';
  */
 export class BedrockConverseAdapter {
   private readonly allTools: Array<ToolDefinition>;
-  private readonly allExecutableTools: Array<ExecutableTool>;
+  private readonly executableTools: Array<ExecutableTool>;
   private readonly clientTools: Array<ToolDefinition>;
   private readonly executableToolByName: Map<string, ExecutableTool> =
     new Map();
@@ -38,14 +38,14 @@ export class BedrockConverseAdapter {
     ),
     eventToolsProvider = new ConversationTurnEventToolsProvider(event)
   ) {
-    this.allExecutableTools = [
+    this.executableTools = [
       ...eventToolsProvider.getEventTools(),
       ...additionalTools,
     ];
     this.clientTools = this.event.toolsConfiguration?.clientTools ?? [];
-    this.allTools = [...this.allExecutableTools, ...this.clientTools];
+    this.allTools = [...this.executableTools, ...this.clientTools];
     const duplicateTools = new Set<string>();
-    this.allExecutableTools.forEach((t) => {
+    this.executableTools.forEach((t) => {
       if (this.executableToolByName.has(t.name)) {
         duplicateTools.add(t.name);
       }
@@ -122,7 +122,7 @@ export class BedrockConverseAdapter {
   };
 
   private createToolConfiguration = (): ToolConfiguration | undefined => {
-    if (this.allExecutableTools.length === 0) {
+    if (this.allTools.length === 0) {
       return undefined;
     }
 

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/event_tools_provider.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/event_tools_provider.test.ts
@@ -64,7 +64,7 @@ void describe('events tool provider', () => {
       responseMutationInputTypeName: '',
       responseMutationName: '',
       toolsConfiguration: {
-        tools: [toolDefinition1, toolDefinition2],
+        dataTools: [toolDefinition1, toolDefinition2],
       },
     };
     const queryFactory = new GraphQlQueryFactory();

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/event_tools_provider.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/event_tools_provider.ts
@@ -16,10 +16,10 @@ export class ConversationTurnEventToolsProvider {
 
   getEventTools = (): Array<ExecutableTool> => {
     const { toolsConfiguration, graphqlApiEndpoint } = this.event;
-    if (!toolsConfiguration || !toolsConfiguration.tools) {
+    if (!toolsConfiguration || !toolsConfiguration.dataTools) {
       return [];
     }
-    const tools = toolsConfiguration.tools?.map((tool) => {
+    const tools = toolsConfiguration.dataTools?.map((tool) => {
       const { name, description, inputSchema } = tool;
       const query = this.graphQlQueryFactory.createQuery(tool);
       return new GraphQlTool(

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/types.ts
@@ -1,5 +1,5 @@
 import { ConversationTurnEvent } from '../types';
 
 export type ConversationTurnEventToolConfiguration = NonNullable<
-  ConversationTurnEvent['toolsConfiguration']
->['tools'][number];
+  NonNullable<ConversationTurnEvent['toolsConfiguration']>['dataTools']
+>[number];

--- a/packages/ai-constructs/src/conversation/runtime/index.ts
+++ b/packages/ai-constructs/src/conversation/runtime/index.ts
@@ -3,6 +3,7 @@ import {
   ConversationMessageContentBlock,
   ConversationTurnEvent,
   ExecutableTool,
+  ToolDefinition,
 } from './types.js';
 
 import { handleConversationTurnEvent } from './conversation_turn_executor.js';
@@ -13,4 +14,5 @@ export {
   ConversationTurnEvent,
   ExecutableTool,
   handleConversationTurnEvent,
+  ToolDefinition,
 };

--- a/packages/ai-constructs/src/conversation/runtime/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/types.ts
@@ -61,9 +61,6 @@ export type ConversationTurnEvent = {
   };
 };
 
-export type ExecutableTool = {
-  name: string;
-  description: string;
-  inputSchema: ToolInputSchema;
+export type ExecutableTool = ToolDefinition & {
   execute: (input: DocumentType | undefined) => Promise<ToolResultContentBlock>;
 };

--- a/packages/ai-constructs/src/conversation/runtime/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/types.ts
@@ -19,6 +19,12 @@ export type ConversationMessageContentBlock = {
   text: string;
 };
 
+export type ToolDefinition = {
+  name: string;
+  description: string;
+  inputSchema: ToolInputSchema;
+};
+
 // Customers are not expected to create events themselves, therefore
 // definition of nested properties is inline.
 export type ConversationTurnEvent = {
@@ -39,16 +45,16 @@ export type ConversationTurnEvent = {
   };
   messages: Array<ConversationMessage>;
   toolsConfiguration?: {
-    tools: Array<{
-      name: string;
-      description: string;
-      inputSchema: ToolInputSchema;
-      graphqlRequestInputDescriptor: {
-        queryName: string;
-        selectionSet: string[];
-        propertyTypes: Record<string, string>;
-      };
-    }>;
+    dataTools?: Array<
+      ToolDefinition & {
+        graphqlRequestInputDescriptor: {
+          queryName: string;
+          selectionSet: string[];
+          propertyTypes: Record<string, string>;
+        };
+      }
+    >;
+    clientTools?: Array<ToolDefinition>;
   };
 };
 

--- a/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
+++ b/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
@@ -273,7 +273,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
         systemPrompt: 'You are helpful bot.',
       },
       toolsConfiguration: {
-        tools: [
+        dataTools: [
           {
             name: 'thermometer',
             description: 'Provides the current temperature for a given city.',

--- a/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
+++ b/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
@@ -386,10 +386,13 @@ class ConversationHandlerTestProject extends TestProjectBase {
       defaultConversationHandlerFunction,
       apolloClient
     );
-    // Assert that tool was used. I.e. that LLM used value returned by the tool.
-    assert.match(response.content, /Seattle/);
+    // Assert that tool use content blocks are emitted in case LLM selects client tool.
+    // The content blocks are string serialized, but not as a proper JSON,
+    // hence string matching is employed below to detect some signals that tool use blocks kinds were emitted.
     assert.match(response.content, /toolUse/);
     assert.match(response.content, /toolUseId/);
+    // Assert that LLM attempts to pass parameter when asking for tool use.
+    assert.match(response.content, /city=Seattle/);
   };
 
   private assertCustomConversationHandlerCanExecuteTurn = async (


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem/Changes

This PR adds "client tools" concept to conversation handler.

They way this works is:
1. Client side can send "client tools" configuration in the event. This propagates through AppSync to conversation handler.
2. "Client tool" purpose is to grab inputs from LLM and execute processing in UI (or whatever "client side" is).
3. Client tool use interrupts a tool use loop in bedrock adapter to yield control back to UI.

## Out of scope

Bedrock API may respond with a tool use response that includes multiple tools.
It is unclear what exactly should we do if mixed tool kinds are requested, so for simplicity, for now if any of the tools is client tool we interrupt, ignore other tools and respond with client side tool usage blocks.
This is to enable exploration of real use cases with client side tools.

## Validation

Added e2e tests and unit tests.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
