### PR TITLE
Fix error names in storage and functions.

### DIFF
--- a/.changeset/kind-drinks-beg.md
+++ b/.changeset/kind-drinks-beg.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend-storage': patch
+---
+
+Fix InvalidFunctionConfigurationError and InvalidStorageAccessDefinitionError error names.

--- a/packages/backend-function/src/function_env_translator.test.ts
+++ b/packages/backend-function/src/function_env_translator.test.ts
@@ -134,7 +134,7 @@ void describe('FunctionEnvironmentTranslator', () => {
         );
       },
       {
-        name: 'InvalidFunctionConfiguration',
+        name: 'InvalidFunctionConfigurationError',
       }
     );
   });

--- a/packages/backend-function/src/function_env_translator.ts
+++ b/packages/backend-function/src/function_env_translator.ts
@@ -95,7 +95,7 @@ export class FunctionEnvironmentTranslator {
         );
       }
       if (typeof value === 'undefined') {
-        throw new AmplifyUserError('InvalidFunctionConfiguration', {
+        throw new AmplifyUserError('InvalidFunctionConfigurationError', {
           message: `The value of environment variable ${key} is undefined.`,
           resolution: `Ensure that all defineFunction environment variables are defined.`,
         });

--- a/packages/backend-storage/src/private_types.ts
+++ b/packages/backend-storage/src/private_types.ts
@@ -8,7 +8,7 @@ import { StorageAction } from './types.js';
  * Storage user error types
  */
 export type StorageError =
-  | 'InvalidStorageAccessDefinition'
+  | 'InvalidStorageAccessDefinitionError'
   | 'InvalidStorageAccessPathError';
 
 /**

--- a/packages/backend-storage/src/storage_access_orchestrator.ts
+++ b/packages/backend-storage/src/storage_access_orchestrator.ts
@@ -99,7 +99,7 @@ export class StorageAccessOrchestrator {
             ({ uniqueDefinitionId, validationErrorOptions }) => {
               if (uniqueDefinitionIdSet.has(uniqueDefinitionId)) {
                 throw new AmplifyUserError<StorageError>(
-                  'InvalidStorageAccessDefinition',
+                  'InvalidStorageAccessDefinitionError',
                   validationErrorOptions
                 );
               } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Two error names are missing `Error` suffix and are classified as unknown faults.

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Add `Error` suffix.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
