### PR TITLE
Do not bundle AWS SDK if default implementation is used.

### DIFF
--- a/.changeset/happy-starfishes-trade.md
+++ b/.changeset/happy-starfishes-trade.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Do not bundle AWS SDK if default implementation is used

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
@@ -62,7 +62,10 @@ export class ConversationHandlerFunction
         entry: this.props.entry ?? defaultHandlerFilePath,
         handler: 'handler',
         bundling: {
-          bundleAwsSDK: true,
+          // Do not bundle SDK if conversation handler is using our default implementation which is
+          // compatible with Lambda provided SDK.
+          // For custom entry we do bundle SDK as we can't control version customer is coding against.
+          bundleAwsSDK: !!this.props.entry,
         },
         logGroup: new LogGroup(this, 'conversationHandlerFunctionLogGroup', {
           retention: RetentionDays.INFINITE,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Bundling Bedrock SDK is problematic in default implementation case. I.e. when data construct uses conversation handler construct under the hood. 

That behavior demands that data construct bundles Bedrock SDK with it's dependencies as well. Which is not optimal.

## Changes

We started conversation handler with bundling of Bedrock SDK because it was not available in Lambda runtime yet.

Since then however. Lambda has updated SDKs and they now include Bedrock. Which is also compatible with our default implementation.
Therefore, we disable bundling if default handler is used to simplify situation on data construct side.

## Note
This is another solution like [this one](https://github.com/aws-amplify/amplify-backend/pull/1962) that aims to simplify caller (upstream) situation and smoothen DX for preview purposes. We do have an action item to revisit bundling on data side.

## Validation

This change is not unit-testable as there's no good way to assert bundling behavior in unit tests.

However, the logical branch introduced here is already covered by e2e tests which deploy both default and custom implementation of conversation handler.

Hence no new tests are added in this PR.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
