### PR TITLE
throw user error when sandbox identifier input validation fails

### DIFF
--- a/.changeset/small-gorillas-remain.md
+++ b/.changeset/small-gorillas-remain.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+throw user error when sandbox identifier validation fails

--- a/package-lock.json
+++ b/package-lock.json
@@ -24670,7 +24670,7 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.0.1",
@@ -24869,7 +24869,7 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.5",
@@ -25511,11 +25511,11 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.1.0",
-        "@aws-amplify/backend-secret": "^1.1.0",
+        "@aws-amplify/backend-secret": "^1.1.1",
         "@aws-amplify/cli-core": "^1.1.2",
         "@aws-amplify/client-config": "^1.1.3",
         "@aws-amplify/deployed-backend-client": "^1.3.0",

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -21,7 +21,7 @@ import { createSandboxSecretCommand } from './sandbox-secret/sandbox_secret_comm
 import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
 import { CommandMiddleware } from '../../command_middleware.js';
 import { PackageManagerController } from '@aws-amplify/plugin-types';
-import { AmplifyUserError } from '@aws-amplify/platform-core';
+import { AmplifyError } from '@aws-amplify/platform-core';
 
 mock.method(fsp, 'mkdir', () => Promise.resolve());
 
@@ -124,19 +124,16 @@ void describe('sandbox command', () => {
 
   void it('throws AmplifyUserError if invalid identifier is provided', async () => {
     const invalidIdentifier = 'invalid@';
-    const invalidIdentifierError = new AmplifyUserError(
-      'InvalidCommandInputError',
-      {
-        message: `Invalid --identifier provided: ${invalidIdentifier}`,
-        resolution:
-          'Use an identifier that matches [a-zA-Z0-9-] and is less than 15 characters.',
-      }
-    );
     await assert.rejects(
       () =>
         commandRunner.runCommand(`sandbox --identifier ${invalidIdentifier}`), // invalid identifier
       (err: TestCommandError) => {
-        assert.deepStrictEqual(err.error, invalidIdentifierError);
+        assert.ok(err.error instanceof AmplifyError);
+        assert.strictEqual(
+          err.error.message,
+          'Invalid --identifier provided: invalid@'
+        );
+        assert.strictEqual(err.error.name, 'InvalidCommandInputError');
         return true;
       }
     );

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -21,6 +21,7 @@ import { CommandMiddleware } from '../../command_middleware.js';
 import { SandboxCommandGlobalOptions } from './option_types.js';
 import { ArgumentsKebabCase } from '../../kebab_case.js';
 import { PackageManagerController } from '@aws-amplify/plugin-types';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 export type SandboxCommandOptionsKebabCase = ArgumentsKebabCase<
   {
@@ -254,9 +255,11 @@ export class SandboxCommand
           if (argv.identifier) {
             const identifierRegex = /^[a-zA-Z0-9-]{1,15}$/;
             if (!argv.identifier.match(identifierRegex)) {
-              throw new Error(
-                `--identifier should match [a-zA-Z0-9-] and be less than 15 characters.`
-              );
+              throw new AmplifyUserError('InvalidCommandInputError', {
+                message: `Invalid --identifier provided: ${argv.identifier}`,
+                resolution:
+                  'Use an identifier that matches [a-zA-Z0-9-] and is less than 15 characters.',
+              });
             }
           }
           return true;

--- a/scripts/components/api-changes-validator/test-resources/test-projects/with-breaks/class-break-constructor/expected-error-message.txt
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/with-breaks/class-break-constructor/expected-error-message.txt
@@ -5,5 +5,6 @@ index.ts(23,18): error TS2558: Expected 1 type arguments, but got 2.
 index.ts(24,18): error TS2558: Expected 1 type arguments, but got 2.
 index.ts(36,34): error TS2554: Expected 1 arguments, but got 2.
 index.ts(42,34): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'number | undefined'.
+  Type 'string' is not assignable to type 'number'.
 index.ts(47,26): error TS2558: Expected 1 type arguments, but got 2.
 index.ts(48,26): error TS2558: Expected 1 type arguments, but got 2.


### PR DESCRIPTION
## Problem

Currently throwing generic Error which is translated to AmplifyFault

**Issue number, if available:**

## Changes

throw user error when sandbox identifier validation fails


**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
