### PR TITLE
Api adjustments for conversation handler

### DIFF
--- a/.changeset/tender-fishes-drive.md
+++ b/.changeset/tender-fishes-drive.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ai-constructs': patch
+'@aws-amplify/backend-ai': patch
+---
+
+Re-export types from backend-ai to support runtime customizations better

--- a/package-lock.json
+++ b/package-lock.json
@@ -24742,6 +24742,7 @@
         "@aws-amplify/plugin-types": "^1.0.1"
       },
       "peerDependencies": {
+        "@smithy/types": "^3.3.0",
         "aws-cdk-lib": "^2.152.0",
         "constructs": "^10.0.0"
       }

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -6,12 +6,11 @@
 
 /// <reference types="node" />
 
+import * as bedrock from '@aws-sdk/client-bedrock-runtime';
 import { Construct } from 'constructs';
 import { DocumentType } from '@smithy/types';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
-import { ToolInputSchema } from '@aws-sdk/client-bedrock-runtime';
-import { ToolResultContentBlock } from '@aws-sdk/client-bedrock-runtime';
 
 declare namespace conversation {
     export {
@@ -45,9 +44,7 @@ type ConversationMessage = {
 };
 
 // @public (undocumented)
-type ConversationMessageContentBlock = {
-    text: string;
-};
+type ConversationMessageContentBlock = bedrock.ContentBlock;
 
 // @public (undocumented)
 type ConversationTurnEvent = {
@@ -104,7 +101,9 @@ declare namespace runtime {
         ConversationTurnEvent,
         ExecutableTool,
         handleConversationTurnEvent,
-        ToolDefinition
+        ToolDefinition,
+        ToolInputSchema,
+        ToolResultContentBlock
     }
 }
 
@@ -114,6 +113,12 @@ type ToolDefinition = {
     description: string;
     inputSchema: ToolInputSchema;
 };
+
+// @public (undocumented)
+type ToolInputSchema = bedrock.ToolInputSchema;
+
+// @public (undocumented)
+type ToolResultContentBlock = bedrock.ToolResultContentBlock;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/ai-constructs/src/conversation/runtime/index.ts
+++ b/packages/ai-constructs/src/conversation/runtime/index.ts
@@ -4,6 +4,8 @@ import {
   ConversationTurnEvent,
   ExecutableTool,
   ToolDefinition,
+  ToolInputSchema,
+  ToolResultContentBlock,
 } from './types.js';
 
 import { handleConversationTurnEvent } from './conversation_turn_executor.js';
@@ -15,4 +17,6 @@ export {
   ExecutableTool,
   handleConversationTurnEvent,
   ToolDefinition,
+  ToolInputSchema,
+  ToolResultContentBlock,
 };

--- a/packages/ai-constructs/src/conversation/runtime/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/types.ts
@@ -1,7 +1,4 @@
-import {
-  ToolInputSchema,
-  ToolResultContentBlock,
-} from '@aws-sdk/client-bedrock-runtime';
+import * as bedrock from '@aws-sdk/client-bedrock-runtime';
 import { DocumentType } from '@smithy/types';
 
 /*
@@ -10,14 +7,15 @@ import { DocumentType } from '@smithy/types';
   public API consumer and potentially pollute syntax assist in IDEs.
  */
 
+export type ToolInputSchema = bedrock.ToolInputSchema;
+export type ToolResultContentBlock = bedrock.ToolResultContentBlock;
+
 export type ConversationMessage = {
   role: 'user' | 'assistant';
   content: Array<ConversationMessageContentBlock>;
 };
 
-export type ConversationMessageContentBlock = {
-  text: string;
-};
+export type ConversationMessageContentBlock = bedrock.ContentBlock;
 
 export type ToolDefinition = {
   name: string;

--- a/packages/backend-ai/API.md
+++ b/packages/backend-ai/API.md
@@ -5,8 +5,10 @@
 ```ts
 
 import { ConstructFactory } from '@aws-amplify/plugin-types';
+import { DocumentType } from '@smithy/types';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
+import * as runtime from '@aws-amplify/ai-constructs/conversation/runtime';
 
 declare namespace __export__conversation {
     export {
@@ -15,6 +17,19 @@ declare namespace __export__conversation {
     }
 }
 export { __export__conversation }
+
+declare namespace __export__conversation_runtime {
+    export {
+        ToolResultContentBlock,
+        ExecutableTool,
+        ConversationTurnEvent,
+        handleConversationTurnEvent
+    }
+}
+export { __export__conversation_runtime }
+
+// @public (undocumented)
+type ConversationTurnEvent = runtime.ConversationTurnEvent;
 
 // @public
 const defineConversationHandlerFunction: (props: DefineConversationHandlerFunctionProps) => ConstructFactory<ResourceProvider<FunctionResources>>;
@@ -30,6 +45,19 @@ type DefineConversationHandlerFunctionProps = {
         region?: string;
     }>;
 };
+
+// @public (undocumented)
+type ExecutableTool = runtime.ToolDefinition & {
+    execute: (input: DocumentType | undefined) => Promise<ToolResultContentBlock>;
+};
+
+// @public (undocumented)
+const handleConversationTurnEvent: (event: ConversationTurnEvent, props?: {
+    tools?: Array<ExecutableTool>;
+}) => Promise<void>;
+
+// @public (undocumented)
+type ToolResultContentBlock = runtime.ToolResultContentBlock;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/backend-ai/API.md
+++ b/packages/backend-ai/API.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { ConstructFactory } from '@aws-amplify/plugin-types';
-import { ConversationHandlerFunctionProps } from '@aws-amplify/ai-constructs/conversation';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 
@@ -23,7 +22,14 @@ const defineConversationHandlerFunction: (props: DefineConversationHandlerFuncti
 // @public (undocumented)
 type DefineConversationHandlerFunctionProps = {
     name: string;
-} & ConversationHandlerFunctionProps;
+    entry?: string;
+    models: Array<{
+        modelId: string | {
+            resourcePath: string;
+        };
+        region?: string;
+    }>;
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/backend-ai/package.json
+++ b/packages/backend-ai/package.json
@@ -9,6 +9,10 @@
     "./conversation": {
       "types": "./lib/conversation/index.d.ts",
       "default": "./lib/conversation/index.js"
+    },
+    "./conversation/runtime": {
+      "types": "./lib/conversation/runtime/index.d.ts",
+      "default": "./lib/conversation/runtime/index.js"
     }
   },
   "main": "lib/index.js",
@@ -25,6 +29,7 @@
     "@aws-amplify/plugin-types": "^1.0.1"
   },
   "peerDependencies": {
+    "@smithy/types": "^3.3.0",
     "aws-cdk-lib": "^2.152.0",
     "constructs": "^10.0.0"
   }

--- a/packages/backend-ai/src/conversation/factory.test.ts
+++ b/packages/backend-ai/src/conversation/factory.test.ts
@@ -77,6 +77,63 @@ void describe('ConversationHandlerFactory', () => {
     });
   });
 
+  void it('accepts modelId as string', () => {
+    const factory = defineConversationHandlerFunction({
+      entry: './test-assets/with-default-entry/handler.ts',
+      name: 'testHandlerName',
+      models: [
+        {
+          modelId: 'testModelId',
+          region: 'testModelRegion',
+        },
+      ],
+    });
+    const lambda = factory.getInstance(getInstanceProps);
+    const template = Template.fromStack(Stack.of(lambda.resources.lambda));
+    template.resourceCountIs('AWS::IAM::Policy', 1);
+    const policy = Object.values(template.findResources('AWS::IAM::Policy'))[0];
+    assert.ok(
+      policy.Properties.PolicyDocument.Statement[0].Resource.includes(
+        'testModelId'
+      )
+    );
+    assert.ok(
+      policy.Properties.PolicyDocument.Statement[0].Resource.includes(
+        'testModelRegion'
+      )
+    );
+  });
+
+  void it('accepts modelId as schema type', () => {
+    const factory = defineConversationHandlerFunction({
+      entry: './test-assets/with-default-entry/handler.ts',
+      name: 'testHandlerName',
+      models: [
+        {
+          modelId: {
+            // this mocks 'a.ai.model.anthropic.claude3Haiku()'
+            resourcePath: 'testModelId',
+          },
+          region: 'testModelRegion',
+        },
+      ],
+    });
+    const lambda = factory.getInstance(getInstanceProps);
+    const template = Template.fromStack(Stack.of(lambda.resources.lambda));
+    template.resourceCountIs('AWS::IAM::Policy', 1);
+    const policy = Object.values(template.findResources('AWS::IAM::Policy'))[0];
+    assert.ok(
+      policy.Properties.PolicyDocument.Statement[0].Resource.includes(
+        'testModelId'
+      )
+    );
+    assert.ok(
+      policy.Properties.PolicyDocument.Statement[0].Resource.includes(
+        'testModelRegion'
+      )
+    );
+  });
+
   void it('throws if resourceNameValidator detects an invalid name', () => {
     mock
       .method(resourceNameValidator, 'validate')

--- a/packages/backend-ai/src/conversation/factory.ts
+++ b/packages/backend-ai/src/conversation/factory.ts
@@ -29,10 +29,25 @@ class ConversationHandlerFunctionGenerator
   ) {}
 
   generateContainerEntry = ({ scope }: GenerateContainerEntryProps) => {
+    const constructProps: ConversationHandlerFunctionProps = {
+      entry: this.props.entry,
+      models: this.props.models.map((model) => {
+        let modelId;
+        if (typeof model.modelId === 'string') {
+          modelId = model.modelId;
+        } else {
+          modelId = model.modelId.resourcePath;
+        }
+        return {
+          modelId,
+          region: model.region,
+        };
+      }),
+    };
     const conversationHandlerFunction = new ConversationHandlerFunction(
       scope,
       this.props.name,
-      this.props
+      constructProps
     );
     this.storeOutput(this.outputStorageStrategy, conversationHandlerFunction);
     return conversationHandlerFunction;
@@ -110,7 +125,17 @@ class ConversationHandlerFunctionFactory
 
 export type DefineConversationHandlerFunctionProps = {
   name: string;
-} & ConversationHandlerFunctionProps;
+  entry?: string;
+  models: Array<{
+    modelId:
+      | string
+      | {
+          // This is to match return of 'a.ai.model.anthropic.claude3Haiku()'
+          resourcePath: string;
+        };
+    region?: string;
+  }>;
+};
 
 /**
  * Entry point for defining a conversation handler function in the Amplify ecosystem

--- a/packages/backend-ai/src/conversation/runtime/index.ts
+++ b/packages/backend-ai/src/conversation/runtime/index.ts
@@ -1,0 +1,17 @@
+import * as runtime from '@aws-amplify/ai-constructs/conversation/runtime';
+import { DocumentType } from '@smithy/types';
+
+// Re-export types useful for lambda runtime customization.
+// Some of these types are partially re-defined so that their member use
+// symbols from same package.
+
+export type ToolResultContentBlock = runtime.ToolResultContentBlock;
+export type ExecutableTool = runtime.ToolDefinition & {
+  execute: (input: DocumentType | undefined) => Promise<ToolResultContentBlock>;
+};
+export type ConversationTurnEvent = runtime.ConversationTurnEvent;
+
+export const handleConversationTurnEvent: (
+  event: ConversationTurnEvent,
+  props?: { tools?: Array<ExecutableTool> }
+) => Promise<void> = runtime.handleConversationTurnEvent;

--- a/packages/backend-ai/src/index.internal.ts
+++ b/packages/backend-ai/src/index.internal.ts
@@ -1,6 +1,8 @@
 // Suppressing to allow special prefix __export__ that is recognized by API checks.
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import * as __export__conversation from './conversation/index.js';
+// eslint-disable-next-line @typescript-eslint/naming-convention
+import * as __export__conversation_runtime from './conversation/runtime/index.js';
 
 /*
  Api-extractor does not ([yet](https://github.com/microsoft/rushstack/issues/1596)) support multiple package entry points
@@ -8,4 +10,4 @@ import * as __export__conversation from './conversation/index.js';
  This allows api-extractor to pick up the submodule exports in its analysis
  */
 
-export { __export__conversation };
+export { __export__conversation, __export__conversation_runtime };

--- a/packages/integration-tests/src/test-projects/conversation-handler/amplify/custom-conversation-handler/custom_handler.ts
+++ b/packages/integration-tests/src/test-projects/conversation-handler/amplify/custom-conversation-handler/custom_handler.ts
@@ -1,9 +1,9 @@
 import {
   ConversationTurnEvent,
   ExecutableTool,
+  ToolResultContentBlock,
   handleConversationTurnEvent,
-} from '@aws-amplify/ai-constructs/conversation/runtime';
-import { ToolResultContentBlock } from '@aws-sdk/client-bedrock-runtime';
+} from '@aws-amplify/backend-ai/conversation/runtime';
 import { expectedTemperatureInProgrammaticToolScenario } from '../constants.js';
 
 const thermometer: ExecutableTool = {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Feedback from API review:
1. We should accept `a.ai.model.anthropic.claude3Haiku()` as input for model Id
2. We should re-export types from `backend-ai` that take part in custom conversation handler implementation.

**Issue number, if available:**

## Changes

1. Re-export types from `backend-ai`
2. Use these types in integration tests
3. Change inputs to `defineConversationHandlerFunction`.

**Corresponding docs PR, if applicable:**

## Validation

This PR's checks

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
