### PR TITLE
fix(ai-constructs): invalid graphql generation for query tools

### DIFF
--- a/.changeset/fuzzy-poems-walk.md
+++ b/.changeset/fuzzy-poems-walk.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+fix invalid graphql in tool query generation

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_query_factory.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_query_factory.test.ts
@@ -37,9 +37,7 @@ const testCases: Array<TestCase> = [
     },
     expectedQuery: `
     query ToolQuery($property1: String!, $property2: Int) {
-      testQueryName1(property1: $property1, property2: $property2) {
-        testSelection1 testSelection2
-      }
+      testQueryName1(property1: $property1, property2: $property2) { testSelection1 testSelection2 }
     }
     `,
   },
@@ -58,9 +56,30 @@ const testCases: Array<TestCase> = [
     },
     expectedQuery: `
     query ToolQuery {
-      testQueryName2 {
-        testSelection3 testSelection4
-      }
+      testQueryName2 { testSelection3 testSelection4 }
+    }
+    `,
+  },
+  {
+    toolDefinition: {
+      name: 'toolName3',
+      description: 'toolDescription3',
+      inputSchema: {
+        json: {
+          type: 'object',
+          properties: {},
+          required: [],
+        },
+      },
+      graphqlRequestInputDescriptor: {
+        queryName: 'testQueryName3',
+        selectionSet: '',
+        propertyTypes: {},
+      },
+    },
+    expectedQuery: `
+    query ToolQuery {
+      testQueryName3
     }
     `,
   },

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_query_factory.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_query_factory.ts
@@ -15,12 +15,11 @@ export class GraphQlQueryFactory {
     const { graphqlRequestInputDescriptor } = toolDefinition;
     const { selectionSet, queryName } = graphqlRequestInputDescriptor;
     const [topLevelQueryArgs, queryArgs] = this.createQueryArgs(toolDefinition);
-
+    const fieldSelection =
+      selectionSet.length > 0 ? ` { ${selectionSet} }` : '';
     const query = `
     query ToolQuery${topLevelQueryArgs} {
-      ${queryName}${queryArgs} {
-        ${selectionSet}
-      }
+      ${queryName}${queryArgs}${fieldSelection}
     }
   `;
 

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_query_factory.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_query_factory.ts
@@ -36,7 +36,20 @@ export class GraphQlQueryFactory {
     }
 
     const { properties } = inputSchema.json as InputSchemaJson;
-    if (!properties) {
+
+    // The conversation resolver should not pass an empty object as input,
+    // but we're defensively checking for it here anyway because if `properties: {}`
+    // is passed, it will generate invalid GraphQL. e.g.
+    // Valid:
+    // query ToolQuery {
+    //   exampleQuery
+    // }
+    //
+    // Invalid:
+    // query ToolQuery {
+    //   exampleQuery()
+    // }
+    if (!properties || Object.keys(properties).length === 0) {
       return ['', ''];
     }
     const { propertyTypes } = toolDefinition.graphqlRequestInputDescriptor;


### PR DESCRIPTION
## Problem
#### 1. Data tool definitions with `inputSchema.properties: {}` generates invalid GraphQL.
This is a test we have today, which works as expected.
```ts
  {
    toolDefinition: {
      name: 'toolName2',
      description: 'toolDescription2',
      inputSchema: {
        json: {},
      },
      graphqlRequestInputDescriptor: {
        queryName: 'testQueryName2',
        selectionSet: 'testSelection3 testSelection4',
        propertyTypes: {},
      },
    },
    expectedQuery: `
    query ToolQuery {
      testQueryName2 {
        testSelection3 testSelection4
      }
    }
    `,
  },
```
The `inputSchema: { json: {} }` is what the resolver should be passing the lambda if there aren’t any arguments. But apparently in some cases. we’re sending this (which is also a valid tool definition):
```ts
toolDefinition: {
  name: 'toolName3',
  description: 'toolDescription3',
  inputSchema: {
    json: {
      type: 'object',
      properties: {},
      required: [],
    },
  },
},
```
I'll make the fix in the transformer to ensure we send `json: {}` for input-less queries, but let's still be defensive about checking for the second case in the lambda. 

#### 2. Scalar return types in tools generates invalid GraphQL selection set (`{ }` )

A scalar return type shouldn’t have a selection set. e.g.
```ts
graphqlRequestInputDescriptor: {
  queryName: 'testQueryName3',
  selectionSet: '',
  propertyTypes: {},
},
```
should generate
```gql
query ToolQuery {
  testQueryName3
}
```
but it currently generates
```gql
query ToolQuery {
  testQueryName3 { }
}
```
which is invalid GraphQL.

That’s because we wrap the provided selection set in `{ }` [here](https://github.com/aws-amplify/amplify-backend/blob/c10f6fc756a0e0c7764af2235a38da14e2b12762/packages/ai-constructs/src/conversation/runtime/event-tools-provider/graphql_query_factory.ts#L21-L23).

**Issue number, if available:**

## Changes
1. Adds check for `Object.keys(properties).length === 0)` to catch `inputSchema.json.properties: {}` case.

2. Conditionally wraps provided selection set in `{ }` only if the selection set is not empty.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] ~If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.~
- [ ] ~If this PR requires a docs update, I have linked to that docs PR above.~
- [ ] ~If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.~

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
