### PR TITLE
Handle aliased symbols in namespaces in api check

### DIFF
--- a/scripts/components/api-changes-validator/api_usage_generator.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.ts
@@ -123,7 +123,7 @@ export class ApiUsageGenerator {
                   if (namedExport.propertyName) {
                     // If property name is present this means that
                     // API Extractor aliased type definition to avoid duplicate
-                    // end exported from namespace as '${symbolNameInApiView} as ${exportedSymbolName}'
+                    // end exported from namespace as 'SomeType_2 as SomeType'
                     symbolNameInApiView = namedExport.propertyName.getText();
                     const exportedSymbolName = namedExport.name.getText();
                     namespaceDefinitions.aliasedSymbols.set(

--- a/scripts/components/api-changes-validator/api_usage_generator.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.ts
@@ -123,7 +123,7 @@ export class ApiUsageGenerator {
                   if (namedExport.propertyName) {
                     // If property name is present this means that
                     // API Extractor aliased type definition to avoid duplicate
-                    // end exported from namespace as 'SomeType_2 as SomeType'
+                    // and exported from namespace as 'SomeType_2 as SomeType'
                     symbolNameInApiView = namedExport.propertyName.getText();
                     const exportedSymbolName = namedExport.name.getText();
                     namespaceDefinitions.aliasedSymbols.set(

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
@@ -4,6 +4,10 @@ export type SomeTypeUnderNamespace = {
   someProperty: string;
 }
 
+export type SomeTypeUnderNamespace_2 = {
+  someProperty: string;
+}
+
 type SomeTypeUnderSubNamespace = {
   someOtherProperty: string;
 }
@@ -23,6 +27,12 @@ declare namespace someNamespace {
     someSubNamespace,
     functionUsingTypes1,
     functionUsingTypes2
+  }
+}
+
+declare namespace someNamespaceWithSameType {
+  export {
+    SomeTypeUnderNamespace_2 as SomeTypeUnderNamespace,
   }
 }
 

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/index.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/index.ts
@@ -1,3 +1,4 @@
 import * as someNamespace from './some_namespace.js';
+import * as someNamespaceWithSameType from './some_namespace_with_same_type.js';
 
-export { someNamespace };
+export { someNamespace, someNamespaceWithSameType };

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
@@ -1,10 +1,7 @@
 import * as someSubNamespace from './some_sub_namespace.js';
+import { SomeTypeUnderNamespace } from './types.js';
 
-export type SomeTypeUnderNamespace = {
-  someProperty: string;
-};
-
-export { someSubNamespace };
+export { someSubNamespace, SomeTypeUnderNamespace };
 
 export const functionUsingTypes1 = (
   props: SomeTypeUnderNamespace

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace_with_same_type.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace_with_same_type.ts
@@ -1,0 +1,3 @@
+import { SomeTypeUnderNamespace } from './types.js';
+
+export { SomeTypeUnderNamespace };

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/types.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/types.ts
@@ -1,0 +1,3 @@
+export type SomeTypeUnderNamespace = {
+  someProperty: string;
+};

--- a/scripts/components/api-changes-validator/types.ts
+++ b/scripts/components/api-changes-validator/types.ts
@@ -25,4 +25,5 @@ export type NamespaceDefinitions = {
   topLevelNamespaces: Set<string>;
   namespaceNames: Set<string>;
   namespaceBySymbol: Map<string, string>;
+  aliasedSymbols: Map<string, string>;
 };

--- a/scripts/components/api-changes-validator/usage_statemets_renderer.ts
+++ b/scripts/components/api-changes-validator/usage_statemets_renderer.ts
@@ -57,9 +57,15 @@ export class UsageStatementsRenderer {
           namespaceHierarchy.unshift(currentSymbolName);
         }
       } while (currentSymbolName);
+      const symbolAlias =
+        this.namespaceDefinitions.aliasedSymbols.get(symbolName);
+      let actualSymbolName = symbolName;
+      if (symbolAlias) {
+        actualSymbolName = symbolAlias;
+      }
       const symbolWithNamespace = `${namespaceHierarchy.join(
         '.'
-      )}.${symbolName}`;
+      )}.${actualSymbolName}`;
 
       // characters that can be found before or after symbol
       // this is to prevent partial matches in case one symbol's characters are subset of longer one


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Sometimes the same symbol name appears under different namespaces.
When this happen API Extractor aliases the type with `_<number>` suffix to de-duplicate it and presents the type as exported with alias.

This became visible after https://github.com/aws-amplify/amplify-backend/pull/1917 got merged.

For example (see https://github.com/aws-amplify/amplify-backend/blob/main/packages/client-config/API.md).

```
// @public
type AmazonCognitoStandardAttributes = 'address' | 'birthdate' | 'email' | 'family_name' | 'gender' | 'given_name' | 'locale' | 'middle_name' | 'name' | 'nickname' | 'phone_number' | 'picture' | 'preferred_username' | 'profile' | 'sub' | 'updated_at' | 'website' | 'zoneinfo';

// @public
type AmazonCognitoStandardAttributes_2 = 'address' | 'birthdate' | 'email' | 'family_name' | 'gender' | 'given_name' | 'locale' | 'middle_name' | 'name' | 'nickname' | 'phone_number' | 'picture' | 'preferred_username' | 'profile' | 'sub' | 'updated_at' | 'website' | 'zoneinfo';

...

declare namespace clientConfigTypesV1_1 {
    export {
        AmazonCognitoStandardAttributes,

...


declare namespace clientConfigTypesV1 {
    export {
        AmazonCognitoStandardAttributes_2 as AmazonCognitoStandardAttributes,
```

This has led to the following error:

```
    Error: Validation of @aws-amplify/client-config failed, compiler output:
    index.ts(6,10): error TS2305: Module '"@aws-amplify/client-config"' has no exported member 'AmazonCognitoStandardAttributes_2'.
    index.ts(7,10): error TS2305: Module '"@aws-amplify/client-config"' has no exported member 'AmazonPinpointChannels_2'.
    index.ts(10,10): error TS2305: Module '"@aws-amplify/client-config"' has no exported member 'AwsAppsyncAuthorizationType_2'.
    index.ts(11,10): error TS2305: Module '"@aws-amplify/client-config"' has no exported member 'AwsRegion_2'.
        at ApiChangesValidator.validate (/home/runner/work/amplify-backend/amplify-backend/scripts/components/api-changes-validator/api_changes_validator.ts:61:13)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:70:5)
        at async Promise.allSettled (index 10)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:50:27)
```


## Changes

This PR adds logic to handle the case where type exported from namespace might be aliased.

## Validation

Added content to test project. (so that `npm run test:scripts` covers it).
This PRs checks.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
