### PR TITLE
update fallback for backend id resolvers if stack, app id, or branch are in args

### DIFF
--- a/.changeset/itchy-vans-behave.md
+++ b/.changeset/itchy-vans-behave.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+update fallback for backend id resolvers if stack, app id, or branch are in args

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.test.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.test.ts
@@ -26,7 +26,7 @@ void it('if backend identifier resolves without error, the resolved id is return
   });
 });
 
-void it('uses the sandbox id if the default identifier resolver fails', async () => {
+void it('uses the sandbox id if the default identifier resolver fails and there is no stack, appId or branch in args', async () => {
   const appName = 'testAppName';
   const namespaceResolver = {
     resolve: () => Promise.resolve(appName),
@@ -53,4 +53,29 @@ void it('uses the sandbox id if the default identifier resolver fails', async ()
     type: 'sandbox',
     name: 'test-user',
   });
+});
+
+void it('does not use sandbox id if the default identifier resolver fails and there is stack, appId or branch in args', async () => {
+  const appName = 'testAppName';
+  const namespaceResolver = {
+    resolve: () => Promise.resolve(appName),
+  };
+
+  const defaultResolver = new AppBackendIdentifierResolver(namespaceResolver);
+  const username = 'test-user';
+  const sandboxResolver = new SandboxBackendIdResolver(
+    namespaceResolver,
+    () =>
+      ({
+        username,
+      } as never)
+  );
+  const backendIdResolver = new BackendIdentifierResolverWithFallback(
+    defaultResolver,
+    sandboxResolver
+  );
+  const resolvedId = await backendIdResolver.resolveDeployedBackendIdentifier({
+    appId: 'testAppName',
+  });
+  assert.deepEqual(resolvedId, undefined);
 });

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
@@ -18,23 +18,25 @@ export class BackendIdentifierResolverWithFallback
     private fallbackResolver: SandboxBackendIdResolver
   ) {}
   /**
-   * resolves the backend id, falling back to the sandbox id if there is an error
+   * resolves to deployed backend id, falling back to the sandbox id if there is an error and stack, appId, and branch are not provided
    */
   resolveDeployedBackendIdentifier = async (
     args: BackendIdentifierParameters
   ) => {
-    return (
-      (await this.defaultResolver.resolveDeployedBackendIdentifier(args)) ??
-      (await this.fallbackResolver.resolve())
-    );
+    if (args.stack || args.appId || args.branch) {
+      return await this.defaultResolver.resolveDeployedBackendIdentifier(args);
+    }
+
+    return this.fallbackResolver.resolve();
   };
   /**
-   * Resolves deployed backend id to backend id, falling back to the sandbox id if there is an error
+   * Resolves deployed backend id to backend id, falling back to the sandbox id if there is an error and stack, appId, and branch are not provided
    */
   resolveBackendIdentifier = async (args: BackendIdentifierParameters) => {
-    return (
-      (await this.defaultResolver.resolveBackendIdentifier(args)) ??
-      (await this.fallbackResolver.resolve())
-    );
+    if (args.stack || args.appId || args.branch) {
+      return await this.defaultResolver.resolveBackendIdentifier(args);
+    }
+
+    return this.fallbackResolver.resolve();
   };
 }

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
@@ -18,23 +18,23 @@ export class BackendIdentifierResolverWithFallback
     private fallbackResolver: SandboxBackendIdResolver
   ) {}
   /**
-   * resolves to deployed backend id, falling back to the sandbox id if there is an error and stack, appId, and branch are not provided
+   * resolves to deployed backend id, falling back to the sandbox id if stack or appId and branch inputs are not provided
    */
   resolveDeployedBackendIdentifier = async (
     args: BackendIdentifierParameters
   ) => {
     if (args.stack || args.appId || args.branch) {
-      return await this.defaultResolver.resolveDeployedBackendIdentifier(args);
+      return this.defaultResolver.resolveDeployedBackendIdentifier(args);
     }
 
     return this.fallbackResolver.resolve();
   };
   /**
-   * Resolves deployed backend id to backend id, falling back to the sandbox id if there is an error and stack, appId, and branch are not provided
+   * Resolves deployed backend id to backend id, falling back to the sandbox id if stack or appId and branch inputs are not provided
    */
   resolveBackendIdentifier = async (args: BackendIdentifierParameters) => {
     if (args.stack || args.appId || args.branch) {
-      return await this.defaultResolver.resolveBackendIdentifier(args);
+      return this.defaultResolver.resolveBackendIdentifier(args);
     }
 
     return this.fallbackResolver.resolve();

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -69,7 +69,11 @@ export class GenerateFormsCommand
       );
 
     if (!backendIdentifier) {
-      throw new Error('Could not resolve the backend identifier');
+      throw new AmplifyUserError('BackendIdentifierResolverError', {
+        message: 'Could not resolve the backend identifier.',
+        resolution:
+          'Ensure stack name or Amplify App ID and branch specified are correct and exists, then re-run this command.',
+      });
     }
 
     const backendOutputClient = this.backendOutputClientBuilder();

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -8,6 +8,7 @@ import {
 import { BackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 export type GenerateOutputsCommandOptions =
   ArgumentsKebabCase<GenerateOutputsCommandOptionsCamelCase>;
@@ -60,7 +61,11 @@ export class GenerateOutputsCommand
       );
 
     if (!backendIdentifier) {
-      throw new Error('Could not resolve the backend identifier');
+      throw new AmplifyUserError('BackendIdentifierResolverError', {
+        message: 'Could not resolve the backend identifier.',
+        resolution:
+          'Ensure stack name or Amplify App ID and branch specified are correct and exists, then re-run this command.',
+      });
     }
 
     await this.clientConfigGenerator.generateClientConfigToFile(

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
@@ -3,7 +3,7 @@ import { BackendIdentifierResolver } from '../../../backend-identifier/backend_i
 import { ArgumentsKebabCase } from '../../../kebab_case.js';
 import { SecretClient } from '@aws-amplify/backend-secret';
 import { SchemaGenerator } from '@aws-amplify/schema-generator';
-import { AmplifyFault } from '@aws-amplify/platform-core';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 const DEFAULT_OUTPUT = 'amplify/data/schema.sql.ts';
 
@@ -57,8 +57,10 @@ export class GenerateSchemaCommand
       await this.backendIdentifierResolver.resolveBackendIdentifier(args);
 
     if (!backendIdentifier) {
-      throw new AmplifyFault('BackendIdentifierFault', {
-        message: 'Could not resolve the backend identifier',
+      throw new AmplifyUserError('BackendIdentifierResolverError', {
+        message: 'Could not resolve the backend identifier.',
+        resolution:
+          'Ensure stack name or Amplify App ID and branch specified are correct and exists, then re-run this command.',
       });
     }
 


### PR DESCRIPTION
## Problem
Came from https://github.com/aws-amplify/amplify-backend/pull/2028#discussion_r1768862801.

If stack, app id, or branch are passed in as an argument for generate commands, there is no intention to run these commands against a sandbox.

**Issue number, if available:**

## Changes

Only fallback to resolving sandbox backend identifier if stack, app id, and branch are not passed in as arguments to generate commands.

**Corresponding docs PR, if applicable:**

## Validation

Updated unit test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
