### PR TITLE
Handling uncaughtException in create-amplify command

### DIFF
--- a/.changeset/happy-students-stare.md
+++ b/.changeset/happy-students-stare.md
@@ -1,0 +1,5 @@
+---
+'create-amplify': patch
+---
+
+add process handler to gracefully exit when Ctrl + C. See Issue #825.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23296,6 +23296,7 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -23970,6 +23971,7 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -30146,6 +30148,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -30929,17 +30932,17 @@
       }
     },
     "packages/ampx": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0"
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "@aws-sdk/util-arn-parser": "^3.568.0"
       },
       "peerDependencies": {
@@ -30949,20 +30952,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^1.1.2",
-        "@aws-amplify/backend-data": "^1.1.3",
-        "@aws-amplify/backend-function": "^1.4.0",
+        "@aws-amplify/backend-auth": "^1.2.0",
+        "@aws-amplify/backend-data": "^1.1.4",
+        "@aws-amplify/backend-function": "^1.5.0",
         "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/backend-secret": "^1.0.1",
-        "@aws-amplify/backend-storage": "^1.1.1",
-        "@aws-amplify/client-config": "^1.3.0",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/backend-secret": "^1.1.2",
+        "@aws-amplify/backend-storage": "^1.2.0",
+        "@aws-amplify/client-config": "^1.3.1",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^1.1.0",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.3.0",
         "@aws-sdk/client-amplify": "^3.624.0",
         "lodash.snakecase": "^4.1.1"
       },
@@ -30995,15 +30998,15 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct": "^1.3.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1"
+        "@aws-amplify/auth-construct": "^1.3.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/plugin-types": "^1.3.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.4",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.5",
         "@aws-amplify/platform-core": "^1.0.6"
       },
       "peerDependencies": {
@@ -31013,17 +31016,17 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
         "@aws-amplify/data-construct": "^1.10.1",
         "@aws-amplify/data-schema-types": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1"
+        "@aws-amplify/plugin-types": "^1.2.2"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.4",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.5",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^1.0.7"
       },
@@ -31034,11 +31037,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.1.2",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.6",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -31049,16 +31052,16 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/plugin-types": "^1.3.0",
         "execa": "^8.0.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.4",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.5",
         "@aws-amplify/platform-core": "^1.1.0",
         "@aws-sdk/client-ssm": "^3.624.0",
         "aws-sdk": "^2.1550.0",
@@ -31096,12 +31099,12 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
         "@aws-amplify/platform-core": "^1.0.6",
-        "@aws-amplify/plugin-types": "^1.2.1"
+        "@aws-amplify/plugin-types": "^1.2.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0"
@@ -31109,21 +31112,21 @@
     },
     "packages/backend-platform-test-stubs": {
       "name": "@aws-amplify/backend-platform-test-stubs",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "aws-cdk-lib": "^2.152.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/plugin-types": "^1.1.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "@aws-sdk/client-ssm": "^3.624.0"
       },
       "devDependencies": {
@@ -31132,15 +31135,15 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1"
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/plugin-types": "^1.3.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend-platform-test-stubs": "^0.3.4",
+        "@aws-amplify/backend-platform-test-stubs": "^0.3.5",
         "@aws-amplify/platform-core": "^1.0.6"
       },
       "peerDependencies": {
@@ -31150,21 +31153,21 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.2.6",
+      "version": "1.2.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.1.1",
+        "@aws-amplify/backend-deployer": "^1.1.3",
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-secret": "^1.1.0",
-        "@aws-amplify/cli-core": "^1.1.2",
-        "@aws-amplify/client-config": "^1.2.1",
-        "@aws-amplify/deployed-backend-client": "^1.3.0",
-        "@aws-amplify/form-generator": "^1.0.1",
-        "@aws-amplify/model-generator": "^1.0.5",
+        "@aws-amplify/backend-secret": "^1.1.2",
+        "@aws-amplify/cli-core": "^1.1.3",
+        "@aws-amplify/client-config": "^1.3.1",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
+        "@aws-amplify/form-generator": "^1.0.3",
+        "@aws-amplify/model-generator": "^1.0.8",
         "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/plugin-types": "^1.2.1",
-        "@aws-amplify/sandbox": "^1.2.0",
-        "@aws-amplify/schema-generator": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.3.0",
+        "@aws-amplify/sandbox": "^1.2.2",
+        "@aws-amplify/schema-generator": "^1.2.4",
         "@aws-sdk/client-amplify": "^3.624.0",
         "@aws-sdk/client-cloudformation": "^3.624.0",
         "@aws-sdk/client-s3": "^3.624.0",
@@ -31197,7 +31200,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.5",
@@ -31304,14 +31307,14 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/deployed-backend-client": "^1.4.0",
-        "@aws-amplify/model-generator": "^1.0.5",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
+        "@aws-amplify/model-generator": "^1.0.7",
         "@aws-amplify/platform-core": "^1.0.7",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -31326,12 +31329,12 @@
       }
     },
     "packages/create-amplify": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^1.1.1",
+        "@aws-amplify/cli-core": "^1.1.3",
         "@aws-amplify/platform-core": "^1.0.3",
-        "@aws-amplify/plugin-types": "^1.1.0",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "execa": "^8.0.1",
         "kleur": "^4.1.5",
         "yargs": "^17.7.2"
@@ -31441,12 +31444,12 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
         "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
@@ -31469,7 +31472,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.11.0",
@@ -31489,20 +31492,20 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
         "@aws-amplify/ai-constructs": "^0.1.0",
-        "@aws-amplify/auth-construct": "^1.2.2",
-        "@aws-amplify/backend": "^1.2.1",
+        "@aws-amplify/auth-construct": "^1.3.1",
+        "@aws-amplify/backend": "^1.2.2",
         "@aws-amplify/backend-ai": "^0.1.0",
-        "@aws-amplify/backend-secret": "^1.0.1",
-        "@aws-amplify/client-config": "^1.1.3",
+        "@aws-amplify/backend-secret": "^1.1.2",
+        "@aws-amplify/client-config": "^1.3.1",
         "@aws-amplify/data-schema": "^1.0.0",
-        "@aws-amplify/deployed-backend-client": "^1.3.0",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/platform-core": "^1.1.0",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "@aws-sdk/client-accessanalyzer": "^3.624.0",
         "@aws-sdk/client-amplify": "^3.624.0",
         "@aws-sdk/client-bedrock-runtime": "^3.622.0",
@@ -31548,15 +31551,15 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.3.0",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/graphql-generator": "^0.4.0",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
         "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.3.0",
         "@aws-sdk/client-appsync": "^3.624.0",
         "@aws-sdk/client-s3": "^3.624.0",
         "@aws-sdk/credential-providers": "^3.624.0",
@@ -31602,7 +31605,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "execa": "^5.1.1"
@@ -31731,16 +31734,16 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.1.0",
-        "@aws-amplify/backend-secret": "^1.1.1",
-        "@aws-amplify/cli-core": "^1.1.2",
-        "@aws-amplify/client-config": "^1.1.3",
-        "@aws-amplify/deployed-backend-client": "^1.3.0",
+        "@aws-amplify/backend-deployer": "^1.1.3",
+        "@aws-amplify/backend-secret": "^1.1.2",
+        "@aws-amplify/cli-core": "^1.1.3",
+        "@aws-amplify/client-config": "^1.3.1",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/platform-core": "^1.0.6",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "@aws-sdk/client-cloudformation": "^3.624.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.624.0",
         "@aws-sdk/client-lambda": "^3.624.0",
@@ -31764,7 +31767,7 @@
     },
     "packages/schema-generator": {
       "name": "@aws-amplify/schema-generator",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-schema-generator": "^0.9.4",

--- a/packages/create-amplify/src/create_amplify.ts
+++ b/packages/create-amplify/src/create_amplify.ts
@@ -7,17 +7,19 @@
   If customers have a cached version of the create-amplify package, they might execute that cached version even after we publish features and fixes to the package on npm.
  */
 
-import {
-  LogLevel,
-  PackageManagerControllerFactory,
-  format,
-  printer,
-} from '@aws-amplify/cli-core';
+import { PackageManagerControllerFactory, format } from '@aws-amplify/cli-core';
 import { ProjectRootValidator } from './project_root_validator.js';
 import { AmplifyProjectCreator } from './amplify_project_creator.js';
 import { getProjectRoot } from './get_project_root.js';
 import { GitIgnoreInitializer } from './gitignore_initializer.js';
 import { InitialProjectFileGenerator } from './initial_project_file_generator.js';
+import {
+  attachUnhandledExceptionListeners,
+  generateCommandFailureHandler,
+} from './error_handler.js';
+
+attachUnhandledExceptionListeners();
+const errorHandler = generateCommandFailureHandler();
 
 const projectRoot = await getProjectRoot();
 
@@ -39,6 +41,7 @@ const amplifyProjectCreator = new AmplifyProjectCreator(
 try {
   await amplifyProjectCreator.create();
 } catch (err) {
-  printer.log(format.error(err), LogLevel.ERROR);
-  process.exitCode = 1;
+  if (err instanceof Error) {
+    await errorHandler(format.error(err), err);
+  }
 }

--- a/packages/create-amplify/src/error_handler.test.ts
+++ b/packages/create-amplify/src/error_handler.test.ts
@@ -1,0 +1,204 @@
+import { after, before, beforeEach, describe, it, mock } from 'node:test';
+import {
+  attachUnhandledExceptionListeners,
+  generateCommandFailureHandler,
+} from './error_handler.js';
+import { LogLevel, printer } from '@aws-amplify/cli-core';
+import assert from 'node:assert';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
+
+const mockPrint = mock.method(printer, 'print');
+const mockLog = mock.method(printer, 'log');
+
+void describe('generateCommandFailureHandler', () => {
+  beforeEach(() => {
+    mockPrint.mock.resetCalls();
+    mockLog.mock.resetCalls();
+  });
+
+  void it('prints specified message with undefined error', async () => {
+    const someMsg = 'some msg';
+    // undefined error is encountered with --help option.
+    await generateCommandFailureHandler()(
+      someMsg,
+      undefined as unknown as Error
+    );
+    assert.equal(mockPrint.mock.callCount(), 1);
+    assert.match(mockPrint.mock.calls[0].arguments[0], new RegExp(someMsg));
+  });
+
+  void it('prints message from error object', async () => {
+    const errMsg = 'some error msg';
+    await generateCommandFailureHandler()('', new Error(errMsg));
+    assert.equal(mockPrint.mock.callCount(), 1);
+    assert.match(
+      mockPrint.mock.calls[0].arguments[0] as string,
+      new RegExp(errMsg)
+    );
+  });
+
+  void it('handles a prompt force close error', async () => {
+    await generateCommandFailureHandler()(
+      '',
+      new Error('User force closed the prompt')
+    );
+    assert.equal(mockPrint.mock.callCount(), 0);
+  });
+
+  void it('prints error cause message, if any', async () => {
+    const errorMessage = 'this is the upstream cause';
+    await generateCommandFailureHandler()(
+      '',
+      new Error('some error msg', { cause: new Error(errorMessage) })
+    );
+    assert.equal(mockPrint.mock.callCount(), 2);
+    assert.match(
+      mockPrint.mock.calls[1].arguments[0] as string,
+      new RegExp(errorMessage)
+    );
+  });
+
+  void it('prints AmplifyErrors', async () => {
+    await generateCommandFailureHandler()(
+      '',
+      new AmplifyUserError('TestNameError', {
+        message: 'test error message',
+        resolution: 'test resolution',
+        details: 'test details',
+      })
+    );
+
+    assert.equal(mockPrint.mock.callCount(), 3);
+    assert.match(
+      mockPrint.mock.calls[0].arguments[0],
+      /TestNameError: test error message/
+    );
+    assert.equal(
+      mockPrint.mock.calls[1].arguments[0],
+      'Resolution: test resolution'
+    );
+    assert.equal(mockPrint.mock.calls[2].arguments[0], 'Details: test details');
+  });
+
+  void it('prints debug stack traces', async () => {
+    const causeError = new Error('test underlying cause error');
+    const amplifyError = new AmplifyUserError(
+      'TestNameError',
+      {
+        message: 'test error message',
+        resolution: 'test resolution',
+        details: 'test details',
+      },
+      causeError
+    );
+    await generateCommandFailureHandler()('', amplifyError);
+    assert.equal(mockLog.mock.callCount(), 2);
+    assert.deepStrictEqual(mockLog.mock.calls[0].arguments, [
+      amplifyError.stack,
+      LogLevel.DEBUG,
+    ]);
+    assert.deepStrictEqual(mockLog.mock.calls[1].arguments, [
+      causeError.stack,
+      LogLevel.DEBUG,
+    ]);
+  });
+});
+
+void describe(
+  'attachUnhandledExceptionListeners',
+  { concurrency: 1 },
+  async () => {
+    before(async () => {
+      attachUnhandledExceptionListeners();
+    });
+
+    beforeEach(() => {
+      mockPrint.mock.resetCalls();
+    });
+
+    after(() => {
+      // remove the exception listeners that were added during setup
+      process.listeners('unhandledRejection').pop();
+      process.listeners('uncaughtException').pop();
+    });
+    void it('handles rejected errors', () => {
+      process.listeners('unhandledRejection').at(-1)?.(
+        new Error('test error'),
+        Promise.resolve()
+      );
+      assert.ok(
+        mockPrint.mock.calls.findIndex((call) =>
+          call.arguments[0].includes('test error')
+        ) >= 0
+      );
+      expectProcessExitCode1AndReset();
+    });
+
+    void it('handles rejected strings', () => {
+      process.listeners('unhandledRejection').at(-1)?.(
+        'test error',
+        Promise.resolve()
+      );
+      assert.ok(
+        mockPrint.mock.calls.findIndex((call) =>
+          call.arguments[0].includes('test error')
+        ) >= 0
+      );
+      expectProcessExitCode1AndReset();
+    });
+
+    void it('handles rejected symbols of other types', () => {
+      process.listeners('unhandledRejection').at(-1)?.(
+        { something: 'weird' },
+        Promise.resolve()
+      );
+      assert.ok(
+        mockPrint.mock.calls.findIndex((call) =>
+          call.arguments[0].includes(
+            'Error: Unhandled rejection of type [object]'
+          )
+        ) >= 0
+      );
+      expectProcessExitCode1AndReset();
+    });
+
+    void it('handles uncaught errors', () => {
+      process.listeners('uncaughtException').at(-1)?.(
+        new Error('test error'),
+        'uncaughtException'
+      );
+      assert.ok(
+        mockPrint.mock.calls.findIndex((call) =>
+          call.arguments[0].includes('test error')
+        ) >= 0
+      );
+      expectProcessExitCode1AndReset();
+    });
+
+    void it('does nothing when called multiple times', () => {
+      // note the first call happened in the before() setup
+
+      const unhandledRejectionListenerCount =
+        process.listenerCount('unhandledRejection');
+      const uncaughtExceptionListenerCount =
+        process.listenerCount('uncaughtException');
+
+      attachUnhandledExceptionListeners();
+      attachUnhandledExceptionListeners();
+
+      assert.equal(
+        process.listenerCount('unhandledRejection'),
+        unhandledRejectionListenerCount
+      );
+      assert.equal(
+        process.listenerCount('uncaughtException'),
+        uncaughtExceptionListenerCount
+      );
+    });
+  }
+);
+
+const expectProcessExitCode1AndReset = () => {
+  assert.equal(process.exitCode, 1);
+  process.exitCode = 0;
+};

--- a/packages/create-amplify/src/error_handler.ts
+++ b/packages/create-amplify/src/error_handler.ts
@@ -1,0 +1,148 @@
+import { LogLevel, format, printer } from '@aws-amplify/cli-core';
+import { AmplifyError } from '@aws-amplify/platform-core';
+
+let hasAttachUnhandledExceptionListenersBeenCalled = false;
+
+type HandleErrorProps = {
+  error?: Error;
+  printMessagePreamble?: () => void;
+  message?: string;
+};
+
+/**
+ * Attaches process listeners to handle unhandled exceptions and rejections
+ */
+export const attachUnhandledExceptionListeners = (): void => {
+  if (hasAttachUnhandledExceptionListenersBeenCalled) {
+    return;
+  }
+  process.on('unhandledRejection', (reason) => {
+    process.exitCode = 1;
+    if (reason instanceof Error) {
+      void handleErrorSafe({ error: reason });
+    } else if (typeof reason === 'string') {
+      // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
+      void handleErrorSafe({ error: new Error(reason) });
+    } else {
+      void handleErrorSafe({
+        // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
+        error: new Error(`Unhandled rejection of type [${typeof reason}]`, {
+          cause: reason,
+        }),
+      });
+    }
+  });
+
+  process.on('uncaughtException', (error) => {
+    process.exitCode = 1;
+    void handleErrorSafe({ error });
+  });
+  hasAttachUnhandledExceptionListenersBeenCalled = true;
+};
+
+/**
+ * Generates a function that is intended to be used as a callback to yargs.fail()
+ * All logic for actually handling errors should be delegated to handleError.
+ */
+export const generateCommandFailureHandler = (): ((
+  message: string,
+  error: Error
+) => Promise<void>) => {
+  /**
+   * Format error output when a command fails
+   * @param message error message
+   * @param error error
+   */
+  const handleCommandFailure = async (message: string, error?: Error) => {
+    await handleErrorSafe({
+      error,
+      message,
+    });
+  };
+  return handleCommandFailure;
+};
+
+const handleErrorSafe = async (props: HandleErrorProps) => {
+  try {
+    await handleError(props);
+  } catch (e) {
+    printer.log(format.error(e), LogLevel.DEBUG);
+    // no-op should gracefully exit
+    return;
+  }
+};
+
+/**
+ * Error handling for uncaught errors during CLI command execution.
+ *
+ * This should be the one and only place where we handle unexpected errors.
+ * This includes console logging, debug logging, metrics recording, etc.
+ * (Note that we don't do all of those things yet, but this is where they should go)
+ */
+const handleError = async ({
+  error,
+  printMessagePreamble,
+  message,
+}: HandleErrorProps) => {
+  // If yargs threw an error because the customer force-closed a prompt (ie Ctrl+C during a prompt) then the intent to exit the process is clear
+  if (isUserForceClosePromptError(error)) {
+    return;
+  }
+
+  printMessagePreamble?.();
+
+  if (error instanceof AmplifyError) {
+    printer.print(format.error(`${error.name}: ${error.message}`));
+
+    if (error.resolution) {
+      printer.print(`Resolution: ${error.resolution}`);
+    }
+    if (error.details) {
+      printer.print(`Details: ${error.details}`);
+    }
+    if (errorHasCauseMessage(error)) {
+      printer.print(`Cause: ${error.cause.message}`);
+    }
+  } else {
+    // non-Amplify Error object
+    printer.print(format.error(message || String(error)));
+
+    if (errorHasCauseMessage(error)) {
+      printer.print(`Cause: ${error.cause.message}`);
+    }
+  }
+
+  // additional debug logging for the stack traces
+  if (error?.stack) {
+    printer.log(error.stack, LogLevel.DEBUG);
+  }
+  if (errorHasCauseStackTrace(error)) {
+    printer.log(error.cause.stack, LogLevel.DEBUG);
+  }
+};
+
+const isUserForceClosePromptError = (err?: Error): boolean => {
+  return !!err && err?.message.includes('User force closed the prompt');
+};
+
+const errorHasCauseStackTrace = (
+  error?: Error
+): error is Error & { cause: { stack: string } } => {
+  return (
+    typeof error?.cause === 'object' &&
+    !!error.cause &&
+    'stack' in error.cause &&
+    typeof error.cause.stack === 'string'
+  );
+};
+
+const errorHasCauseMessage = (
+  error?: Error
+): error is Error & { cause: { message: string } } => {
+  return (
+    typeof error?.cause === 'object' &&
+    !!error.cause &&
+    'message' in error.cause &&
+    typeof error.cause.message === 'string'
+  );
+};


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**
#825

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

1. Add top level error handling with reference to similar fix #865 
In #865, parser and usageDataEmitter appears to be used for subcommands (e.g. ampx sandbox), so omit these parameters because `create-amplify` command are not followed by subcommands

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

- `error_handler.ts` and it's test cases are based on a similar issue fix #865 
- Pressing Ctrl  + C during `Where should we create your project?` prompt causes no error.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
