### PR TITLE
Adjust API.md generation in backend-ai for api check to work.

### DIFF
--- a/.changeset/modern-vans-fetch.md
+++ b/.changeset/modern-vans-fetch.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-ai': patch
+---
+
+update API report generation

--- a/packages/backend-ai/API.md
+++ b/packages/backend-ai/API.md
@@ -9,11 +9,19 @@ import { ConversationHandlerFunctionProps } from '@aws-amplify/ai-constructs/con
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 
+declare namespace __export__conversation {
+    export {
+        DefineConversationHandlerFunctionProps,
+        defineConversationHandlerFunction
+    }
+}
+export { __export__conversation }
+
 // @public
-export const defineConversationHandlerFunction: (props: DefineConversationHandlerFunctionProps) => ConstructFactory<ResourceProvider<FunctionResources>>;
+const defineConversationHandlerFunction: (props: DefineConversationHandlerFunctionProps) => ConstructFactory<ResourceProvider<FunctionResources>>;
 
 // @public (undocumented)
-export type DefineConversationHandlerFunctionProps = {
+type DefineConversationHandlerFunctionProps = {
     name: string;
 } & ConversationHandlerFunctionProps;
 

--- a/packages/backend-ai/src/index.internal.ts
+++ b/packages/backend-ai/src/index.internal.ts
@@ -1,7 +1,11 @@
+// Suppressing to allow special prefix __export__ that is recognized by API checks.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+import * as __export__conversation from './conversation/index.js';
+
 /*
  Api-extractor does not ([yet](https://github.com/microsoft/rushstack/issues/1596)) support multiple package entry points
  Because this package has a submodule export, we are working around this issue by including that export here and directing api-extract to this entry point instead
  This allows api-extractor to pick up the submodule exports in its analysis
  */
 
-export * from './conversation/index.js';
+export { __export__conversation };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->


## Changes

Adjust `index.internal.ts` (workaround for API extractor) to leverage mechanism created in https://github.com/aws-amplify/amplify-backend/pull/1864 . I.e. to recognize extra exports defined in package.json while validating APIs exported from there.

## Validation

This was validated manually, locally. Check will get green when main is merged to feature branch later after this PR goes in (so that baseline API.md) looks good.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
