### PR TITLE
Serialize tool us blocks

### DIFF
--- a/.changeset/spicy-swans-enjoy.md
+++ b/.changeset/spicy-swans-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Serialize client tool input property

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
@@ -53,6 +53,16 @@ export class ConversationTurnResponseSender {
             }
         }
     `;
+    content = content.map((block) => {
+      if (block.toolUse) {
+        // The `input` field is typed as `AWS JSON` in the GraphQL API because it can represent
+        // arbitrary JSON values.
+        // We need to stringify it before sending it to AppSync to prevent type errors.
+        const input = JSON.stringify(block.toolUse.input);
+        return { toolUse: { ...block.toolUse, input } };
+      }
+      return block;
+    });
     const variables: MutationResponseInput = {
       input: {
         conversationId: this.event.conversationId,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Input for client tool is defined as AWSJSON in appsync. We have to serialize it before sending.
The reason for this strategy is that tool input can be arbitrary shape and can't be otherwise modeled in upstream appsync schema.

## Changes

Serialize content if tool block is detected.

## Validation

Added unit test.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
