### PR TITLE
Handle usage of namespaced types in api check

### DIFF
--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
@@ -12,9 +12,14 @@ type SomeTypeUnderSubNamespace = {
   someOtherProperty: string;
 }
 
+type SomeOtherTypeUnderSubNamespace = {
+  someProperty: SomeTypeUnderSubNamespace;
+};
+
 declare namespace someSubNamespace {
   export {
-    SomeTypeUnderSubNamespace
+    SomeTypeUnderSubNamespace,
+    SomeOtherTypeUnderSubNamespace
   }
 }
 

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_sub_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_sub_namespace.ts
@@ -1,3 +1,7 @@
 export type SomeTypeUnderSubNamespace = {
   someOtherProperty: string;
 };
+
+export type SomeOtherTypeUnderSubNamespace = {
+  someProperty: SomeTypeUnderSubNamespace;
+};

--- a/scripts/components/api-changes-validator/usage_statemets_renderer.ts
+++ b/scripts/components/api-changes-validator/usage_statemets_renderer.ts
@@ -69,7 +69,7 @@ export class UsageStatementsRenderer {
 
       // characters that can be found before or after symbol
       // this is to prevent partial matches in case one symbol's characters are subset of longer one
-      const symbolTerminators = '[\\s\\,\\(\\)<>]';
+      const symbolTerminators = '[\\s\\,\\(\\)<>;]';
       const regex = new RegExp(
         `(${symbolTerminators})(${symbolName})(${symbolTerminators})`,
         'g'


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Usage of namespaced type in other type was not handled properly.

<img width="981" alt="image" src="https://github.com/user-attachments/assets/555fe574-5688-4434-b497-a8a45d6fd63f">


## Changes

Add `;` as one of possible characters surrounding a symbol.

I.e. have `inputSchema: ToolInputSchema;` to be replaced by `inputSchema: conversation.runtime.ToolInputSchema;`

## Validation

Finally green check in the PR.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
