### PR TITLE
wrap SyntaxErrors in AmplifyUserError

### DIFF
--- a/.changeset/friendly-melons-hear.md
+++ b/.changeset/friendly-melons-hear.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+wrap SyntaxErrors in AmplifyUserError

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -21,7 +21,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     // (undocumented)
     readonly details?: string;
     // (undocumented)
-    static fromError: (error: unknown) => AmplifyError<'UnknownFault' | 'CredentialsError' | 'InvalidCommandInputError' | 'DomainNotFoundError'>;
+    static fromError: (error: unknown) => AmplifyError<'UnknownFault' | 'CredentialsError' | 'InvalidCommandInputError' | 'DomainNotFoundError' | 'SyntaxError'>;
     // (undocumented)
     static fromStderr: (_stderr: string) => AmplifyError | undefined;
     // (undocumented)

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -179,4 +179,13 @@ void describe('AmplifyError.fromError', async () => {
       `Failed the test for error ${error.message}`
     );
   });
+  void it('wraps SyntaxErrors in AmplifyUserError', () => {
+    const error = new Error('Typescript validation check failed.');
+    error.name = 'SyntaxError';
+    const actual = AmplifyError.fromError(error);
+    assert.ok(
+      actual instanceof AmplifyError && actual.name === 'SyntaxError',
+      `Failed the test for error ${error.message}`
+    );
+  });
 });

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -105,6 +105,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     | 'CredentialsError'
     | 'InvalidCommandInputError'
     | 'DomainNotFoundError'
+    | 'SyntaxError'
   > => {
     const errorMessage =
       error instanceof Error
@@ -139,6 +140,21 @@ export abstract class AmplifyError<T extends string = string> extends Error {
           message: 'Unable to establish a connection to a domain',
           resolution:
             'Ensure domain name is correct and network connection is stable.',
+        },
+        error
+      );
+    }
+    /**
+     * catches SyntaxErrors that were somehow not instances of AmplifyError
+     * this can be removed once we can properly identify where AmplifyError is being stripped off
+     */
+    if (error instanceof Error && isSyntaxError(error)) {
+      return new AmplifyUserError(
+        'SyntaxError',
+        {
+          message: error.message,
+          resolution:
+            'Check your backend definition in the `amplify` folder for syntax and type errors.',
         },
         error
       );
@@ -178,6 +194,10 @@ const isYargsValidationError = (err?: Error): boolean => {
 
 const isENotFoundError = (err?: Error): boolean => {
   return !!err && err.message.startsWith('getaddrinfo ENOTFOUND');
+};
+
+const isSyntaxError = (err?: Error): boolean => {
+  return !!err && err.name === 'SyntaxError';
 };
 
 /**


### PR DESCRIPTION
## Problem

`SyntaxError`s that we throw during `ampx sandbox` [here](https://github.com/aws-amplify/amplify-backend/blob/main/packages/backend-deployer/src/cdk_deployer.ts#L210) and [here](https://github.com/aws-amplify/amplify-backend/blob/main/packages/backend-deployer/src/cdk_deployer.ts#L239) are being sent to our telemetry as `UnknownFaults`.

**Issue number, if available:**

## Changes

Make sure we wrap `SyntaxError`s in `AmplifyUserError`.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
