### PR TITLE
[POC] Attempt to use data and auth as stack providers for function. This won't work.

### DIFF
--- a/packages/backend-ai/src/conversation/factory.ts
+++ b/packages/backend-ai/src/conversation/factory.ts
@@ -75,6 +75,8 @@ class ConversationHandlerFunctionGenerator
 class ConversationHandlerFunctionFactory
   implements ConstructFactory<ConversationHandlerFunction>
 {
+  readonly resourceGroupName = 'conversationHandlerFunction';
+
   private generator: ConstructContainerEntryGenerator;
 
   constructor(

--- a/packages/backend-auth/src/access_builder.test.ts
+++ b/packages/backend-auth/src/access_builder.test.ts
@@ -41,6 +41,7 @@ void describe('allowAccessBuilder', () => {
           ({
             getResourceAccessAcceptor: getResourceAccessAcceptorMock,
           } as unknown as ResourceProvider & ResourceAccessAcceptorFactory),
+        resourceGroupName: 'testGroup',
       })
       .to(['createUser', 'deleteUser', 'setUserPassword']);
 

--- a/packages/backend-auth/src/factory.test.ts
+++ b/packages/backend-auth/src/factory.test.ts
@@ -236,6 +236,7 @@ void describe('AmplifyAuthFactory', () => {
             },
           };
         },
+        resourceGroupName: 'testGroup',
       };
 
       resetFactoryCount();

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -72,6 +72,8 @@ export class AmplifyAuthFactory implements ConstructFactory<BackendAuth> {
 
   readonly provides = 'AuthResources';
 
+  readonly resourceGroupName = 'auth';
+
   private generator: ConstructContainerEntryGenerator;
 
   /**

--- a/packages/backend-data/src/convert_authorization_modes.test.ts
+++ b/packages/backend-data/src/convert_authorization_modes.test.ts
@@ -273,6 +273,7 @@ void describe('convertAuthorizationModesToCDK', () => {
           },
         },
       }),
+      resourceGroupName: 'test',
     };
 
     const authModes: AuthorizationModes = {
@@ -321,6 +322,7 @@ void describe('convertAuthorizationModesToCDK', () => {
           },
         },
       }),
+      resourceGroupName: 'test',
     };
 
     const authModes: AuthorizationModes = {

--- a/packages/backend-data/src/convert_functions.test.ts
+++ b/packages/backend-data/src/convert_functions.test.ts
@@ -40,6 +40,7 @@ void describe('convertFunctionNameMapToCDK', () => {
           },
         },
       }),
+      resourceGroupName: 'test',
     };
     const updateFn = new Function(stack, 'UpdateFn', {
       runtime: Runtime.NODEJS_18_X,
@@ -57,6 +58,7 @@ void describe('convertFunctionNameMapToCDK', () => {
           },
         },
       }),
+      resourceGroupName: 'test',
     };
 
     const convertedOutput = convertFunctionNameMapToCDK(getInstancePropsStub, {

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -73,6 +73,7 @@ const createConstructContainerWithUserPoolAuthRegistered = (
   const sampleUserPool = new UserPool(stack, 'UserPool');
   constructContainer.registerConstructFactory('AuthResources', {
     provides: 'AuthResources',
+    resourceGroupName: 'auth',
     getInstance: (): ResourceProvider<AuthResources> => ({
       resources: {
         userPool: sampleUserPool,
@@ -307,6 +308,7 @@ void describe('DataFactory', () => {
           },
         },
       }),
+      resourceGroupName: 'test',
     };
     dataFactory = defineData({
       schema: testSchema,
@@ -428,6 +430,7 @@ void describe('DataFactory', () => {
           },
         },
       }),
+      resourceGroupName: 'test',
     };
     dataFactory = defineData({
       schema: /* GraphQL */ `
@@ -501,6 +504,7 @@ void describe('DataFactory', () => {
             acceptResourceAccess: acceptResourceAccessMock,
           }),
         }),
+        resourceGroupName: 'test',
       };
       const schema = a
         .schema({
@@ -655,6 +659,7 @@ void describe('DataFactory', () => {
             acceptResourceAccess: acceptResourceAccessMock1,
           }),
         }),
+        resourceGroupName: 'test',
       };
 
       // create lambda1 stub
@@ -683,6 +688,7 @@ void describe('DataFactory', () => {
             acceptResourceAccess: acceptResourceAccessMock2,
           }),
         }),
+        resourceGroupName: 'test',
       };
       const schema = a
         .schema({

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -55,6 +55,8 @@ export class DataFactory implements ConstructFactory<AmplifyData> {
   // publicly accessible for testing purpose only.
   static factoryCount = 0;
 
+  readonly resourceGroupName = 'data';
+
   private generator: ConstructContainerEntryGenerator;
 
   /**
@@ -147,6 +149,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
             schema.transform();
           schemasJsFunctions.push(...jsFunctions);
           schemasFunctionSchemaAccess.push(...functionSchemaAccess);
+          // @ts-expect-error TODO figure this out later
           schemasLambdaFunctions = {
             ...schemasLambdaFunctions,
             ...lambdaFunctions,

--- a/packages/backend-storage/src/access_builder.test.ts
+++ b/packages/backend-storage/src/access_builder.test.ts
@@ -139,6 +139,7 @@ void describe('storageAccessBuilder', () => {
           ({
             getResourceAccessAcceptor: getResourceAccessAcceptorMock,
           } as unknown as ResourceProvider & ResourceAccessAcceptorFactory),
+        resourceGroupName: 'testGroup',
       })
       .to(['read', 'write', 'delete']);
 

--- a/packages/backend-storage/src/factory.ts
+++ b/packages/backend-storage/src/factory.ts
@@ -17,6 +17,8 @@ import { StorageOutputsAspect } from './storage_outputs_aspect.js';
 export class AmplifyStorageFactory
   implements ConstructFactory<ResourceProvider<StorageResources>>
 {
+  readonly resourceGroupName: 'storage';
+
   private generator: ConstructContainerEntryGenerator;
 
   /**

--- a/packages/backend-storage/src/storage_container_entry_generator.test.ts
+++ b/packages/backend-storage/src/storage_container_entry_generator.test.ts
@@ -153,6 +153,7 @@ void describe('StorageGenerator', () => {
             },
           };
         },
+        resourceGroupName: 'test',
       };
 
       const storageGenerator = new StorageContainerEntryGenerator(

--- a/packages/backend/src/backend_factory.test.ts
+++ b/packages/backend/src/backend_factory.test.ts
@@ -51,6 +51,7 @@ void describe('Backend', () => {
           },
         }) as TestResourceProvider;
       },
+      resourceGroupName: 'test',
     };
 
     new BackendFactory(
@@ -90,6 +91,7 @@ void describe('Backend', () => {
           },
         }) as TestResourceProvider;
       },
+      resourceGroupName: 'test',
     };
 
     new BackendFactory(
@@ -134,6 +136,7 @@ void describe('Backend', () => {
           },
         }) as TestResourceProvider;
       },
+      resourceGroupName: 'test',
     };
 
     const backend = new BackendFactory(

--- a/packages/plugin-types/src/construct_factory.ts
+++ b/packages/plugin-types/src/construct_factory.ts
@@ -21,5 +21,11 @@ export type ConstructFactory<T extends ResourceProvider = ResourceProvider> = {
    * Registering as a provider allows other construct factories to fetch this one based on the provides token
    */
   readonly provides?: string;
+
+  /**
+   * TODO: docs.
+   * This is lifted from ConstructContainerEntryGenerator
+   */
+  readonly resourceGroupName: string;
   getInstance: (props: ConstructFactoryGetInstanceProps) => T;
 };

--- a/test-projects/function-stack-1/amplify/data/resource.ts
+++ b/test-projects/function-stack-1/amplify/data/resource.ts
@@ -5,6 +5,20 @@ import {
   type ClientSchema,
 } from "@aws-amplify/backend";
 
+// WELL WELL WELL, after all that coding...
+// Now here's the problem.
+// Even if we allow passing data stack to function....
+// The function is an input to the schema
+// The schema is an input to data
+// and having data being an input to function creates circular dependency
+// not even at runtime....
+// Therefore, this approach is deemed to fail regardless of implementation.
+// The only solution of such sort would be to externalize stack definition
+// for both data and function.
+//
+// BTW this is second attempt of building DX like this.
+// I also tried implementing some magic in container and factories to surface access to scope/stack.
+// But such solution would also hit exact same cycle problem.
 const testHandler = defineFunction({
 });
 


### PR DESCRIPTION
## Problem

Certain usage patterns of functions end up with `Caused By: ❌ Deployment failed: Error [ValidationError]: Circular dependency between resources:`.

This happens is scenarios where it could have been avoided. Just because we pack all functions into same stack and therefore coupling them together.

## Changes

This PR is a failed attempt to make `auth` and `data` a "donor" of stack/scope.

At some point I realized that such design will be deemed to fail in generic case.
I.e. it would create cyclic compile time problem, where writing an elegant code that would compile is just impossible. 
See [here](https://github.com/aws-amplify/amplify-backend/blob/92214735348917330dad263b90298af1d15f218d/test-projects/function-stack-1/amplify/data/resource.ts#L8-L45).

This perhaps could be further explored by adding "post defineX" APIs. I.e. by exposing additional mutators on construct factories (like `func.useScopeOf(data)` or so). 


## Validation

There are two test projects used to reproduce the original problem:
1. `test-projects/function-stack-1`
3. `test-projects/function-stack-2`

Both deployed successfully with new setting.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
