### PR TITLE
[POC] Put every function in own stack

### DIFF
--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -279,12 +279,16 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
 type HydratedFunctionProps = Required<FunctionProps>;
 
 class FunctionGenerator implements ConstructContainerEntryGenerator {
-  readonly resourceGroupName = 'function';
+  readonly resourceGroupName: string;
 
   constructor(
     private readonly props: HydratedFunctionProps,
     private readonly outputStorageStrategy: BackendOutputStorageStrategy<FunctionOutput>
-  ) {}
+  ) {
+    // TODO function name can have [a-zA-Z0-9-_]+
+    // Stack [a-zA-Z0-9-]+ . I.e. we should also sanitize this.
+    this.resourceGroupName = `function-${props.name}`;
+  }
 
   generateContainerEntry = ({
     scope,


### PR DESCRIPTION
## Problem

Certain usage patterns of functions end up with `Caused By: ❌ Deployment failed: Error [ValidationError]: Circular dependency between resources:`.

This happens is scenarios where it could have been avoided. Just because we pack all functions into same stack and therefore coupling them together.

## Changes

This PR explores potential mitigation of the problem in a form of permanently moving each function to own stack and using function name to name the stack.

Some thoughts:
1. This is potentially a runtime break. While function itself should be "stateless" there's always a possibility that customer attaches stateful resources to function stack and therefore changing topology of deployment resource graph might be destructive.
2. We need to use function name for stack naming. No counters, hashes etc. otherwise deployment would be unstable and depend on changes like moving symbols around in the code or changing lambda sources.
    1. It is worth noting that making function stack depending on function name (or any other property of function) makes the deployer always replace full stack. Which might be unwanted if other resources are placed in same stack with the function.
3. Currently, one can't add functions with same same multiple times (including inferred names from entry point name). This solution preserves that behavior, it's just that collision will be at stack not function resource.


## Validation

There are two test projects used to reproduce the original problem:
1. `test-projects/function-stack-1`
3. `test-projects/function-stack-2`

Both deployed successfully with new setting.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
