### PR TITLE
adds architecture prop on defineFunction

### DIFF
--- a/.changeset/swift-starfishes-relate.md
+++ b/.changeset/swift-starfishes-relate.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': minor
+---
+
+adds support for architecture property on defineFunction

--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -16,6 +16,9 @@ export type AddEnvironmentFactory = {
 };
 
 // @public (undocumented)
+export type ArchitectureType = 'x86_64' | 'arm64';
+
+// @public (undocumented)
 export type CronSchedule = `${string} ${string} ${string} ${string} ${string}` | `${string} ${string} ${string} ${string} ${string} ${string}`;
 
 // @public
@@ -29,6 +32,7 @@ export type FunctionProps = {
     memoryMB?: number;
     environment?: Record<string, string | BackendSecret>;
     runtime?: NodeVersion;
+    architecture?: ArchitectureType;
     schedule?: FunctionSchedule | FunctionSchedule[];
 };
 

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -1,22 +1,22 @@
-import { beforeEach, describe, it, mock } from 'node:test';
-import { App, Stack } from 'aws-cdk-lib';
-import {
-  ConstructFactoryGetInstanceProps,
-  ResourceNameValidator,
-} from '@aws-amplify/plugin-types';
-import assert from 'node:assert';
 import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
 import {
   ConstructContainerStub,
   ResourceNameValidatorStub,
   StackResolverStub,
 } from '@aws-amplify/backend-platform-test-stubs';
-import { defaultLambda } from './test-assets/default-lambda/resource.js';
+import {
+  ConstructFactoryGetInstanceProps,
+  ResourceNameValidator,
+} from '@aws-amplify/plugin-types';
+import { App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { NodeVersion, defineFunction } from './factory.js';
-import { lambdaWithDependencies } from './test-assets/lambda-with-dependencies/resource.js';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import assert from 'node:assert';
+import { beforeEach, describe, it, mock } from 'node:test';
+import { NodeVersion, defineFunction } from './factory.js';
+import { defaultLambda } from './test-assets/default-lambda/resource.js';
+import { lambdaWithDependencies } from './test-assets/lambda-with-dependencies/resource.js';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -331,6 +331,31 @@ void describe('AmplifyFunctionFactory', () => {
       const currentDate = new Date();
 
       assert.ok(endDate > currentDate);
+    });
+  });
+
+  void describe('architectures property', () => {
+    void it('sets valid architectures', () => {
+      const lambda = defineFunction({
+        entry: './test-assets/default-lambda/handler.ts',
+        architecture: 'arm64',
+      }).getInstance(getInstanceProps);
+      const template = Template.fromStack(Stack.of(lambda.resources.lambda));
+
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        Architectures: ['arm64'],
+      });
+    });
+
+    void it('defaults to x86_64 architecture', () => {
+      const lambda = defineFunction({
+        entry: './test-assets/default-lambda/handler.ts',
+      }).getInstance(getInstanceProps);
+      const template = Template.fromStack(Stack.of(lambda.resources.lambda));
+
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        Architectures: ['x86_64'],
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

Allows users to chooses between `x86_64` and `arm64` for the function. As arm64 could provide a better price and performance than the equivalent function running on x86_64 architecture
https://aws.amazon.com/blogs/apn/comparing-aws-lambda-arm-vs-x86-performance-cost-and-analysis-2/
https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html



**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
