### PR TITLE
Fix for create-amplify

### DIFF
--- a/.changeset/famous-dryers-lie.md
+++ b/.changeset/famous-dryers-lie.md
@@ -1,0 +1,5 @@
+---
+'create-amplify': patch
+---
+
+reverted change that was made in activate prefer-amplify-errors for create-amplify

--- a/packages/create-amplify/src/project_root_validator.ts
+++ b/packages/create-amplify/src/project_root_validator.ts
@@ -1,4 +1,3 @@
-import { AmplifyUserError } from '@aws-amplify/platform-core';
 import { existsSync } from 'fs';
 import * as path from 'path';
 
@@ -23,10 +22,10 @@ export class ProjectRootValidator {
   validate = async (): Promise<void> => {
     const testPath = path.resolve(this.projectRoot, 'amplify');
     if (this.exists(testPath)) {
-      throw new AmplifyUserError('AmplifyDirectoryAlreadyExistsError', {
-        message: `An amplify directory already exists at ${testPath}.`,
-        resolution: `If you are trying to run an Amplify Gen 2 command inside an Amplify Gen 1 project we recommend creating the project in another directory. Learn more about AWS Amplify Gen 2: ${amplifyLearnMoreUrl}`,
-      });
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
+      throw new Error(
+        `An amplify directory already exists at ${testPath}. If you are trying to run an Amplify Gen 2 command inside an Amplify Gen 1 project we recommend creating the project in another directory. Learn more about AWS Amplify Gen 2: ${amplifyLearnMoreUrl}`
+      );
     }
   };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
e2e tests for `create-amplify` were not happy about the change from an `Error `to an `AmplifyUserError`
<!--
Describe the issue this PR is solving
-->

**Issue number, if available:** N/A

## Changes
- Reverted `AmplifyUserError` to `Error` in `create-amplify` that had been changed with the Activate prefer-amplify-errors PR
- added inline ignore to the `Error` so the linter stays happy
- marked with e2e to make sure all the `create-amplify` health checks are successful
<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
