### PR TITLE
Handle namespaces better in api check

### DIFF
--- a/scripts/components/api-changes-validator/api_usage_statements_generators.ts
+++ b/scripts/components/api-changes-validator/api_usage_statements_generators.ts
@@ -1,7 +1,6 @@
 import {
-  NamespaceDefinitions,
-  UsageStatements,
   UsageStatementsGenerator,
+  UsageStatementsGeneratorOutput,
 } from './types.js';
 import ts from 'typescript';
 import { EOL } from 'os';
@@ -30,7 +29,7 @@ export class GenericTypeParameterDeclarationUsageStatementsGenerator
   /**
    * @inheritDoc
    */
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     if (!this.typeParameters || this.typeParameters.length === 0) {
       return {};
     }
@@ -70,7 +69,7 @@ export class GenericTypeParameterUsageStatementsGenerator
   /**
    * @inheritDoc
    */
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     if (!this.typeParameters || this.typeParameters.length === 0) {
       return {};
     }
@@ -95,7 +94,7 @@ export class ImportUsageStatementsGenerator
    * @inheritDoc
    */
   constructor(private readonly node: ts.ImportDeclaration) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     return {
       importStatement: this.node.getText(),
     };
@@ -123,10 +122,9 @@ export class TypeUsageStatementsGenerator implements UsageStatementsGenerator {
    */
   constructor(
     private readonly typeAliasDeclaration: ts.TypeAliasDeclaration,
-    private readonly packageName: string,
-    private readonly namespaceDefinitions: NamespaceDefinitions
+    private readonly packageName: string
   ) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const typeName = this.typeAliasDeclaration.name.getText();
     const constName = toLowerCamelCase(typeName);
     const genericTypeParametersDeclaration =
@@ -139,35 +137,19 @@ export class TypeUsageStatementsGenerator implements UsageStatementsGenerator {
       ).generate().usageStatement ?? '';
     const baselineTypeName = `${typeName}Baseline`;
     const functionParameterName = `${constName}FunctionParameter`;
-    let importStatement: string | undefined;
-    let typeNameWithNamespace: string;
-    if (this.namespaceDefinitions.namespaceBySymbol.has(typeName)) {
-      let currentSymbolName: string | undefined = typeName;
-      const namespaceHierarchy: Array<string> = [];
-      do {
-        currentSymbolName =
-          this.namespaceDefinitions.namespaceBySymbol.get(currentSymbolName);
-        if (currentSymbolName) {
-          namespaceHierarchy.unshift(currentSymbolName);
-        }
-      } while (currentSymbolName);
-
-      typeNameWithNamespace = `${namespaceHierarchy.join('.')}.${typeName}`;
-    } else {
-      importStatement = `import { ${typeName} } from '${this.packageName}';`;
-      typeNameWithNamespace = typeName;
-    }
     // declare type with same content under different name.
     let usageStatement = `type ${baselineTypeName}${genericTypeParametersDeclaration} = ${this.typeAliasDeclaration.type.getText()}${EOL}`;
     // add statement that checks if old type can be assigned to new type.
-    const assignmentStatement = `const ${constName}: ${typeNameWithNamespace}${genericTypeParameters} = ${functionParameterName};`;
+    const assignmentStatement = `const ${constName}: ${typeName}${genericTypeParameters} = ${functionParameterName};`;
     usageStatement += `const ${toLowerCamelCase(
       typeName
     )}UsageFunction = ${genericTypeParametersDeclaration}(${functionParameterName}: ${baselineTypeName}${genericTypeParameters}) => {${EOL}`;
     usageStatement += `${indent(assignmentStatement)}${EOL}`;
     usageStatement += `}${EOL}`;
     return {
-      importStatement,
+      symbolDescriptor: {
+        symbolName: typeName,
+      },
       usageStatement: usageStatement,
     };
   };
@@ -192,7 +174,7 @@ export class EnumUsageStatementsGenerator implements UsageStatementsGenerator {
     private readonly enumDeclaration: ts.EnumDeclaration,
     private readonly packageName: string
   ) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const enumName = this.enumDeclaration.name.getText();
     const varName = `${toLowerCamelCase(enumName)}UsageVariable`;
     let usageStatement = `let ${varName}: ${enumName};${EOL}`;
@@ -200,7 +182,9 @@ export class EnumUsageStatementsGenerator implements UsageStatementsGenerator {
       usageStatement += `${varName} = ${enumName}.${enumMember.name.getText()};${EOL}`;
     }
     return {
-      importStatement: `import { ${enumName} } from '${this.packageName}';`,
+      symbolDescriptor: {
+        symbolName: enumName,
+      },
       usageStatement: usageStatement,
     };
   };
@@ -221,7 +205,7 @@ export class ClassUsageStatementsGenerator implements UsageStatementsGenerator {
     private readonly classDeclaration: ts.ClassDeclaration,
     private readonly packageName: string
   ) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const className = this.classDeclaration.name?.getText();
     if (!className) {
       throw new Error('Class name is missing');
@@ -264,7 +248,9 @@ export class ClassUsageStatementsGenerator implements UsageStatementsGenerator {
     }
 
     return {
-      importStatement: `import { ${className} } from '${this.packageName}';`,
+      symbolDescriptor: {
+        symbolName: className,
+      },
       usageStatement,
     };
   };
@@ -287,7 +273,7 @@ class ClassPropertyUsageStatementsGenerator
     private readonly classDeclaration: ts.ClassDeclaration,
     private readonly propertyDeclaration: ts.PropertyDeclaration
   ) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const className = this.classDeclaration.name?.getText();
     if (!className) {
       throw new Error('Class name is missing');
@@ -348,7 +334,7 @@ class ClassConstructorUsageStatementsGenerator
     private readonly constructorDeclaration: ts.ConstructorDeclaration
   ) {}
 
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const isAbstract = this.classDeclaration.modifiers?.find(
       (modifier) => modifier.kind === ts.SyntaxKind.AbstractKeyword
     );
@@ -363,85 +349,87 @@ class ClassConstructorUsageStatementsGenerator
    * Generated snippets attempt to invoke constructor with min and max parameters.
    * Enclosing usage function is used to deliver parameters for constructor call.
    */
-  private generateConcreteClassConstructorUsage = (): UsageStatements => {
-    const className = this.classDeclaration.name?.getText();
-    if (!className) {
-      throw new Error('Class name is missing');
-    }
-    const usageFunctionName = toLowerCamelCase(
-      `${className}ConstructorUsageFunction`
-    );
-    const usageFunctionParameterDeclaration =
-      new CallableParameterDeclarationUsageStatementsGenerator(
-        this.constructorDeclaration.parameters
-      ).generate().usageStatement ?? '';
-    const usageFunctionGenericParametersDeclaration =
-      new GenericTypeParameterDeclarationUsageStatementsGenerator(
-        this.classDeclaration.typeParameters
-      ).generate().usageStatement ?? '';
-    const minParameterUsage =
-      new CallableParameterUsageStatementsGenerator(
-        this.constructorDeclaration.parameters,
-        'min'
-      ).generate().usageStatement ?? '';
-    const maxParameterUsage =
-      new CallableParameterUsageStatementsGenerator(
-        this.constructorDeclaration.parameters,
-        'max'
-      ).generate().usageStatement ?? '';
-    const genericTypeParameters =
-      new GenericTypeParameterUsageStatementsGenerator(
-        this.classDeclaration.typeParameters
-      ).generate().usageStatement ?? '';
-    const callableSymbol = `new ${className}${genericTypeParameters}`;
-    const minParameterCallWithReturnValue = `${callableSymbol}(${minParameterUsage});`;
-    const maxParameterCall = `${callableSymbol}(${maxParameterUsage});`;
+  private generateConcreteClassConstructorUsage =
+    (): UsageStatementsGeneratorOutput => {
+      const className = this.classDeclaration.name?.getText();
+      if (!className) {
+        throw new Error('Class name is missing');
+      }
+      const usageFunctionName = toLowerCamelCase(
+        `${className}ConstructorUsageFunction`
+      );
+      const usageFunctionParameterDeclaration =
+        new CallableParameterDeclarationUsageStatementsGenerator(
+          this.constructorDeclaration.parameters
+        ).generate().usageStatement ?? '';
+      const usageFunctionGenericParametersDeclaration =
+        new GenericTypeParameterDeclarationUsageStatementsGenerator(
+          this.classDeclaration.typeParameters
+        ).generate().usageStatement ?? '';
+      const minParameterUsage =
+        new CallableParameterUsageStatementsGenerator(
+          this.constructorDeclaration.parameters,
+          'min'
+        ).generate().usageStatement ?? '';
+      const maxParameterUsage =
+        new CallableParameterUsageStatementsGenerator(
+          this.constructorDeclaration.parameters,
+          'max'
+        ).generate().usageStatement ?? '';
+      const genericTypeParameters =
+        new GenericTypeParameterUsageStatementsGenerator(
+          this.classDeclaration.typeParameters
+        ).generate().usageStatement ?? '';
+      const callableSymbol = `new ${className}${genericTypeParameters}`;
+      const minParameterCallWithReturnValue = `${callableSymbol}(${minParameterUsage});`;
+      const maxParameterCall = `${callableSymbol}(${maxParameterUsage});`;
 
-    let usageStatement = `const ${usageFunctionName} = ${usageFunctionGenericParametersDeclaration}(${usageFunctionParameterDeclaration}) => {${EOL}`;
-    usageStatement += `${indent(minParameterCallWithReturnValue)}${EOL}`;
-    usageStatement += `${indent(maxParameterCall)}${EOL}`;
-    usageStatement += `}${EOL}`;
-    return { usageStatement };
-  };
+      let usageStatement = `const ${usageFunctionName} = ${usageFunctionGenericParametersDeclaration}(${usageFunctionParameterDeclaration}) => {${EOL}`;
+      usageStatement += `${indent(minParameterCallWithReturnValue)}${EOL}`;
+      usageStatement += `${indent(maxParameterCall)}${EOL}`;
+      usageStatement += `}${EOL}`;
+      return { usageStatement };
+    };
 
   /**
    * Generates usage snippets for abstract class constructor.
    * Generated snippets have an attempt to derive from abstract class
    * and call it's constructor via super() call with matching list of parameters.
    */
-  private generateAbstractClassConstructorUsage = (): UsageStatements => {
-    const className = this.classDeclaration.name?.getText();
-    if (!className) {
-      throw new Error('Class name is missing');
-    }
-    const derivedClassConstructorParameterUsage =
-      new CallableParameterUsageStatementsGenerator(
-        this.constructorDeclaration.parameters,
-        // exploring just max is fine as abstract and derived class ctor
-        // signatures match
-        'max'
-      ).generate().usageStatement ?? '';
-    const derivedClassGenericParametersDeclaration =
-      new GenericTypeParameterDeclarationUsageStatementsGenerator(
-        this.classDeclaration.typeParameters
-      ).generate().usageStatement ?? '';
-    const genericTypeParameters =
-      new GenericTypeParameterUsageStatementsGenerator(
-        this.classDeclaration.typeParameters
-      ).generate().usageStatement ?? '';
-    const derivedClassName = `${className}DerivedUsageClass`;
-    const constructorDeclaration = this.constructorDeclaration
-      .getText()
-      // Strip trailing ';' as we want to define body.
-      .replace(';', '');
-    const superConstructorCall = `super(${derivedClassConstructorParameterUsage});`;
-    let usageStatement = `class ${derivedClassName}${derivedClassGenericParametersDeclaration} extends ${className}${genericTypeParameters}{${EOL}`;
-    usageStatement += `${indent(constructorDeclaration)} {${EOL}`;
-    usageStatement += `${indent(indent(superConstructorCall))}${EOL}`;
-    usageStatement += `${indent('}')}${EOL}`;
-    usageStatement += `}${EOL}`;
-    return { usageStatement };
-  };
+  private generateAbstractClassConstructorUsage =
+    (): UsageStatementsGeneratorOutput => {
+      const className = this.classDeclaration.name?.getText();
+      if (!className) {
+        throw new Error('Class name is missing');
+      }
+      const derivedClassConstructorParameterUsage =
+        new CallableParameterUsageStatementsGenerator(
+          this.constructorDeclaration.parameters,
+          // exploring just max is fine as abstract and derived class ctor
+          // signatures match
+          'max'
+        ).generate().usageStatement ?? '';
+      const derivedClassGenericParametersDeclaration =
+        new GenericTypeParameterDeclarationUsageStatementsGenerator(
+          this.classDeclaration.typeParameters
+        ).generate().usageStatement ?? '';
+      const genericTypeParameters =
+        new GenericTypeParameterUsageStatementsGenerator(
+          this.classDeclaration.typeParameters
+        ).generate().usageStatement ?? '';
+      const derivedClassName = `${className}DerivedUsageClass`;
+      const constructorDeclaration = this.constructorDeclaration
+        .getText()
+        // Strip trailing ';' as we want to define body.
+        .replace(';', '');
+      const superConstructorCall = `super(${derivedClassConstructorParameterUsage});`;
+      let usageStatement = `class ${derivedClassName}${derivedClassGenericParametersDeclaration} extends ${className}${genericTypeParameters}{${EOL}`;
+      usageStatement += `${indent(constructorDeclaration)} {${EOL}`;
+      usageStatement += `${indent(indent(superConstructorCall))}${EOL}`;
+      usageStatement += `${indent('}')}${EOL}`;
+      usageStatement += `}${EOL}`;
+      return { usageStatement };
+    };
 }
 
 /**
@@ -457,7 +445,7 @@ class ClassInheritanceUsageStatementsGenerator
     private readonly heritageClauses: ts.NodeArray<ts.HeritageClause>
   ) {}
 
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const className = this.classDeclaration.name?.getText();
     if (!className) {
       throw new Error('Class name is missing');
@@ -507,7 +495,7 @@ export class VariableUsageStatementsGenerator
     private readonly variableStatement: ts.VariableStatement,
     private readonly packageName: string
   ) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     if (this.variableStatement.declarationList.declarations.length != 1) {
       throw new Error('Unexpected variable declarations count');
     }
@@ -528,7 +516,9 @@ export class VariableUsageStatementsGenerator
     }
 
     return {
-      importStatement: `import { ${variableName} } from '${this.packageName}';`,
+      symbolDescriptor: {
+        symbolName: variableName,
+      },
       usageStatement,
     };
   };
@@ -561,7 +551,7 @@ export class CallableUsageStatementsGenerator
     private readonly callableSymbol: string,
     private readonly usageFunctionName: string
   ) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const usageFunctionParameterDeclaration =
       new CallableParameterDeclarationUsageStatementsGenerator(
         this.functionType.parameters
@@ -609,7 +599,7 @@ export class CallableParameterDeclarationUsageStatementsGenerator
   constructor(
     private readonly parameters: ts.NodeArray<ts.ParameterDeclaration>
   ) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const usageStatement = this.parameters
       .map((parameter) => parameter.getText())
       .join(', ');
@@ -638,7 +628,7 @@ export class CallableParameterUsageStatementsGenerator
     private readonly parameters: ts.NodeArray<ts.ParameterDeclaration>,
     private readonly strategy: 'min' | 'max'
   ) {}
-  generate = (): UsageStatements => {
+  generate = (): UsageStatementsGeneratorOutput => {
     const usageStatement = this.parameters
       .filter((parameter) => {
         switch (this.strategy) {

--- a/scripts/components/api-changes-validator/import_statements_renderer.ts
+++ b/scripts/components/api-changes-validator/import_statements_renderer.ts
@@ -1,0 +1,58 @@
+import {
+  NamespaceDefinitions,
+  UsageStatementsGeneratorOutput,
+} from './types.js';
+import { EOL } from 'os';
+
+/**
+ * Renders import statements.
+ */
+export class ImportStatementsRenderer {
+  /**
+   * Creates import statements renderer.
+   */
+  constructor(
+    private readonly generatorOutputs: Array<UsageStatementsGeneratorOutput>,
+    private readonly namespaceDefinitions: NamespaceDefinitions,
+    private readonly packageName: string
+  ) {}
+  render = (): string => {
+    const importStatements: Array<string> = [];
+    for (const generatorOutput of this.generatorOutputs) {
+      if (generatorOutput.importStatement) {
+        importStatements.push(generatorOutput.importStatement);
+      } else if (generatorOutput.symbolDescriptor) {
+        if (
+          !this.namespaceDefinitions.namespaceBySymbol.has(
+            generatorOutput.symbolDescriptor.symbolName
+          )
+        ) {
+          importStatements.push(
+            `import { ${generatorOutput.symbolDescriptor.symbolName} } from '${this.packageName}';`
+          );
+        }
+      }
+    }
+
+    for (const namespaceName of this.namespaceDefinitions.topLevelNamespaces) {
+      if (namespaceName.startsWith('__export__')) {
+        /*
+           Api-extractor does not ([yet](https://github.com/microsoft/rushstack/issues/1596)) support multiple package entry points
+           To work around this we use 'index.internal.ts' files where we export entry points as namespaces.
+           Api validator uses special naming convention for these special exports and converts them into start imports
+           so that they look like imported namespace.
+         */
+        const entryPointPath = namespaceName.replace('__export__', '');
+        importStatements.push(
+          `import * as ${namespaceName} from '${this.packageName}/${entryPointPath}';`
+        );
+      } else {
+        importStatements.push(
+          `import { ${namespaceName} } from '${this.packageName}';`
+        );
+      }
+    }
+
+    return importStatements.join(EOL);
+  };
+}

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
@@ -14,10 +14,25 @@ declare namespace someSubNamespace {
   }
 }
 
+export const functionUsingTypes1: (props: SomeTypeUnderNamespace) => SomeTypeUnderSubNamespace;
+export const functionUsingTypes2: (props: SomeTypeUnderNamespace, extraArg: string) => Array<SomeTypeUnderSubNamespace>;
+
 declare namespace someNamespace {
   export {
     SomeTypeUnderNamespace,
-    someSubNamespace
+    someSubNamespace,
+    functionUsingTypes1,
+    functionUsingTypes2
+  }
+}
+
+type SomeTypeUnderOtherEntryPoint = {
+  somePropertyUnderOtherEntryPoint: string;
+}
+
+declare namespace __export__other_entry_point {
+  export {
+    SomeTypeUnderOtherEntryPoint
   }
 }
 

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/package.json
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/package.json
@@ -6,6 +6,11 @@
       "import": "./lib/index.js",
       "require": "./lib/index.js",
       "types": "./lib/index.d.ts"
+    },
+    "./other_entry_point": {
+      "import": "./lib/some_other_entry_point.js",
+      "require": "./lib/some_other_entry_point.js",
+      "types": "./lib/some_other_entry_point.d.ts"
     }
   },
   "types": "lib/index.d.ts"

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
@@ -5,3 +5,15 @@ export type SomeTypeUnderNamespace = {
 };
 
 export { someSubNamespace };
+
+export const functionUsingTypes1 = (
+  props: SomeTypeUnderNamespace
+): someSubNamespace.SomeTypeUnderSubNamespace => {
+  throw new Error();
+};
+export const functionUsingTypes2 = (
+  props: SomeTypeUnderNamespace,
+  extraArg: string
+): Array<someSubNamespace.SomeTypeUnderSubNamespace> => {
+  throw new Error();
+};

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_other_entry_point.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_other_entry_point.ts
@@ -1,0 +1,3 @@
+export type SomeTypeUnderOtherEntryPoint = {
+  somePropertyUnderOtherEntryPoint: string;
+};

--- a/scripts/components/api-changes-validator/types.ts
+++ b/scripts/components/api-changes-validator/types.ts
@@ -1,13 +1,24 @@
-export type UsageStatements = {
-  importStatement?: string;
-  usageStatement?: string;
+export type SymbolDescriptor = {
+  symbolName: string;
 };
+
+export type UsageStatementsGeneratorOutput =
+  | {
+      symbolDescriptor?: undefined;
+      importStatement?: string;
+      usageStatement?: string;
+    }
+  | {
+      symbolDescriptor?: SymbolDescriptor;
+      importStatement?: undefined;
+      usageStatement?: string;
+    };
 
 export type UsageStatementsGenerator = {
   /**
    * Generates usage statements
    */
-  generate: () => UsageStatements;
+  generate: () => UsageStatementsGeneratorOutput;
 };
 
 export type NamespaceDefinitions = {

--- a/scripts/components/api-changes-validator/usage_statemets_renderer.ts
+++ b/scripts/components/api-changes-validator/usage_statemets_renderer.ts
@@ -1,0 +1,79 @@
+import {
+  NamespaceDefinitions,
+  UsageStatementsGeneratorOutput,
+} from './types.js';
+import { EOL } from 'os';
+
+/**
+ * Renders usage statements.
+ */
+export class UsageStatementsRenderer {
+  /**
+   * Creates import statements renderer.
+   */
+  constructor(
+    private readonly generatorOutputs: Array<UsageStatementsGeneratorOutput>,
+    private readonly namespaceDefinitions: NamespaceDefinitions
+  ) {}
+  render = (): string => {
+    let usageStatements = this.renderCombinedUsageStatements();
+    usageStatements = this.applyNamespaces(usageStatements);
+    return usageStatements;
+  };
+
+  private renderCombinedUsageStatements = (): string => {
+    const usageStatements: Array<string> = [];
+    for (const generatorOutput of this.generatorOutputs) {
+      if (generatorOutput.usageStatement) {
+        usageStatements.push(generatorOutput.usageStatement);
+      }
+    }
+    return usageStatements.join(EOL);
+  };
+
+  /**
+   * This function applies namespaces using a simple algorithm that
+   * regex match symbols in generated code with namespaced version.
+   *
+   * This a cheap alternative to a proper but more expensive solution
+   * that would involve inspecting symbols during generation.
+   * Proper solution is expensive because we'd need to unpack every statement
+   * that can contain these types like generic type arguments, function arguments, etc.
+   * We do leverage fact that these snippets can be copied over from API extract verbatim in generators to simplify them.
+   * Proper solution should be considered when this approach no longer works.
+   */
+  private applyNamespaces = (usageStatements: string): string => {
+    for (const symbolName of this.namespaceDefinitions.namespaceBySymbol.keys()) {
+      if (this.namespaceDefinitions.namespaceNames.has(symbolName)) {
+        // skip namespaces
+        continue;
+      }
+      let currentSymbolName: string | undefined = symbolName;
+      const namespaceHierarchy: Array<string> = [];
+      do {
+        currentSymbolName =
+          this.namespaceDefinitions.namespaceBySymbol.get(currentSymbolName);
+        if (currentSymbolName) {
+          namespaceHierarchy.unshift(currentSymbolName);
+        }
+      } while (currentSymbolName);
+      const symbolWithNamespace = `${namespaceHierarchy.join(
+        '.'
+      )}.${symbolName}`;
+
+      // characters that can be found before or after symbol
+      // this is to prevent partial matches in case one symbol's characters are subset of longer one
+      const symbolTerminators = '[\\s\\,\\(\\)<>]';
+      const regex = new RegExp(
+        `(${symbolTerminators})(${symbolName})(${symbolTerminators})`,
+        'g'
+      );
+      usageStatements = usageStatements.replaceAll(
+        regex,
+        `$1${symbolWithNamespace}$3`
+      );
+    }
+
+    return usageStatements;
+  };
+}

--- a/scripts/components/api-changes-validator/usage_statemets_renderer.ts
+++ b/scripts/components/api-changes-validator/usage_statemets_renderer.ts
@@ -33,7 +33,7 @@ export class UsageStatementsRenderer {
 
   /**
    * This function applies namespaces using a simple algorithm that
-   * regex match symbols in generated code with namespaced version.
+   * regex match and replace symbols in generated code with namespace prefix.
    *
    * This a cheap alternative to a proper but more expensive solution
    * that would involve inspecting symbols during generation.


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

This PR solves two problems:
1. The existing solution to add namespace to symbols doesn't scale well. I.e. there's a need to cover every place a symbol is used in usage snippets.
2. API extractor does not support multiple entry point in package.json (exports section). We workaround this with `index.internal.ts` but this workaround needs more refinement to handle more advanced usage on `feature/conversation-handler` branch.

I.e.
![image](https://github.com/user-attachments/assets/d633a5d4-6654-4031-84e8-f822ee27bfeb)


## Changes

1. Refactor namespacing solution to use match-replace after snippet generation. This is cheap and covers everything we need without complicating generators to process every possible type usage (which would otherwise require unpacking generics in every place, which is a lot of work).
2. Add special convention with `__export__` prefix in `index.internal.ts`. So that we can leverage most of namespacing logic to handle extra exports from package.json (see modified test project). The idea is to use magic prefix to instruct api validator to "star import extra export as namespace" and use rest of namespacing logic to handle this.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Out of scope

This PR prepares check to deal with namespaces better, but it does not change any of packages yet, neither on main nor in branches (that work will be done separately).

## Validation

1. This PRs validation is green (no regressions on main)
2. Added tests.
3. Verified locally with `feature/conversation-handler` (this PR is to `main` since it's independent from feature work).

![image](https://github.com/user-attachments/assets/cd02fd18-532b-496e-89d2-596386337a09)
![image](https://github.com/user-attachments/assets/3d33095a-ae81-42a7-9a8b-86e8d9fe1b62)


<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
