### PR TITLE
Pass profile explicitly to CDK CLI when using `npx ampx sandbox --profile <profile_name>`

### DIFF
--- a/.changeset/lovely-eels-tap.md
+++ b/.changeset/lovely-eels-tap.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-deployer': minor
+'@aws-amplify/sandbox': minor
+'@aws-amplify/backend-cli': patch
+---
+
+Pass profile explicitly to CDK CLI when using `npx ampx sandbox --profile <profile_name>`

--- a/packages/backend-deployer/API.md
+++ b/packages/backend-deployer/API.md
@@ -10,7 +10,7 @@ import { PackageManagerController } from '@aws-amplify/plugin-types';
 // @public
 export type BackendDeployer = {
     deploy: (backendId: BackendIdentifier, deployProps?: DeployProps) => Promise<DeployResult>;
-    destroy: (backendId: BackendIdentifier) => Promise<DestroyResult>;
+    destroy: (backendId: BackendIdentifier, destroyProps?: DestroyProps) => Promise<DestroyResult>;
 };
 
 // @public
@@ -34,11 +34,17 @@ export type DeploymentTimes = {
 export type DeployProps = {
     secretLastUpdated?: Date;
     validateAppSources?: boolean;
+    profile?: string;
 };
 
 // @public (undocumented)
 export type DeployResult = {
     deploymentTimes: DeploymentTimes;
+};
+
+// @public (undocumented)
+export type DestroyProps = {
+    profile?: string;
 };
 
 // @public (undocumented)

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -167,6 +167,20 @@ void describe('invokeCDKCommand', () => {
     ]);
   });
 
+  void it('deploy handles profile', async () => {
+    const profile = 'test_profile';
+    await invoker.deploy(sandboxBackendId, { profile });
+    assert.strictEqual(executeCommandMock.mock.callCount(), 2);
+    assert.ok(
+      executeCommandMock.mock.calls[0].arguments[0].includes('--profile')
+    );
+    assert.ok(executeCommandMock.mock.calls[0].arguments[0].includes(profile));
+    assert.ok(
+      executeCommandMock.mock.calls[1].arguments[0].includes('--profile')
+    );
+    assert.ok(executeCommandMock.mock.calls[1].arguments[0].includes(profile));
+  });
+
   void it('handles options and deployProps for sandbox', async () => {
     await invoker.deploy(sandboxBackendId, sandboxDeployProps);
     assert.strictEqual(executeCommandMock.mock.callCount(), 2);
@@ -240,6 +254,16 @@ void describe('invokeCDKCommand', () => {
       'amplify-backend-type=sandbox',
       '--force',
     ]);
+  });
+
+  void it('destroy handles profile', async () => {
+    const profile = 'test_profile';
+    await invoker.destroy(sandboxBackendId, { profile });
+    assert.strictEqual(executeCommandMock.mock.callCount(), 1);
+    assert.ok(
+      executeCommandMock.mock.calls[0].arguments[0].includes('--profile')
+    );
+    assert.ok(executeCommandMock.mock.calls[0].arguments[0].includes(profile));
   });
 
   void it('enables type checking for branch deployments', async () => {

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -4,6 +4,7 @@ import {
   BackendDeployer,
   DeployProps,
   DeployResult,
+  DestroyProps,
   DestroyResult,
 } from './cdk_deployer_singleton_factory.js';
 import { CDKDeploymentError, CdkErrorMapper } from './cdk_error_mapper.js';
@@ -56,6 +57,10 @@ export class CDKDeployer implements BackendDeployer {
       }
     }
 
+    if (deployProps?.profile) {
+      cdkCommandArgs.push('--profile', deployProps.profile);
+    }
+
     // first synth with the backend definition but suppress any errors.
     // We want to show errors from the TS compiler rather than the ESBuild as
     // TS errors are more relevant (Library validations are type reliant).
@@ -102,12 +107,19 @@ export class CDKDeployer implements BackendDeployer {
   /**
    * Invokes cdk destroy command
    */
-  destroy = async (backendId: BackendIdentifier) => {
+  destroy = async (
+    backendId: BackendIdentifier,
+    destroyProps?: DestroyProps
+  ) => {
+    const cdkCommandArgs: string[] = ['--force'];
+    if (destroyProps?.profile) {
+      cdkCommandArgs.push('--profile', destroyProps.profile);
+    }
     return this.tryInvokeCdk(
       InvokableCommand.DESTROY,
       backendId,
       this.getAppCommand(),
-      ['--force']
+      cdkCommandArgs
     );
   };
 

--- a/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
+++ b/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
@@ -10,6 +10,11 @@ import { BackendDeployerOutputFormatter } from './types.js';
 export type DeployProps = {
   secretLastUpdated?: Date;
   validateAppSources?: boolean;
+  profile?: string;
+};
+
+export type DestroyProps = {
+  profile?: string;
 };
 
 export type DeployResult = {
@@ -33,7 +38,10 @@ export type BackendDeployer = {
     backendId: BackendIdentifier,
     deployProps?: DeployProps
   ) => Promise<DeployResult>;
-  destroy: (backendId: BackendIdentifier) => Promise<DestroyResult>;
+  destroy: (
+    backendId: BackendIdentifier,
+    destroyProps?: DestroyProps
+  ) => Promise<DestroyResult>;
 };
 
 /**

--- a/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.test.ts
@@ -68,11 +68,30 @@ void describe('sandbox delete command', () => {
     assert.equal(sandboxDeleteMock.mock.callCount(), 1);
     assert.deepStrictEqual(sandboxDeleteMock.mock.calls[0].arguments[0], {
       identifier: undefined,
+      profile: undefined,
     });
     assert.equal(mockHandleProfile.mock.callCount(), 1);
     assert.equal(
       mockHandleProfile.mock.calls[0].arguments[0]?.profile,
       undefined
+    );
+  });
+
+  void it('deletes sandbox with profile', async (contextual) => {
+    contextual.mock.method(AmplifyPrompter, 'yesOrNo', () =>
+      Promise.resolve(true)
+    );
+    await commandRunner.runCommand('sandbox delete --profile test_profile');
+
+    assert.equal(sandboxDeleteMock.mock.callCount(), 1);
+    assert.deepStrictEqual(sandboxDeleteMock.mock.calls[0].arguments[0], {
+      identifier: undefined,
+      profile: 'test_profile',
+    });
+    assert.equal(mockHandleProfile.mock.callCount(), 1);
+    assert.equal(
+      mockHandleProfile.mock.calls[0].arguments[0]?.profile,
+      'test_profile'
     );
   });
 
@@ -85,6 +104,7 @@ void describe('sandbox delete command', () => {
     assert.equal(sandboxDeleteMock.mock.callCount(), 1);
     assert.deepStrictEqual(sandboxDeleteMock.mock.calls[0].arguments[0], {
       identifier: 'test-App-Name',
+      profile: undefined,
     });
   });
 

--- a/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-delete/sandbox_delete_command.ts
@@ -45,7 +45,7 @@ export class SandboxDeleteCommand
     if (isConfirmed) {
       await (
         await this.sandboxFactory.getInstance()
-      ).delete({ identifier: args.identifier });
+      ).delete({ identifier: args.identifier, profile: args.profile });
     }
   };
 

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -239,10 +239,10 @@ void describe('sandbox command', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     assert.equal(sandboxStartMock.mock.callCount(), 1);
     assert.equal(sandboxDeleteMock.mock.callCount(), 1);
-    assert.strictEqual(
-      sandboxDeleteMock.mock.calls[0].arguments[0].profile,
-      profile
-    );
+    assert.deepStrictEqual(sandboxDeleteMock.mock.calls[0].arguments[0], {
+      identifier: undefined,
+      profile,
+    });
   });
 
   void it('asks to delete the sandbox environment when users send ctrl-C and say no to delete', async (contextual) => {

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -205,6 +205,46 @@ void describe('sandbox command', () => {
     assert.equal(sandboxDeleteMock.mock.callCount(), 1);
   });
 
+  void it('asks to delete the sandbox environment when users send ctrl-C and say yes to delete with profile', async (contextual) => {
+    // Mock process and extract the sigint handler after calling the sandbox command
+    const processSignal = contextual.mock.method(process, 'on', () => {
+      /* no op */
+    });
+    const sandboxStartMock = contextual.mock.method(
+      sandbox,
+      'start',
+      async () => Promise.resolve()
+    );
+
+    const sandboxDeleteMock = contextual.mock.method(sandbox, 'delete', () =>
+      Promise.resolve()
+    );
+
+    // User said yes to delete
+    contextual.mock.method(AmplifyPrompter, 'yesOrNo', () =>
+      Promise.resolve(true)
+    );
+
+    const profile = 'test_profile';
+    await commandRunner.runCommand(`sandbox --profile ${profile}`);
+
+    // Similar to the later 0ms timeout. Without this tests in github action are failing
+    // but working locally
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const sigIntHandlerFn = processSignal.mock.calls[0].arguments[1];
+    if (sigIntHandlerFn) sigIntHandlerFn();
+
+    // I can't find any open node:test or yargs issues that would explain why this is necessary
+    // but for some reason the mock call count does not update without this 0ms wait
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(sandboxStartMock.mock.callCount(), 1);
+    assert.equal(sandboxDeleteMock.mock.callCount(), 1);
+    assert.strictEqual(
+      sandboxDeleteMock.mock.calls[0].arguments[0].profile,
+      profile
+    );
+  });
+
   void it('asks to delete the sandbox environment when users send ctrl-C and say no to delete', async (contextual) => {
     // Mock process and extract the sigint handler after calling the sandbox command
     const processSignal = contextual.mock.method(process, 'on', () => {
@@ -319,6 +359,10 @@ void describe('sandbox command', () => {
     commandRunner = new TestCommandRunner(parser);
     await commandRunner.runCommand(`sandbox --profile ${sandboxProfile}`);
     assert.equal(sandboxStartMock.mock.callCount(), 1);
+    assert.strictEqual(
+      sandboxStartMock.mock.calls[0].arguments[0].profile,
+      sandboxProfile
+    );
     assert.equal(
       mockHandleProfile.mock.calls[0].arguments[0]?.profile,
       sandboxProfile

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -70,6 +70,7 @@ export class SandboxCommand
   readonly describe: string;
 
   private sandboxIdentifier?: string;
+  private profile?: string;
 
   /**
    * Creates sandbox command.
@@ -95,6 +96,7 @@ export class SandboxCommand
   ): Promise<void> => {
     const sandbox = await this.sandboxFactory.getInstance();
     this.sandboxIdentifier = args.identifier;
+    this.profile = args.profile;
 
     // attaching event handlers
     const clientConfigLifecycleHandler = new ClientConfigLifecycleHandler(
@@ -287,7 +289,7 @@ export class SandboxCommand
     if (answer)
       await (
         await this.sandboxFactory.getInstance()
-      ).delete({ identifier: this.sandboxIdentifier });
+      ).delete({ identifier: this.sandboxIdentifier, profile: this.profile });
   };
 
   private validateDirectory = async (option: string, dir: string) => {

--- a/packages/sandbox/API.md
+++ b/packages/sandbox/API.md
@@ -25,6 +25,7 @@ export type Sandbox = {
 // @public (undocumented)
 export type SandboxDeleteOptions = {
     identifier?: string;
+    profile?: string;
 };
 
 // @public (undocumented)

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -326,6 +326,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: false,
       },
@@ -357,6 +358,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -394,6 +396,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -432,6 +435,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -454,6 +458,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: false,
       },
@@ -482,6 +487,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -506,6 +512,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -514,6 +521,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[1].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -553,6 +561,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -561,6 +570,7 @@ void describe('Sandbox using local project name resolver', () => {
     assert.deepEqual(backendDeployerDeployMock.mock.calls[1].arguments, [
       testSandboxBackendId,
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -582,6 +592,27 @@ void describe('Sandbox using local project name resolver', () => {
     // BackendDeployer should be called with the right params
     assert.deepEqual(backendDeployerDestroyMock.mock.calls[0].arguments, [
       testSandboxBackendId,
+      { profile: undefined },
+    ]);
+  });
+
+  void it('calls BackendDeployer destroy when delete is called with profile', async () => {
+    ({ sandboxInstance } = await setupAndStartSandbox({
+      executor: sandboxExecutor,
+      ssmClient: ssmClientMock,
+      functionsLogStreamer:
+        functionsLogStreamerMock as unknown as LambdaFunctionLogStreamer,
+    }));
+    const profile = 'test_profile';
+    await sandboxInstance.delete({ profile });
+
+    // BackendDeployer should be called once to destroy
+    assert.strictEqual(backendDeployerDestroyMock.mock.callCount(), 1);
+
+    // BackendDeployer should be called with the right params
+    assert.deepEqual(backendDeployerDestroyMock.mock.calls[0].arguments, [
+      testSandboxBackendId,
+      { profile },
     ]);
   });
 
@@ -772,6 +803,7 @@ void describe('Sandbox using local project name resolver', () => {
         type: 'sandbox',
       },
       {
+        profile: undefined,
         secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
         validateAppSources: true,
       },
@@ -800,6 +832,7 @@ void describe('Sandbox using local project name resolver', () => {
         name: 'customSandboxName',
         type: 'sandbox',
       },
+      { profile: undefined },
     ]);
   });
 

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -234,7 +234,8 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       '[Sandbox] Deleting all the resources in the sandbox environment...'
     );
     await this.executor.destroy(
-      await this.backendIdSandboxResolver(options.identifier)
+      await this.backendIdSandboxResolver(options.identifier),
+      options.profile
     );
     this.emit('successfulDeletion');
     this.printer.log('[Sandbox] Finished deleting.');
@@ -258,7 +259,8 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
         await this.backendIdSandboxResolver(options.identifier),
         // It's important to pass this as callback so that debounce does
         // not reset tracker prematurely
-        this.shouldValidateAppSources
+        this.shouldValidateAppSources,
+        options.profile
       );
       this.printer.log('[Sandbox] Deployment successful', LogLevel.DEBUG);
       this.emit('successfulDeployment', deployResult);

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -48,6 +48,7 @@ export type SandboxFunctionStreamingOptions = {
 
 export type SandboxDeleteOptions = {
   identifier?: string;
+  profile?: string;
 };
 export type BackendIdSandboxResolver = (
   identifier?: string

--- a/packages/sandbox/src/sandbox_executor.test.ts
+++ b/packages/sandbox/src/sandbox_executor.test.ts
@@ -82,7 +82,8 @@ void describe('Sandbox executor', () => {
         name: 'testSandboxName',
         type: 'sandbox',
       },
-      validateAppSourcesProvider
+      validateAppSourcesProvider,
+      undefined
     );
 
     const secondDeployPromise = sandboxExecutor.deploy(
@@ -91,7 +92,8 @@ void describe('Sandbox executor', () => {
         name: 'testSandboxName',
         type: 'sandbox',
       },
-      validateAppSourcesProvider
+      validateAppSourcesProvider,
+      undefined
     );
 
     await Promise.all([firstDeployPromise, secondDeployPromise]);
@@ -119,7 +121,8 @@ void describe('Sandbox executor', () => {
             name: 'testSandboxName',
             type: 'sandbox',
           },
-          validateAppSourcesProvider
+          validateAppSourcesProvider,
+          undefined
         ),
       new AmplifyUserError(
         'SecretsExpiredTokenError',
@@ -147,7 +150,8 @@ void describe('Sandbox executor', () => {
             name: 'testSandboxName',
             type: 'sandbox',
           },
-          validateAppSourcesProvider
+          validateAppSourcesProvider,
+          undefined
         ),
       new AmplifyUserError(
         'SecretsExpiredTokenError',
@@ -174,7 +178,8 @@ void describe('Sandbox executor', () => {
             name: 'testSandboxName',
             type: 'sandbox',
           },
-          validateAppSourcesProvider
+          validateAppSourcesProvider,
+          undefined
         ),
       new AmplifyFault(
         'ListSecretsFailedFault',
@@ -204,7 +209,8 @@ void describe('Sandbox executor', () => {
             name: 'testSandboxName',
             type: 'sandbox',
           },
-          validateAppSourcesProvider
+          validateAppSourcesProvider,
+          undefined
         ),
       new AmplifyFault(
         'ListSecretsFailedFault',
@@ -228,7 +234,8 @@ void describe('Sandbox executor', () => {
           name: 'testSandboxName',
           type: 'sandbox',
         },
-        validateAppSourcesProvider
+        validateAppSourcesProvider,
+        undefined
       );
 
       assert.strictEqual(backendDeployerDeployMock.mock.callCount(), 1);
@@ -242,8 +249,43 @@ void describe('Sandbox executor', () => {
             type: 'sandbox',
           },
           {
+            profile: undefined,
             secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
             validateAppSources: shouldValidateSources,
+          },
+        ]
+      );
+    });
+  });
+
+  ['test_profile', undefined].forEach((profile) => {
+    void it(`calls deployer with correct profile=${
+      profile ?? 'undefined'
+    } setting`, async () => {
+      await sandboxExecutor.deploy(
+        {
+          namespace: 'testSandboxId',
+          name: 'testSandboxName',
+          type: 'sandbox',
+        },
+        validateAppSourcesProvider,
+        profile
+      );
+
+      assert.strictEqual(backendDeployerDeployMock.mock.callCount(), 1);
+      // BackendDeployer should be called with the right params
+      assert.deepStrictEqual(
+        backendDeployerDeployMock.mock.calls[0].arguments,
+        [
+          {
+            name: 'testSandboxName',
+            namespace: 'testSandboxId',
+            type: 'sandbox',
+          },
+          {
+            profile: profile,
+            secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
+            validateAppSources: true,
           },
         ]
       );

--- a/packages/sandbox/src/sandbox_executor.ts
+++ b/packages/sandbox/src/sandbox_executor.ts
@@ -39,7 +39,8 @@ export class AmplifySandboxExecutor {
    */
   deploy = async (
     backendId: BackendIdentifier,
-    validateAppSourcesProvider: () => boolean
+    validateAppSourcesProvider: () => boolean,
+    profile: string | undefined
   ): Promise<DeployResult> => {
     this.printer.log('[Sandbox] Executing command `deploy`', LogLevel.DEBUG);
     const secretLastUpdated = await this.getSecretLastUpdated(backendId);
@@ -51,6 +52,7 @@ export class AmplifySandboxExecutor {
       return this.backendDeployer.deploy(backendId, {
         secretLastUpdated,
         validateAppSources,
+        profile,
       });
     });
   };
@@ -58,9 +60,16 @@ export class AmplifySandboxExecutor {
   /**
    * Destroy sandbox. Do not swallow errors
    */
-  destroy = (backendId: BackendIdentifier): Promise<DestroyResult> => {
+  destroy = (
+    backendId: BackendIdentifier,
+    profile: string | undefined
+  ): Promise<DestroyResult> => {
     this.printer.log('[Sandbox] Executing command `destroy`', LogLevel.DEBUG);
-    return this.invoke(() => this.backendDeployer.destroy(backendId));
+    return this.invoke(() =>
+      this.backendDeployer.destroy(backendId, {
+        profile,
+      })
+    );
   };
 
   private getSecretLastUpdated = async (


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Passing profile via environment variables (see [here](https://github.com/aws-amplify/amplify-backend/blob/b2464ab051a1e4b8380fda8ebd911a610d64ac6e/packages/cli/src/command_middleware.ts#L35-L37)) is not enough to assure consistency.

Customer using `npx ampx sandbox --profile <profile_name>` might run into edge case scenarios where local or user home scoped cdk configuration might override environemnt.
See [code in CDK](https://github.com/aws/aws-cdk/blob/c7980a2e068b5336914364050f72e41259aebc90/packages/aws-cdk/lib/settings.ts#L134-L139). I.e. config is resolved in such a way that env variables have the least priority (implicitly).

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Pass profile explicitly when calling CDK commands. So that it has the same priority as in ampx cli.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

1. Added tests.
2. Manual validations with debugger.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
