### PR TITLE
Classify pointing client config generator at metadata-less stack as u…

### DIFF
--- a/.changeset/poor-owls-listen.md
+++ b/.changeset/poor-owls-listen.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+Classify pointing client config generator at metadata-less stack as user error

--- a/packages/client-config/src/unified_client_config_generator.test.ts
+++ b/packages/client-config/src/unified_client_config_generator.test.ts
@@ -449,6 +449,39 @@ void describe('UnifiedClientConfigGenerator', () => {
       );
     });
 
+    void it('throws user error if the stack is missing metadata', async () => {
+      const outputRetrieval = mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR,
+          'Stack template metadata is not a string'
+        );
+      });
+      const modelSchemaAdapter = new ModelIntrospectionSchemaAdapter(
+        stubClientProvider
+      );
+
+      const configContributors = new ClientConfigContributorFactory(
+        modelSchemaAdapter
+      ).getContributors('1.1');
+
+      const clientConfigGenerator = new UnifiedClientConfigGenerator(
+        outputRetrieval,
+        configContributors
+      );
+
+      await assert.rejects(
+        () => clientConfigGenerator.generateClientConfig(),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(
+            error.message,
+            'Stack was not created with Amplify.'
+          );
+          assert.ok(error.resolution);
+          return true;
+        }
+      );
+    });
+
     void it('throws user error if credentials are expired when getting backend outputs', async () => {
       const outputRetrieval = mock.fn(() => {
         throw new BackendOutputClientError(

--- a/packages/client-config/src/unified_client_config_generator.ts
+++ b/packages/client-config/src/unified_client_config_generator.ts
@@ -68,6 +68,20 @@ export class UnifiedClientConfigGenerator implements ClientConfigGenerator {
       }
       if (
         error instanceof BackendOutputClientError &&
+        error.code === BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR
+      ) {
+        throw new AmplifyUserError(
+          'NonAmplifyStackError',
+          {
+            message: 'Stack was not created with Amplify.',
+            resolution:
+              'Ensure the CloudFormation stack ID references a main stack created with Amplify, then re-run this command.',
+          },
+          error
+        );
+      }
+      if (
+        error instanceof BackendOutputClientError &&
         error.code === BackendOutputClientErrorType.CREDENTIALS_ERROR
       ) {
         throw new AmplifyUserError(


### PR DESCRIPTION
…ser error

<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Absence of metadata in a stack implies that CLI / config generator was pointed to a stack that was not created by Amplify.

## Changes

Classify such error as user error.

## Validation

Added test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
