### PR TITLE
Feat/allow optional props for nodejs function to be passed to define function

### DIFF
--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -513,4 +513,20 @@ void describe('AmplifyFunctionFactory', () => {
       'function-Lambda'
     );
   });
+
+  void it('allows passing retryAttempts prop to NodejsFunction', () => {
+    const functionFactory = defineFunction({
+      entry: './test-assets/default-lambda/handler.ts',
+      name: 'myCoolNodejsFunctionLambda',
+      retryAttempts: 2,
+    });
+    const lambda = functionFactory.getInstance(getInstanceProps);
+    const stack = Stack.of(lambda.resources.lambda);
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::Lambda::Function', 1);
+    template.resourceCountIs('AWS::Lambda::EventInvokeConfig', 1);
+    template.hasResourceProperties('AWS::Lambda::EventInvokeConfig', {
+      MaximumRetryAttempts: 2,
+    });
+  });
 });


### PR DESCRIPTION
## Problem

#1968 

**Issue number, if available:**

## Changes

- [Allow passing optional props to `NodejsFunction` via `defineFunction`](https://github.com/aws-amplify/amplify-backend/commit/0cd26c38c36c7d83579fa619443d1b224c9aa730)
- [Add test to allow passing `retryAttempts` prop to `NodejsFunction` via `defineFunction`](https://github.com/aws-amplify/amplify-backend/commit/e9de792b0baf98ea57303028259a3cbb727f729a)


## Validation

I created a unit test that validates the presence of `AWS::Lambda::EventInvokeConfig` with `MaximumRetryAttempts` in the generated CloudFormation when `retryAttempts` is passed as a prop to `defineFunction`

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
