### PR TITLE
correctly handle stack argument for generate schema command

### DIFF
--- a/.changeset/fluffy-months-prove.md
+++ b/.changeset/fluffy-months-prove.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+correctly handle stack argument for generate schema command

--- a/packages/cli/src/backend-identifier/backend_identifier_resolver.test.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_resolver.test.ts
@@ -3,13 +3,15 @@ import { describe, it } from 'node:test';
 import { AppBackendIdentifierResolver } from './backend_identifier_resolver.js';
 
 void describe('BackendIdentifierResolver', () => {
-  void describe('resolve', () => {
+  void describe('resolveDeployedBackendIdentifier', () => {
     void it('returns an App Name and Branch identifier', async () => {
       const backendIdResolver = new AppBackendIdentifierResolver({
         resolve: () => Promise.resolve('testAppName'),
       });
       assert.deepStrictEqual(
-        await backendIdResolver.resolve({ branch: 'test' }),
+        await backendIdResolver.resolveDeployedBackendIdentifier({
+          branch: 'test',
+        }),
         {
           appName: 'testAppName',
           branchName: 'test',
@@ -20,7 +22,7 @@ void describe('BackendIdentifierResolver', () => {
       const backendIdResolver = new AppBackendIdentifierResolver({
         resolve: () => Promise.resolve('testAppName'),
       });
-      const actual = await backendIdResolver.resolve({
+      const actual = await backendIdResolver.resolveDeployedBackendIdentifier({
         appId: 'my-id',
         branch: 'my-branch',
       });
@@ -34,9 +36,14 @@ void describe('BackendIdentifierResolver', () => {
       const backendIdResolver = new AppBackendIdentifierResolver({
         resolve: () => Promise.resolve('testAppName'),
       });
-      assert.deepEqual(await backendIdResolver.resolve({ stack: 'my-stack' }), {
-        stackName: 'my-stack',
-      });
+      assert.deepEqual(
+        await backendIdResolver.resolveDeployedBackendIdentifier({
+          stack: 'my-stack',
+        }),
+        {
+          stackName: 'my-stack',
+        }
+      );
     });
   });
 
@@ -46,9 +53,9 @@ void describe('BackendIdentifierResolver', () => {
         resolve: () => Promise.resolve('testAppName'),
       });
       assert.deepEqual(
-        await backendIdResolver.resolveDeployedBackendIdToBackendId({
-          appName: 'testAppName',
-          branchName: 'test',
+        await backendIdResolver.resolveBackendIdentifier({
+          appId: 'testAppName',
+          branch: 'test',
         }),
         {
           namespace: 'testAppName',
@@ -62,31 +69,14 @@ void describe('BackendIdentifierResolver', () => {
         resolve: () => Promise.resolve('testAppName'),
       });
       assert.deepEqual(
-        await backendIdResolver.resolveDeployedBackendIdToBackendId({
-          stackName: 'amplify-reasonableName-userName-branch-testHash',
+        await backendIdResolver.resolveBackendIdentifier({
+          stack: 'amplify-reasonableName-userName-branch-testHash',
         }),
         {
           namespace: 'reasonableName',
           name: 'userName',
           type: 'branch',
           hash: 'testHash',
-        }
-      );
-    });
-    void it('does nothing if already backend identifier', async () => {
-      const backendIdResolver = new AppBackendIdentifierResolver({
-        resolve: () => Promise.resolve('testAppName'),
-      });
-      assert.deepEqual(
-        await backendIdResolver.resolveDeployedBackendIdToBackendId({
-          namespace: 'testAppName',
-          name: 'test',
-          type: 'branch',
-        }),
-        {
-          namespace: 'testAppName',
-          name: 'test',
-          type: 'branch',
         }
       );
     });

--- a/packages/cli/src/backend-identifier/backend_identifier_resolver.test.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_resolver.test.ts
@@ -3,38 +3,92 @@ import { describe, it } from 'node:test';
 import { AppBackendIdentifierResolver } from './backend_identifier_resolver.js';
 
 void describe('BackendIdentifierResolver', () => {
-  void it('returns an App Name and Branch identifier', async () => {
-    const backendIdResolver = new AppBackendIdentifierResolver({
-      resolve: () => Promise.resolve('testAppName'),
+  void describe('resolve', () => {
+    void it('returns an App Name and Branch identifier', async () => {
+      const backendIdResolver = new AppBackendIdentifierResolver({
+        resolve: () => Promise.resolve('testAppName'),
+      });
+      assert.deepStrictEqual(
+        await backendIdResolver.resolve({ branch: 'test' }),
+        {
+          appName: 'testAppName',
+          branchName: 'test',
+        }
+      );
     });
-    assert.deepStrictEqual(
-      await backendIdResolver.resolve({ branch: 'test' }),
-      {
-        appName: 'testAppName',
-        branchName: 'test',
-      }
-    );
+    void it('returns a App Id identifier', async () => {
+      const backendIdResolver = new AppBackendIdentifierResolver({
+        resolve: () => Promise.resolve('testAppName'),
+      });
+      const actual = await backendIdResolver.resolve({
+        appId: 'my-id',
+        branch: 'my-branch',
+      });
+      assert.deepStrictEqual(actual, {
+        namespace: 'my-id',
+        name: 'my-branch',
+        type: 'branch',
+      });
+    });
+    void it('returns a Stack name identifier', async () => {
+      const backendIdResolver = new AppBackendIdentifierResolver({
+        resolve: () => Promise.resolve('testAppName'),
+      });
+      assert.deepEqual(await backendIdResolver.resolve({ stack: 'my-stack' }), {
+        stackName: 'my-stack',
+      });
+    });
   });
-  void it('returns a App Id identifier', async () => {
-    const backendIdResolver = new AppBackendIdentifierResolver({
-      resolve: () => Promise.resolve('testAppName'),
+
+  void describe('resolveDeployedBackendIdToBackendId', () => {
+    void it('returns backend identifier from App Name and Branch identifier', async () => {
+      const backendIdResolver = new AppBackendIdentifierResolver({
+        resolve: () => Promise.resolve('testAppName'),
+      });
+      assert.deepEqual(
+        await backendIdResolver.resolveDeployedBackendIdToBackendId({
+          appName: 'testAppName',
+          branchName: 'test',
+        }),
+        {
+          namespace: 'testAppName',
+          name: 'test',
+          type: 'branch',
+        }
+      );
     });
-    const actual = await backendIdResolver.resolve({
-      appId: 'my-id',
-      branch: 'my-branch',
+    void it('returns backend identifier from Stack identifier', async () => {
+      const backendIdResolver = new AppBackendIdentifierResolver({
+        resolve: () => Promise.resolve('testAppName'),
+      });
+      assert.deepEqual(
+        await backendIdResolver.resolveDeployedBackendIdToBackendId({
+          stackName: 'amplify-reasonableName-userName-branch-testHash',
+        }),
+        {
+          namespace: 'reasonableName',
+          name: 'userName',
+          type: 'branch',
+          hash: 'testHash',
+        }
+      );
     });
-    assert.deepStrictEqual(actual, {
-      namespace: 'my-id',
-      name: 'my-branch',
-      type: 'branch',
-    });
-  });
-  void it('returns a Stack name identifier', async () => {
-    const backendIdResolver = new AppBackendIdentifierResolver({
-      resolve: () => Promise.resolve('testAppName'),
-    });
-    assert.deepEqual(await backendIdResolver.resolve({ stack: 'my-stack' }), {
-      stackName: 'my-stack',
+    void it('does nothing if already backend identifier', async () => {
+      const backendIdResolver = new AppBackendIdentifierResolver({
+        resolve: () => Promise.resolve('testAppName'),
+      });
+      assert.deepEqual(
+        await backendIdResolver.resolveDeployedBackendIdToBackendId({
+          namespace: 'testAppName',
+          name: 'test',
+          type: 'branch',
+        }),
+        {
+          namespace: 'testAppName',
+          name: 'test',
+          type: 'branch',
+        }
+      );
     });
   });
 });

--- a/packages/cli/src/backend-identifier/backend_identifier_resolver.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_resolver.ts
@@ -1,6 +1,6 @@
 import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 import { NamespaceResolver } from './local_namespace_resolver.js';
-import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { BackendIdentifier, DeploymentType } from '@aws-amplify/plugin-types';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 
 export type BackendIdentifierParameters = {
@@ -61,7 +61,7 @@ export class AppBackendIdentifierResolver implements BackendIdentifierResolver {
       return {
         namespace: deployedBackendId.appName,
         name: deployedBackendId.branchName,
-        type: 'branch' as 'sandbox' | 'branch',
+        type: 'branch' as DeploymentType,
       };
     }
 

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.test.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.test.ts
@@ -15,7 +15,7 @@ void it('if backend identifier resolves without error, the resolved id is return
     defaultResolver,
     sandboxResolver
   );
-  const resolvedId = await backendIdResolver.resolve({
+  const resolvedId = await backendIdResolver.resolveDeployedBackendIdentifier({
     appId: 'hello',
     branch: 'world',
   });
@@ -45,7 +45,9 @@ void it('uses the sandbox id if the default identifier resolver fails', async ()
     defaultResolver,
     sandboxResolver
   );
-  const resolvedId = await backendIdResolver.resolve({});
+  const resolvedId = await backendIdResolver.resolveDeployedBackendIdentifier(
+    {}
+  );
   assert.deepEqual(resolvedId, {
     namespace: appName,
     type: 'sandbox',

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
@@ -34,9 +34,9 @@ export class BackendIdentifierResolverWithFallback
     deployedBackendId?: DeployedBackendIdentifier
   ) => {
     return (
-      this.defaultResolver.resolveDeployedBackendIdToBackendId(
+      (await this.defaultResolver.resolveDeployedBackendIdToBackendId(
         deployedBackendId
-      ) ?? (await this.fallbackResolver.resolve())
+      )) ?? (await this.fallbackResolver.resolve())
     );
   };
 }

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
@@ -1,3 +1,4 @@
+import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 import { SandboxBackendIdResolver } from '../commands/sandbox/sandbox_id_resolver.js';
 import {
   BackendIdentifierParameters,
@@ -24,6 +25,18 @@ export class BackendIdentifierResolverWithFallback
     return (
       (await this.defaultResolver.resolve(args)) ??
       (await this.fallbackResolver.resolve())
+    );
+  };
+  /**
+   * Resolves deployed backend id to backend id, falling back to the sandbox id if there is an error
+   */
+  resolveDeployedBackendIdToBackendId = async (
+    deployedBackendId?: DeployedBackendIdentifier
+  ) => {
+    return (
+      this.defaultResolver.resolveDeployedBackendIdToBackendId(
+        deployedBackendId
+      ) ?? (await this.fallbackResolver.resolve())
     );
   };
 }

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
@@ -1,4 +1,3 @@
-import { DeployedBackendIdentifier } from '@aws-amplify/deployed-backend-client';
 import { SandboxBackendIdResolver } from '../commands/sandbox/sandbox_id_resolver.js';
 import {
   BackendIdentifierParameters,
@@ -21,22 +20,21 @@ export class BackendIdentifierResolverWithFallback
   /**
    * resolves the backend id, falling back to the sandbox id if there is an error
    */
-  resolve = async (args: BackendIdentifierParameters) => {
+  resolveDeployedBackendIdentifier = async (
+    args: BackendIdentifierParameters
+  ) => {
     return (
-      (await this.defaultResolver.resolve(args)) ??
+      (await this.defaultResolver.resolveDeployedBackendIdentifier(args)) ??
       (await this.fallbackResolver.resolve())
     );
   };
   /**
    * Resolves deployed backend id to backend id, falling back to the sandbox id if there is an error
    */
-  resolveDeployedBackendIdToBackendId = async (
-    deployedBackendId?: DeployedBackendIdentifier
-  ) => {
+  resolveBackendIdentifier = async (args: BackendIdentifierParameters) => {
     return (
-      (await this.defaultResolver.resolveDeployedBackendIdToBackendId(
-        deployedBackendId
-      )) ?? (await this.fallbackResolver.resolve())
+      (await this.defaultResolver.resolveBackendIdentifier(args)) ??
+      (await this.fallbackResolver.resolve())
     );
   };
 }

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
@@ -242,14 +242,14 @@ void describe('generate forms command', () => {
   void it('throws user error if the stack deployment is currently in progress', async () => {
     const fakeSandboxId = 'my-fake-app-my-fake-username';
     const backendIdResolver = {
-      resolve: mock.fn(() =>
+      resolveDeployedBackendIdentifier: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,
           type: 'sandbox',
         })
       ),
-      resolveDeployedBackendIdToBackendId: mock.fn(() =>
+      resolveBackendIdentifier: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,
@@ -296,14 +296,14 @@ void describe('generate forms command', () => {
   void it('throws user error if the stack does not exist', async () => {
     const fakeSandboxId = 'my-fake-app-my-fake-username';
     const backendIdResolver = {
-      resolve: mock.fn(() =>
+      resolveDeployedBackendIdentifier: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,
           type: 'sandbox',
         })
       ),
-      resolveDeployedBackendIdToBackendId: mock.fn(() =>
+      resolveBackendIdentifier: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,
@@ -347,14 +347,14 @@ void describe('generate forms command', () => {
   void it('throws user error if credentials are expired when getting backend outputs', async () => {
     const fakeSandboxId = 'my-fake-app-my-fake-username';
     const backendIdResolver = {
-      resolve: mock.fn(() =>
+      resolveDeployedBackendIdentifier: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,
           type: 'sandbox',
         })
       ),
-      resolveDeployedBackendIdToBackendId: mock.fn(() =>
+      resolveBackendIdentifier: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,
@@ -401,14 +401,14 @@ void describe('generate forms command', () => {
   void it('throws user error if access is denied when getting backend outputs', async () => {
     const fakeSandboxId = 'my-fake-app-my-fake-username';
     const backendIdResolver = {
-      resolve: mock.fn(() =>
+      resolveDeployedBackendIdentifier: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,
           type: 'sandbox',
         })
       ),
-      resolveDeployedBackendIdToBackendId: mock.fn(() =>
+      resolveBackendIdentifier: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.test.ts
@@ -249,6 +249,13 @@ void describe('generate forms command', () => {
           type: 'sandbox',
         })
       ),
+      resolveDeployedBackendIdToBackendId: mock.fn(() =>
+        Promise.resolve({
+          namespace: fakeSandboxId,
+          name: fakeSandboxId,
+          type: 'sandbox',
+        })
+      ),
     } as BackendIdentifierResolver;
     const formGenerationHandler = new FormGenerationHandler({
       awsClientProvider,
@@ -290,6 +297,13 @@ void describe('generate forms command', () => {
     const fakeSandboxId = 'my-fake-app-my-fake-username';
     const backendIdResolver = {
       resolve: mock.fn(() =>
+        Promise.resolve({
+          namespace: fakeSandboxId,
+          name: fakeSandboxId,
+          type: 'sandbox',
+        })
+      ),
+      resolveDeployedBackendIdToBackendId: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,
@@ -340,6 +354,13 @@ void describe('generate forms command', () => {
           type: 'sandbox',
         })
       ),
+      resolveDeployedBackendIdToBackendId: mock.fn(() =>
+        Promise.resolve({
+          namespace: fakeSandboxId,
+          name: fakeSandboxId,
+          type: 'sandbox',
+        })
+      ),
     } as BackendIdentifierResolver;
     const formGenerationHandler = new FormGenerationHandler({
       awsClientProvider,
@@ -381,6 +402,13 @@ void describe('generate forms command', () => {
     const fakeSandboxId = 'my-fake-app-my-fake-username';
     const backendIdResolver = {
       resolve: mock.fn(() =>
+        Promise.resolve({
+          namespace: fakeSandboxId,
+          name: fakeSandboxId,
+          type: 'sandbox',
+        })
+      ),
+      resolveDeployedBackendIdToBackendId: mock.fn(() =>
         Promise.resolve({
           namespace: fakeSandboxId,
           name: fakeSandboxId,

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -52,7 +52,9 @@ export class GenerateFormsCommand
   }
 
   getBackendIdentifier = async (args: GenerateFormsCommandOptions) => {
-    return await this.backendIdentifierResolver.resolve(args);
+    return await this.backendIdentifierResolver.resolveDeployedBackendIdentifier(
+      args
+    );
   };
 
   /**
@@ -61,9 +63,10 @@ export class GenerateFormsCommand
   handler = async (
     args: ArgumentsCamelCase<GenerateFormsCommandOptions>
   ): Promise<void> => {
-    const backendIdentifier = await this.backendIdentifierResolver.resolve(
-      args
-    );
+    const backendIdentifier =
+      await this.backendIdentifierResolver.resolveDeployedBackendIdentifier(
+        args
+      );
 
     if (!backendIdentifier) {
       throw new Error('Could not resolve the backend identifier');

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
@@ -89,9 +89,10 @@ export class GenerateGraphqlClientCodeCommand
   handler = async (
     args: ArgumentsCamelCase<GenerateGraphqlClientCodeCommandOptions>
   ): Promise<void> => {
-    const backendIdentifier = await this.backendIdentifierResolver.resolve(
-      args
-    );
+    const backendIdentifier =
+      await this.backendIdentifierResolver.resolveDeployedBackendIdentifier(
+        args
+      );
     const out = this.getOutDir(args);
     const format = args.format ?? GenerateApiCodeFormat.GRAPHQL_CODEGEN;
     const formatParams = this.formatParamBuilders[format](args);

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -54,9 +54,10 @@ export class GenerateOutputsCommand
   handler = async (
     args: ArgumentsCamelCase<GenerateOutputsCommandOptions>
   ): Promise<void> => {
-    const backendIdentifier = await this.backendIdentifierResolver.resolve(
-      args
-    );
+    const backendIdentifier =
+      await this.backendIdentifierResolver.resolveDeployedBackendIdentifier(
+        args
+      );
 
     if (!backendIdentifier) {
       throw new Error('Could not resolve the backend identifier');

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
@@ -117,9 +117,15 @@ void describe('generate graphql-client-code command', () => {
 
   void it('generates and writes schema for stack', async () => {
     await commandRunner.runCommand(
-      'schema-from-database --stack stack_name --connection-uri-secret CONN_STRING --out schema.rds.ts'
+      'schema-from-database --stack amplify-reasonableName-userName-sandbox-testHash --connection-uri-secret CONN_STRING --out schema.rds.ts'
     );
     assert.equal(secretClientGetSecret.mock.callCount(), 1);
+    assert.deepEqual(secretClientGetSecret.mock.calls[0].arguments[0], {
+      namespace: 'reasonableName',
+      name: 'userName',
+      type: 'sandbox',
+      hash: 'testHash',
+    });
     assert.equal(schemaGeneratorGenerateMethod.mock.callCount(), 1);
     assert.deepEqual(schemaGeneratorGenerateMethod.mock.calls[0].arguments[0], {
       connectionUri: {

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
@@ -4,7 +4,10 @@ import { ArgumentsKebabCase } from '../../../kebab_case.js';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { SchemaGenerator } from '@aws-amplify/schema-generator';
-import { AmplifyFault } from '@aws-amplify/platform-core';
+import {
+  AmplifyFault,
+  BackendIdentifierConversions,
+} from '@aws-amplify/platform-core';
 
 const DEFAULT_OUTPUT = 'amplify/data/schema.sql.ts';
 
@@ -67,8 +70,13 @@ export class GenerateSchemaCommand
     const connectionUriSecretName = args.connectionUriSecret as string;
     const outputFile = args.out as string;
 
+    const backendIdentifierIsStack = 'stackName' in backendIdentifier;
+    const sanitizedBackendId = backendIdentifierIsStack
+      ? BackendIdentifierConversions.fromStackName(backendIdentifier.stackName)
+      : backendIdentifier;
+
     const connectionUriSecret = await this.secretClient.getSecret(
-      backendIdentifier as BackendIdentifier,
+      sanitizedBackendId as BackendIdentifier,
       {
         name: connectionUriSecretName,
       }
@@ -78,7 +86,7 @@ export class GenerateSchemaCommand
     let sslCertSecret;
     if (sslCertSecretName) {
       sslCertSecret = await this.secretClient.getSecret(
-        backendIdentifier as BackendIdentifier,
+        sanitizedBackendId as BackendIdentifier,
         {
           name: sslCertSecretName,
         }

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
@@ -53,15 +53,10 @@ export class GenerateSchemaCommand
   handler = async (
     args: ArgumentsCamelCase<GenerateSchemaCommandOptions>
   ): Promise<void> => {
-    const backendIdentifier = await this.backendIdentifierResolver.resolve(
-      args
-    );
-    const resolvedBackendId =
-      await this.backendIdentifierResolver.resolveDeployedBackendIdToBackendId(
-        backendIdentifier
-      );
+    const backendIdentifier =
+      await this.backendIdentifierResolver.resolveBackendIdentifier(args);
 
-    if (!resolvedBackendId) {
+    if (!backendIdentifier) {
       throw new AmplifyFault('BackendIdentifierFault', {
         message: 'Could not resolve the backend identifier',
       });
@@ -71,7 +66,7 @@ export class GenerateSchemaCommand
     const outputFile = args.out as string;
 
     const connectionUriSecret = await this.secretClient.getSecret(
-      resolvedBackendId,
+      backendIdentifier,
       {
         name: connectionUriSecretName,
       }
@@ -80,7 +75,7 @@ export class GenerateSchemaCommand
     const sslCertSecretName = args.sslCertSecret as string;
     let sslCertSecret;
     if (sslCertSecretName) {
-      sslCertSecret = await this.secretClient.getSecret(resolvedBackendId, {
+      sslCertSecret = await this.secretClient.getSecret(backendIdentifier, {
         name: sslCertSecretName,
       });
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

When passing stack option for `generate schema-from-database` command, secret client `getSecret` is expecting backend identifier to be like https://github.com/aws-amplify/amplify-backend/blob/main/packages/plugin-types/src/backend_identifier.ts#L17 but it is resolved to `{ stackName: '<stack>' }`. So we fail to convert the backend identifier to parameter path strings for connection URI and SSL Cert secrets.

**Issue number, if available:**

## Changes

If stack is passed, we correctly convert to `BackendIdentifier` before getting secrets.

**Corresponding docs PR, if applicable:**

## Validation

Updated test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
