### PR TITLE
Fix for cli-core so it is no longer unresolvable

### DIFF
--- a/.changeset/strange-jobs-refuse.md
+++ b/.changeset/strange-jobs-refuse.md
@@ -1,0 +1,14 @@
+---
+'@aws-amplify/backend-platform-test-stubs': patch
+'@aws-amplify/deployed-backend-client': patch
+'@aws-amplify/backend-output-storage': patch
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/model-generator': patch
+'@aws-amplify/client-config': patch
+'@aws-amplify/plugin-types': patch
+'@aws-amplify/cli-core': patch
+'@aws-amplify/sandbox': patch
+'@aws-amplify/backend-cli': patch
+---
+
+fixed errors in plugin-types and cli-core along with any extraneous dependencies in other packages

--- a/packages/backend-output-storage/package.json
+++ b/packages/backend-output-storage/package.json
@@ -20,7 +20,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-amplify/backend-output-schemas": "^1.2.0",
-    "@aws-amplify/platform-core": "^1.0.6"
+    "@aws-amplify/platform-core": "^1.0.6",
+    "@aws-amplify/plugin-types": "^1.2.1"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0"

--- a/packages/backend-output-storage/tsconfig.json
+++ b/packages/backend-output-storage/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
   "references": [
     { "path": "../backend-output-schemas" },
-    { "path": "../platform-core" }
+    { "path": "../platform-core" },
+    { "path": "../plugin-types" }
   ]
 }

--- a/packages/backend-platform-test-stubs/package.json
+++ b/packages/backend-platform-test-stubs/package.json
@@ -16,6 +16,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-amplify/plugin-types": "^1.2.1",
     "aws-cdk-lib": "^2.152.0",
     "constructs": "^10.0.0"
   }

--- a/packages/backend-platform-test-stubs/tsconfig.json
+++ b/packages/backend-platform-test-stubs/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
-  "references": []
+  "references": [{ "path": "../plugin-types" }]
 }

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -12,6 +12,7 @@
       "require": "./lib/index.js"
     }
   },
+  "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "update:api": "api-extractor run --local"

--- a/packages/cli-core/src/package-manager-controller/execute_with_debugger_logger.ts
+++ b/packages/cli-core/src/package-manager-controller/execute_with_debugger_logger.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from '@aws-amplify/cli-core';
+import { LogLevel } from '../printer/printer.js';
 import { type Options, execa as _execa } from 'execa';
 import { printer } from '../printer.js';
 

--- a/packages/cli-core/src/package-manager-controller/yarn_modern_package_manager_controller.test.ts
+++ b/packages/cli-core/src/package-manager-controller/yarn_modern_package_manager_controller.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { beforeEach, describe, it, mock } from 'node:test';
 import assert from 'assert';
 import { execa } from 'execa';
-import { Printer } from '@aws-amplify/cli-core';
+import { Printer } from '../printer/printer.js';
 import { YarnModernPackageManagerController } from './yarn_modern_package_manager_controller.js';
 import { executeWithDebugLogger } from './execute_with_debugger_logger.js';
 

--- a/packages/cli-core/src/package-manager-controller/yarn_modern_package_manager_controller.ts
+++ b/packages/cli-core/src/package-manager-controller/yarn_modern_package_manager_controller.ts
@@ -2,7 +2,8 @@ import { existsSync as _existsSync } from 'fs';
 import _fsp from 'fs/promises';
 import { execa as _execa } from 'execa';
 import * as _path from 'path';
-import { LogLevel, Printer, format } from '@aws-amplify/cli-core';
+import { LogLevel, Printer } from '../printer/printer.js';
+import { format } from '../format/format.js';
 import { executeWithDebugLogger as _executeWithDebugLogger } from './execute_with_debugger_logger.js';
 import { PackageManagerControllerBase } from './package_manager_controller_base.js';
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,7 @@
     "@aws-amplify/form-generator": "^1.0.1",
     "@aws-amplify/model-generator": "^1.0.5",
     "@aws-amplify/platform-core": "^1.0.5",
+    "@aws-amplify/plugin-types": "^1.2.1",
     "@aws-amplify/sandbox": "^1.2.0",
     "@aws-amplify/schema-generator": "^1.2.1",
     "@aws-sdk/client-amplify": "^3.624.0",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../form-generator" },
     { "path": "../model-generator" },
     { "path": "../platform-core" },
+    { "path": "../plugin-types" },
     { "path": "../sandbox" },
     { "path": "../schema-generator" }
   ]

--- a/packages/client-config/package.json
+++ b/packages/client-config/package.json
@@ -27,6 +27,7 @@
     "@aws-amplify/deployed-backend-client": "^1.4.0",
     "@aws-amplify/model-generator": "^1.0.5",
     "@aws-amplify/platform-core": "^1.0.7",
+    "@aws-amplify/plugin-types": "^1.2.1",
     "zod": "^3.22.2"
   },
   "devDependencies": {

--- a/packages/client-config/tsconfig.json
+++ b/packages/client-config/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "../backend-output-schemas" },
     { "path": "../deployed-backend-client" },
     { "path": "../model-generator" },
-    { "path": "../platform-core" }
+    { "path": "../platform-core" },
+    { "path": "../plugin-types" }
   ]
 }

--- a/packages/deployed-backend-client/package.json
+++ b/packages/deployed-backend-client/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-schemas": "^1.2.0",
     "@aws-amplify/platform-core": "^1.0.5",
+    "@aws-amplify/plugin-types": "^1.2.1",
     "zod": "^3.22.2"
   },
   "peerDependencies": {

--- a/packages/deployed-backend-client/tsconfig.json
+++ b/packages/deployed-backend-client/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
   "references": [
     { "path": "../backend-output-schemas" },
-    { "path": "../platform-core" }
+    { "path": "../platform-core" },
+    { "path": "../plugin-types" }
   ]
 }

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -14,6 +14,7 @@
     "@aws-amplify/data-schema": "^1.0.0",
     "@aws-amplify/deployed-backend-client": "^1.3.0",
     "@aws-amplify/platform-core": "^1.1.0",
+    "@aws-amplify/plugin-types": "^1.2.1",
     "@aws-sdk/client-accessanalyzer": "^3.624.0",
     "@aws-sdk/client-amplify": "^3.624.0",
     "@aws-sdk/client-bedrock-runtime": "^3.622.0",

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "../client-config" },
     { "path": "../deployed-backend-client" },
     { "path": "../platform-core" },
+    { "path": "../plugin-types" },
     { "path": "./src/test-projects/data-storage-auth-with-triggers-ts" }
   ],
   "exclude": ["**/node_modules", "**/lib", "src/e2e-tests"]

--- a/packages/model-generator/package.json
+++ b/packages/model-generator/package.json
@@ -23,6 +23,7 @@
     "@aws-amplify/graphql-generator": "^0.4.0",
     "@aws-amplify/graphql-types-generator": "^3.6.0",
     "@aws-amplify/platform-core": "^1.0.5",
+    "@aws-amplify/plugin-types": "^1.2.1",
     "@aws-sdk/client-appsync": "^3.624.0",
     "@aws-sdk/client-s3": "^3.624.0",
     "@aws-sdk/credential-providers": "^3.624.0",

--- a/packages/model-generator/tsconfig.json
+++ b/packages/model-generator/tsconfig.json
@@ -8,6 +8,7 @@
   "references": [
     { "path": "../backend-output-schemas" },
     { "path": "../deployed-backend-client" },
-    { "path": "../platform-core" }
+    { "path": "../platform-core" },
+    { "path": "../plugin-types" }
   ]
 }

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -3,7 +3,6 @@
   "version": "1.2.1",
   "types": "lib/index.d.ts",
   "type": "commonjs",
-  "main": "lib/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "types": "lib/index.d.ts",
   "type": "commonjs",
+  "main": "lib/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -24,6 +24,7 @@
     "@aws-amplify/client-config": "^1.1.3",
     "@aws-amplify/deployed-backend-client": "^1.3.0",
     "@aws-amplify/platform-core": "^1.0.6",
+    "@aws-amplify/plugin-types": "^1.2.1",
     "@aws-sdk/client-cloudformation": "^3.624.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.624.0",
     "@aws-sdk/client-lambda": "^3.624.0",

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "../cli-core" },
     { "path": "../client-config" },
     { "path": "../deployed-backend-client" },
-    { "path": "../platform-core" }
+    { "path": "../platform-core" },
+    { "path": "../plugin-types" }
   ]
 }

--- a/scripts/check_package_json.ts
+++ b/scripts/check_package_json.ts
@@ -3,8 +3,8 @@ import { readPackageJson } from './components/package-json/package_json.js';
 
 const packagePaths = await glob('./packages/*');
 
-// Excluding packages that violate 'import/no-extraneous-dependencies' rule until they're fixed.
-const tempExclude: string[] = ['@aws-amplify/plugin-types'];
+// Excluding packages that cannot have a main field due to status as a types only package
+const excludedPackages: string[] = ['@aws-amplify/plugin-types'];
 const errors: string[] = [];
 for (const packagePath of packagePaths) {
   const {
@@ -12,7 +12,7 @@ for (const packagePath of packagePaths) {
     name,
     private: privatePackage,
   } = await readPackageJson(packagePath);
-  if (privatePackage || tempExclude.includes(name)) {
+  if (privatePackage || excludedPackages.includes(name)) {
     continue;
   }
   if (!main) {

--- a/scripts/check_package_json.ts
+++ b/scripts/check_package_json.ts
@@ -4,10 +4,7 @@ import { readPackageJson } from './components/package-json/package_json.js';
 const packagePaths = await glob('./packages/*');
 
 // Excluding packages that violate 'import/no-extraneous-dependencies' rule until they're fixed.
-const tempExclude: string[] = [
-  '@aws-amplify/plugin-types',
-  '@aws-amplify/cli-core',
-];
+const tempExclude: string[] = ['@aws-amplify/plugin-types'];
 const errors: string[] = [];
 for (const packagePath of packagePaths) {
   const {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
`cli-core` was previously unresolvable and would not trigger errors for `no-extraneous-dependencies`

**Issue number, if available:** https://github.com/aws-amplify/amplify-backend/issues/2001

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
- added main field to `cli-core`
- fixed violations adding a main field to `cli-core` and `plugin-types` caused
- `plugin-types` cannot keep its main field because of this test -- expected behavior for `plugin-types` is that it cannot export functional code can only be used for types, main field breaks this behavior
<img width="626" alt="image" src="https://github.com/user-attachments/assets/c428f19d-9428-4d35-ab49-33511b559dd7">

- updated comment in `check_package_json.ts` to explain why `plugin-types` must be ignored

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
linter is happy, violations of `no-extraneous-dependencies` relating to `cli-core` now appear
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
