### PR TITLE
[POC] Ability to define a stack.

### DIFF
--- a/packages/backend-auth/API.md
+++ b/packages/backend-auth/API.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AmazonProviderProps } from '@aws-amplify/auth-construct';
+import { AmplifyStackResources } from '@aws-amplify/plugin-types';
 import { AppleProviderProps } from '@aws-amplify/auth-construct';
 import { AuthProps } from '@aws-amplify/auth-construct';
 import { AuthResources } from '@aws-amplify/plugin-types';
@@ -39,6 +40,7 @@ export type AmplifyAuthProps = Expand<Omit<AuthProps, 'outputStorageStrategy' | 
     loginWith: Expand<AuthLoginWithFactoryProps>;
     triggers?: Partial<Record<TriggerEvent, ConstructFactory<ResourceProvider<FunctionResources>>>>;
     access?: AuthAccessGenerator;
+    scope?: ConstructFactory<ResourceProvider<AmplifyStackResources>>;
 }>;
 
 // @public

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -8,6 +8,7 @@ import {
   TriggerEvent,
 } from '@aws-amplify/auth-construct';
 import {
+  AmplifyStackResources,
   AuthResources,
   AuthRoleName,
   ConstructContainerEntryGenerator,
@@ -58,6 +59,8 @@ export type AmplifyAuthProps = Expand<
      * access: (allow) => [allow.resource(groupManager).to(["manageGroups"])]
      */
     access?: AuthAccessGenerator;
+
+    scope?: ConstructFactory<ResourceProvider<AmplifyStackResources>>;
   }
 >;
 
@@ -110,7 +113,10 @@ export class AmplifyAuthFactory implements ConstructFactory<BackendAuth> {
     if (!this.generator) {
       this.generator = new AmplifyAuthGenerator(this.props, getInstanceProps);
     }
-    return constructContainer.getOrCompute(this.generator) as BackendAuth;
+    return constructContainer.getOrCompute(
+      this.generator,
+      this.props.scope?.getInstance(getInstanceProps).resources.stack
+    ) as BackendAuth;
   };
 }
 

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -6,9 +6,11 @@
 
 import { AmplifyData } from '@aws-amplify/data-construct';
 import { AmplifyFunction } from '@aws-amplify/plugin-types';
+import { AmplifyStackResources } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { DerivedCombinedSchema } from '@aws-amplify/data-schema-types';
 import { DerivedModelSchema } from '@aws-amplify/data-schema-types';
+import { ResourceProvider } from '@aws-amplify/plugin-types';
 
 // @public
 export type ApiKeyAuthorizationModeProps = {
@@ -30,6 +32,7 @@ export type DataProps = {
     name?: string;
     authorizationModes?: AuthorizationModes;
     functions?: Record<string, ConstructFactory<AmplifyFunction>>;
+    scope?: ConstructFactory<ResourceProvider<AmplifyStackResources>>;
 };
 
 // @public

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -106,7 +106,10 @@ export class DataFactory implements ConstructFactory<AmplifyData> {
         outputStorageStrategy
       );
     }
-    return constructContainer.getOrCompute(this.generator) as AmplifyData;
+    return constructContainer.getOrCompute(
+      this.generator,
+      this.props.scope?.getInstance(props).resources.stack
+    ) as AmplifyData;
   };
 }
 

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -2,7 +2,13 @@ import {
   DerivedCombinedSchema,
   DerivedModelSchema,
 } from '@aws-amplify/data-schema-types';
-import { AmplifyFunction, ConstructFactory } from '@aws-amplify/plugin-types';
+import {
+  AmplifyFunction,
+  AmplifyStackResources,
+  ConstructFactory,
+  ResourceProvider,
+} from '@aws-amplify/plugin-types';
+import { Stack } from 'aws-cdk-lib';
 
 /**
  * Authorization modes used in by client side Amplify represented in camelCase.
@@ -139,6 +145,8 @@ export type DataProps = {
    * Functions invokable by the API. The specific input type of the function is subject to change or removal.
    */
   functions?: Record<string, ConstructFactory<AmplifyFunction>>;
+
+  scope?: ConstructFactory<ResourceProvider<AmplifyStackResources>>;
 };
 
 export type AmplifyDataError =

--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AmplifyStackResources } from '@aws-amplify/plugin-types';
 import { BackendSecret } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { FunctionResources } from '@aws-amplify/plugin-types';
@@ -30,6 +31,7 @@ export type FunctionProps = {
     environment?: Record<string, string | BackendSecret>;
     runtime?: NodeVersion;
     schedule?: FunctionSchedule | FunctionSchedule[];
+    scope?: ConstructFactory<ResourceProvider<AmplifyStackResources>>;
 };
 
 // @public (undocumented)

--- a/packages/backend/API.md
+++ b/packages/backend/API.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { a } from '@aws-amplify/data-schema';
+import { AmplifyStackResources } from '@aws-amplify/plugin-types';
 import { AuthCfnResources } from '@aws-amplify/plugin-types';
 import { AuthResources } from '@aws-amplify/plugin-types';
 import { AuthRoleName } from '@aws-amplify/plugin-types';
@@ -80,6 +81,9 @@ export type DefineBackendProps = Record<string, ConstructFactory<ResourceProvide
 export { defineData }
 
 export { defineFunction }
+
+// @public
+export const defineStack: (name: string) => ConstructFactory<ResourceProvider<AmplifyStackResources>>;
 
 export { defineStorage }
 

--- a/packages/backend/src/engine/singleton_construct_container.ts
+++ b/packages/backend/src/engine/singleton_construct_container.ts
@@ -9,6 +9,7 @@ import { getBackendIdentifier } from '../backend_identifier.js';
 import { DefaultBackendSecretResolver } from './backend-secret/backend_secret_resolver.js';
 import { BackendIdScopedSsmEnvironmentEntriesGenerator } from './backend_id_scoped_ssm_environment_entries_generator.js';
 import { BackendIdScopedStableBackendIdentifiers } from '../backend_id_scoped_stable_backend_identifiers.js';
+import { Stack } from 'aws-cdk-lib';
 
 /**
  * Serves as a DI container and shared state store for initializing Amplify constructs
@@ -33,10 +34,13 @@ export class SingletonConstructContainer implements ConstructContainer {
    * Otherwise, the generator is called and the value is cached and returned
    */
   getOrCompute = (
-    generator: ConstructContainerEntryGenerator
+    generator: ConstructContainerEntryGenerator,
+    scope?: Stack
   ): ResourceProvider => {
     if (!this.providerCache.has(generator)) {
-      const scope = this.stackResolver.getStackFor(generator.resourceGroupName);
+      if (!scope) {
+        scope = this.stackResolver.getStackFor(generator.resourceGroupName);
+      }
       const backendId = getBackendIdentifier(scope);
       const ssmEnvironmentEntriesGenerator =
         new BackendIdScopedSsmEnvironmentEntriesGenerator(scope, backendId);

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -7,6 +7,7 @@ if (isBrowser()) {
 }
 
 export { defineBackend } from './backend_factory.js';
+export { defineStack } from './stack_factory.js';
 export * from './backend.js';
 export * from './secret.js';
 

--- a/packages/backend/src/stack_factory.ts
+++ b/packages/backend/src/stack_factory.ts
@@ -1,0 +1,56 @@
+import {
+  AmplifyStackResources,
+  ConstructContainerEntryGenerator,
+  ConstructFactory,
+  ConstructFactoryGetInstanceProps,
+  GenerateContainerEntryProps,
+  ResourceProvider,
+} from '@aws-amplify/plugin-types';
+import { Stack } from 'aws-cdk-lib';
+
+class StackGenerator
+  implements ConstructContainerEntryGenerator<AmplifyStackResources>
+{
+  readonly resourceGroupName: string;
+
+  constructor(name: string) {
+    this.resourceGroupName = name;
+  }
+
+  generateContainerEntry = ({
+    scope,
+  }: GenerateContainerEntryProps): ResourceProvider<AmplifyStackResources> => {
+    return {
+      resources: {
+        stack: scope as Stack,
+      },
+    };
+  };
+}
+
+class StackFactory
+  implements ConstructFactory<ResourceProvider<AmplifyStackResources>>
+{
+  private generator: ConstructContainerEntryGenerator;
+
+  constructor(private readonly name: string) {}
+
+  getInstance(
+    props: ConstructFactoryGetInstanceProps
+  ): ResourceProvider<AmplifyStackResources> {
+    if (!this.generator) {
+      this.generator = new StackGenerator(this.name);
+    }
+    return props.constructContainer.getOrCompute(
+      this.generator
+    ) as ResourceProvider<AmplifyStackResources>;
+  }
+}
+
+/**
+ * TODO
+ */
+export const defineStack = (
+  name: string
+): ConstructFactory<ResourceProvider<AmplifyStackResources>> =>
+  new StackFactory(name);

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -26,6 +26,11 @@ import { Stack } from 'aws-cdk-lib';
 // @public (undocumented)
 export type AmplifyFunction = ResourceProvider<FunctionResources>;
 
+// @public (undocumented)
+export type AmplifyStackResources = {
+    readonly stack: Stack;
+};
+
 // @public
 export type AppId = string;
 
@@ -110,7 +115,7 @@ export type BranchName = string;
 
 // @public
 export type ConstructContainer = {
-    getOrCompute: (generator: ConstructContainerEntryGenerator) => ResourceProvider;
+    getOrCompute: (generator: ConstructContainerEntryGenerator, scope?: Stack) => ResourceProvider;
     registerConstructFactory: (token: string, provider: ConstructFactory) => void;
     getConstructFactory: <T extends ResourceProvider>(token: string) => ConstructFactory<T> | undefined;
 };

--- a/packages/plugin-types/src/construct_container.ts
+++ b/packages/plugin-types/src/construct_container.ts
@@ -4,6 +4,7 @@ import { BackendSecretResolver } from './backend_secret_resolver.js';
 import { ResourceProvider } from './resource_provider.js';
 import { SsmEnvironmentEntriesGenerator } from './ssm_environment_entries_generator.js';
 import { StableBackendIdentifiers } from './stable_backend_identifiers.js';
+import { Stack } from 'aws-cdk-lib';
 /**
  * Initializes a CDK Construct in a given scope
  */
@@ -34,7 +35,9 @@ export type GenerateContainerEntryProps = {
  */
 export type ConstructContainer = {
   getOrCompute: (
-    generator: ConstructContainerEntryGenerator
+    generator: ConstructContainerEntryGenerator,
+    // TODO: are there better ways?
+    scope?: Stack
   ) => ResourceProvider;
   registerConstructFactory: (token: string, provider: ConstructFactory) => void;
   getConstructFactory: <T extends ResourceProvider>(

--- a/packages/plugin-types/src/index.ts
+++ b/packages/plugin-types/src/index.ts
@@ -1,3 +1,5 @@
+import { Stack } from 'aws-cdk-lib';
+
 export * from './backend_stack_creator.js';
 export * from './backend_stack_resolver.js';
 export * from './construct_container.js';
@@ -20,3 +22,7 @@ export * from './deep_partial.js';
 export * from './stable_backend_identifiers.js';
 export * from './resource_name_validator.js';
 export * from './aws_client_provider.js';
+
+export type AmplifyStackResources = {
+  readonly stack: Stack;
+};

--- a/test-projects/function-stack-1/amplify/data/resource.ts
+++ b/test-projects/function-stack-1/amplify/data/resource.ts
@@ -2,10 +2,14 @@ import {
   a,
   defineData,
   defineFunction,
+  defineStack,
   type ClientSchema,
 } from "@aws-amplify/backend";
 
+const stack = defineStack('awesome-stack');
+
 const testHandler = defineFunction({
+  scope: stack
 });
 
 const schema = a
@@ -28,4 +32,5 @@ export const data = defineData({
     defaultAuthorizationMode: "apiKey",
     apiKeyAuthorizationMode: { expiresInDays: 30 },
   },
+  scope: stack
 });

--- a/test-projects/function-stack-2/amplify/functions/test-function/resource.ts
+++ b/test-projects/function-stack-2/amplify/functions/test-function/resource.ts
@@ -1,7 +1,12 @@
-import { defineFunction } from '@aws-amplify/backend';
+import { defineFunction, defineStack } from '@aws-amplify/backend';
 
-export const testFunction = defineFunction();
+const stack1 = defineStack('awesome-stack1');
+const stack2 = defineStack('awesome-stack2');
+
+
+export const testFunction = defineFunction({scope: stack1});
 
 export const myApiFunction = defineFunction({
   name: 'api-function',
+  scope: stack2
 });


### PR DESCRIPTION
## Problem

Certain usage patterns of functions end up with `Caused By: ❌ Deployment failed: Error [ValidationError]: Circular dependency between resources:`.

This happens is scenarios where it could have been avoided. Just because we pack all functions into same stack and therefore coupling them together.

## Changes

This PR explores an option to have separate `defineStack` (we could name it as `defineResourceGroup` as well if we don't want CDK naming, but then could resource group be just a string like in other POC?). 


The code using this solution looks like this:
```
import { defineFunction, defineStack } from '@aws-amplify/backend';

const stack1 = defineStack('awesome-stack1');
const stack2 = defineStack('awesome-stack2');


export const testFunction = defineFunction({scope: stack1});

export const myApiFunction = defineFunction({
  name: 'api-function',
  scope: stack2
});
```

## Validation

There are two test projects used to reproduce the original problem:
1. `test-projects/function-stack-1`
3. `test-projects/function-stack-2`

Both deployed successfully with new setting.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
