### PR TITLE
Select random region in health check

### DIFF
--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -51,3 +51,5 @@ runs:
     - name: Run script
       shell: ${{ inputs.shell }}
       run: ${{ inputs.run }}
+      env:
+        AWS_REGION: ${{ inputs.aws_region }}

--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -3,11 +3,16 @@ description: Runs commands with e2e test account
 inputs:
   run:
     description: Script to run
+    required: true
+  shell:
+    description: Shell
+    required: false
   e2e_test_accounts:
     description: Serialized JSON array of strings with account numbers
+    required: true
 runs:
   using: composite
   steps:
     - name: Run script
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: ${{ inputs.run }}

--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -1,0 +1,13 @@
+name: run_with_e2e_account
+description: Runs commands with e2e test account
+inputs:
+  run:
+    description: Script to run
+  e2e_test_accounts:
+    description: Serialized JSON array of strings with account numbers
+runs:
+  using: composite
+  steps:
+    - name: Run script
+      shell: bash
+      run: ${{ inputs.run }}

--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -19,6 +19,9 @@ inputs:
   link_cli:
     description: Whether should link Gen2 CLI globally
     default: false
+  fresh_build:
+    description: Whether should build from scratch
+    default: false
 runs:
   using: composite
   steps:
@@ -27,7 +30,11 @@ runs:
       with:
         node-version: ${{ inputs.node_version }}
     - name: Restore Build Cache
+      if: inputs.fresh_build != 'true'
       uses: ./.github/actions/restore_build_cache
+    - name: Build With Cache
+      if: inputs.fresh_build == 'true'
+      uses: ./.github/actions/build_with_cache
     - name: Link CLI
       if: inputs.link_cli == 'true'
       shell: bash

--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   aws_region:
     description: AWS region
-    default: us-west-2
+    required: false
   link_cli:
     description: Whether should link Gen2 CLI globally
     default: false
@@ -44,19 +44,31 @@ runs:
       id: selectE2EAccount
       with:
         e2e_test_accounts: ${{ inputs.e2e_test_accounts }}
+    - name: Select region
+      id: selectE2ERegion
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.aws_region }}" ]; then
+          regions=("us-west-2" "us-east-1" "ca-central-1" "eu-central-1")
+          rand=$[$RANDOM % ${#regions[@]}]
+          selected_aws_region=${regions[$rand]}
+        else
+          selected_aws_region="${{ inputs.aws_region }}"
+        fi
+        echo "selected_aws_region=$selected_aws_region" >> "$GITHUB_OUTPUT"
     - name: Configure test tooling credentials
       uses: ./.github/actions/setup_profile
       with:
         role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
-        aws-region: ${{ inputs.aws_region }}
+        aws-region: ${{ steps.selectE2ERegion.outputs.selected_aws_region }}
         profile-name: e2e-tooling
     - name: Configure test execution credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
       with:
         role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
-        aws-region: ${{ inputs.aws_region }}
+        aws-region: ${{ steps.selectE2ERegion.outputs.selected_aws_region }}
     - name: Run script
       shell: ${{ inputs.shell }}
       run: ${{ inputs.run }}
       env:
-        AWS_REGION: ${{ inputs.aws_region }}
+        AWS_REGION: ${{ steps.selectE2ERegion.outputs.selected_aws_region }}

--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -55,6 +55,7 @@ runs:
         else
           selected_aws_region="${{ inputs.aws_region }}"
         fi
+        echo "Selected AWS Region is $selected_aws_region"
         echo "selected_aws_region=$selected_aws_region" >> "$GITHUB_OUTPUT"
     - name: Configure test tooling credentials
       uses: ./.github/actions/setup_profile

--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Serialized JSON array of strings with account numbers
     required: true
   aws_region:
-    description: AWS region
+    description: AWS region. If not provided random will be selected
     required: false
   link_cli:
     description: Whether should link Gen2 CLI globally

--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -7,12 +7,47 @@ inputs:
   shell:
     description: Shell
     required: false
+  node_version:
+    description: node version used to configure environment with
+    required: false
   e2e_test_accounts:
     description: Serialized JSON array of strings with account numbers
     required: true
+  aws_region:
+    description: AWS region
+    default: us-west-2
+  link_cli:
+    description: Whether should link Gen2 CLI globally
+    default: false
 runs:
   using: composite
   steps:
+    - name: Setup Node.js
+      uses: ./.github/actions/setup_node
+      with:
+        node-version: ${{ inputs.node_version }}
+    - name: Restore Build Cache
+      uses: ./.github/actions/restore_build_cache
+    - name: Link CLI
+      if: inputs.link_cli == 'true'
+      shell: bash
+      run: cd packages/cli && npm link
+    - name: Select E2E test account
+      uses: ./.github/actions/select_e2e_account
+      id: selectE2EAccount
+      with:
+        e2e_test_accounts: ${{ inputs.e2e_test_accounts }}
+    - name: Configure test tooling credentials
+      uses: ./.github/actions/setup_profile
+      with:
+        role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
+        aws-region: ${{ inputs.aws_region }}
+        profile-name: e2e-tooling
+    - name: Configure test execution credentials
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
+      with:
+        role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
+        aws-region: ${{ inputs.aws_region }}
     - name: Run script
       shell: ${{ inputs.shell }}
       run: ${{ inputs.run }}

--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -48,5 +48,6 @@ jobs:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
           node_version: ${{ matrix.node-version }}
           aws_region: ${{ matrix.region }}
+          fresh_build: true
           shell: bash
           run: ./scripts/retry.js npm run live-dependency-health-checks

--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -36,33 +36,17 @@ jobs:
       matrix:
         region: [us-west-2, us-east-1, ca-central-1, eu-central-1]
     timeout-minutes: 20
-    env:
-      AWS_REGION: ${{ matrix.region }}
     permissions:
       # these permissions are required for the configure-aws-credentials action to get a JWT from GitHub
       id-token: write
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - uses: ./.github/actions/setup_node
-      - uses: ./.github/actions/build_with_cache
-      - name: Select E2E test account
-        uses: ./.github/actions/select_e2e_account
-        id: selectE2EAccount
+      - name: Run live dependency health checks
+        uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-      - name: Configure test tooling credentials
-        uses: ./.github/actions/setup_profile
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
-          aws-region: ${{ matrix.region }}
-          profile-name: e2e-tooling
-      - name: Configure test execution credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
-          aws-region: ${{ matrix.region }}
-      - name: Run live dependency health checks
-        shell: bash
-        run: |
-          ./scripts/retry.js npm run live-dependency-health-checks
+          node_version: ${{ matrix.node-version }}
+          aws_region: ${{ matrix.region }}
+          shell: bash
+          run: ./scripts/retry.js npm run live-dependency-health-checks

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -428,9 +428,11 @@ jobs:
           role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
           aws-region: us-west-2
       - name: Run E2E flow tests with ${{ matrix.pkg-manager }}
-        shell: bash
-        run: |
-          PACKAGE_MANAGER=${{matrix.pkg-manager}} npm run test:dir packages/integration-tests/src/package_manager_sanity_checks.test.ts
+        uses: ./.github/actions/run_with_e2e_account
+        with:
+          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
+          run: |
+            PACKAGE_MANAGER=${{matrix.pkg-manager}} npm run test:dir packages/integration-tests/src/package_manager_sanity_checks.test.ts
   lint:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -271,7 +271,11 @@ jobs:
           role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
           aws-region: us-west-2
       - name: Run e2e deployment tests
-        run: npm run test:dir packages/integration-tests/lib/test-e2e/deployment.test.js
+        uses: ./.github/actions/run_with_e2e_account
+        with:
+          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
+          run: |
+            npm run test:dir packages/integration-tests/lib/test-e2e/deployment.test.js
   e2e_sandbox:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
     strategy:
@@ -431,6 +435,7 @@ jobs:
         uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
+          shell: bash
           run: |
             PACKAGE_MANAGER=${{matrix.pkg-manager}} npm run test:dir packages/integration-tests/src/package_manager_sanity_checks.test.ts
   lint:

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -249,31 +249,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - uses: ./.github/actions/setup_node
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: ./.github/actions/restore_build_cache
-      - run: cd packages/cli && npm link
-      - name: Select E2E test account
-        uses: ./.github/actions/select_e2e_account
-        id: selectE2EAccount
-        with:
-          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-      - name: Configure test tooling credentials
-        uses: ./.github/actions/setup_profile
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
-          aws-region: us-west-2
-          profile-name: e2e-tooling
-      - name: Configure test execution credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
-          aws-region: us-west-2
       - name: Run e2e deployment tests
         uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
+          node_version: ${{ matrix.node-version }}
+          link_cli: true
           run: |
             npm run test:dir packages/integration-tests/lib/test-e2e/deployment.test.js
   e2e_sandbox:
@@ -407,34 +388,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Checkout aws-amplify/amplify-cli repo
+      - name: Checkout aws-amplify/amplify-backend repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Setup Node.js
-        uses: ./.github/actions/setup_node
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Restore Build Cache
-        uses: ./.github/actions/restore_build_cache
-      - name: Select E2E test account
-        uses: ./.github/actions/select_e2e_account
-        id: selectE2EAccount
-        with:
-          e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-      - name: Configure test tooling credentials
-        uses: ./.github/actions/setup_profile
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
-          aws-region: us-west-2
-          profile-name: e2e-tooling
-      - name: Configure test execution credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
-          aws-region: us-west-2
       - name: Run E2E flow tests with ${{ matrix.pkg-manager }}
         uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
+          node_version: ${{ matrix.node-version }}
           shell: bash
           run: |
             PACKAGE_MANAGER=${{matrix.pkg-manager}} npm run test:dir packages/integration-tests/src/package_manager_sanity_checks.test.ts

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -202,26 +202,12 @@ jobs:
           echo "baseline_dir=$BASELINE_DIR" >> "$GITHUB_OUTPUT";
       - name: Checkout current version
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - uses: ./.github/actions/setup_node
-      - uses: ./.github/actions/restore_build_cache
-      - name: Select E2E test account
-        uses: ./.github/actions/select_e2e_account
-        id: selectE2EAccount
+      - name: Run e2e iam access drift test
+        uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-      - name: Configure test tooling credentials
-        uses: ./.github/actions/setup_profile
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
-          aws-region: us-west-2
-          profile-name: e2e-tooling
-      - name: Configure test execution credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
-          aws-region: us-west-2
-      - name: Run e2e iam access drift test
-        run: npm run test:dir packages/integration-tests/lib/test-e2e/iam_access_drift.test.js
+          node_version: ${{ matrix.node-version }}
+          run: npm run test:dir packages/integration-tests/lib/test-e2e/iam_access_drift.test.js
         env:
           BASELINE_DIR: ${{ steps.move_baseline_version.outputs.baseline_dir }}
   e2e_deployment:
@@ -282,29 +268,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - uses: ./.github/actions/setup_node
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: ./.github/actions/restore_build_cache
-      - run: cd packages/cli && npm link
-      - name: Select E2E test account
-        uses: ./.github/actions/select_e2e_account
-        id: selectE2EAccount
+      - name: Run e2e sandbox tests
+        uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-      - name: Configure test tooling credentials
-        uses: ./.github/actions/setup_profile
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
-          aws-region: us-west-2
-          profile-name: e2e-tooling
-      - name: Configure test execution credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
-          aws-region: us-west-2
-      - name: Run e2e sandbox tests
-        run: npm run test:dir packages/integration-tests/lib/test-e2e/sandbox.test.js
+          node_version: ${{ matrix.node-version }}
+          link_cli: true
+          run: npm run test:dir packages/integration-tests/lib/test-e2e/sandbox.test.js
   e2e_backend_output:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
@@ -318,27 +288,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - uses: ./.github/actions/setup_node
-      - uses: ./.github/actions/restore_build_cache
-      - run: cd packages/cli && npm link
-      - name: Select E2E test account
-        uses: ./.github/actions/select_e2e_account
-        id: selectE2EAccount
+      - name: Run e2e backend output tests
+        uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-      - name: Configure test tooling credentials
-        uses: ./.github/actions/setup_profile
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_test_tooling_role }}
-          aws-region: us-west-2
-          profile-name: e2e-tooling
-      - name: Configure test execution credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
-        with:
-          role-to-assume: ${{ steps.selectE2EAccount.outputs.e2e_execution_role }}
-          aws-region: us-west-2
-      - name: Run e2e backend output tests
-        run: npm run test:dir packages/integration-tests/lib/test-e2e/backend_output.test.js
+          node_version: ${{ matrix.node-version }}
+          link_cli: true
+          run: npm run test:dir packages/integration-tests/lib/test-e2e/backend_output.test.js
   e2e_create_amplify:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
     strategy:


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

We could spread health_checks traffic across regions we also use for canaries (since they're bootstrapped anyway).

This is a follow up on this https://github.com/aws-amplify/amplify-backend/pull/1902#issuecomment-2305168439 .

## Changes

1. Refactor out a new action that can run a script with "e2e context". I.e. reduce duplication of constantly growing jobs that share same steps.
2. Add mechanism that can select region randomly if not provided.
    1. In canaries region is provided explicitly, so we use that
    2. In health checks a jobs pick region randomly.

## Validation

1. Canary checks: https://github.com/aws-amplify/amplify-backend/actions/runs/10531663942
2. This PR checks.

I looked at jobs to see if canaries keep their stickyness and if health checks select random regions.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
