### PR TITLE
fix: classify error for running pipeline-deploy in local as user error

### DIFF
--- a/.changeset/shiny-beans-happen.md
+++ b/.changeset/shiny-beans-happen.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+fix: classify error for running pipeline-deploy in local as user error

--- a/package-lock.json
+++ b/package-lock.json
@@ -28440,12 +28440,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.0.2",
-        "@aws-amplify/plugin-types": "^1.1.1",
+        "@aws-amplify/backend-output-storage": "^1.1.1",
+        "@aws-amplify/plugin-types": "^1.2.1",
         "@aws-sdk/util-arn-parser": "^3.568.0"
       },
       "peerDependencies": {
@@ -28455,20 +28455,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^1.1.0",
-        "@aws-amplify/backend-data": "^1.0.3",
-        "@aws-amplify/backend-function": "^1.3.1",
+        "@aws-amplify/backend-auth": "^1.1.2",
+        "@aws-amplify/backend-data": "^1.1.1",
+        "@aws-amplify/backend-function": "^1.3.2",
         "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/backend-output-storage": "^1.1.0",
+        "@aws-amplify/backend-output-storage": "^1.1.1",
         "@aws-amplify/backend-secret": "^1.0.1",
-        "@aws-amplify/backend-storage": "^1.1.0",
+        "@aws-amplify/backend-storage": "^1.1.1",
         "@aws-amplify/client-config": "^1.2.0",
         "@aws-amplify/data-schema": "^1.0.0",
-        "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/plugin-types": "^1.2.0",
+        "@aws-amplify/platform-core": "^1.0.6",
+        "@aws-amplify/plugin-types": "^1.2.1",
         "@aws-sdk/client-amplify": "^3.624.0",
         "lodash.snakecase": "^4.1.1"
       },
@@ -28484,16 +28484,16 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct": "^1.1.5",
-        "@aws-amplify/backend-output-storage": "^1.0.2",
-        "@aws-amplify/plugin-types": "^1.0.1"
+        "@aws-amplify/auth-construct": "^1.2.2",
+        "@aws-amplify/backend-output-storage": "^1.1.1",
+        "@aws-amplify/plugin-types": "^1.2.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
-        "@aws-amplify/platform-core": "^1.0.4"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.4",
+        "@aws-amplify/platform-core": "^1.0.6"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0",
@@ -28502,19 +28502,19 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.0.2",
+        "@aws-amplify/backend-output-storage": "^1.1.1",
         "@aws-amplify/data-construct": "^1.9.1",
         "@aws-amplify/data-schema-types": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.0.1"
+        "@aws-amplify/plugin-types": "^1.2.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.4",
         "@aws-amplify/data-schema": "^1.0.0",
-        "@aws-amplify/platform-core": "^1.0.1"
+        "@aws-amplify/platform-core": "^1.0.6"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0",
@@ -28523,11 +28523,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/plugin-types": "^1.1.1",
+        "@aws-amplify/platform-core": "^1.0.6",
+        "@aws-amplify/plugin-types": "^1.2.1",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -28538,17 +28538,17 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.0.2",
-        "@aws-amplify/plugin-types": "^1.1.1",
+        "@aws-amplify/backend-output-storage": "^1.1.1",
+        "@aws-amplify/plugin-types": "^1.2.1",
         "execa": "^8.0.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
-        "@aws-amplify/platform-core": "^1.0.5",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.4",
+        "@aws-amplify/platform-core": "^1.0.6",
         "@aws-sdk/client-ssm": "^3.624.0",
         "aws-sdk": "^2.1550.0",
         "uuid": "^9.0.1"
@@ -28584,11 +28584,11 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/platform-core": "^1.0.0"
+        "@aws-amplify/platform-core": "^1.0.6"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0"
@@ -28596,7 +28596,7 @@
     },
     "packages/backend-platform-test-stubs": {
       "name": "@aws-amplify/backend-platform-test-stubs",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-cdk-lib": "^2.152.0",
@@ -28618,16 +28618,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/backend-output-storage": "^1.1.0",
-        "@aws-amplify/plugin-types": "^1.2.0"
+        "@aws-amplify/backend-output-storage": "^1.1.1",
+        "@aws-amplify/plugin-types": "^1.2.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.3",
-        "@aws-amplify/platform-core": "^1.0.1"
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.4",
+        "@aws-amplify/platform-core": "^1.0.6"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0",
@@ -28956,17 +28956,17 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
-        "@aws-amplify/auth-construct": "^1.2.1",
-        "@aws-amplify/backend": "^1.0.5",
+        "@aws-amplify/auth-construct": "^1.2.2",
+        "@aws-amplify/backend": "^1.1.1",
         "@aws-amplify/backend-secret": "^1.0.1",
         "@aws-amplify/client-config": "^1.1.3",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/deployed-backend-client": "^1.3.0",
-        "@aws-amplify/platform-core": "^1.0.5",
+        "@aws-amplify/platform-core": "^1.0.6",
         "@aws-sdk/client-accessanalyzer": "^3.624.0",
         "@aws-sdk/client-amplify": "^3.624.0",
         "@aws-sdk/client-bedrock-runtime": "^3.602.0",
@@ -29032,10 +29032,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.1.1",
+        "@aws-amplify/plugin-types": "^1.2.1",
         "@aws-sdk/client-sts": "^3.624.0",
         "is-ci": "^3.0.1",
         "lodash.mergewith": "^4.6.2",
@@ -29062,7 +29062,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "execa": "^5.1.1"
@@ -29182,15 +29182,15 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.0.4",
+        "@aws-amplify/backend-deployer": "^1.0.5",
         "@aws-amplify/backend-secret": "^1.0.1",
         "@aws-amplify/cli-core": "^1.1.2",
         "@aws-amplify/client-config": "^1.1.3",
         "@aws-amplify/deployed-backend-client": "^1.3.0",
-        "@aws-amplify/platform-core": "^1.0.5",
+        "@aws-amplify/platform-core": "^1.0.6",
         "@aws-sdk/client-cloudformation": "^3.624.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.624.0",
         "@aws-sdk/client-lambda": "^3.624.0",

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -93,7 +93,7 @@ void describe('deploy command', () => {
         );
         assert.deepStrictEqual(
           err.error.name,
-          'RunningPipelineDeployLocallyError'
+          'RunningPipelineDeployNotInCiError'
         );
         return true;
       }

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -91,6 +91,10 @@ void describe('deploy command', () => {
           err.error.message,
           /It looks like this command is being run outside of a CI\/CD workflow/
         );
+        assert.deepStrictEqual(
+          err.error.name,
+          'RunningPipelineDeployLocallyError'
+        );
         return true;
       }
     );

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -60,7 +60,7 @@ export class PipelineDeployCommand
     args: ArgumentsCamelCase<PipelineDeployCommandOptions>
   ): Promise<void> => {
     if (!this.isCiEnvironment) {
-      throw new AmplifyUserError('RunningPipelineDeployLocallyError', {
+      throw new AmplifyUserError('RunningPipelineDeployNotInCiError', {
         message:
           'It looks like this command is being run outside of a CI/CD workflow.',
         resolution: `To deploy locally use ${format.normalizeAmpxCommand(

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -10,6 +10,8 @@ import {
   ClientConfigVersionOption,
   DEFAULT_CLIENT_CONFIG_VERSION,
 } from '@aws-amplify/client-config';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
+import { format } from '@aws-amplify/cli-core';
 
 export type PipelineDeployCommandOptions =
   ArgumentsKebabCase<PipelineDeployCommandOptionsCamelCase>;
@@ -58,9 +60,13 @@ export class PipelineDeployCommand
     args: ArgumentsCamelCase<PipelineDeployCommandOptions>
   ): Promise<void> => {
     if (!this.isCiEnvironment) {
-      throw new Error(
-        'It looks like this command is being run outside of a CI/CD workflow. To deploy locally use `amplify sandbox` instead.'
-      );
+      throw new AmplifyUserError('RunningPipelineDeployLocallyError', {
+        message:
+          'It looks like this command is being run outside of a CI/CD workflow.',
+        resolution: `To deploy locally use ${format.normalizeAmpxCommand(
+          'sandbox'
+        )} instead.`,
+      });
     }
 
     const backendId: BackendIdentifier = {


### PR DESCRIPTION
## Problem

A generic error is thrown for running pipeline-deploy in local

**Issue number, if available:**

## Changes

Mark it as a user error

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
