### PR TITLE
Prefer amplify errors in generators

### DIFF
--- a/.changeset/forty-squids-help.md
+++ b/.changeset/forty-squids-help.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/schema-generator': patch
+'@aws-amplify/model-generator': patch
+'@aws-amplify/form-generator': patch
+---
+
+Prefer amplify errors in generators

--- a/packages/eslint-rules/src/index.ts
+++ b/packages/eslint-rules/src/index.ts
@@ -27,6 +27,9 @@ export const configs = {
           'packages/backend-auth/src/**',
           'packages/backend-deployer/src/**',
           'packages/create-amplify/src/**',
+          'packages/form-generator/src/**',
+          'packages/model-generator/src/**',
+          'packages/schema-generator/src/**',
         ],
         excludedFiles: ['**/*.test.ts'],
         rules: {
@@ -39,9 +42,6 @@ export const configs = {
           'packages/ai-constructs/src/**',
           'packages/backend-output-storage/src/**',
           'packages/deployed-backend-client/src/**',
-          'packages/form-generator/src/**',
-          'packages/model-generator/src/**',
-          'packages/schema-generator/src/**',
         ],
         rules: {
           'amplify-backend-rules/no-amplify-errors': 'error',

--- a/packages/form-generator/src/local_codegen_graphql_form_generator.ts
+++ b/packages/form-generator/src/local_codegen_graphql_form_generator.ts
@@ -222,11 +222,13 @@ export class LocalGraphqlFormGenerator implements GraphqlFormGenerator {
             ([key]) => key.toLowerCase() === model.toLowerCase()
           );
           if (!entry) {
+            // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
             throw new Error(`Could not find specified model ${model}`);
           }
           prev.push(entry);
           return prev;
         }
+        // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
         throw new Error(`Could not find specified model ${model}`);
       },
       []

--- a/packages/form-generator/src/s3_string_object_fetcher.ts
+++ b/packages/form-generator/src/s3_string_object_fetcher.ts
@@ -19,6 +19,7 @@ export class S3StringObjectFetcher {
     );
     const schema = await getSchemaCommandResult.Body?.transformToString();
     if (!schema) {
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
       throw new Error('Error on parsing output schema');
     }
     return schema;

--- a/packages/model-generator/src/create_graphql_document_generator.ts
+++ b/packages/model-generator/src/create_graphql_document_generator.ts
@@ -29,9 +29,11 @@ export const createGraphqlDocumentGenerator = ({
   awsClientProvider,
 }: GraphqlDocumentGeneratorFactoryParams): GraphqlDocumentGenerator => {
   if (!backendIdentifier) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error('`backendIdentifier` must be defined');
   }
   if (!awsClientProvider) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error('`awsClientProvider` must be defined');
   }
 
@@ -44,6 +46,7 @@ export const createGraphqlDocumentGenerator = ({
     );
     const apiId = output[graphqlOutputKey]?.payload.awsAppsyncApiId;
     if (!apiId) {
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
       throw new Error(`Unable to determine AppSync API ID.`);
     }
 

--- a/packages/model-generator/src/create_graphql_models_generator.ts
+++ b/packages/model-generator/src/create_graphql_models_generator.ts
@@ -61,9 +61,11 @@ const createGraphqlModelsGeneratorFromBackendIdentifier = ({
   awsClientProvider,
 }: GraphqlModelsFromBackendIdentifierParams): GraphqlModelsGenerator => {
   if (!backendIdentifier) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error('`backendIdentifier` must be defined');
   }
   if (!awsClientProvider) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error('`awsClientProvider` must be defined');
   }
 
@@ -90,9 +92,11 @@ export const createGraphqlModelsFromS3UriGenerator = ({
   awsClientProvider,
 }: GraphqlModelsFromS3UriGeneratorFactoryParams): GraphqlModelsGenerator => {
   if (!modelSchemaS3Uri) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error('`modelSchemaS3Uri` must be defined');
   }
   if (!awsClientProvider) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error('`awsClientProvider` must be defined');
   }
   return new StackMetadataGraphqlModelsGenerator(
@@ -118,6 +122,7 @@ const getModelSchema = async (
   const modelSchemaS3Uri =
     output[graphqlOutputKey]?.payload.amplifyApiModelSchemaS3Uri;
   if (!modelSchemaS3Uri) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error(`Cannot find model schema at amplifyApiModelSchemaS3Uri`);
   }
 

--- a/packages/model-generator/src/create_graphql_types_generator.ts
+++ b/packages/model-generator/src/create_graphql_types_generator.ts
@@ -29,9 +29,11 @@ export const createGraphqlTypesGenerator = ({
   awsClientProvider,
 }: GraphqlTypesGeneratorFactoryParams): GraphqlTypesGenerator => {
   if (!backendIdentifier) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error('`backendIdentifier` must be defined');
   }
   if (!awsClientProvider) {
+    // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
     throw new Error('`awsClientProvider` must be defined');
   }
 
@@ -44,6 +46,7 @@ export const createGraphqlTypesGenerator = ({
     );
     const apiId = output[graphqlOutputKey]?.payload.awsAppsyncApiId;
     if (!apiId) {
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
       throw new Error(`Unable to determine AppSync API ID.`);
     }
 

--- a/packages/model-generator/src/generate_api_code.ts
+++ b/packages/model-generator/src/generate_api_code.ts
@@ -145,6 +145,7 @@ export class ApiCodeGenerator {
         return this.generateIntrospectionApiCode();
       }
       default:
+        // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
         throw new Error(
           `${
             (props as GenerateApiCodeProps).format as string

--- a/packages/model-generator/src/get_backend_output_with_error_handling.ts
+++ b/packages/model-generator/src/get_backend_output_with_error_handling.ts
@@ -20,7 +20,6 @@ export const getBackendOutputWithErrorHandling = async (
       error instanceof BackendOutputClientError &&
       error.code === BackendOutputClientErrorType.DEPLOYMENT_IN_PROGRESS
     ) {
-      // eslint-disable-next-line amplify-backend-rules/no-amplify-errors
       throw new AmplifyUserError(
         'DeploymentInProgressError',
         {
@@ -34,7 +33,6 @@ export const getBackendOutputWithErrorHandling = async (
       error instanceof BackendOutputClientError &&
       error.code === BackendOutputClientErrorType.NO_STACK_FOUND
     ) {
-      // eslint-disable-next-line amplify-backend-rules/no-amplify-errors
       throw new AmplifyUserError(
         'StackDoesNotExistError',
         {
@@ -49,7 +47,6 @@ export const getBackendOutputWithErrorHandling = async (
       error instanceof BackendOutputClientError &&
       error.code === BackendOutputClientErrorType.CREDENTIALS_ERROR
     ) {
-      // eslint-disable-next-line amplify-backend-rules/no-amplify-errors
       throw new AmplifyUserError(
         'CredentialsError',
         {
@@ -64,7 +61,6 @@ export const getBackendOutputWithErrorHandling = async (
       error instanceof BackendOutputClientError &&
       error.code === BackendOutputClientErrorType.ACCESS_DENIED
     ) {
-      // eslint-disable-next-line amplify-backend-rules/no-amplify-errors
       throw new AmplifyUserError(
         'AccessDeniedError',
         {

--- a/packages/model-generator/src/graphql_document_generator.ts
+++ b/packages/model-generator/src/graphql_document_generator.ts
@@ -27,6 +27,7 @@ export class AppSyncGraphqlDocumentGenerator
     const schema = await this.fetchSchema();
 
     if (!schema) {
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
       throw new Error('Invalid schema');
     }
 

--- a/packages/model-generator/src/graphql_models_generator.ts
+++ b/packages/model-generator/src/graphql_models_generator.ts
@@ -33,6 +33,7 @@ export class StackMetadataGraphqlModelsGenerator
     const schema = await this.fetchSchema();
 
     if (!schema) {
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
       throw new Error('Invalid schema');
     }
 

--- a/packages/model-generator/src/graphql_types_generator.ts
+++ b/packages/model-generator/src/graphql_types_generator.ts
@@ -30,6 +30,7 @@ export class AppSyncGraphqlTypesGenerator implements GraphqlTypesGenerator {
     const schema = await this.fetchSchema();
 
     if (!schema) {
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
       throw new Error('Invalid schema');
     }
 

--- a/packages/model-generator/src/s3_string_object_fetcher.ts
+++ b/packages/model-generator/src/s3_string_object_fetcher.ts
@@ -19,6 +19,7 @@ export class S3StringObjectFetcher {
     );
     const schema = await getSchemaCommandResult.Body?.transformToString();
     if (!schema) {
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
       throw new Error('Error on parsing output schema');
     }
     return schema;

--- a/packages/schema-generator/src/generate_schema.test.ts
+++ b/packages/schema-generator/src/generate_schema.test.ts
@@ -154,4 +154,14 @@ void describe('SchemaGenerator', () => {
         'Unable to parse the database URL. One or more parts of the database URL is missing. Missing [username, password].',
     });
   });
+
+  void it('should throw error if database engine is incorrect', async () => {
+    const parse = () =>
+      parseDatabaseUrl('incorrect://user:password@test-host-name/db');
+    assert.throws(parse, {
+      name: 'DatabaseUrlParseError',
+      message:
+        'Unable to parse the database URL. Unsupported database engine: incorrect',
+    });
+  });
 });

--- a/packages/schema-generator/src/generate_schema.ts
+++ b/packages/schema-generator/src/generate_schema.ts
@@ -16,6 +16,7 @@ export type SchemaGeneratorConfig = {
 
 type AmplifyGenerateSchemaError =
   | 'DatabaseConnectionError'
+  | 'DatabaseUnsupportedEngineError'
   | 'DatabaseUrlParseError';
 
 /**
@@ -39,7 +40,6 @@ export class SchemaGenerator {
     } catch (err) {
       const databaseError = err as DatabaseConnectError;
       if (databaseError.code === 'ETIMEDOUT') {
-        // eslint-disable-next-line amplify-backend-rules/no-amplify-errors
         throw new AmplifyUserError<AmplifyGenerateSchemaError>(
           'DatabaseConnectionError',
           {
@@ -118,7 +118,6 @@ export const parseDatabaseUrl = (databaseUrl: string): SQLDataSourceConfig => {
     ).filter((part) => !config[part]);
 
     if (missingParts.length > 0) {
-      // eslint-disable-next-line amplify-backend-rules/no-amplify-errors
       throw new AmplifyUserError<AmplifyGenerateSchemaError>(
         'DatabaseUrlParseError',
         {
@@ -134,7 +133,6 @@ export const parseDatabaseUrl = (databaseUrl: string): SQLDataSourceConfig => {
     return config;
   } catch (err) {
     const error = err as Error;
-    // eslint-disable-next-line amplify-backend-rules/no-amplify-errors
     throw new AmplifyUserError<AmplifyGenerateSchemaError>(
       'DatabaseUrlParseError',
       {
@@ -153,7 +151,14 @@ const constructDBEngine = (engine: string): SQLEngine => {
     case 'postgres':
       return 'postgresql';
     default:
-      throw new Error(`Unsupported database engine: ${engine}`);
+      throw new AmplifyUserError<AmplifyGenerateSchemaError>(
+        'DatabaseUnsupportedEngineError',
+        {
+          message: `Unsupported database engine: ${engine}`,
+          resolution:
+            'Ensure that database URL specifies supported engine. Supported engines are "mysql", "postgresql", "postgres".',
+        }
+      );
   }
 };
 


### PR DESCRIPTION


## Changes

This PR revises expectations about errors for `X-generator` packages to prefer Amplify Errors.

Reasons:
1. We already use Amplify Errors in them. Changing that would be a break.
2. Translating errors in CLI would leak implementation details. This is unwanted.
3. In order to surface necessary information each of them would need to use error system similar to Amplify Errors.
4. Amplify Errors are part if `platform-types`. I.e. usable not only in "cli-ish" packages.

## Out of scope

I fixed only one violation which was simple and left rest for the future. The priority is to establish these rules.

## Validation

PR checks.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
