### PR TITLE
Use multiple accounts in canary workflow

### DIFF
--- a/.github/actions/select_e2e_account/action.yml
+++ b/.github/actions/select_e2e_account/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: echo "e2e_test_account_number=$(npx tsx scripts/select_e2e_test_account.ts)" >> "$GITHUB_OUTPUT"
       env:
-        E2E_TEST_ACCOUNTS: ${{ inputs.e2e-test-accounts }}
+        E2E_TEST_ACCOUNTS: ${{ inputs.e2e_test_accounts }}
     - name: Output E2E roles
       id: outputE2ERoles
       shell: bash

--- a/.github/actions/select_e2e_account/action.yml
+++ b/.github/actions/select_e2e_account/action.yml
@@ -1,0 +1,30 @@
+name: select_e2e_account
+description: Selects random e2e account
+inputs:
+  e2e_test_accounts:
+    description: Serialized JSON array of strings with account numbers
+outputs:
+  e2e_test_account_number:
+    description: 'Selected e2e account'
+    value: ${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}
+  e2e_execution_role:
+    description: "Selected e2e account's execution role"
+    value: ${{ steps.outputE2ERoles.outputs.e2e_execution_role }}
+  e2e_test_tooling_role:
+    description: "Selected e2e account's test tooling role"
+    value: ${{ steps.outputE2ERoles.outputs.e2e_test_tooling_role }}
+runs:
+  using: composite
+  steps:
+    - name: Select E2E test account
+      id: selectE2EAccount
+      shell: bash
+      run: echo "e2e_test_account_number=$(npx tsx scripts/select_e2e_test_account.ts)" >> "$GITHUB_OUTPUT"
+      env:
+        E2E_TEST_ACCOUNTS: ${{ inputs.e2e-test-accounts }}
+    - name: Output E2E roles
+      id: outputE2ERoles
+      shell: bash
+      run: |
+        echo "e2e_execution_role=arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-execution" >> "$GITHUB_OUTPUT"
+        echo "e2e_test_tooling_role=arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-test-tooling" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -46,16 +46,21 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/build_with_cache
+      - name: Select E2E test account
+        uses: ./.github/actions/select_e2e_account
+        id: selectE2EAccount
+        with:
+          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
       - name: Configure test tooling credentials
         uses: ./.github/actions/setup_profile
         with:
-          role-to-assume: ${{ secrets.E2E_TOOLING_ROLE_ARN }}
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
           aws-region: ${{ matrix.region }}
           profile-name: e2e-tooling
       - name: Configure test execution credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
         with:
-          role-to-assume: ${{ secrets.E2E_RUNNER_ROLE_ARN }}
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
           aws-region: ${{ matrix.region }}
       - name: Run live dependency health checks
         shell: bash

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -205,21 +205,20 @@ jobs:
       - uses: ./.github/actions/setup_node
       - uses: ./.github/actions/restore_build_cache
       - name: Select E2E test account
+        uses: ./.github/actions/select_e2e_account
         id: selectE2EAccount
-        shell: bash
-        run: echo "e2e_test_account_number=$(npx tsx scripts/select_e2e_test_account.ts)" >> "$GITHUB_OUTPUT"
-        env:
-          E2E_TEST_ACCOUNTS: ${{ vars.E2E_TEST_ACCOUNTS }}
+        with:
+          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
       - name: Configure test tooling credentials
         uses: ./.github/actions/setup_profile
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-test-tooling
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
           aws-region: us-west-2
           profile-name: e2e-tooling
       - name: Configure test execution credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-execution
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
           aws-region: us-west-2
       - name: Run e2e iam access drift test
         run: npm run test:dir packages/integration-tests/lib/test-e2e/iam_access_drift.test.js
@@ -256,21 +255,20 @@ jobs:
       - uses: ./.github/actions/restore_build_cache
       - run: cd packages/cli && npm link
       - name: Select E2E test account
+        uses: ./.github/actions/select_e2e_account
         id: selectE2EAccount
-        shell: bash
-        run: echo "e2e_test_account_number=$(npx tsx scripts/select_e2e_test_account.ts)" >> "$GITHUB_OUTPUT"
-        env:
-          E2E_TEST_ACCOUNTS: ${{ vars.E2E_TEST_ACCOUNTS }}
+        with:
+          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
       - name: Configure test tooling credentials
         uses: ./.github/actions/setup_profile
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-test-tooling
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
           aws-region: us-west-2
           profile-name: e2e-tooling
       - name: Configure test execution credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-execution
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
           aws-region: us-west-2
       - name: Run e2e deployment tests
         run: npm run test:dir packages/integration-tests/lib/test-e2e/deployment.test.js
@@ -305,21 +303,20 @@ jobs:
       - uses: ./.github/actions/restore_build_cache
       - run: cd packages/cli && npm link
       - name: Select E2E test account
+        uses: ./.github/actions/select_e2e_account
         id: selectE2EAccount
-        shell: bash
-        run: echo "e2e_test_account_number=$(npx tsx scripts/select_e2e_test_account.ts)" >> "$GITHUB_OUTPUT"
-        env:
-          E2E_TEST_ACCOUNTS: ${{ vars.E2E_TEST_ACCOUNTS }}
+        with:
+          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
       - name: Configure test tooling credentials
         uses: ./.github/actions/setup_profile
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-test-tooling
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
           aws-region: us-west-2
           profile-name: e2e-tooling
       - name: Configure test execution credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-execution
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
           aws-region: us-west-2
       - name: Run e2e sandbox tests
         run: npm run test:dir packages/integration-tests/lib/test-e2e/sandbox.test.js
@@ -340,21 +337,20 @@ jobs:
       - uses: ./.github/actions/restore_build_cache
       - run: cd packages/cli && npm link
       - name: Select E2E test account
+        uses: ./.github/actions/select_e2e_account
         id: selectE2EAccount
-        shell: bash
-        run: echo "e2e_test_account_number=$(npx tsx scripts/select_e2e_test_account.ts)" >> "$GITHUB_OUTPUT"
-        env:
-          E2E_TEST_ACCOUNTS: ${{ vars.E2E_TEST_ACCOUNTS }}
+        with:
+          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
       - name: Configure test tooling credentials
         uses: ./.github/actions/setup_profile
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-test-tooling
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
           aws-region: us-west-2
           profile-name: e2e-tooling
       - name: Configure test execution credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-execution
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
           aws-region: us-west-2
       - name: Run e2e backend output tests
         run: npm run test:dir packages/integration-tests/lib/test-e2e/backend_output.test.js
@@ -416,21 +412,20 @@ jobs:
       - name: Restore Build Cache
         uses: ./.github/actions/restore_build_cache
       - name: Select E2E test account
+        uses: ./.github/actions/select_e2e_account
         id: selectE2EAccount
-        shell: bash
-        run: echo "e2e_test_account_number=$(npx tsx scripts/select_e2e_test_account.ts)" >> "$GITHUB_OUTPUT"
-        env:
-          E2E_TEST_ACCOUNTS: ${{ vars.E2E_TEST_ACCOUNTS }}
+        with:
+          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
       - name: Configure test tooling credentials
         uses: ./.github/actions/setup_profile
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-test-tooling
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
           aws-region: us-west-2
           profile-name: e2e-tooling
       - name: Configure test execution credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ steps.selectE2EAccount.outputs.e2e_test_account_number }}:role/e2e-execution
+          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
           aws-region: us-west-2
       - name: Run E2E flow tests with ${{ matrix.pkg-manager }}
         shell: bash


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Canary workflow doesn't use multiple e2e accounts yet.

Previous PR that introduced multiple accounts to health checks https://github.com/aws-amplify/amplify-backend/pull/1879 .

## Changes

1. Create action to encapsulate account selection logic.
2. Use it canaries in addition to health checks.

## Validation

1. This PR checks
2. Canary run https://github.com/aws-amplify/amplify-backend/actions/runs/10497624775

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
