### PR TITLE
[POC] Use resource name to have functions in separate stacks.

### DIFF
--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -30,6 +30,7 @@ export type FunctionProps = {
     environment?: Record<string, string | BackendSecret>;
     runtime?: NodeVersion;
     schedule?: FunctionSchedule | FunctionSchedule[];
+    resourceGroupName?: string;
 };
 
 // @public (undocumented)

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -124,6 +124,9 @@ export type FunctionProps = {
    * schedule: "0 9 ? * 2 *" // every Monday at 9am
    */
   schedule?: FunctionSchedule | FunctionSchedule[];
+
+  // TODO Naming, but maybe it's not a bad name given this concept exists in plugin types already.
+  resourceGroupName?: string;
 };
 
 /**
@@ -169,6 +172,7 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
       environment: this.props.environment ?? {},
       runtime: this.resolveRuntime(),
       schedule: this.resolveSchedule(),
+      resourceGroupName: this.props.resourceGroupName ?? 'function',
     };
   };
 
@@ -279,12 +283,14 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
 type HydratedFunctionProps = Required<FunctionProps>;
 
 class FunctionGenerator implements ConstructContainerEntryGenerator {
-  readonly resourceGroupName = 'function';
+  readonly resourceGroupName: string;
 
   constructor(
     private readonly props: HydratedFunctionProps,
     private readonly outputStorageStrategy: BackendOutputStorageStrategy<FunctionOutput>
-  ) {}
+  ) {
+    this.resourceGroupName = props.resourceGroupName;
+  }
 
   generateContainerEntry = ({
     scope,

--- a/test-projects/function-stack-1/amplify/data/resource.ts
+++ b/test-projects/function-stack-1/amplify/data/resource.ts
@@ -6,6 +6,7 @@ import {
 } from "@aws-amplify/backend";
 
 const testHandler = defineFunction({
+  resourceGroupName: 'function2'
 });
 
 const schema = a

--- a/test-projects/function-stack-1/amplify/functions/test-function/resource.ts
+++ b/test-projects/function-stack-1/amplify/functions/test-function/resource.ts
@@ -2,4 +2,6 @@ import {
   defineFunction,
 } from "@aws-amplify/backend";
 
-export const myApiFunction = defineFunction();
+export const myApiFunction = defineFunction({
+  resourceGroupName: 'function1'
+});

--- a/test-projects/function-stack-2/amplify/functions/test-function/resource.ts
+++ b/test-projects/function-stack-2/amplify/functions/test-function/resource.ts
@@ -1,7 +1,10 @@
 import { defineFunction } from '@aws-amplify/backend';
 
-export const testFunction = defineFunction();
+export const testFunction = defineFunction({
+  resourceGroupName: 'function1'
+});
 
 export const myApiFunction = defineFunction({
   name: 'api-function',
+  resourceGroupName: 'function2'
 });


### PR DESCRIPTION
## Problem

Certain usage patterns of functions end up with `Caused By: ❌ Deployment failed: Error [ValidationError]: Circular dependency between resources:`.

This happens is scenarios where it could have been avoided. Just because we pack all functions into same stack and therefore coupling them together.

## Changes

This PR explores potential mitigation of the problem in a form of elevating an internal concept of `resourceGroup` that we're using internally to organize resources into stacks. I.e. this https://github.com/aws-amplify/amplify-backend/blob/05d98e2087c8a5d054e3d7588b0ae0e554232d65/packages/plugin-types/src/construct_container.ts#L11-L15

The usage then looks like this:
```
export const testFunction = defineFunction({
  resourceGroupName: 'function1'
});

export const myApiFunction = defineFunction({
  name: 'api-function',
  resourceGroupName: 'function2'
});
```

This could be extended to other categories as well. And potentially provide an alternative way of squashing whole app into single stack.


## Validation

There are two test projects used to reproduce the original problem:
1. `test-projects/function-stack-1`
2. `test-projects/function-stack-2`

Both deployed successfully with new setting.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
