### PR TITLE
wrap InvalidSignatureException in AmplifyUserError

### DIFF
--- a/.changeset/red-lamps-press.md
+++ b/.changeset/red-lamps-press.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-secret': patch
+'@aws-amplify/sandbox': patch
+---
+
+wrap InvalidSignatureException in AmplifyUserError

--- a/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
+++ b/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
@@ -82,6 +82,7 @@ export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
           'NotAuthorized',
           'ExpiredTokenException',
           'CredentialsProviderError',
+          'InvalidSignatureException',
         ].includes(error.cause.name)
       ) {
         return new AmplifyUserError('SSMCredentialsError', {

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -352,6 +352,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
           'AccessDeniedException',
           'NotAuthorized',
           'ExpiredTokenException',
+          'InvalidSignatureException',
         ].includes(e.name)
       ) {
         throw new AmplifyUserError(


### PR DESCRIPTION
## Problem

When part of the AWS credentials are incorrect we do not throw `InvalidSignatureException` as a user error.

An example of running into this scenario is partially copying the access key by double clicking to select (which selects the key up to a non alphanumeric character) which selects only part of the key when modifying the credential file directly.

**Issue number, if available:**

## Changes

Wrap `InvalidSignatureException` in AmplifyUserError.

I'll follow up in another PR for `SignatureDoesNotMatch` errors, which throws with the same message but is in different parts of the codebase.

**Corresponding docs PR, if applicable:**

## Validation

Existing unit tests for `SSMCredentialsError`

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
