### PR TITLE
Remove runtime from main exports in ai-constructs

### DIFF
--- a/.changeset/sixty-pears-relate.md
+++ b/.changeset/sixty-pears-relate.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Remove runtime namespace from main exports

--- a/package-lock.json
+++ b/package-lock.json
@@ -24670,7 +24670,7 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.0.1",

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -12,14 +12,28 @@ import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 import * as smithy from '@smithy/types';
 
-declare namespace conversation {
+declare namespace __export__conversation {
     export {
         ConversationHandlerFunction,
-        ConversationHandlerFunctionProps,
-        runtime
+        ConversationHandlerFunctionProps
     }
 }
-export { conversation }
+export { __export__conversation }
+
+declare namespace __export__conversation__runtime {
+    export {
+        ConversationMessage,
+        ConversationMessageContentBlock,
+        ConversationTurnEvent,
+        ExecutableTool,
+        handleConversationTurnEvent,
+        ToolDefinition,
+        ToolExecutionInput,
+        ToolInputSchema,
+        ToolResultContentBlock
+    }
+}
+export { __export__conversation__runtime }
 
 // @public
 class ConversationHandlerFunction extends Construct implements ResourceProvider<FunctionResources> {
@@ -100,19 +114,12 @@ const handleConversationTurnEvent: (event: ConversationTurnEvent, props?: {
     tools?: Array<ExecutableTool>;
 }) => Promise<void>;
 
-declare namespace runtime {
+declare namespace main {
     export {
-        ConversationMessage,
-        ConversationMessageContentBlock,
-        ConversationTurnEvent,
-        ExecutableTool,
-        handleConversationTurnEvent,
-        ToolDefinition,
-        ToolExecutionInput,
-        ToolInputSchema,
-        ToolResultContentBlock
+        __export__conversation as conversation
     }
 }
+export { main }
 
 // @public (undocumented)
 type ToolDefinition = {

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -114,13 +114,6 @@ const handleConversationTurnEvent: (event: ConversationTurnEvent, props?: {
     tools?: Array<ExecutableTool>;
 }) => Promise<void>;
 
-declare namespace main {
-    export {
-        __export__conversation as conversation
-    }
-}
-export { main }
-
 // @public (undocumented)
 type ToolDefinition = {
     name: string;

--- a/packages/ai-constructs/api-extractor.json
+++ b/packages/ai-constructs/api-extractor.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../api-extractor.base.json"
+  "extends": "../../api-extractor.base.json",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.internal.d.ts"
 }

--- a/packages/ai-constructs/src/conversation/index.ts
+++ b/packages/ai-constructs/src/conversation/index.ts
@@ -1,11 +1,6 @@
-import * as runtime from './runtime';
 import {
   ConversationHandlerFunction,
   ConversationHandlerFunctionProps,
 } from './conversation_handler_construct.js';
 
-export {
-  ConversationHandlerFunction,
-  ConversationHandlerFunctionProps,
-  runtime,
-};
+export { ConversationHandlerFunction, ConversationHandlerFunctionProps };

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
@@ -1,5 +1,5 @@
 import { ConversationTurnEvent } from './types.js';
-import { ContentBlock } from '@aws-sdk/client-bedrock-runtime';
+import type { ContentBlock } from '@aws-sdk/client-bedrock-runtime';
 
 type MutationResponseInput = {
   input: {

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_tool.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_tool.ts
@@ -1,5 +1,5 @@
 import { ExecutableTool } from '../types';
-import {
+import type {
   ToolInputSchema,
   ToolResultContentBlock,
 } from '@aws-sdk/client-bedrock-runtime';

--- a/packages/ai-constructs/src/index.internal.ts
+++ b/packages/ai-constructs/src/index.internal.ts
@@ -4,13 +4,10 @@ import * as __export__conversation from './conversation/index.js';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import * as __export__conversation__runtime from './conversation/runtime/index.js';
 
-// We're exporting from main entry point too.
-import * as main from './index.js';
-
 /*
  Api-extractor does not ([yet](https://github.com/microsoft/rushstack/issues/1596)) support multiple package entry points
  Because this package has a submodule export, we are working around this issue by including that export here and directing api-extract to this entry point instead
  This allows api-extractor to pick up the submodule exports in its analysis
  */
 
-export { __export__conversation, __export__conversation__runtime, main };
+export { __export__conversation, __export__conversation__runtime };

--- a/packages/ai-constructs/src/index.internal.ts
+++ b/packages/ai-constructs/src/index.internal.ts
@@ -1,0 +1,16 @@
+// Suppressing to allow special prefix __export__ that is recognized by API checks.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+import * as __export__conversation from './conversation/index.js';
+// eslint-disable-next-line @typescript-eslint/naming-convention
+import * as __export__conversation__runtime from './conversation/runtime/index.js';
+
+// We're exporting from main entry point too.
+import * as main from './index.js';
+
+/*
+ Api-extractor does not ([yet](https://github.com/microsoft/rushstack/issues/1596)) support multiple package entry points
+ Because this package has a submodule export, we are working around this issue by including that export here and directing api-extract to this entry point instead
+ This allows api-extractor to pick up the submodule exports in its analysis
+ */
+
+export { __export__conversation, __export__conversation__runtime, main };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Exporting `runtime` via `<root_entry_point>` -> `conversation` -> `runtime` 
is causing module loader eagerly load bedrock sdk in IaC (CDK) context.
I.e. attempt to use just construct triggers it.

The runtime sub namespace is only needed for esbuild bundling of function and building custom handlers.

I.e.
```
"Error: Cannot find module '@aws-sdk/middleware-host-header'\r
Require stack:\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs/index.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/conversation/runtime/bedrock_converse_adapter.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/conversation/runtime/conversation_turn_executor.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/conve"]
[11.935,"o","rsation/runtime/index.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/conversation/index.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/index.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer/lib/transformer-steps/conversation-resolver-generator.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer/lib/grapqhl-conversation-transformer.js\r
- /private/var/f"]
[11.935,"o","olders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer/lib/index.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer/lib/graphql-transformer.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer/lib/index.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/lib/amplify-graphql-api.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/"]
[11.935,"o","lib/index.js\r
- /private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/bin/generation-model_7149fdda9_20dc2c2f.ts\r
\u001b[90m    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)\u001b[39m\r
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] \u001b[90m(/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/\u001b[39mnode_modules/\u001b[4m@cspotcode\u001b[24m/source-map-support/source-map-support.js:811:30\u001b[90m)\u001b[39m\r
\u001b[90m    at Function.Module._load (node:internal/modules/cjs/loader:981:27)\u001b[39m\r
\u001b[90m    at Module.require (node:internal/modules/cjs/loader:1231:19)\u001b[39m\r
\u001b[90m    at require (node:internal/modules/helpers:177:18)\u001b[39m\r
    at Object.<anonymous> \u001b[90m(/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/\u001b[39mnode_modules/\u001b[4m@aws-amplify\u001b[24m/graphql-api-construct/no"]
[11.936,"o","de_modules/\u001b[4m@aws-sdk\u001b[24m/client-bedrock-runtime/dist-cjs/index.js:94:37\u001b[90m)\u001b[39m\r
\u001b[90m    at Module._compile (node:internal/modules/cjs/loader:1364:14)\u001b[39m\r
\u001b[90m    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)\u001b[39m\r
    at Object.require.extensions.<computed> [as .js] \u001b[90m(/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/\u001b[39mnode_modules/\u001b[4mts-node\u001b[24m/src/index.ts:1608:43\u001b[90m)\u001b[39m\r
\u001b[90m    at Module.load (node:internal/modules/cjs/loader:1203:32)\u001b[39m {\r
  code: \u001b[32m'MODULE_NOT_FOUND'\u001b[39m,\r
  requireStack: [\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs/index.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-const"]
[11.936,"o","ruct/node_modules/@aws-amplify/ai-constructs/lib/conversation/runtime/bedrock_converse_adapter.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/conversation/runtime/conversation_turn_executor.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/conversation/runtime/index.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/conversation/index.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graph"]
[11.936,"o","ql-api-construct/node_modules/@aws-amplify/ai-constructs/lib/index.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer/lib/transformer-steps/conversation-resolver-generator.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer/lib/grapqhl-conversation-transformer.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer/lib/index.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_mo"]
[11.936,"o","dules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer/lib/graphql-transformer.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer/lib/index.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/lib/amplify-graphql-api.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/node_modules/@aws-amplify/graphql-api-construct/lib/index.js'\u001b[39m,\r
    \u001b[32m'/private/var/folders/rd/hr92pbz54kx78lddndlp9jg40000gr/T/amplify-e2e-tests/generation-model_7149fdda9_20dc2c2f/bin/generation-model_7149fdda9_20dc2c2f.ts'\u001b[39m\r
  ]\r
}\r
"]
```

## Changes

1. Remove `runtime` from `conversation` namespace.
2. Redo `API.md` generation to use exports from package.json instead of main namespace (since main namespace is just to satisfy imports in data construct, package.json exports are enough for custom function authoring).


## Note

This change is to reduce surface because we can do it without any harm. But solving the bundling problem on data side should be pursued separately (this is out of scope here).

## Validation

PR checks, including e2e tests.

A snapshot release was tested with data construct, their tests and e2e app.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
