### PR TITLE
fix: surface synth errors if the function declaration files have not been written yet

### DIFF
--- a/.changeset/flat-hounds-speak.md
+++ b/.changeset/flat-hounds-speak.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+surface synth errors if the function declaration files have not been written yet.

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -621,6 +621,91 @@ void describe('invokeCDKCommand', () => {
     ]);
   });
 
+  void it('throws the original synth error if the synth failed to generate function env declaration files', async () => {
+    // simulate first execa call for synth as throwing error
+    const synthErrorOnStderr =
+      `some rubbish before` +
+      EOL +
+      `Error: some cdk synth error` +
+      EOL +
+      `    at lookup (/some_random/path.js:1:3005)` +
+      EOL +
+      `    at lookup2 (/some_random/path2.js:2:3005)`;
+    const typeScriptErrorOnStderr = `amplify/functions/handler.ts(1,21): error TS2307: Cannot find module '$amplify/env/myFunction' or its corresponding type declarations.`;
+
+    executeCommandMock.mock.mockImplementation((commandArgs: string[]) => {
+      if (commandArgs.includes('synth')) {
+        return Promise.reject(new Error(synthErrorOnStderr));
+      }
+      if (commandArgs.includes('tsc') && commandArgs.includes('--noEmit')) {
+        return Promise.reject(new Error(typeScriptErrorOnStderr));
+      }
+      return Promise.resolve();
+    });
+
+    await assert.rejects(
+      () =>
+        invoker.deploy(sandboxBackendId, {
+          validateAppSources: true,
+        }),
+      new AmplifyUserError(
+        'BackendSynthError',
+        {
+          message: 'Unable to build the Amplify backend definition.',
+          resolution:
+            'Check your backend definition in the `amplify` folder for syntax and type errors.',
+        },
+        new Error(
+          `Error: some cdk synth error` +
+            EOL +
+            `    at lookup (/some_random/path.js:1:3005)`
+        )
+      )
+    );
+    assert.strictEqual(executeCommandMock.mock.callCount(), 3);
+
+    // Call 0 -> synth
+    assert.equal(executeCommandMock.mock.calls[0].arguments[0]?.length, 17);
+    assert.deepStrictEqual(executeCommandMock.mock.calls[0].arguments[0], [
+      'cdk',
+      'synth',
+      '--ci',
+      '--app',
+      "'npx tsx amplify/backend.ts'",
+      '--all',
+      '--output',
+      '.amplify/artifacts/cdk.out',
+      '--context',
+      'amplify-backend-namespace=foo',
+      '--context',
+      'amplify-backend-name=bar',
+      '--context',
+      'amplify-backend-type=sandbox',
+      '--hotswap-fallback',
+      '--method=direct',
+      '--quiet',
+    ]);
+
+    // Call 1 -> tsc showConfig (ts checks are still run)
+    assert.equal(executeCommandMock.mock.calls[1].arguments[0]?.length, 4);
+    assert.deepStrictEqual(executeCommandMock.mock.calls[1].arguments[0], [
+      'tsc',
+      '--showConfig',
+      '--project',
+      'amplify',
+    ]);
+
+    // Call 2 -> tsc
+    assert.equal(executeCommandMock.mock.calls[2].arguments[0]?.length, 5);
+    assert.deepStrictEqual(executeCommandMock.mock.calls[2].arguments[0], [
+      'tsc',
+      '--noEmit',
+      '--skipLibCheck',
+      '--project',
+      'amplify',
+    ]);
+  });
+
   void it('returns human readable errors', async () => {
     mock.method(invoker, 'executeCommand', () => {
       throw new Error('Access Denied');

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -91,8 +91,8 @@ export class CDKDeployer implements BackendDeployer {
           /Cannot find module '\$amplify\/env\/.*' or its corresponding type declarations/
         )
       ) {
-        // synth have failed and we don't have auto generated function environment definition files. This will
-        // result in the exception caught here which is not very useful for the customers.
+        // synth has failed and we don't have auto generated function environment definition files. This
+        // resulted in the exception caught here, which is not very useful for the customers.
         // We instead throw the synth error for customers to fix what caused the synth to fail.
         throw synthError;
       }


### PR DESCRIPTION
## Problem

fixes #1722

When customers are deploying their apps for the first time, i.e. `.amplify/generated/env` doesn’t yet exist, if an issue happens during the ESBuild step as part of cdk synth, the env files fail to get auto-generated. TypeScript check that run after then complain

```console
amplify/func-src/handler.ts(1,21): error TS2307: Cannot find module '$amplify/env/defaultNodeFunction' or its corresponding type declarations.
TypeScript validation check failed.
```

The root cause is a cyclic dependency issue between Synth process and TS checks.

### Typescript dependency on Synth:

Synth generates the .env files which are required to make TS happy. Without that TS will complain about the above error.

### Synth  dependency on TypeScript:

The coding errors that are caught by TS and ESBuild overlap by a lot. However, ESBuild is run by cdk in a child process and TS is run by us, meaning we have a better handle of error handling and error display to the customers for TS errors and not so much for the ESBuild errors. Moreover, some ESBuild errors are sometimes cryptic and TS errors are lot more helpful

To break this cycle, the following was implemented:

```ts
let synthError;
try {
  runSynth();
} catch (e) {
  synthError = e;
}

runTSC();

if (synthError) {
  throw synthError;
}
```

**Issue number, if available:**

## Changes

The change in this PR is to evaluate the TS error and see if it's because of missing function env declaration files. If that's the case *and* synth had failed, we throw synth error instead.

Another accompanying change is to route the TS's `stdout` to `stderr` as TS errors (from TS perspective user errors) are printed on `stdout`. This way we correctly populate the TS error in the `AmplifyError`'s downstream cause.

**Corresponding docs PR, if applicable:**

## Validation

Automated and manual testing

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
