### PR TITLE
Bundle Bedrock SDK in ai-constructs

### DIFF
--- a/.changeset/few-panthers-cross.md
+++ b/.changeset/few-panthers-cross.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Bundle Bedrock SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -24670,7 +24670,10 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "bundleDependencies": [
+        "@aws-sdk/client-bedrock-runtime"
+      ],
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.0.1",

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -22,6 +22,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
+    "prepublishOnly": "tsx prepublish.ts",
     "update:api": "api-extractor run --local"
   },
   "license": "Apache-2.0",
@@ -33,5 +34,8 @@
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0",
     "constructs": "^10.0.0"
-  }
+  },
+  "bundledDependencies": [
+    "@aws-sdk/client-bedrock-runtime"
+  ]
 }

--- a/packages/ai-constructs/prepublish.ts
+++ b/packages/ai-constructs/prepublish.ts
@@ -1,0 +1,44 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { execSync } from 'child_process';
+
+/**
+ * This is a workaround for the https://github.com/npm/rfcs/issues/287.
+ * The issue is causing 'bundledDependencies' functionality not working correctly.
+ * Dependencies that are supposed to be bundled must be available locally
+ * in node_modules under package being published.
+ * The workaround prepares nested node_modules before running publish.
+ */
+
+const main = async () => {
+  const tempDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), 'ai-constructs-packaging')
+  );
+
+  try {
+    const packageJsonPath = path.resolve(__dirname, 'package.json');
+    const packageLockPath = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      'package-lock.json'
+    );
+    // Use current package's package.json and top level lock file.
+    await fsp.copyFile(packageJsonPath, path.resolve(tempDir, 'package.json'));
+    await fsp.copyFile(
+      packageLockPath,
+      path.resolve(tempDir, 'package-lock.json')
+    );
+    execSync('npm ci --omit=peer --omit=dev', { cwd: tempDir });
+    await fsp.cp(
+      path.resolve(tempDir, 'node_modules'),
+      path.resolve(__dirname, 'node_modules'),
+      { recursive: true }
+    );
+  } finally {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  }
+};
+
+void main();

--- a/packages/ai-constructs/tsconfig.json
+++ b/packages/ai-constructs/tsconfig.json
@@ -9,5 +9,6 @@
     "outDir": "lib",
     "allowJs": true
   },
+  "exclude": ["prepublish.ts"],
   "references": [{ "path": "../plugin-types" }]
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
