### PR TITLE
Handle CDK version mismatch

### DIFF
--- a/.changeset/spicy-monkeys-guess.md
+++ b/.changeset/spicy-monkeys-guess.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Handle CDK version mismatch

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -14,6 +14,7 @@
   "argv",
   "arn",
   "arns",
+  "aws",
   "backends",
   "birthdate",
   "bundler",

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -259,6 +259,15 @@ const testErrorMappings = [
     errorName: 'FilePermissionsError',
     expectedDownstreamErrorMessage: `EACCES: permission denied, unlink '.amplify/artifacts/cdk.out/synth.lock'`,
   },
+  {
+    errorMessage: `This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
+      (Cloud assembly schema version mismatch: Maximum schema version supported is 36.0.0, but found 36.1.1)`,
+    expectedTopLevelErrorMessage:
+      "Installed 'aws-cdk' is not compatible with installed 'aws-cdk-lib'.",
+    errorName: 'CDKVersionMismatchError',
+    expectedDownstreamErrorMessage: `This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
+      (Cloud assembly schema version mismatch: Maximum schema version supported is 36.0.0, but found 36.1.1)`,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -111,6 +111,16 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex:
+        /This CDK CLI is not compatible with the CDK library used by your application\. Please upgrade the CLI to the latest version\./,
+      humanReadableErrorMessage:
+        "Installed 'aws-cdk' is not compatible with installed 'aws-cdk-lib'.",
+      resolutionMessage:
+        "Make sure that version of 'aws-cdk' is greater or equal to version of 'aws-cdk-lib'",
+      errorName: 'CDKVersionMismatchError',
+      classification: 'ERROR',
+    },
+    {
       errorRegex: new RegExp(
         `(SyntaxError|ReferenceError|TypeError):((?:.|${this.multiLineEolRegex})*?at .*)`
       ),
@@ -272,6 +282,7 @@ export type CDKDeploymentError =
   | 'BackendSynthError'
   | 'BootstrapNotDetectedError'
   | 'CDKResolveAWSAccountError'
+  | 'CDKVersionMismatchError'
   | 'CFNUpdateNotSupportedError'
   | 'CloudFormationDeploymentError'
   | 'FilePermissionsError'


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

When installed `aws-cdk` and `aws-cdk-lib` are not compatible a fault is raised.

**Repro.**

Create project like and use mismatched CDK versions.
```
{
  "name": "testapp048",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "devDependencies": {
    "@aws-amplify/backend": "^1.2.1",
    "@aws-amplify/backend-cli": "^1.2.6",
    "aws-cdk": "2.130.0",
    "aws-cdk-lib": "2.158.0",
    "constructs": "^10.3.0",
    "esbuild": "^0.23.1",
    "tsx": "^4.19.1",
    "typescript": "^5.6.2"
  },
  "dependencies": {
    "aws-amplify": "^6.6.1"
  }
}

```

Observe
![image](https://github.com/user-attachments/assets/472a0dcc-c9f5-43e0-a76c-daf2457005db)


## Changes

Add mapping and classify as user error.

## Validation

1. Added test.
2. Manual verification

![image](https://github.com/user-attachments/assets/81f5f89b-afa3-4a3b-ac6a-394885f0ce29)


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
