### PR TITLE
add ExpiredToken in the list of credentials error

### DIFF
--- a/.changeset/fresh-dancers-peel.md
+++ b/.changeset/fresh-dancers-peel.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-secret': patch
+'@aws-amplify/sandbox': patch
+---
+
+add ExpiredToken in the list of credentials error

--- a/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
+++ b/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
@@ -81,6 +81,7 @@ export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
           'AccessDeniedException',
           'NotAuthorized',
           'ExpiredTokenException',
+          'ExpiredToken',
           'CredentialsProviderError',
           'InvalidSignatureException',
         ].includes(error.cause.name)

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -352,6 +352,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
           'AccessDeniedException',
           'NotAuthorized',
           'ExpiredTokenException',
+          'ExpiredToken',
           'InvalidSignatureException',
         ].includes(e.name)
       ) {


### PR DESCRIPTION
## Problem

Seeing the following errors in telemetry

`Failed to list secrets. ExpiredToken: The security token included in the request is expired`

**Issue number, if available:**

## Changes

add ExpiredToken in the list of credentials error

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
