### PR TITLE
chore: refactor error handling for secrets client

### DIFF
--- a/.changeset/lazy-radios-do.md
+++ b/.changeset/lazy-radios-do.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-secret': minor
+'@aws-amplify/sandbox': patch
+'@aws-amplify/backend-cli': patch
+---
+
+chore: refactor error handling for secrets client

--- a/packages/backend-secret/API.md
+++ b/packages/backend-secret/API.md
@@ -12,6 +12,9 @@ import { BackendIdentifier } from '@aws-amplify/plugin-types';
 export const getSecretClient: (secretClientOptions?: SecretClientOptions) => SecretClient;
 
 // @public
+export const getSecretClientWithAmplifyErrorHandling: (secretClientOptions?: SecretClientOptions) => SecretClient;
+
+// @public
 export type Secret = SecretIdentifier & {
     value: string;
     lastUpdated?: Date;

--- a/packages/backend-secret/src/secret.ts
+++ b/packages/backend-secret/src/secret.ts
@@ -2,6 +2,7 @@ import { SSMSecretClient } from './ssm_secret.js';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { SSM } from '@aws-sdk/client-ssm';
 import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
+import { SSMSecretClientWithAmplifyErrorHandling } from './ssm_secret_with_amplify_error_handling.js';
 
 /**
  * The unique identifier of the secret.
@@ -72,7 +73,7 @@ export type SecretClientOptions = {
 };
 
 /**
- * Creates an Amplify secret client.
+ * Creates an Amplify secret client. Used in the backend lambda for fetching secrets
  */
 export const getSecretClient = (
   secretClientOptions?: SecretClientOptions
@@ -82,5 +83,17 @@ export const getSecretClient = (
       credentials: secretClientOptions?.credentials,
       region: secretClientOptions?.region,
     })
+  );
+};
+
+/**
+ * Creates an Amplify secret client with inbuilt amplify error handling
+ * Used in the amplify CLI commands such as sandbox and pipeline-deploy
+ */
+export const getSecretClientWithAmplifyErrorHandling = (
+  secretClientOptions?: SecretClientOptions
+): SecretClient => {
+  return new SSMSecretClientWithAmplifyErrorHandling(
+    getSecretClient(secretClientOptions)
   );
 };

--- a/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.test.ts
+++ b/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import { getSecretClient } from './secret.js';
+import assert from 'node:assert';
+import { AmplifyFault, AmplifyUserError } from '@aws-amplify/platform-core';
+import { SSMServiceException } from '@aws-sdk/client-ssm';
+import { SecretError } from './secret_error.js';
+import { SSMSecretClientWithAmplifyErrorHandling } from './ssm_secret_with_amplify_error_handling.js';
+
+void describe('getSecretClientWithAmplifyErrorHandling', () => {
+  const rawSecretClient = getSecretClient();
+  const classUnderTest = new SSMSecretClientWithAmplifyErrorHandling(
+    rawSecretClient
+  );
+  void it('throws AmplifyUserError if listSecrets fails due to ExpiredTokenException', async (context) => {
+    const ssmError = new SSMServiceException({
+      name: 'ExpiredTokenException',
+      $fault: 'client',
+      message: 'tokens expired',
+      $metadata: {},
+    });
+    const secretsError = SecretError.createInstance(ssmError);
+    context.mock.method(rawSecretClient, 'listSecrets', () => {
+      throw secretsError;
+    });
+
+    await assert.rejects(
+      () =>
+        classUnderTest.listSecrets({
+          namespace: 'testSandboxId',
+          name: 'testSandboxName',
+          type: 'sandbox',
+        }),
+      new AmplifyUserError('SSMCredentialsError', {
+        message:
+          'Failed to List secrets. ExpiredTokenException: tokens expired',
+        resolution:
+          'Make sure your AWS credentials are set up correctly, refreshed and have necessary permissions to call SSM service',
+      })
+    );
+  });
+
+  void it('throws AmplifyUserError if listSecrets fails due to CredentialsProviderError', async (context) => {
+    const credentialsError = new Error('credentials error');
+    credentialsError.name = 'CredentialsProviderError';
+    const secretsError = SecretError.createInstance(credentialsError);
+    context.mock.method(rawSecretClient, 'listSecrets', () => {
+      throw secretsError;
+    });
+    await assert.rejects(
+      () =>
+        classUnderTest.listSecrets({
+          namespace: 'testSandboxId',
+          name: 'testSandboxName',
+          type: 'sandbox',
+        }),
+      new AmplifyUserError('SSMCredentialsError', {
+        message:
+          'Failed to List secrets. CredentialsProviderError: credentials error',
+        resolution:
+          'Make sure your AWS credentials are set up correctly, refreshed and have necessary permissions to call SSM service',
+      })
+    );
+  });
+
+  void it('throws AmplifyFault if listSecrets fails due to a non-SSM exception other than expired credentials', async (context) => {
+    const underlyingError = new Error('some secret error');
+    const secretsError = SecretError.createInstance(underlyingError);
+    context.mock.method(rawSecretClient, 'listSecrets', () => {
+      throw secretsError;
+    });
+    await assert.rejects(
+      () =>
+        classUnderTest.listSecrets({
+          namespace: 'testSandboxId',
+          name: 'testSandboxName',
+          type: 'sandbox',
+        }),
+      new AmplifyFault(
+        'ListSecretsFailedFault',
+        {
+          message: 'Failed to List secrets. Error: some secret error',
+        },
+        underlyingError // If it's not an SSM exception, we use the original error instead of secrets error
+      )
+    );
+  });
+
+  void it('throws AmplifyFault if getSecret fails due to an SSM exception other than expired credentials', async (context) => {
+    const underlyingError = new SSMServiceException({
+      name: 'SomeException',
+      message: 'some error',
+      $fault: 'client',
+      $metadata: {},
+    });
+    const secretsError = SecretError.createInstance(underlyingError);
+    context.mock.method(rawSecretClient, 'getSecret', () => {
+      throw secretsError;
+    });
+    await assert.rejects(
+      () =>
+        classUnderTest.getSecret(
+          {
+            namespace: 'testSandboxId',
+            name: 'testSandboxName',
+            type: 'sandbox',
+          },
+          { name: 'testSecret' }
+        ),
+      new AmplifyFault(
+        'GetSecretsFailedFault',
+        {
+          message: 'Failed to Get secrets. SomeException: some error',
+        },
+        secretsError // If it's an SSM exception, we use the wrapper secret error
+      )
+    );
+  });
+});

--- a/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.test.ts
+++ b/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.test.ts
@@ -32,7 +32,7 @@ void describe('getSecretClientWithAmplifyErrorHandling', () => {
         }),
       new AmplifyUserError('SSMCredentialsError', {
         message:
-          'Failed to List secrets. ExpiredTokenException: tokens expired',
+          'Failed to list secrets. ExpiredTokenException: tokens expired',
         resolution:
           'Make sure your AWS credentials are set up correctly, refreshed and have necessary permissions to call SSM service',
       })
@@ -55,7 +55,7 @@ void describe('getSecretClientWithAmplifyErrorHandling', () => {
         }),
       new AmplifyUserError('SSMCredentialsError', {
         message:
-          'Failed to List secrets. CredentialsProviderError: credentials error',
+          'Failed to list secrets. CredentialsProviderError: credentials error',
         resolution:
           'Make sure your AWS credentials are set up correctly, refreshed and have necessary permissions to call SSM service',
       })
@@ -78,7 +78,7 @@ void describe('getSecretClientWithAmplifyErrorHandling', () => {
       new AmplifyFault(
         'ListSecretsFailedFault',
         {
-          message: 'Failed to List secrets. Error: some secret error',
+          message: 'Failed to list secrets. Error: some secret error',
         },
         underlyingError // If it's not an SSM exception, we use the original error instead of secrets error
       )
@@ -109,7 +109,7 @@ void describe('getSecretClientWithAmplifyErrorHandling', () => {
       new AmplifyFault(
         'GetSecretsFailedFault',
         {
-          message: 'Failed to Get secrets. SomeException: some error',
+          message: 'Failed to get secrets. SomeException: some error',
         },
         secretsError // If it's an SSM exception, we use the wrapper secret error
       )

--- a/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
+++ b/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
@@ -1,0 +1,110 @@
+import { AppId, BackendIdentifier } from '@aws-amplify/plugin-types';
+import {
+  Secret,
+  SecretClient,
+  SecretIdentifier,
+  SecretListItem,
+} from './secret.js';
+import { SecretError } from './secret_error.js';
+import { AmplifyFault, AmplifyUserError } from '@aws-amplify/platform-core';
+import { SSMServiceException } from '@aws-sdk/client-ssm';
+
+/**
+ * Handles errors and translate them to AmplifyUserError or AmplifyFaults
+ * To be used exclusively by the amplify cli
+ */
+export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
+  /**
+   * wraps the secretClient with Amplify CLI specific error handling
+   */
+  constructor(private readonly secretClient: SecretClient) {}
+
+  getSecret = async (
+    backendIdentifier: BackendIdentifier | AppId,
+    secretIdentifier: SecretIdentifier
+  ): Promise<Secret> => {
+    try {
+      return await this.secretClient.getSecret(
+        backendIdentifier,
+        secretIdentifier
+      );
+    } catch (e) {
+      throw this.translateToAmplifyError(e, 'Get');
+    }
+  };
+
+  listSecrets = async (
+    backendIdentifier: BackendIdentifier | AppId
+  ): Promise<SecretListItem[]> => {
+    try {
+      return await this.secretClient.listSecrets(backendIdentifier);
+    } catch (e) {
+      throw this.translateToAmplifyError(e, 'List');
+    }
+  };
+
+  setSecret = async (
+    backendIdentifier: BackendIdentifier | AppId,
+    secretName: string,
+    secretValue: string
+  ): Promise<SecretIdentifier> => {
+    try {
+      return await this.secretClient.setSecret(
+        backendIdentifier,
+        secretName,
+        secretValue
+      );
+    } catch (e) {
+      throw this.translateToAmplifyError(e, 'Set');
+    }
+  };
+
+  removeSecret = async (
+    backendIdentifier: BackendIdentifier | AppId,
+    secretName: string
+  ): Promise<void> => {
+    try {
+      return await this.secretClient.removeSecret(
+        backendIdentifier,
+        secretName
+      );
+    } catch (e) {
+      throw this.translateToAmplifyError(e, 'Remove');
+    }
+  };
+
+  private translateToAmplifyError = (error: unknown, apiName: string) => {
+    if (error instanceof SecretError && error.cause) {
+      if (
+        [
+          'UnrecognizedClientException',
+          'AccessDeniedException',
+          'NotAuthorized',
+          'ExpiredTokenException',
+          'CredentialsProviderError',
+        ].includes(error.cause.name)
+      ) {
+        return new AmplifyUserError('SSMCredentialsError', {
+          message: `Failed to ${apiName} secrets. ${error.cause.name}: ${error.cause?.message}`,
+          resolution:
+            'Make sure your AWS credentials are set up correctly, refreshed and have necessary permissions to call SSM service',
+        });
+      }
+      let downstreamException: Error = error;
+      if (
+        !(error.cause instanceof SSMServiceException) &&
+        error.cause instanceof Error
+      ) {
+        downstreamException = error.cause;
+      }
+      throw new AmplifyFault(
+        `${apiName}SecretsFailedFault`,
+        {
+          message: `Failed to ${apiName} secrets. ${error.cause.name}: ${error.cause?.message}`,
+        },
+        downstreamException
+      );
+    }
+    return error;
+  };
+}

--- a/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
+++ b/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
@@ -85,7 +85,9 @@ export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
         ].includes(error.cause.name)
       ) {
         return new AmplifyUserError('SSMCredentialsError', {
-          message: `Failed to ${apiName} secrets. ${error.cause.name}: ${error.cause?.message}`,
+          message: `Failed to ${apiName.toLowerCase()} secrets. ${
+            error.cause.name
+          }: ${error.cause?.message}`,
           resolution:
             'Make sure your AWS credentials are set up correctly, refreshed and have necessary permissions to call SSM service',
         });
@@ -100,7 +102,9 @@ export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
       throw new AmplifyFault(
         `${apiName}SecretsFailedFault`,
         {
-          message: `Failed to ${apiName} secrets. ${error.cause.name}: ${error.cause?.message}`,
+          message: `Failed to ${apiName.toLowerCase()} secrets. ${
+            error.cause.name
+          }: ${error.cause?.message}`,
         },
         downstreamException
       );

--- a/packages/cli/src/commands/generate/generate_command_factory.ts
+++ b/packages/cli/src/commands/generate/generate_command_factory.ts
@@ -14,7 +14,7 @@ import { CommandMiddleware } from '../../command_middleware.js';
 import { BackendIdentifierResolverWithFallback } from '../../backend-identifier/backend_identifier_with_sandbox_fallback.js';
 import { AppBackendIdentifierResolver } from '../../backend-identifier/backend_identifier_resolver.js';
 import { GenerateSchemaCommand } from './schema-from-database/generate_schema_command.js';
-import { getSecretClient } from '@aws-amplify/backend-secret';
+import { getSecretClientWithAmplifyErrorHandling } from '@aws-amplify/backend-secret';
 import { SchemaGenerator } from '@aws-amplify/schema-generator';
 import { printer } from '@aws-amplify/cli-core';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
@@ -34,7 +34,7 @@ export const createGenerateCommand = (): CommandModule => {
     getAmplifyClient: () => amplifyClient,
     getCloudFormationClient: () => cloudFormationClient,
   };
-  const secretClient = getSecretClient();
+  const secretClient = getSecretClientWithAmplifyErrorHandling();
 
   const clientConfigGenerator = new ClientConfigGeneratorAdapter(
     awsClientProvider

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
@@ -7,7 +7,7 @@ import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { SandboxBackendIdResolver } from '../../sandbox/sandbox_id_resolver.js';
 import { BackendIdentifierResolverWithFallback } from '../../../backend-identifier/backend_identifier_with_sandbox_fallback.js';
-import { getSecretClient } from '@aws-amplify/backend-secret';
+import { getSecretClientWithAmplifyErrorHandling } from '@aws-amplify/backend-secret';
 import { SchemaGenerator } from '@aws-amplify/schema-generator';
 
 void describe('generate graphql-client-code command', () => {
@@ -27,7 +27,7 @@ void describe('generate graphql-client-code command', () => {
     sandboxIdResolver
   );
 
-  const secretClient = getSecretClient();
+  const secretClient = getSecretClientWithAmplifyErrorHandling();
 
   const schemaGenerator = new SchemaGenerator();
   const schemaGeneratorGenerateMethod = mock.method(

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command.test.ts
@@ -3,14 +3,14 @@ import yargs, { CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { getSecretClient } from '@aws-amplify/backend-secret';
+import { getSecretClientWithAmplifyErrorHandling } from '@aws-amplify/backend-secret';
 import { SandboxSecretCommand } from './sandbox_secret_command.js';
 import { SandboxSecretGetCommand } from './sandbox_secret_get_command.js';
 
 const testBackendId = 'testBackendId';
 
 void describe('sandbox secret command', () => {
-  const secretClient = getSecretClient();
+  const secretClient = getSecretClientWithAmplifyErrorHandling();
   const sandboxIdResolver = new SandboxBackendIdResolver({
     resolve: () => Promise.resolve(testBackendId),
   });

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command_factory.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_command_factory.ts
@@ -1,7 +1,7 @@
 import { CommandModule } from 'yargs';
 
 import { PackageJsonReader } from '@aws-amplify/platform-core';
-import { getSecretClient } from '@aws-amplify/backend-secret';
+import { getSecretClientWithAmplifyErrorHandling } from '@aws-amplify/backend-secret';
 import { SandboxSecretCommand } from './sandbox_secret_command.js';
 import { SandboxSecretSetCommand } from './sandbox_secret_set_command.js';
 import { SandboxSecretRemoveCommand } from './sandbox_secret_remove_command.js';
@@ -18,7 +18,7 @@ export const createSandboxSecretCommand = (): CommandModule => {
     new LocalNamespaceResolver(new PackageJsonReader())
   );
 
-  const secretClient = getSecretClient();
+  const secretClient = getSecretClientWithAmplifyErrorHandling();
   const setCommand = new SandboxSecretSetCommand(
     sandboxIdResolver,
     secretClient

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_get_command.test.ts
@@ -6,7 +6,7 @@ import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import {
   Secret,
   SecretIdentifier,
-  getSecretClient,
+  getSecretClientWithAmplifyErrorHandling,
 } from '@aws-amplify/backend-secret';
 import { SandboxSecretGetCommand } from './sandbox_secret_get_command.js';
 import { format, printer } from '@aws-amplify/cli-core';
@@ -26,7 +26,7 @@ const testSecret: Secret = {
 };
 
 void describe('sandbox secret get command', () => {
-  const secretClient = getSecretClient();
+  const secretClient = getSecretClientWithAmplifyErrorHandling();
   const secretGetMock = mock.method(
     secretClient,
     'getSecret',

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_list_command.test.ts
@@ -3,7 +3,10 @@ import yargs from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { SecretListItem, getSecretClient } from '@aws-amplify/backend-secret';
+import {
+  SecretListItem,
+  getSecretClientWithAmplifyErrorHandling,
+} from '@aws-amplify/backend-secret';
 import { SandboxSecretListCommand } from './sandbox_secret_list_command.js';
 import { format, printer } from '@aws-amplify/cli-core';
 
@@ -24,7 +27,7 @@ void describe('sandbox secret list command', () => {
   const listSecretsResponseMock = mock.fn<() => Promise<SecretListItem[]>>(
     async () => testSecrets
   );
-  const secretClient = getSecretClient();
+  const secretClient = getSecretClientWithAmplifyErrorHandling();
   const secretListMock = mock.method(
     secretClient,
     'listSecrets',

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_remove_command.test.ts
@@ -3,7 +3,7 @@ import yargs, { CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { getSecretClient } from '@aws-amplify/backend-secret';
+import { getSecretClientWithAmplifyErrorHandling } from '@aws-amplify/backend-secret';
 import { SandboxSecretRemoveCommand } from './sandbox_secret_remove_command.js';
 import { printer } from '@aws-amplify/cli-core';
 
@@ -12,7 +12,7 @@ const testBackendId = 'testBackendId';
 const testSandboxName = 'testSandboxName';
 
 void describe('sandbox secret remove command', () => {
-  const secretClient = getSecretClient();
+  const secretClient = getSecretClientWithAmplifyErrorHandling();
   const secretRemoveMock = mock.method(
     secretClient,
     'removeSecret',

--- a/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-secret/sandbox_secret_set_command.test.ts
@@ -4,7 +4,10 @@ import yargs, { CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { SecretIdentifier, getSecretClient } from '@aws-amplify/backend-secret';
+import {
+  SecretIdentifier,
+  getSecretClientWithAmplifyErrorHandling,
+} from '@aws-amplify/backend-secret';
 import { SandboxSecretSetCommand } from './sandbox_secret_set_command.js';
 import { ReadStream } from 'node:tty';
 import { PassThrough } from 'node:stream';
@@ -20,7 +23,7 @@ const testBackendId = 'testBackendId';
 const testSandboxName = 'testSandboxName';
 
 void describe('sandbox secret set command', () => {
-  const secretClient = getSecretClient();
+  const secretClient = getSecretClientWithAmplifyErrorHandling();
   const secretSetMock = mock.method(
     secretClient,
     'setSecret',

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -15,7 +15,10 @@ import {
 import fs from 'fs';
 import parseGitIgnore from 'parse-gitignore';
 import _open from 'open';
-import { SecretListItem, getSecretClient } from '@aws-amplify/backend-secret';
+import {
+  SecretListItem,
+  getSecretClientWithAmplifyErrorHandling,
+} from '@aws-amplify/backend-secret';
 import { Sandbox, SandboxOptions } from './sandbox.js';
 import {
   AmplifyPrompter,
@@ -53,7 +56,7 @@ const backendDeployerFactory = new BackendDeployerFactory(
 );
 const backendDeployer = backendDeployerFactory.getInstance();
 
-const secretClient = getSecretClient();
+const secretClient = getSecretClientWithAmplifyErrorHandling();
 const newlyUpdatedSecretItem: SecretListItem = {
   name: 'C',
   lastUpdated: new Date(1234567),

--- a/packages/sandbox/src/sandbox_executor.test.ts
+++ b/packages/sandbox/src/sandbox_executor.test.ts
@@ -11,12 +11,9 @@ import {
   Printer,
 } from '@aws-amplify/cli-core';
 import {
-  SecretError,
   SecretListItem,
-  getSecretClient,
+  getSecretClientWithAmplifyErrorHandling,
 } from '@aws-amplify/backend-secret';
-import { AmplifyFault, AmplifyUserError } from '@aws-amplify/platform-core';
-import { SSMServiceException } from '@aws-sdk/client-ssm';
 
 const logMock = mock.fn();
 const mockedPrinter = {
@@ -36,7 +33,7 @@ const backendDeployerFactory = new BackendDeployerFactory(
   formatterStub
 );
 const backendDeployer = backendDeployerFactory.getInstance();
-const secretClient = getSecretClient();
+const secretClient = getSecretClientWithAmplifyErrorHandling();
 const sandboxExecutor = new AmplifySandboxExecutor(
   backendDeployer,
   secretClient,
@@ -99,121 +96,6 @@ void describe('Sandbox executor', () => {
     // Assert debounce worked as expected
     assert.strictEqual(backendDeployerDeployMock.mock.callCount(), 1);
     assert.strictEqual(validateAppSourcesProvider.mock.callCount(), 1);
-  });
-
-  void it('throws AmplifyUserError if listSecrets fails due to ExpiredTokenException', async () => {
-    const ssmError = new SSMServiceException({
-      name: 'ExpiredTokenException',
-      $fault: 'client',
-      $metadata: {},
-    });
-    const secretsError = SecretError.createInstance(ssmError);
-    listSecretMock.mock.mockImplementationOnce(() => {
-      throw secretsError;
-    });
-    await assert.rejects(
-      () =>
-        sandboxExecutor.deploy(
-          {
-            namespace: 'testSandboxId',
-            name: 'testSandboxName',
-            type: 'sandbox',
-          },
-          validateAppSourcesProvider
-        ),
-      new AmplifyUserError(
-        'SecretsExpiredTokenError',
-        {
-          message: 'Fetching the list of secrets failed due to expired tokens',
-          resolution: 'Please refresh your credentials and try again',
-        },
-        secretsError
-      )
-    );
-  });
-
-  void it('throws AmplifyUserError if listSecrets fails due to CredentialsProviderError', async () => {
-    const credentialsError = new Error('credentials error');
-    credentialsError.name = 'CredentialsProviderError';
-    const secretsError = SecretError.createInstance(credentialsError);
-    listSecretMock.mock.mockImplementationOnce(() => {
-      throw secretsError;
-    });
-    await assert.rejects(
-      () =>
-        sandboxExecutor.deploy(
-          {
-            namespace: 'testSandboxId',
-            name: 'testSandboxName',
-            type: 'sandbox',
-          },
-          validateAppSourcesProvider
-        ),
-      new AmplifyUserError(
-        'SecretsExpiredTokenError',
-        {
-          message: 'Fetching the list of secrets failed due to expired tokens',
-          resolution: 'Please refresh your credentials and try again',
-        },
-        secretsError
-      )
-    );
-  });
-
-  void it('throws AmplifyFault if listSecrets fails due to a non-SSM exception other than expired credentials', async () => {
-    const underlyingError = new Error('some secret error');
-    const secretError = SecretError.createInstance(underlyingError);
-    listSecretMock.mock.mockImplementationOnce(() => {
-      throw secretError;
-    });
-    await assert.rejects(
-      () =>
-        sandboxExecutor.deploy(
-          {
-            namespace: 'testSandboxId',
-            name: 'testSandboxName',
-            type: 'sandbox',
-          },
-          validateAppSourcesProvider
-        ),
-      new AmplifyFault(
-        'ListSecretsFailedFault',
-        {
-          message: 'Fetching the list of secrets failed',
-        },
-        underlyingError // If it's not an SSM exception, we use the original error instead of secrets error
-      )
-    );
-  });
-
-  void it('throws AmplifyFault if listSecrets fails due to an SSM exception other than expired credentials', async () => {
-    const underlyingError = new SSMServiceException({
-      name: 'SomeException',
-      $fault: 'client',
-      $metadata: {},
-    });
-    const secretError = SecretError.createInstance(underlyingError);
-    listSecretMock.mock.mockImplementationOnce(() => {
-      throw secretError;
-    });
-    await assert.rejects(
-      () =>
-        sandboxExecutor.deploy(
-          {
-            namespace: 'testSandboxId',
-            name: 'testSandboxName',
-            type: 'sandbox',
-          },
-          validateAppSourcesProvider
-        ),
-      new AmplifyFault(
-        'ListSecretsFailedFault',
-        {
-          message: 'Fetching the list of secrets failed',
-        },
-        secretError // If it's an SSM exception, we use the wrapper secret error
-      )
-    );
   });
 
   [true, false].forEach((shouldValidateSources) => {

--- a/packages/sandbox/src/sandbox_executor.ts
+++ b/packages/sandbox/src/sandbox_executor.ts
@@ -5,10 +5,8 @@ import {
   DeployResult,
   DestroyResult,
 } from '@aws-amplify/backend-deployer';
-import { SecretClient, SecretError } from '@aws-amplify/backend-secret';
+import { SecretClient } from '@aws-amplify/backend-secret';
 import { LogLevel, Printer } from '@aws-amplify/cli-core';
-import { AmplifyFault, AmplifyUserError } from '@aws-amplify/platform-core';
-import { SSMServiceException } from '@aws-sdk/client-ssm';
 
 /**
  * Execute CDK commands.
@@ -66,42 +64,7 @@ export class AmplifySandboxExecutor {
   private getSecretLastUpdated = async (
     backendId: BackendIdentifier
   ): Promise<Date | undefined> => {
-    let secrets = undefined;
-    try {
-      secrets = await this.secretClient.listSecrets(backendId);
-    } catch (err) {
-      if (err instanceof SecretError && err.cause) {
-        if (
-          err.cause.name === 'ExpiredTokenException' ||
-          err.cause.name === 'CredentialsProviderError'
-        ) {
-          throw new AmplifyUserError(
-            'SecretsExpiredTokenError',
-            {
-              message:
-                'Fetching the list of secrets failed due to expired tokens',
-              resolution: 'Please refresh your credentials and try again',
-            },
-            err
-          );
-        }
-      }
-      let downstreamException = err as Error;
-      if (
-        err instanceof SecretError &&
-        !(err.cause instanceof SSMServiceException) &&
-        err.cause instanceof Error
-      ) {
-        downstreamException = err.cause;
-      }
-      throw new AmplifyFault(
-        'ListSecretsFailedFault',
-        {
-          message: 'Fetching the list of secrets failed',
-        },
-        downstreamException
-      );
-    }
+    const secrets = await this.secretClient.listSecrets(backendId);
     let latestTimestamp = -1;
     let secretLastUpdate: Date | undefined;
 

--- a/packages/sandbox/src/sandbox_singleton_factory.ts
+++ b/packages/sandbox/src/sandbox_singleton_factory.ts
@@ -8,7 +8,7 @@ import { BackendIdSandboxResolver, Sandbox } from './sandbox.js';
 import { BackendDeployerFactory } from '@aws-amplify/backend-deployer';
 import { AmplifySandboxExecutor } from './sandbox_executor.js';
 import { SSMClient } from '@aws-sdk/client-ssm';
-import { getSecretClient } from '@aws-amplify/backend-secret';
+import { getSecretClientWithAmplifyErrorHandling } from '@aws-amplify/backend-secret';
 import { CloudWatchLogsClient } from '@aws-sdk/client-cloudwatch-logs';
 import { LambdaClient } from '@aws-sdk/client-lambda';
 import { BackendOutputClientFactory } from '@aws-amplify/deployed-backend-client';
@@ -46,7 +46,7 @@ export class SandboxSingletonFactory {
         this.sandboxIdResolver,
         new AmplifySandboxExecutor(
           backendDeployerFactory.getInstance(),
-          getSecretClient(),
+          getSecretClientWithAmplifyErrorHandling(),
           this.printer
         ),
         new SSMClient(),


### PR DESCRIPTION
## Problem

Secrets client is used between a lambda to fetch secrets at runtime as well as by the cli commands for CRUD operations. The error handling for cli commands was either happening at the call site or none at all.

**Issue number, if available:**

## Changes

This PR introduces another wrapper over `SSMSecretClient` to perform error handling for amplify cli commands use case.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
