### PR TITLE
Detect more non bootstrapped account variants

### DIFF
--- a/.changeset/plenty-years-clap.md
+++ b/.changeset/plenty-years-clap.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Detect more non bootstrapped account variants

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -63,6 +63,20 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: 'Has the environment been bootstrapped',
   },
   {
+    errorMessage: 'Is account 12345 bootstrapped',
+    expectedTopLevelErrorMessage:
+      'This AWS account and region has not been bootstrapped.',
+    errorName: 'BootstrapNotDetectedError',
+    expectedDownstreamErrorMessage: 'Is account 12345 bootstrapped',
+  },
+  {
+    errorMessage: 'Is this account bootstrapped',
+    expectedTopLevelErrorMessage:
+      'This AWS account and region has not been bootstrapped.',
+    errorName: 'BootstrapNotDetectedError',
+    expectedDownstreamErrorMessage: 'Is this account bootstrapped',
+  },
+  {
     errorMessage: 'Amplify Backend not found in amplify/backend.ts',
     expectedTopLevelErrorMessage:
       'Backend definition could not be found in amplify directory.',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -101,7 +101,8 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex: /Has the environment been bootstrapped/,
+      errorRegex:
+        /(Has the environment been bootstrapped)|(Is account \d+ bootstrapped)|(Is this account bootstrapped)/,
       humanReadableErrorMessage:
         'This AWS account and region has not been bootstrapped.',
       resolutionMessage:


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

CDK can emit more variants of error for non bootstrapped accounts.

![image](https://github.com/user-attachments/assets/a48a7acc-5b4c-4aa7-a004-4755e9d77ee5)


**Issue number, if available:**

## Changes

Expand error capturing pattern.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

Added test.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
