### PR TITLE
throw ESBuild error with correct messages

### DIFF
--- a/.changeset/fuzzy-drinks-attend.md
+++ b/.changeset/fuzzy-drinks-attend.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-function': patch
+---
+
+throw ESBuild error with correct messages

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -171,6 +171,29 @@ const testErrorMappings = [
   },
   {
     errorMessage:
+      `✘ [ERROR] Could not resolve "$amplify/env/defaultNodeFunctions"` +
+      EOL +
+      EOL +
+      `    amplify/func-src/handler.ts:1:20:` +
+      EOL +
+      `      1 │ ...t { env } from '$amplify/env/defaultNodeFunctions';` +
+      EOL +
+      `1 error`,
+    expectedTopLevelErrorMessage:
+      'Unable to build the Amplify backend definition.',
+    errorName: 'ESBuildError',
+    expectedDownstreamErrorMessage:
+      `✘ [ERROR] Could not resolve "$amplify/env/defaultNodeFunctions"` +
+      EOL +
+      EOL +
+      `    amplify/func-src/handler.ts:1:20:` +
+      EOL +
+      `      1 │ ...t { env } from '$amplify/env/defaultNodeFunctions';` +
+      EOL +
+      `1 error`,
+  },
+  {
+    errorMessage:
       `Error [TransformError]: Transform failed with 1 error:` +
       EOL +
       `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Expected "}" but found "email"` +

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -171,6 +171,18 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      // Also extracts the first line in the stack where the error happened
+      errorRegex: new RegExp(
+        `[✘X] \\[ERROR\\] ((?:.|${this.multiLineEolRegex})*error.*)`
+      ),
+      humanReadableErrorMessage:
+        'Unable to build the Amplify backend definition.',
+      resolutionMessage:
+        'Check your backend definition in the `amplify` folder for syntax and type errors.',
+      errorName: 'ESBuildError',
+      classification: 'ERROR',
+    },
+    {
       errorRegex: new RegExp(
         `\\[TransformError\\]: Transform failed with .* error:${this.multiLineEolRegex}(?<esBuildErrorMessage>.*)`
       ),

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -373,11 +373,22 @@ class AmplifyFunction
         },
       });
     } catch (error) {
+      // If the error is from ES Bundler which is executed as a child process by CDK,
+      // then the error from CDK contains the command that was executed along with the exit status.
+      // Wrapping it here  would cause the cdk_deployer to re-throw this wrapped exception
+      // instead of scraping the stderr for actual ESBuild error.
+      if (
+        error instanceof Error &&
+        error.message.match(/Failed to bundle asset.*exited with status/)
+      ) {
+        throw error;
+      }
       throw new AmplifyUserError(
         'NodeJSFunctionConstructInitializationError',
         {
           message: 'Failed to instantiate nodejs function construct',
-          resolution: 'See the underlying error message for more details.',
+          resolution:
+            'See the underlying error message for more details. Use `--debug` for additional debugging information.',
         },
         error as Error
       );


### PR DESCRIPTION
## Problem

Currently if ESBuild running as a child process by CDK cli fails, CDK throws an error `Failed to bundle asset.....` without the actual error message. The actual error message is printed by the esbuild cli on the stderr which we skip scraping because of wrapping and throwing CDK error in an `AmplifyError`

**Issue number, if available:**

## Changes

This PR prevents wrapping if the error for instantiating the NodeJSFunction construct is from esbuild and let the cdk_deployer scrape the stderr and throw meaningful message.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
