### PR TITLE
feat: add log group to defineFunction

### DIFF
--- a/.changeset/nice-pianos-fetch.md
+++ b/.changeset/nice-pianos-fetch.md
@@ -2,4 +2,4 @@
 '@aws-amplify/backend-function': minor
 ---
 
-Added the ability to specify a function log group through defineFunction
+Added the ability to specify a functions log retention period through defineFunction

--- a/.changeset/nice-pianos-fetch.md
+++ b/.changeset/nice-pianos-fetch.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': minor
+---
+
+Added the ability to specify a function log group through defineFunction

--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -9,6 +9,7 @@ import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceAccessAcceptorFactory } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { StackProvider } from '@aws-amplify/plugin-types';
 
 // @public (undocumented)
@@ -31,6 +32,7 @@ export type FunctionProps = {
     environment?: Record<string, string | BackendSecret>;
     runtime?: NodeVersion;
     schedule?: FunctionSchedule | FunctionSchedule[];
+    logRetention?: RetentionDays;
 };
 
 // @public (undocumented)

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -17,7 +17,7 @@ import { NodeVersion, defineFunction } from './factory.js';
 import { lambdaWithDependencies } from './test-assets/lambda-with-dependencies/resource.js';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -297,32 +297,25 @@ void describe('AmplifyFunctionFactory', () => {
 
   void describe('logGroup property', () => {
     void it('sets valid logGroup', () => {
-      const logGroup = new LogGroup(rootStack, 'LambdaLogGroup', {
-        retention: RetentionDays.ONE_WEEK,
-      });
       const lambda = defineFunction({
         entry: './test-assets/default-lambda/handler.ts',
-        logGroup,
+        logRetention: RetentionDays.ONE_WEEK,
       }).getInstance(getInstanceProps);
       const template = Template.fromStack(lambda.stack);
 
-      template.hasResourceProperties('AWS::Lambda::Function', {
-        LoggingConfig: Match.objectLike({
-          LogGroup: {
-            Ref: Match.stringLikeRegexp('referencetoLambdaLogGroup'),
-          },
-        }),
+      template.hasResourceProperties('Custom::LogRetention', {
+        RetentionInDays: 7,
       });
     });
 
-    void it('doesnt set LogGroup if not provided', () => {
+    void it('doesnt set retention days if not provided', () => {
       const lambda = defineFunction({
         entry: './test-assets/default-lambda/handler.ts',
       }).getInstance(getInstanceProps);
       const template = Template.fromStack(lambda.stack);
 
-      template.hasResourceProperties('AWS::Lambda::Function', {
-        LoggingConfig: Match.absent(),
+      template.hasResourceProperties('Custom::LogRetention', {
+        RetentionInDays: Match.absent(),
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Currently there is no way to set the log retention or log group of a function created using defineFunction. This is a fairly obvious issue as it means people will be paying for logs they may no longer want

**Issue number, if available:**

## Changes

Added the option to specify a log retention period when using defineFunction

**Corresponding docs PR, if applicable:**

## Validation

Added unit test that validate the cloud formation properties are correctly added

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
