### PR TITLE
feat: allow s3 cors options to be configured

### DIFF
--- a/.changeset/seven-buttons-melt.md
+++ b/.changeset/seven-buttons-melt.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': minor
+---
+
+Enable bucket CORS to be set via defineStorage

--- a/package-lock.json
+++ b/package-lock.json
@@ -24670,7 +24670,7 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.0.1",
@@ -24869,7 +24869,7 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.5",
@@ -25511,11 +25511,11 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.1.0",
-        "@aws-amplify/backend-secret": "^1.1.0",
+        "@aws-amplify/backend-secret": "^1.1.1",
         "@aws-amplify/cli-core": "^1.1.2",
         "@aws-amplify/client-config": "^1.1.3",
         "@aws-amplify/deployed-backend-client": "^1.3.0",

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -9,6 +9,7 @@ import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { CfnBucket } from 'aws-cdk-lib/aws-s3';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { ConstructFactoryGetInstanceProps } from '@aws-amplify/plugin-types';
+import { CorsRule } from 'aws-cdk-lib/aws-s3';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { ResourceAccessAcceptor } from '@aws-amplify/plugin-types';
@@ -28,6 +29,7 @@ export type AmplifyStorageProps = {
     versioned?: boolean;
     outputStorageStrategy?: BackendOutputStorageStrategy<StorageOutput>;
     triggers?: Partial<Record<AmplifyStorageTriggerEvent, ConstructFactory<ResourceProvider<FunctionResources>>>>;
+    cors?: CorsRule[];
 };
 
 // @public (undocumented)

--- a/packages/backend-storage/src/construct.test.ts
+++ b/packages/backend-storage/src/construct.test.ts
@@ -3,6 +3,7 @@ import { AmplifyStorage } from './construct.js';
 import { App, Stack } from 'aws-cdk-lib';
 import { Capture, Template } from 'aws-cdk-lib/assertions';
 import assert from 'node:assert';
+import { HttpMethods } from 'aws-cdk-lib/aws-s3';
 
 void describe('AmplifyStorage', () => {
   void it('creates a bucket', () => {
@@ -56,6 +57,37 @@ void describe('AmplifyStorage', () => {
               'ETag',
             ],
             MaxAge: 3000,
+          },
+        ],
+      },
+    });
+  });
+
+  void it('allows the user to override the default cors settings', () => {
+    const expectedCorsSettings = {
+      maxAge: 100,
+      allowedHeaders: ['example-header'],
+      allowedMethods: [HttpMethods.GET],
+      allowedOrigins: ['my-origin.aws.com'],
+      exposedHeaders: ['*'],
+    };
+    const app = new App();
+    const stack = new Stack(app);
+    new AmplifyStorage(stack, 'testAuth', {
+      name: 'testName',
+      cors: [expectedCorsSettings],
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      CorsConfiguration: {
+        CorsRules: [
+          {
+            AllowedHeaders: expectedCorsSettings.allowedHeaders,
+            AllowedMethods: expectedCorsSettings.allowedMethods,
+            AllowedOrigins: expectedCorsSettings.allowedOrigins,
+            ExposedHeaders: expectedCorsSettings.exposedHeaders,
+            MaxAge: expectedCorsSettings.maxAge,
           },
         ],
       },

--- a/packages/backend-storage/src/construct.ts
+++ b/packages/backend-storage/src/construct.ts
@@ -3,6 +3,7 @@ import {
   Bucket,
   BucketProps,
   CfnBucket,
+  CorsRule,
   EventType,
   HttpMethods,
   IBucket,
@@ -61,6 +62,7 @@ export type AmplifyStorageProps = {
       ConstructFactory<ResourceProvider<FunctionResources>>
     >
   >;
+  cors?: CorsRule[];
 };
 
 export type StorageResources = {
@@ -92,7 +94,7 @@ export class AmplifyStorage
 
     const bucketProps: BucketProps = {
       versioned: props.versioned || false,
-      cors: [
+      cors: props.cors ?? [
         {
           maxAge: 3000,
           exposedHeaders: [


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favour of a short description of the changes.
-->

## Problem

Currently there is no nice way of setting the CORS configuration of an S3 bucket without using CloudFormation templates and escape hatches

The core problem here is that the default CORS options do not expose amzn-meta-* headers which means meta data is useless to a frontend consumer

## Changes

Added the option to define a CORSRule array at the defineStorage level, if present, this will be used over the default


## Validation

Added a unit test that validates the CORS settings are applied to the CDK template when the option is set
There is already a unit test that validates the default CORS options are used when the setting is not provided

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [X ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ X] If this PR requires a docs update, I have linked to that docs PR above.
- [X ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
