### PR TITLE
Improve type error regex

### DIFF
--- a/.changeset/rich-jokes-divide.md
+++ b/.changeset/rich-jokes-divide.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Improve type error regex

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -56,6 +56,17 @@ const testErrorMappings = [
       `    at lookup(/some_random/path.js: 1: 3005)`,
   },
   {
+    errorMessage: `TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module ..../function/foo/resource.ts is not a valid package name imported from 
+/Users/foo/Desktop/amplify-app/amplify/storage/foo/resource.ts
+    at new NodeError (node:internal/errors:405:5)`,
+    expectedTopLevelErrorMessage:
+      'Unable to build the Amplify backend definition.',
+    errorName: 'SyntaxError',
+    expectedDownstreamErrorMessage: `TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module ..../function/foo/resource.ts is not a valid package name imported from 
+/Users/foo/Desktop/amplify-app/amplify/storage/foo/resource.ts
+    at new NodeError (node:internal/errors:405:5)`,
+  },
+  {
     errorMessage: 'Has the environment been bootstrapped',
     expectedTopLevelErrorMessage:
       'This AWS account and region has not been bootstrapped.',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -122,7 +122,7 @@ export class CdkErrorMapper {
     },
     {
       errorRegex: new RegExp(
-        `(SyntaxError|ReferenceError|TypeError):((?:.|${this.multiLineEolRegex})*?at .*)`
+        `(SyntaxError|ReferenceError|TypeError)( \\[[A-Z_]+])?:((?:.|${this.multiLineEolRegex})*?at .*)`
       ),
       humanReadableErrorMessage:
         'Unable to build the Amplify backend definition.',


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Errors in a form of
```
TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module ..../function/foo/resource.ts is not a valid package name imported from 
/Users/foo/Desktop/amplify-app/amplify/storage/foo/resource.ts
    at new NodeError (node:internal/errors:405:5)
```
I.e. with extra `[ERR_INVALID_MODULE_SPECIFIER]`
were not captured.

## Changes

Adjust regex.

## Validation

Test added.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
