### PR TITLE
Add api_id to the client output file amplify_outputs.json.

### DIFF
--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
@@ -220,6 +220,7 @@ export class DataClientConfigContributor implements ClientConfigContributor {
     config.data = {
       url: graphqlOutput.payload.awsAppsyncApiEndpoint,
       aws_region: graphqlOutput.payload.awsAppsyncRegion,
+      api_id: graphqlOutput.payload.awsAppsyncApiId,
       api_key: graphqlOutput.payload.awsAppsyncApiKey,
       default_authorization_type:
         graphqlOutput.payload.awsAppsyncAuthenticationType,

--- a/packages/client-config/src/client-config-schema/client_config_v1.1.ts
+++ b/packages/client-config/src/client-config-schema/client_config_v1.1.ts
@@ -163,6 +163,7 @@ export interface AWSAmplifyBackendOutputs {
     model_introspection?: {
       [k: string]: unknown;
     };
+    api_id?: string;
     api_key?: string;
     default_authorization_type: AwsAppsyncAuthorizationType;
     authorization_types: AwsAppsyncAuthorizationType[];


### PR DESCRIPTION

## Problem

Using DBB in lambda would result in issues since the table names generated contain the api_id

**Issue number, if available:**

## Changes

Added the api_id to the json output file so it can be used for the dynamically generated tables.


**Corresponding docs PR, if applicable:**

## Validation

I'm using the changed files myself currently to generate the needed file.

I tested it with this lambda code



```js
import { DynamoDBClient } from "@aws-sdk/client-dynamodb"; import { DynamoDBDocumentClient, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";

import config from '../../../../amplify_outputs.json';

const client = new DynamoDBClient({});
const docClient = DynamoDBDocumentClient.from(client);

const createTableName = (name: string) => {
    return `${name}-${config.data.api_id}-NONE`;
}

export const handler = async (event: any) => {
    const { userId, amount } = event.arguments;

    const transactItems = [
        // Update UserProfile
        {
            Update: {
                TableName: createTableName('UserProfile'),
                Key: { id: userId },
                UpdateExpression: 'ADD currentPoints :pointsToAdd',
                ExpressionAttributeValues: { ':pointsToAdd': amount }
            }
        }
    ];

    try {
        const results = await docClient.send(new TransactWriteCommand({ TransactItems: transactItems }));

        console.log(results)

        return results['$metadata']
    } catch (error) {
        console.error('Error:', error);
        throw new Error('Failed to process the transaction');
    }
};
```

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
