### PR TITLE
[POC] Use single stack for top level functions

### DIFF
--- a/packages/backend/API.md
+++ b/packages/backend/API.md
@@ -70,7 +70,12 @@ export { ConstructFactoryGetInstanceProps }
 export { defineAuth }
 
 // @public
-export const defineBackend: <T extends DefineBackendProps>(constructFactories: T) => Backend<T>;
+export const defineBackend: <T extends DefineBackendProps>(constructFactories: T, options?: DefineBackendOptions) => Backend<T>;
+
+// @public (undocumented)
+export type DefineBackendOptions = {
+    useSingleStack?: boolean;
+};
 
 // @public (undocumented)
 export type DefineBackendProps = Record<string, ConstructFactory<ResourceProvider & Partial<ResourceAccessAcceptorFactory<never>>>> & {

--- a/packages/backend/src/backend.ts
+++ b/packages/backend/src/backend.ts
@@ -33,3 +33,8 @@ export type Backend<T extends DefineBackendProps> = BackendBase & {
     keyof ResourceAccessAcceptorFactory
   >;
 };
+
+export type DefineBackendOptions = {
+  // TODO This is not the best name given that there are still nested stacks in the system.
+  useSingleStack?: boolean;
+};

--- a/packages/backend/src/backend_factory.test.ts
+++ b/packages/backend/src/backend_factory.test.ts
@@ -57,6 +57,7 @@ void describe('Backend', () => {
       {
         testConstructFactory,
       },
+      undefined,
       rootStack
     );
 
@@ -96,6 +97,7 @@ void describe('Backend', () => {
       {
         testConstructFactory,
       },
+      undefined,
       rootStack
     );
 
@@ -140,6 +142,7 @@ void describe('Backend', () => {
       {
         testConstructFactory,
       },
+      undefined,
       rootStack
     );
     assert.equal(
@@ -149,7 +152,7 @@ void describe('Backend', () => {
   });
 
   void it('stores attribution metadata in root stack', () => {
-    new BackendFactory({}, rootStack);
+    new BackendFactory({}, undefined, rootStack);
     const rootStackTemplate = Template.fromStack(rootStack);
     assert.equal(
       JSON.parse(rootStackTemplate.toJSON().Description).stackType,
@@ -158,27 +161,27 @@ void describe('Backend', () => {
   });
 
   void it('registers branch linker for branch deployments', () => {
-    new BackendFactory({}, rootStack);
+    new BackendFactory({}, undefined, rootStack);
     const rootStackTemplate = Template.fromStack(rootStack);
     rootStackTemplate.resourceCountIs('Custom::AmplifyBranchLinkerResource', 1);
   });
 
   void it('does not register branch linker for sandbox deployments', () => {
     const rootStack = createStackAndSetContext('sandbox');
-    new BackendFactory({}, rootStack);
+    new BackendFactory({}, undefined, rootStack);
     const rootStackTemplate = Template.fromStack(rootStack);
     rootStackTemplate.resourceCountIs('Custom::AmplifyBranchLinkerResource', 0);
   });
 
   void describe('createStack', () => {
     void it('returns nested stack', () => {
-      const backend = new BackendFactory({}, rootStack);
+      const backend = new BackendFactory({}, undefined, rootStack);
       const testStack = backend.createStack('testStack');
       assert.strictEqual(rootStack.node.findChild('testStack'), testStack);
     });
 
     void it('throws if stack has already been created with specified name', () => {
-      const backend = new BackendFactory({}, rootStack);
+      const backend = new BackendFactory({}, undefined, rootStack);
       backend.createStack('testStack');
       assert.throws(() => backend.createStack('testStack'), {
         message: 'Custom stack named testStack has already been created',
@@ -188,7 +191,7 @@ void describe('Backend', () => {
 
   void it('can add custom output', () => {
     const rootStack = createStackAndSetContext('sandbox');
-    const backend = new BackendFactory({}, rootStack);
+    const backend = new BackendFactory({}, undefined, rootStack);
     const clientConfigPartial: DeepPartialAmplifyGeneratedConfigs<ClientConfig> =
       {
         version: '1.1',

--- a/test-projects/function-stack-1/amplify/backend.ts
+++ b/test-projects/function-stack-1/amplify/backend.ts
@@ -9,6 +9,8 @@ const backend = defineBackend({
   auth,
   data,
   myApiFunction,
+}, {
+  useSingleStack: true
 });
 
 const eventSource = new DynamoEventSource(

--- a/test-projects/function-stack-2/amplify/backend.ts
+++ b/test-projects/function-stack-2/amplify/backend.ts
@@ -8,6 +8,8 @@ const backend = defineBackend({
   auth,
   data,
   myApiFunction,
+},{
+  useSingleStack: true,
 });
 
 backend.myApiFunction.resources.lambda.addToRolePolicy(


### PR DESCRIPTION
## Problem

Certain usage patterns of functions end up with `Caused By: ❌ Deployment failed: Error [ValidationError]: Circular dependency between resources:`.

This happens is scenarios where it could have been avoided. Just because we pack all functions into same stack and therefore coupling them together.

## Changes

This PR explores potential mitigation of the problem in a form of a knob that makes backend to put all top level resources in single stack.

I.e.
```
const backend = defineBackend({
  auth,
  data,
  myApiFunction,
},{
  useSingleStack: true,
});
```

## Validation

There are two test projects used to reproduce the original problem:
1. `test-projects/function-stack-1`
2. `test-projects/function-stack-2`

Both deployed successfully with new setting.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
