### PR TITLE
Stream conversation logs in sandbox

### DIFF
--- a/.changeset/eleven-snails-move.md
+++ b/.changeset/eleven-snails-move.md
@@ -1,6 +1,6 @@
 ---
 '@aws-amplify/ai-constructs': minor
-'@aws-amplify/backend-ai': patch
+'@aws-amplify/backend-ai': minor
 '@aws-amplify/backend-output-schemas': minor
 '@aws-amplify/backend': patch
 '@aws-amplify/sandbox': patch

--- a/.changeset/eleven-snails-move.md
+++ b/.changeset/eleven-snails-move.md
@@ -1,0 +1,8 @@
+---
+'@aws-amplify/ai-constructs': minor
+'@aws-amplify/backend-ai': patch
+'@aws-amplify/backend': patch
+'@aws-amplify/sandbox': patch
+---
+
+Stream conversation logs in sandbox

--- a/.changeset/eleven-snails-move.md
+++ b/.changeset/eleven-snails-move.md
@@ -1,6 +1,7 @@
 ---
 '@aws-amplify/ai-constructs': minor
 '@aws-amplify/backend-ai': patch
+'@aws-amplify/backend-output-schemas': minor
 '@aws-amplify/backend': patch
 '@aws-amplify/sandbox': patch
 ---

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 # Ignore artifacts:
+.amplify
 build
 coverage
 bin
@@ -10,6 +11,7 @@ verdaccio-cache
 expected-cdk-out
 .changeset/pre.json
 concurrent_workspace_script_cache.json
+packages/integration-tests/src/e2e-tests
 scripts/components/api-changes-validator/test-resources/working-directory
 /test-projects
 testDir

--- a/package-lock.json
+++ b/package-lock.json
@@ -31437,6 +31437,9 @@
         "@aws-sdk/client-bedrock-runtime": "^3.622.0",
         "@smithy/types": "^3.3.0"
       },
+      "devDependencies": {
+        "@aws-amplify/backend-output-storage": "^1.1.2"
+      },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0",
         "constructs": "^10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32256,7 +32256,6 @@
         "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/platform-core": "^1.0.6",
         "@aws-amplify/plugin-types": "^1.2.2",
-        "@aws-sdk/client-cloudformation": "^3.624.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.624.0",
         "@aws-sdk/client-lambda": "^3.624.0",
         "@aws-sdk/client-ssm": "^3.624.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31456,10 +31456,8 @@
         "json-schema-to-ts": "^3.1.1"
       },
       "devDependencies": {
+        "@aws-amplify/backend-output-storage": "^1.1.2",
         "typescript": "^5.0.0"
-      },
-      "devDependencies": {
-        "@aws-amplify/backend-output-storage": "^1.1.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31428,9 +31428,11 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
+        "@aws-amplify/platform-core": "^1.1.0",
         "@aws-amplify/plugin-types": "^1.0.1",
         "@aws-sdk/client-bedrock-runtime": "^3.622.0",
         "@smithy/types": "^3.3.0"
@@ -31461,17 +31463,17 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.2.0",
         "@aws-amplify/backend-data": "^1.1.4",
         "@aws-amplify/backend-function": "^1.5.0",
-        "@aws-amplify/backend-output-schemas": "^1.2.0",
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
         "@aws-amplify/backend-output-storage": "^1.1.2",
         "@aws-amplify/backend-secret": "^1.1.2",
-        "@aws-amplify/backend-storage": "^1.2.0",
-        "@aws-amplify/client-config": "^1.3.1",
+        "@aws-amplify/backend-storage": "^1.2.1",
+        "@aws-amplify/client-config": "^1.4.0",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^1.1.0",
         "@aws-amplify/plugin-types": "^1.3.0",
@@ -31490,11 +31492,11 @@
     },
     "packages/backend-ai": {
       "name": "@aws-amplify/backend-ai",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^0.1.4",
-        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/ai-constructs": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
         "@aws-amplify/backend-output-storage": "^1.0.2",
         "@aws-amplify/platform-core": "^1.1.0",
         "@aws-amplify/plugin-types": "^1.0.1"
@@ -31597,7 +31599,7 @@
     },
     "packages/backend-output-schemas": {
       "name": "@aws-amplify/backend-output-schemas",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-amplify/plugin-types": "^1.2.0"
@@ -31644,10 +31646,10 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.2.0",
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
         "@aws-amplify/backend-output-storage": "^1.1.2",
         "@aws-amplify/plugin-types": "^1.3.0"
       },
@@ -31662,14 +31664,14 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.1.3",
-        "@aws-amplify/backend-output-schemas": "^1.1.0",
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
         "@aws-amplify/backend-secret": "^1.1.2",
         "@aws-amplify/cli-core": "^1.1.3",
-        "@aws-amplify/client-config": "^1.3.1",
+        "@aws-amplify/client-config": "^1.4.0",
         "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/form-generator": "^1.0.3",
         "@aws-amplify/model-generator": "^1.0.8",
@@ -31816,10 +31818,10 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.2.0",
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
         "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/model-generator": "^1.0.7",
         "@aws-amplify/platform-core": "^1.0.7",
@@ -32001,16 +32003,16 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
-        "@aws-amplify/ai-constructs": "^0.1.0",
+        "@aws-amplify/ai-constructs": "^0.2.0",
         "@aws-amplify/auth-construct": "^1.3.1",
-        "@aws-amplify/backend": "^1.2.2",
-        "@aws-amplify/backend-ai": "^0.1.0",
+        "@aws-amplify/backend": "^1.3.1",
+        "@aws-amplify/backend-ai": "^0.1.2",
         "@aws-amplify/backend-secret": "^1.1.2",
-        "@aws-amplify/client-config": "^1.3.1",
+        "@aws-amplify/client-config": "^1.4.0",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/platform-core": "^1.1.0",
@@ -32260,7 +32262,6 @@
         "@aws-sdk/client-ssm": "^3.624.0",
         "@aws-sdk/credential-providers": "^3.624.0",
         "@aws-sdk/types": "^3.609.0",
-        "@aws-sdk/util-arn-parser": "^3.568.0",
         "@parcel/watcher": "^2.4.1",
         "debounce-promise": "^3.1.2",
         "glob": "^10.2.7",

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -6,8 +6,10 @@
 
 /// <reference types="node" />
 
+import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import * as bedrock from '@aws-sdk/client-bedrock-runtime';
 import { Construct } from 'constructs';
+import { FunctionOutput } from '@aws-amplify/backend-output-schemas';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 import * as smithy from '@smithy/types';
@@ -49,6 +51,7 @@ type ConversationHandlerFunctionProps = {
         modelId: string;
         region?: string;
     }>;
+    outputStorageStrategy?: BackendOutputStorageStrategy<FunctionOutput>;
 };
 
 // @public (undocumented)

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -6,10 +6,10 @@
 
 /// <reference types="node" />
 
+import { AiConversationOutput } from '@aws-amplify/backend-output-schemas';
 import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import * as bedrock from '@aws-sdk/client-bedrock-runtime';
 import { Construct } from 'constructs';
-import { FunctionOutput } from '@aws-amplify/backend-output-schemas';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 import * as smithy from '@smithy/types';
@@ -51,7 +51,7 @@ type ConversationHandlerFunctionProps = {
         modelId: string;
         region?: string;
     }>;
-    outputStorageStrategy?: BackendOutputStorageStrategy<FunctionOutput>;
+    outputStorageStrategy?: BackendOutputStorageStrategy<AiConversationOutput>;
 };
 
 // @public (undocumented)

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -6,7 +6,7 @@
 
 /// <reference types="node" />
 
-import { AiConversationOutput } from '@aws-amplify/backend-output-schemas';
+import { AIConversationOutput } from '@aws-amplify/backend-output-schemas';
 import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import * as bedrock from '@aws-sdk/client-bedrock-runtime';
 import { Construct } from 'constructs';
@@ -51,7 +51,7 @@ type ConversationHandlerFunctionProps = {
         modelId: string;
         region?: string;
     }>;
-    outputStorageStrategy?: BackendOutputStorageStrategy<AiConversationOutput>;
+    outputStorageStrategy?: BackendOutputStorageStrategy<AIConversationOutput>;
 };
 
 // @public (undocumented)

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -26,6 +26,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-amplify/backend-output-schemas": "^1.2.1",
+    "@aws-amplify/platform-core": "^1.1.0",
     "@aws-amplify/plugin-types": "^1.0.1",
     "@aws-sdk/client-bedrock-runtime": "^3.622.0",
     "@smithy/types": "^3.3.0"

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -32,6 +32,9 @@
     "@aws-sdk/client-bedrock-runtime": "^3.622.0",
     "@smithy/types": "^3.3.0"
   },
+  "devDependencies": {
+    "@aws-amplify/backend-output-storage": "^1.1.2"
+  },
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0",
     "constructs": "^10.0.0"

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -34,10 +34,8 @@
     "json-schema-to-ts": "^3.1.1"
   },
   "devDependencies": {
+    "@aws-amplify/backend-output-storage": "^1.1.2",
     "typescript": "^5.0.0"
-  },
-  "devDependencies": {
-    "@aws-amplify/backend-output-storage": "^1.1.2"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0",

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.test.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.test.ts
@@ -153,7 +153,9 @@ void describe('Conversation Handler Function construct', () => {
       outputStorageStrategy: undefined,
     });
     const template = Template.fromStack(stack);
-    const output = template.findOutputs('definedFunctions').definedFunctions;
+    const output = template.findOutputs(
+      'definedConversationHandlers'
+    ).definedConversationHandlers;
     assert.ok(!output);
   });
 
@@ -171,8 +173,8 @@ void describe('Conversation Handler Function construct', () => {
       ),
     });
     const template = Template.fromStack(stack);
-    const outputValue =
-      template.findOutputs('definedFunctions').definedFunctions.Value;
+    const outputValue = template.findOutputs('definedConversationHandlers')
+      .definedConversationHandlers.Value;
     assert.deepStrictEqual(outputValue, {
       'Fn::Join': [
         '',

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.test.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.test.ts
@@ -4,6 +4,7 @@ import { App, Stack } from 'aws-cdk-lib';
 import { ConversationHandlerFunction } from './conversation_handler_construct';
 import { Template } from 'aws-cdk-lib/assertions';
 import path from 'path';
+import { StackMetadataBackendOutputStorageStrategy } from '@aws-amplify/backend-output-storage';
 
 void describe('Conversation Handler Function construct', () => {
   void it('creates handler with log group with JWT token redacting policy', () => {
@@ -136,6 +137,54 @@ void describe('Conversation Handler Function construct', () => {
           // eslint-disable-next-line spellcheck/spell-checker
           Ref: 'conversationHandlerconversationHandlerFunctionServiceRole49C4C6FB',
         },
+      ],
+    });
+  });
+
+  void it('does not store output if output strategy is absent', () => {
+    const app = new App();
+    const stack = new Stack(app);
+    new ConversationHandlerFunction(stack, 'conversationHandler', {
+      models: [
+        {
+          modelId: 'testModelId',
+        },
+      ],
+      outputStorageStrategy: undefined,
+    });
+    const template = Template.fromStack(stack);
+    const output = template.findOutputs('definedFunctions').definedFunctions;
+    assert.ok(!output);
+  });
+
+  void it('stores output if output strategy is present', () => {
+    const app = new App();
+    const stack = new Stack(app);
+    new ConversationHandlerFunction(stack, 'conversationHandler', {
+      models: [
+        {
+          modelId: 'testModelId',
+        },
+      ],
+      outputStorageStrategy: new StackMetadataBackendOutputStorageStrategy(
+        stack
+      ),
+    });
+    const template = Template.fromStack(stack);
+    const outputValue =
+      template.findOutputs('definedFunctions').definedFunctions.Value;
+    assert.deepStrictEqual(outputValue, {
+      'Fn::Join': [
+        '',
+        [
+          '["',
+          {
+            /* eslint-disable spellcheck/spell-checker */
+            Ref: 'conversationHandlerconversationHandlerFunction45BC2E1F',
+            /* eslint-enable spellcheck/spell-checker */
+          },
+          '"]',
+        ],
       ],
     });
   });

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
@@ -21,7 +21,7 @@ import { Construct } from 'constructs';
 import path from 'path';
 import { TagName } from '@aws-amplify/platform-core';
 import {
-  AiConversationOutput,
+  AIConversationOutput,
   aiConversationOutputKey,
 } from '@aws-amplify/backend-output-schemas';
 
@@ -37,7 +37,7 @@ export type ConversationHandlerFunctionProps = {
   /**
    * @internal
    */
-  outputStorageStrategy?: BackendOutputStorageStrategy<AiConversationOutput>;
+  outputStorageStrategy?: BackendOutputStorageStrategy<AIConversationOutput>;
 };
 
 /**
@@ -141,7 +141,7 @@ export class ConversationHandlerFunction
    */
   private storeOutput = (
     outputStorageStrategy:
-      | BackendOutputStorageStrategy<AiConversationOutput>
+      | BackendOutputStorageStrategy<AIConversationOutput>
       | undefined
   ): void => {
     outputStorageStrategy?.appendToBackendOutputList(aiConversationOutputKey, {

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
@@ -123,7 +123,6 @@ export class ConversationHandlerFunction
         'amplify-output-storage-strategy'
       );
     }
-    this.storeOutput(this.props.outputStorageStrategy, conversationHandler);
 
     this.resources = {
       lambda: conversationHandler,
@@ -133,6 +132,8 @@ export class ConversationHandlerFunction
         ) as CfnFunction,
       },
     };
+
+    this.storeOutput(this.props.outputStorageStrategy);
   }
 
   /**
@@ -141,13 +142,12 @@ export class ConversationHandlerFunction
   private storeOutput = (
     outputStorageStrategy:
       | BackendOutputStorageStrategy<FunctionOutput>
-      | undefined,
-    lambda: NodejsFunction
+      | undefined
   ): void => {
     outputStorageStrategy?.appendToBackendOutputList(functionOutputKey, {
       version: '1',
       payload: {
-        definedFunctions: lambda.functionName,
+        definedFunctions: this.resources.lambda.functionName,
       },
     });
   };

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
@@ -21,8 +21,8 @@ import { Construct } from 'constructs';
 import path from 'path';
 import { TagName } from '@aws-amplify/platform-core';
 import {
-  FunctionOutput,
-  functionOutputKey,
+  AiConversationOutput,
+  aiConversationOutputKey,
 } from '@aws-amplify/backend-output-schemas';
 
 const resourcesRoot = path.normalize(path.join(__dirname, 'runtime'));
@@ -37,7 +37,7 @@ export type ConversationHandlerFunctionProps = {
   /**
    * @internal
    */
-  outputStorageStrategy?: BackendOutputStorageStrategy<FunctionOutput>;
+  outputStorageStrategy?: BackendOutputStorageStrategy<AiConversationOutput>;
 };
 
 /**
@@ -134,13 +134,13 @@ export class ConversationHandlerFunction
    */
   private storeOutput = (
     outputStorageStrategy:
-      | BackendOutputStorageStrategy<FunctionOutput>
+      | BackendOutputStorageStrategy<AiConversationOutput>
       | undefined
   ): void => {
-    outputStorageStrategy?.appendToBackendOutputList(functionOutputKey, {
+    outputStorageStrategy?.appendToBackendOutputList(aiConversationOutputKey, {
       version: '1',
       payload: {
-        definedFunctions: this.resources.lambda.functionName,
+        definedConversationHandlers: this.resources.lambda.functionName,
       },
     });
   };

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
@@ -117,6 +117,13 @@ export class ConversationHandlerFunction
       );
     }
 
+    // TODO this is a hack
+    if (!this.props.outputStorageStrategy) {
+      this.props.outputStorageStrategy = scope.node.tryGetContext(
+        'amplify-output-storage-strategy'
+      );
+    }
+
     this.resources = {
       lambda: conversationHandler,
       cfnResources: {

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
@@ -117,13 +117,6 @@ export class ConversationHandlerFunction
       );
     }
 
-    // TODO this is a hack
-    if (!this.props.outputStorageStrategy) {
-      this.props.outputStorageStrategy = scope.node.tryGetContext(
-        'amplify-output-storage-strategy'
-      );
-    }
-
     this.resources = {
       lambda: conversationHandler,
       cfnResources: {

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_executor.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_executor.test.ts
@@ -47,9 +47,11 @@ void describe('Conversation turn executor', () => {
 
     const consoleErrorMock = mock.fn();
     const consoleLogMock = mock.fn();
+    const consoleDebugMock = mock.fn();
     const consoleMock = {
       error: consoleErrorMock,
       log: consoleLogMock,
+      debug: consoleDebugMock,
     } as unknown as Console;
 
     await new ConversationTurnExecutor(
@@ -100,9 +102,11 @@ void describe('Conversation turn executor', () => {
 
     const consoleErrorMock = mock.fn();
     const consoleLogMock = mock.fn();
+    const consoleDebugMock = mock.fn();
     const consoleMock = {
       error: consoleErrorMock,
       log: consoleLogMock,
+      debug: consoleDebugMock,
     } as unknown as Console;
 
     await assert.rejects(
@@ -164,9 +168,11 @@ void describe('Conversation turn executor', () => {
 
     const consoleErrorMock = mock.fn();
     const consoleLogMock = mock.fn();
+    const consoleDebugMock = mock.fn();
     const consoleMock = {
       error: consoleErrorMock,
       log: consoleLogMock,
+      debug: consoleDebugMock,
     } as unknown as Console;
 
     await assert.rejects(

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_executor.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_executor.ts
@@ -29,6 +29,7 @@ export class ConversationTurnExecutor {
       this.logger.log(
         `Handling conversation turn event, currentMessageId=${this.event.currentMessageId}, conversationId=${this.event.conversationId}`
       );
+      this.logger.debug('Event received:', this.event);
 
       const assistantResponse = await this.bedrockConverseAdapter.askBedrock();
 

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
@@ -23,18 +23,17 @@ export class ConversationTurnResponseSender {
     private readonly graphqlRequestExecutor = new GraphqlRequestExecutor(
       event.graphqlApiEndpoint,
       event.request.headers.authorization
-    )
+    ),
+    private readonly logger = console
   ) {}
 
   sendResponse = async (message: ContentBlock[]) => {
-    const { query, variables } = this.createMutationRequest(message);
+    const responseMutationRequest = this.createMutationRequest(message);
+    this.logger.debug('Sending response mutation:', responseMutationRequest);
     await this.graphqlRequestExecutor.executeGraphql<
       MutationResponseInput,
       void
-    >({
-      query,
-      variables,
-    });
+    >(responseMutationRequest);
   };
 
   private createMutationRequest = (content: ContentBlock[]) => {

--- a/packages/ai-constructs/tsconfig.json
+++ b/packages/ai-constructs/tsconfig.json
@@ -12,6 +12,7 @@
   "references": [
     { "path": "../backend-output-schemas" },
     { "path": "../platform-core" },
-    { "path": "../plugin-types" }
+    { "path": "../plugin-types" },
+    { "path": "../backend-output-storage" }
   ]
 }

--- a/packages/ai-constructs/tsconfig.json
+++ b/packages/ai-constructs/tsconfig.json
@@ -9,5 +9,9 @@
     "outDir": "lib",
     "allowJs": true
   },
-  "references": [{ "path": "../plugin-types" }]
+  "references": [
+    { "path": "../backend-output-schemas" },
+    { "path": "../platform-core" },
+    { "path": "../plugin-types" }
+  ]
 }

--- a/packages/backend-ai/src/conversation/factory.test.ts
+++ b/packages/backend-ai/src/conversation/factory.test.ts
@@ -158,8 +158,8 @@ void describe('ConversationHandlerFactory', () => {
       });
       factory.getInstance(getInstanceProps);
       const template = Template.fromStack(rootStack);
-      const outputValue =
-        template.findOutputs('definedFunctions').definedFunctions.Value;
+      const outputValue = template.findOutputs('definedConversationHandlers')
+        .definedConversationHandlers.Value;
       assert.deepStrictEqual(outputValue, {
         ['Fn::Join']: [
           '',

--- a/packages/backend-ai/src/conversation/factory.ts
+++ b/packages/backend-ai/src/conversation/factory.ts
@@ -1,4 +1,4 @@
-import { FunctionOutput } from '@aws-amplify/backend-output-schemas';
+import { AiConversationOutput } from '@aws-amplify/backend-output-schemas';
 import {
   BackendOutputStorageStrategy,
   ConstructContainerEntryGenerator,
@@ -22,7 +22,7 @@ class ConversationHandlerFunctionGenerator
 
   constructor(
     private readonly props: DefineConversationHandlerFunctionProps,
-    private readonly outputStorageStrategy: BackendOutputStorageStrategy<FunctionOutput>
+    private readonly outputStorageStrategy: BackendOutputStorageStrategy<AiConversationOutput>
   ) {}
 
   generateContainerEntry = ({ scope }: GenerateContainerEntryProps) => {

--- a/packages/backend-ai/src/conversation/factory.ts
+++ b/packages/backend-ai/src/conversation/factory.ts
@@ -1,7 +1,4 @@
-import {
-  FunctionOutput,
-  functionOutputKey,
-} from '@aws-amplify/backend-output-schemas';
+import { FunctionOutput } from '@aws-amplify/backend-output-schemas';
 import {
   BackendOutputStorageStrategy,
   ConstructContainerEntryGenerator,
@@ -43,32 +40,14 @@ class ConversationHandlerFunctionGenerator
           region: model.region,
         };
       }),
+      outputStorageStrategy: this.outputStorageStrategy,
     };
     const conversationHandlerFunction = new ConversationHandlerFunction(
       scope,
       this.props.name,
       constructProps
     );
-    this.storeOutput(this.outputStorageStrategy, conversationHandlerFunction);
     return conversationHandlerFunction;
-  };
-
-  /**
-   * Append conversation handler to defined functions.
-   * Explicitly defined custom handler is customer's function and should be visible
-   * in the outputs.
-   */
-  private storeOutput = (
-    outputStorageStrategy: BackendOutputStorageStrategy<FunctionOutput>,
-    conversationHandlerFunction: ConversationHandlerFunction
-  ): void => {
-    outputStorageStrategy.appendToBackendOutputList(functionOutputKey, {
-      version: '1',
-      payload: {
-        definedFunctions:
-          conversationHandlerFunction.resources.lambda.functionName,
-      },
-    });
   };
 }
 

--- a/packages/backend-ai/src/conversation/factory.ts
+++ b/packages/backend-ai/src/conversation/factory.ts
@@ -1,4 +1,4 @@
-import { AiConversationOutput } from '@aws-amplify/backend-output-schemas';
+import { AIConversationOutput } from '@aws-amplify/backend-output-schemas';
 import {
   BackendOutputStorageStrategy,
   ConstructContainerEntryGenerator,
@@ -22,7 +22,7 @@ class ConversationHandlerFunctionGenerator
 
   constructor(
     private readonly props: DefineConversationHandlerFunctionProps,
-    private readonly outputStorageStrategy: BackendOutputStorageStrategy<AiConversationOutput>
+    private readonly outputStorageStrategy: BackendOutputStorageStrategy<AIConversationOutput>
   ) {}
 
   generateContainerEntry = ({ scope }: GenerateContainerEntryProps) => {

--- a/packages/backend-output-schemas/API.md
+++ b/packages/backend-output-schemas/API.md
@@ -7,7 +7,7 @@
 import { z } from 'zod';
 
 // @public (undocumented)
-export type AiConversationOutput = z.infer<typeof versionedAiConversationOutputSchema>;
+export type AIConversationOutput = z.infer<typeof versionedAIConversationOutputSchema>;
 
 // @public
 export const aiConversationOutputKey = "AWS::Amplify::AI::Conversation";
@@ -511,7 +511,7 @@ export const unifiedBackendOutputSchema: z.ZodObject<{
 }>;
 
 // @public (undocumented)
-export const versionedAiConversationOutputSchema: z.ZodDiscriminatedUnion<"version", [z.ZodObject<{
+export const versionedAIConversationOutputSchema: z.ZodDiscriminatedUnion<"version", [z.ZodObject<{
     version: z.ZodLiteral<"1">;
     payload: z.ZodObject<{
         definedConversationHandlers: z.ZodString;

--- a/packages/backend-output-schemas/API.md
+++ b/packages/backend-output-schemas/API.md
@@ -7,6 +7,12 @@
 import { z } from 'zod';
 
 // @public (undocumented)
+export type AiConversationOutput = z.infer<typeof versionedAiConversationOutputSchema>;
+
+// @public
+export const aiConversationOutputKey = "AWS::Amplify::AI::Conversation";
+
+// @public (undocumented)
 export type AuthOutput = z.infer<typeof versionedAuthOutputSchema>;
 
 // @public
@@ -340,6 +346,26 @@ export const unifiedBackendOutputSchema: z.ZodObject<{
             definedFunctions: string;
         };
     }>]>>;
+    "AWS::Amplify::AI::Conversation": z.ZodOptional<z.ZodDiscriminatedUnion<"version", [z.ZodObject<{
+        version: z.ZodLiteral<"1">;
+        payload: z.ZodObject<{
+            definedConversationHandlers: z.ZodString;
+        }, "strip", z.ZodTypeAny, {
+            definedConversationHandlers: string;
+        }, {
+            definedConversationHandlers: string;
+        }>;
+    }, "strip", z.ZodTypeAny, {
+        version: "1";
+        payload: {
+            definedConversationHandlers: string;
+        };
+    }, {
+        version: "1";
+        payload: {
+            definedConversationHandlers: string;
+        };
+    }>]>>;
 }, "strip", z.ZodTypeAny, {
     "AWS::Amplify::Platform"?: {
         version: "1";
@@ -403,6 +429,12 @@ export const unifiedBackendOutputSchema: z.ZodObject<{
         version: "1";
         payload: {
             definedFunctions: string;
+        };
+    } | undefined;
+    "AWS::Amplify::AI::Conversation"?: {
+        version: "1";
+        payload: {
+            definedConversationHandlers: string;
         };
     } | undefined;
 }, {
@@ -470,7 +502,35 @@ export const unifiedBackendOutputSchema: z.ZodObject<{
             definedFunctions: string;
         };
     } | undefined;
+    "AWS::Amplify::AI::Conversation"?: {
+        version: "1";
+        payload: {
+            definedConversationHandlers: string;
+        };
+    } | undefined;
 }>;
+
+// @public (undocumented)
+export const versionedAiConversationOutputSchema: z.ZodDiscriminatedUnion<"version", [z.ZodObject<{
+    version: z.ZodLiteral<"1">;
+    payload: z.ZodObject<{
+        definedConversationHandlers: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        definedConversationHandlers: string;
+    }, {
+        definedConversationHandlers: string;
+    }>;
+}, "strip", z.ZodTypeAny, {
+    version: "1";
+    payload: {
+        definedConversationHandlers: string;
+    };
+}, {
+    version: "1";
+    payload: {
+        definedConversationHandlers: string;
+    };
+}>]>;
 
 // @public (undocumented)
 export const versionedAuthOutputSchema: z.ZodDiscriminatedUnion<"version", [z.ZodObject<{

--- a/packages/backend-output-schemas/src/ai/conversation/index.ts
+++ b/packages/backend-output-schemas/src/ai/conversation/index.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { aiConversationOutputSchema as aiConversationOutputSchemaV1 } from './v1';
 
-export const versionedAiConversationOutputSchema = z.discriminatedUnion(
+export const versionedAIConversationOutputSchema = z.discriminatedUnion(
   'version',
   [
     aiConversationOutputSchemaV1,
@@ -9,6 +9,6 @@ export const versionedAiConversationOutputSchema = z.discriminatedUnion(
   ]
 );
 
-export type AiConversationOutput = z.infer<
-  typeof versionedAiConversationOutputSchema
+export type AIConversationOutput = z.infer<
+  typeof versionedAIConversationOutputSchema
 >;

--- a/packages/backend-output-schemas/src/ai/conversation/index.ts
+++ b/packages/backend-output-schemas/src/ai/conversation/index.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { aiConversationOutputSchema as aiConversationOutputSchemaV1 } from './v1';
+
+export const versionedAiConversationOutputSchema = z.discriminatedUnion(
+  'version',
+  [
+    aiConversationOutputSchemaV1,
+    // this is where additional function major version schemas would go
+  ]
+);
+
+export type AiConversationOutput = z.infer<
+  typeof versionedAiConversationOutputSchema
+>;

--- a/packages/backend-output-schemas/src/ai/conversation/v1.ts
+++ b/packages/backend-output-schemas/src/ai/conversation/v1.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const aiConversationOutputSchema = z.object({
+  version: z.literal('1'),
+  payload: z.object({
+    definedConversationHandlers: z.string(), // JSON array as string
+  }),
+});

--- a/packages/backend-output-schemas/src/index.ts
+++ b/packages/backend-output-schemas/src/index.ts
@@ -5,7 +5,7 @@ import { versionedStorageOutputSchema } from './storage/index.js';
 import { versionedStackOutputSchema } from './stack/index.js';
 import { versionedCustomOutputSchema } from './custom';
 import { versionedFunctionOutputSchema } from './function/index.js';
-import { versionedAiConversationOutputSchema } from './ai/conversation/index.js';
+import { versionedAIConversationOutputSchema } from './ai/conversation/index.js';
 
 /**
  * The auth, graphql and storage exports here are duplicated from the submodule exports in the package.json file
@@ -114,7 +114,7 @@ export const unifiedBackendOutputSchema = z.object({
   [storageOutputKey]: versionedStorageOutputSchema.optional(),
   [customOutputKey]: versionedCustomOutputSchema.optional(),
   [functionOutputKey]: versionedFunctionOutputSchema.optional(),
-  [aiConversationOutputKey]: versionedAiConversationOutputSchema.optional(),
+  [aiConversationOutputKey]: versionedAIConversationOutputSchema.optional(),
 });
 /**
  * This type is a subset of the BackendOutput type that is exposed by the platform.

--- a/packages/backend-output-schemas/src/index.ts
+++ b/packages/backend-output-schemas/src/index.ts
@@ -5,6 +5,7 @@ import { versionedStorageOutputSchema } from './storage/index.js';
 import { versionedStackOutputSchema } from './stack/index.js';
 import { versionedCustomOutputSchema } from './custom';
 import { versionedFunctionOutputSchema } from './function/index.js';
+import { versionedAiConversationOutputSchema } from './ai/conversation/index.js';
 
 /**
  * The auth, graphql and storage exports here are duplicated from the submodule exports in the package.json file
@@ -85,6 +86,20 @@ export * from './function/index.js';
 export const functionOutputKey = 'AWS::Amplify::Function';
 
 /**
+ * ---------- AI conversation exports ----------
+ */
+
+/**
+ * re-export the AI conversation output schema
+ */
+export * from './ai/conversation/index.js';
+
+/**
+ * Expected key that AI conversation output is stored under
+ */
+export const aiConversationOutputKey = 'AWS::Amplify::AI::Conversation';
+
+/**
  * ---------- Unified exports ----------
  */
 
@@ -99,6 +114,7 @@ export const unifiedBackendOutputSchema = z.object({
   [storageOutputKey]: versionedStorageOutputSchema.optional(),
   [customOutputKey]: versionedCustomOutputSchema.optional(),
   [functionOutputKey]: versionedFunctionOutputSchema.optional(),
+  [aiConversationOutputKey]: versionedAiConversationOutputSchema.optional(),
 });
 /**
  * This type is a subset of the BackendOutput type that is exposed by the platform.

--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -76,6 +76,12 @@ export class BackendFactory<
       stack
     );
 
+    // TODO this is a hack
+    stack.node.setContext(
+      'amplify-output-storage-strategy',
+      outputStorageStrategy
+    );
+
     this.customOutputsAccumulator = new CustomOutputsAccumulator(
       outputStorageStrategy,
       new ObjectAccumulator<ClientConfig>({})

--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -76,12 +76,6 @@ export class BackendFactory<
       stack
     );
 
-    // TODO this is a hack
-    stack.node.setContext(
-      'amplify-output-storage-strategy',
-      outputStorageStrategy
-    );
-
     this.customOutputsAccumulator = new CustomOutputsAccumulator(
       outputStorageStrategy,
       new ObjectAccumulator<ClientConfig>({})

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -26,7 +26,6 @@
     "@aws-amplify/deployed-backend-client": "^1.4.1",
     "@aws-amplify/platform-core": "^1.0.6",
     "@aws-amplify/plugin-types": "^1.2.2",
-    "@aws-sdk/client-cloudformation": "^3.624.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.624.0",
     "@aws-sdk/client-lambda": "^3.624.0",
     "@aws-sdk/client-ssm": "^3.624.0",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -32,7 +32,6 @@
     "@aws-sdk/client-ssm": "^3.624.0",
     "@aws-sdk/credential-providers": "^3.624.0",
     "@aws-sdk/types": "^3.609.0",
-    "@aws-sdk/util-arn-parser": "^3.568.0",
     "@parcel/watcher": "^2.4.1",
     "debounce-promise": "^3.1.2",
     "glob": "^10.2.7",

--- a/packages/sandbox/src/lambda_function_log_streamer.test.ts
+++ b/packages/sandbox/src/lambda_function_log_streamer.test.ts
@@ -20,6 +20,10 @@ void describe('LambdaFunctionLogStreamer', () => {
     'func1FullName',
     'func2FullName',
   ]);
+  const definedConversationHandlers = JSON.stringify([
+    'conversationHandler1FullName',
+    'conversationHandler2FullName',
+  ]);
 
   // CW default implementation
   const cloudWatchClientMock = new CloudWatchLogsClient({ region });
@@ -63,6 +67,12 @@ void describe('LambdaFunctionLogStreamer', () => {
         ['AWS::Amplify::Function']: {
           payload: {
             definedFunctions: customerDefinedFunctions,
+          },
+          version: '1',
+        },
+        ['AWS::Amplify::AI::Conversation']: {
+          payload: {
+            definedConversationHandlers: definedConversationHandlers,
           },
           version: '1',
         },
@@ -137,13 +147,13 @@ void describe('LambdaFunctionLogStreamer', () => {
     assert.strictEqual(lambdaClientSendMock.mock.callCount(), 0);
   });
 
-  void it('calls logs monitor with all the customer defined functions if no function name filter is provided', async () => {
+  void it('calls logs monitor with all the customer defined functions and conversation handlers if no function name filter is provided', async () => {
     await classUnderTest.startStreamingLogs(testSandboxBackendId, {
       enabled: true,
     });
 
     // assert that lambda calls to retrieve tags were with the right function arn
-    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 2);
+    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 4);
     assert.strictEqual(
       lambdaClientSendMock.mock.calls[0].arguments[0].input.FunctionName,
       'func1FullName'
@@ -152,11 +162,19 @@ void describe('LambdaFunctionLogStreamer', () => {
       lambdaClientSendMock.mock.calls[1].arguments[0].input.FunctionName,
       'func2FullName'
     );
+    assert.strictEqual(
+      lambdaClientSendMock.mock.calls[2].arguments[0].input.FunctionName,
+      'conversationHandler1FullName'
+    );
+    assert.strictEqual(
+      lambdaClientSendMock.mock.calls[3].arguments[0].input.FunctionName,
+      'conversationHandler2FullName'
+    );
 
     // assert that logs groups were added to the monitor and was then called activate
     assert.strictEqual(
       cloudWatchLogMonitorMock.addLogGroups.mock.callCount(),
-      2
+      4
     );
     assert.strictEqual(
       cloudWatchLogMonitorMock.addLogGroups.mock.calls[0].arguments[0],
@@ -174,6 +192,22 @@ void describe('LambdaFunctionLogStreamer', () => {
       cloudWatchLogMonitorMock.addLogGroups.mock.calls[1].arguments[1],
       '/aws/lambda/func2FullName'
     );
+    assert.strictEqual(
+      cloudWatchLogMonitorMock.addLogGroups.mock.calls[2].arguments[0],
+      'conversationHandler1FriendlyName'
+    );
+    assert.strictEqual(
+      cloudWatchLogMonitorMock.addLogGroups.mock.calls[2].arguments[1],
+      '/aws/lambda/conversationHandler1FullName'
+    );
+    assert.strictEqual(
+      cloudWatchLogMonitorMock.addLogGroups.mock.calls[3].arguments[0],
+      'conversationHandler2FriendlyName'
+    );
+    assert.strictEqual(
+      cloudWatchLogMonitorMock.addLogGroups.mock.calls[3].arguments[1],
+      '/aws/lambda/conversationHandler2FullName'
+    );
     assert.strictEqual(cloudWatchLogMonitorMock.activate.mock.callCount(), 1);
   });
 
@@ -187,7 +221,7 @@ void describe('LambdaFunctionLogStreamer', () => {
 
     // assert that lambda calls to retrieve tags were with the right function arn
     // We do it for all customer defined functions, filtering happens after
-    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 2);
+    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 4);
     assert.strictEqual(
       lambdaClientSendMock.mock.calls[0].arguments[0].input.FunctionName,
       'func1FullName'
@@ -195,6 +229,14 @@ void describe('LambdaFunctionLogStreamer', () => {
     assert.strictEqual(
       lambdaClientSendMock.mock.calls[1].arguments[0].input.FunctionName,
       'func2FullName'
+    );
+    assert.strictEqual(
+      lambdaClientSendMock.mock.calls[2].arguments[0].input.FunctionName,
+      'conversationHandler1FullName'
+    );
+    assert.strictEqual(
+      lambdaClientSendMock.mock.calls[3].arguments[0].input.FunctionName,
+      'conversationHandler2FullName'
     );
 
     // assert that logs groups were added to the monitor for only filtered functions and was then called activate
@@ -221,7 +263,7 @@ void describe('LambdaFunctionLogStreamer', () => {
 
     // assert that lambda calls to retrieve tags were with the right function arn
     // We do it for all customer defined functions, filtering happens after
-    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 2);
+    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 4);
     assert.strictEqual(
       lambdaClientSendMock.mock.calls[0].arguments[0].input.FunctionName,
       'func1FullName'
@@ -229,6 +271,14 @@ void describe('LambdaFunctionLogStreamer', () => {
     assert.strictEqual(
       lambdaClientSendMock.mock.calls[1].arguments[0].input.FunctionName,
       'func2FullName'
+    );
+    assert.strictEqual(
+      lambdaClientSendMock.mock.calls[2].arguments[0].input.FunctionName,
+      'conversationHandler1FullName'
+    );
+    assert.strictEqual(
+      lambdaClientSendMock.mock.calls[3].arguments[0].input.FunctionName,
+      'conversationHandler2FullName'
     );
 
     // assert that logs groups were added to the monitor for only filtered functions and was then called activate
@@ -263,7 +313,7 @@ void describe('LambdaFunctionLogStreamer', () => {
 
     // assert that lambda calls to retrieve tags were with the right function arn
     // We do it for all customer defined functions, filtering happens after
-    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 2);
+    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 4);
     assert.strictEqual(
       lambdaClientSendMock.mock.calls[0].arguments[0].input.FunctionName,
       'func1FullName'
@@ -271,6 +321,14 @@ void describe('LambdaFunctionLogStreamer', () => {
     assert.strictEqual(
       lambdaClientSendMock.mock.calls[1].arguments[0].input.FunctionName,
       'func2FullName'
+    );
+    assert.strictEqual(
+      lambdaClientSendMock.mock.calls[2].arguments[0].input.FunctionName,
+      'conversationHandler1FullName'
+    );
+    assert.strictEqual(
+      lambdaClientSendMock.mock.calls[3].arguments[0].input.FunctionName,
+      'conversationHandler2FullName'
     );
 
     // assert that no logs groups were added to the monitor

--- a/packages/sandbox/src/lambda_function_log_streamer.test.ts
+++ b/packages/sandbox/src/lambda_function_log_streamer.test.ts
@@ -3,21 +3,16 @@ import { LambdaFunctionLogStreamer } from './lambda_function_log_streamer.js';
 import assert from 'node:assert';
 import { BackendOutputClient } from '@aws-amplify/deployed-backend-client';
 
-import {
-  CloudFormationClient,
-  DescribeStacksOutput,
-} from '@aws-sdk/client-cloudformation';
 import { CloudWatchLogsClient } from '@aws-sdk/client-cloudwatch-logs';
 import {
+  GetFunctionCommand,
+  GetFunctionCommandOutput,
   LambdaClient,
-  ListTagsCommand,
-  ListTagsCommandOutput,
 } from '@aws-sdk/client-lambda';
 import { CloudWatchLogEventMonitor } from './cloudwatch_logs_monitor.js';
 import { Printer } from '@aws-amplify/cli-core';
 import { BackendIdentifier, BackendOutput } from '@aws-amplify/plugin-types';
 import { TagName } from '@aws-amplify/platform-core';
-import { parse as parseArn } from '@aws-sdk/util-arn-parser';
 
 void describe('LambdaFunctionLogStreamer', () => {
   const region = 'test-region';
@@ -25,20 +20,6 @@ void describe('LambdaFunctionLogStreamer', () => {
     'func1FullName',
     'func2FullName',
   ]);
-
-  // CFN default implementation
-  const cfnClientMock = new CloudFormationClient({ region });
-  const cfnClientSendMock = mock.fn(() => {
-    return Promise.resolve({
-      Stacks: [
-        {
-          StackId:
-            'arn:aws:cloudformation:us-west-2:123456789012:stack/stack-name/uuid',
-        },
-      ],
-    } as DescribeStacksOutput);
-  });
-  mock.method(cfnClientMock, 'send', cfnClientSendMock);
 
   // CW default implementation
   const cloudWatchClientMock = new CloudWatchLogsClient({ region });
@@ -48,15 +29,26 @@ void describe('LambdaFunctionLogStreamer', () => {
   // Lambda default implementation.
   // Given a resource Arn with lambda function name with `FullName` suffix, this will return the function name with `friendlyName` as suffix
   const lambdaClientMock = new LambdaClient({ region });
-  const lambdaClientSendMock = mock.fn((listTagsCommand: ListTagsCommand) => {
-    return Promise.resolve({
-      Tags: {
-        [TagName.FRIENDLY_NAME]: parseArn(listTagsCommand.input.Resource ?? '')
-          .resource?.split(':')[1]
-          .replace('FullName', 'FriendlyName'),
-      } as unknown as ListTagsCommandOutput,
-    });
-  });
+  const lambdaClientSendMock = mock.fn(
+    (getFunctionCommand: GetFunctionCommand) => {
+      return Promise.resolve({
+        Configuration: {
+          LoggingConfig: {
+            LogGroup: `/aws/lambda/${
+              getFunctionCommand.input.FunctionName ?? ''
+            }`,
+          },
+        },
+        Tags: {
+          [TagName.FRIENDLY_NAME]:
+            getFunctionCommand.input.FunctionName?.replace(
+              'FullName',
+              'FriendlyName'
+            ),
+        } as unknown as GetFunctionCommandOutput,
+      });
+    }
+  );
   mock.method(lambdaClientMock, 'send', lambdaClientSendMock);
 
   // backendOutputClient default implementation
@@ -91,14 +83,12 @@ void describe('LambdaFunctionLogStreamer', () => {
 
   const classUnderTest = new LambdaFunctionLogStreamer(
     lambdaClientMock,
-    cfnClientMock,
     cloudWatchLogMonitorMock as unknown as CloudWatchLogEventMonitor,
     backendOutputClientMock as unknown as BackendOutputClient,
     printer as unknown as Printer
   );
 
   beforeEach(() => {
-    cfnClientSendMock.mock.resetCalls();
     cloudWatchClientSendMock.mock.resetCalls();
     lambdaClientSendMock.mock.resetCalls();
     backendOutputClientMock.getOutput.mock.resetCalls();
@@ -155,12 +145,12 @@ void describe('LambdaFunctionLogStreamer', () => {
     // assert that lambda calls to retrieve tags were with the right function arn
     assert.strictEqual(lambdaClientSendMock.mock.callCount(), 2);
     assert.strictEqual(
-      lambdaClientSendMock.mock.calls[0].arguments[0].input.Resource,
-      'arn:aws:lambda:us-west-2:123456789012:function:func1FullName'
+      lambdaClientSendMock.mock.calls[0].arguments[0].input.FunctionName,
+      'func1FullName'
     );
     assert.strictEqual(
-      lambdaClientSendMock.mock.calls[1].arguments[0].input.Resource,
-      'arn:aws:lambda:us-west-2:123456789012:function:func2FullName'
+      lambdaClientSendMock.mock.calls[1].arguments[0].input.FunctionName,
+      'func2FullName'
     );
 
     // assert that logs groups were added to the monitor and was then called activate
@@ -199,12 +189,12 @@ void describe('LambdaFunctionLogStreamer', () => {
     // We do it for all customer defined functions, filtering happens after
     assert.strictEqual(lambdaClientSendMock.mock.callCount(), 2);
     assert.strictEqual(
-      lambdaClientSendMock.mock.calls[0].arguments[0].input.Resource,
-      'arn:aws:lambda:us-west-2:123456789012:function:func1FullName'
+      lambdaClientSendMock.mock.calls[0].arguments[0].input.FunctionName,
+      'func1FullName'
     );
     assert.strictEqual(
-      lambdaClientSendMock.mock.calls[1].arguments[0].input.Resource,
-      'arn:aws:lambda:us-west-2:123456789012:function:func2FullName'
+      lambdaClientSendMock.mock.calls[1].arguments[0].input.FunctionName,
+      'func2FullName'
     );
 
     // assert that logs groups were added to the monitor for only filtered functions and was then called activate
@@ -233,12 +223,12 @@ void describe('LambdaFunctionLogStreamer', () => {
     // We do it for all customer defined functions, filtering happens after
     assert.strictEqual(lambdaClientSendMock.mock.callCount(), 2);
     assert.strictEqual(
-      lambdaClientSendMock.mock.calls[0].arguments[0].input.Resource,
-      'arn:aws:lambda:us-west-2:123456789012:function:func1FullName'
+      lambdaClientSendMock.mock.calls[0].arguments[0].input.FunctionName,
+      'func1FullName'
     );
     assert.strictEqual(
-      lambdaClientSendMock.mock.calls[1].arguments[0].input.Resource,
-      'arn:aws:lambda:us-west-2:123456789012:function:func2FullName'
+      lambdaClientSendMock.mock.calls[1].arguments[0].input.FunctionName,
+      'func2FullName'
     );
 
     // assert that logs groups were added to the monitor for only filtered functions and was then called activate
@@ -275,12 +265,12 @@ void describe('LambdaFunctionLogStreamer', () => {
     // We do it for all customer defined functions, filtering happens after
     assert.strictEqual(lambdaClientSendMock.mock.callCount(), 2);
     assert.strictEqual(
-      lambdaClientSendMock.mock.calls[0].arguments[0].input.Resource,
-      'arn:aws:lambda:us-west-2:123456789012:function:func1FullName'
+      lambdaClientSendMock.mock.calls[0].arguments[0].input.FunctionName,
+      'func1FullName'
     );
     assert.strictEqual(
-      lambdaClientSendMock.mock.calls[1].arguments[0].input.Resource,
-      'arn:aws:lambda:us-west-2:123456789012:function:func2FullName'
+      lambdaClientSendMock.mock.calls[1].arguments[0].input.FunctionName,
+      'func2FullName'
     );
 
     // assert that no logs groups were added to the monitor

--- a/packages/sandbox/src/lambda_function_log_streamer.ts
+++ b/packages/sandbox/src/lambda_function_log_streamer.ts
@@ -42,9 +42,17 @@ export class LambdaFunctionLogStreamer {
 
     const definedFunctionsPayload =
       backendOutput['AWS::Amplify::Function']?.payload.definedFunctions;
+    const definedConversationHandlersPayload =
+      backendOutput['AWS::Amplify::AI::Conversation']?.payload
+        .definedConversationHandlers;
     const deployedFunctionNames = definedFunctionsPayload
       ? (JSON.parse(definedFunctionsPayload) as string[])
       : [];
+    deployedFunctionNames.push(
+      ...(definedConversationHandlersPayload
+        ? (JSON.parse(definedConversationHandlersPayload) as string[])
+        : [])
+    );
 
     for (const functionName of deployedFunctionNames) {
       const getFunctionResponse = await this.lambda.send(

--- a/packages/sandbox/src/lambda_function_log_streamer.ts
+++ b/packages/sandbox/src/lambda_function_log_streamer.ts
@@ -56,7 +56,7 @@ export class LambdaFunctionLogStreamer {
         getFunctionResponse.Configuration?.LoggingConfig?.LogGroup;
       if (!logGroupName) {
         this.printer.log(
-          `[Sandbox] Could not log group for lambda function ${functionName}. Logs will not be streamed for this function.`,
+          `[Sandbox] Could not find logGroup for lambda function ${functionName}. Logs will not be streamed for this function.`,
           LogLevel.DEBUG
         );
         continue;

--- a/packages/sandbox/src/lambda_function_log_streamer.ts
+++ b/packages/sandbox/src/lambda_function_log_streamer.ts
@@ -1,17 +1,10 @@
 import { LogLevel, Printer } from '@aws-amplify/cli-core';
 import { BackendOutputClient } from '@aws-amplify/deployed-backend-client';
-import {
-  BackendIdentifierConversions,
-  TagName,
-} from '@aws-amplify/platform-core';
+import { TagName } from '@aws-amplify/platform-core';
 import { BackendIdentifier, BackendOutput } from '@aws-amplify/plugin-types';
-import {
-  CloudFormationClient,
-  DescribeStacksCommand,
-} from '@aws-sdk/client-cloudformation';
-import { LambdaClient, ListTagsCommand } from '@aws-sdk/client-lambda';
+
+import { GetFunctionCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import { CloudWatchLogEventMonitor } from './cloudwatch_logs_monitor.js';
-import { build as buildArn, parse as parseArn } from '@aws-sdk/util-arn-parser';
 import { SandboxFunctionStreamingOptions } from './sandbox.js';
 
 /**
@@ -24,7 +17,6 @@ export class LambdaFunctionLogStreamer {
    */
   constructor(
     private readonly lambda: LambdaClient,
-    private readonly cfnClient: CloudFormationClient,
     private readonly logsMonitor: CloudWatchLogEventMonitor,
     private readonly backendOutputClient: BackendOutputClient,
     private readonly printer: Printer
@@ -54,33 +46,26 @@ export class LambdaFunctionLogStreamer {
       ? (JSON.parse(definedFunctionsPayload) as string[])
       : [];
 
-    // To use list-tags API we need to convert function name to function Arn since it only accepts ARN as input
-    const deployedFunctionNameToArnMap = await this.getFunctionArnFromNames(
-      sandboxBackendId,
-      deployedFunctionNames
-    );
-
-    if (!deployedFunctionNameToArnMap) {
-      this.printer.log(
-        `[Sandbox] Could not find any function in stack ${BackendIdentifierConversions.toStackName(
-          sandboxBackendId
-        )}. Streaming function logs will be turned off.`,
-        LogLevel.DEBUG
-      );
-      return;
-    }
-
-    for (const entry of deployedFunctionNameToArnMap) {
-      const listTagsResponse = await this.lambda.send(
-        new ListTagsCommand({
-          Resource: entry.arn,
+    for (const functionName of deployedFunctionNames) {
+      const getFunctionResponse = await this.lambda.send(
+        new GetFunctionCommand({
+          FunctionName: functionName,
         })
       );
+      const logGroupName =
+        getFunctionResponse.Configuration?.LoggingConfig?.LogGroup;
+      if (!logGroupName) {
+        this.printer.log(
+          `[Sandbox] Could not log group for lambda function ${functionName}. Logs will not be streamed for this function.`,
+          LogLevel.DEBUG
+        );
+        continue;
+      }
       const friendlyFunctionName =
-        listTagsResponse.Tags?.[TagName.FRIENDLY_NAME];
+        getFunctionResponse.Tags?.[TagName.FRIENDLY_NAME];
       if (!friendlyFunctionName) {
         this.printer.log(
-          `[Sandbox] Could not find user defined name for lambda function ${entry.name}. Logs will not be streamed for this function.`,
+          `[Sandbox] Could not find user defined name for lambda function ${functionName}. Logs will not be streamed for this function.`,
           LogLevel.DEBUG
         );
         continue;
@@ -109,11 +94,7 @@ export class LambdaFunctionLogStreamer {
       }
 
       if (shouldStreamLogs) {
-        this.logsMonitor?.addLogGroups(
-          friendlyFunctionName,
-          // a CW log group is implicitly created for each lambda function with the lambda function's name
-          `/aws/lambda/${entry.name}`
-        );
+        this.logsMonitor?.addLogGroups(friendlyFunctionName, logGroupName);
       } else {
         this.printer.log(
           `[Sandbox] Skipping logs streaming for function ${friendlyFunctionName} since it did not match any filters. To stream logs for this function, ensure at least one of your logs-filters match this function name.`,
@@ -135,51 +116,5 @@ export class LambdaFunctionLogStreamer {
       LogLevel.DEBUG
     );
     this.logsMonitor?.pause();
-  };
-
-  /**
-   * Adds functionArn for each function name provided. All the ARN components are taken from the root stack Arn
-   * @param sandboxBackendId backendId for retrieving the root stack
-   * @param functionNames Name of the functions for which ARN needs to be generated
-   * @returns An object containing function name and ARN for each function name provided
-   */
-  private getFunctionArnFromNames = async (
-    sandboxBackendId: BackendIdentifier,
-    functionNames?: string[]
-  ) => {
-    if (!functionNames || functionNames.length === 0) {
-      return;
-    }
-
-    const rootStackResources = await this.cfnClient.send(
-      new DescribeStacksCommand({
-        StackName: BackendIdentifierConversions.toStackName(sandboxBackendId),
-      })
-    );
-
-    if (!rootStackResources?.Stacks?.[0]?.StackId) {
-      this.printer.log(
-        `[Sandbox] Cannot load root stack for Id ${BackendIdentifierConversions.toStackName(
-          sandboxBackendId
-        )}. Streaming function logs will be turned off.`,
-        LogLevel.DEBUG
-      );
-      return;
-    }
-
-    const arnParts = parseArn(rootStackResources.Stacks[0].StackId);
-
-    return functionNames.map((name) => {
-      return {
-        name,
-        arn: buildArn({
-          resource: `function:${name}`,
-          service: 'lambda',
-          accountId: arnParts.accountId,
-          partition: arnParts.partition,
-          region: arnParts.region,
-        }),
-      };
-    });
   };
 }

--- a/packages/sandbox/src/sandbox_singleton_factory.ts
+++ b/packages/sandbox/src/sandbox_singleton_factory.ts
@@ -14,7 +14,6 @@ import { LambdaClient } from '@aws-sdk/client-lambda';
 import { BackendOutputClientFactory } from '@aws-amplify/deployed-backend-client';
 import { LambdaFunctionLogStreamer } from './lambda_function_log_streamer.js';
 import { CloudWatchLogEventMonitor } from './cloudwatch_logs_monitor.js';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 
 /**
  * Factory to create a new sandbox
@@ -41,7 +40,6 @@ export class SandboxSingletonFactory {
         packageManagerControllerFactory.getPackageManagerController(),
         this.format
       );
-      const cfnClient = new CloudFormationClient();
       this.instance = new FileWatchingSandbox(
         this.sandboxIdResolver,
         new AmplifySandboxExecutor(
@@ -52,7 +50,6 @@ export class SandboxSingletonFactory {
         new SSMClient(),
         new LambdaFunctionLogStreamer(
           new LambdaClient(),
-          cfnClient,
           new CloudWatchLogEventMonitor(new CloudWatchLogsClient()),
           BackendOutputClientFactory.getInstance(),
           this.printer


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Conversation handler logs should show up when executing `npx ampx sandbox --stream-function-logs`.

## Changes

This PR makes the following changes to stream and improve logs in conversation handler.

1. Adds logs with log level in conversation handler runtime componenets.
    1. Conversation handler lambda is configured to emit structured logs. So that it supports log levels, see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html for reference. I.e. we set log format to `json` as opposed to `text` (which doesn't support application log levels).
    2. We add more `info` and `debug` logs around incoming event, bedrock invocations, tools invocation, emitting response. Debug logs dump request/response payloads.
2. We change Sandbox component to support arbitrary log group attached to lambda function.
    1. Previously Sandbox assumed that log group is `/aws/lambda/<functionName>`. This however won't work for conversation handler (and later if we expose knobs related to logging configuration.
    2. Conversation handler requires custom log group. I attempted to use `<functionName>` to mimic default convention, but the problem is that log group is input to function ctor, therefore it's impossible to use function's properties to create log group (as this happens first). The only alternative I found was to generate function name ourselves, but that wasn't great either - components used by function ctor internally are not available to us, so if we generate name it would look differently than other functions. Hence I figured that it's better to just make sandbox support arbitrary log group.
    3. The `ListTags` call in Sandbox is replaced by `GetFunction` which gives both information that we need - `tags` and `logGroupName`. The `AmplifyBackendDeployFullAccess ` already has necessary permissions to call `GetFunction`.
3. I moved outputs generation from `backend-ai` to `ai-construct`. So that data construct can pass `outputStrategy` to it in default scenario.

## Out of scope

1. Setting log level for function at runtime. This should be covered separately with https://github.com/aws-amplify/amplify-backend/issues/2058 . Meanwhile customers can adjust the level on AWS Console after deployment.
2. This PR exposes ability to pass `outputStrategy` to ai construct. The necessary plumbing on data side will be pursued separately. The idea was validated by a temporary change (reverted [here](https://github.com/aws-amplify/amplify-backend/pull/2073/commits/3e8b590a7a9d3957d0bb2a31ab5dcfa5b0c25e1a))

## Validation

1. Added/modified unit tests.
5. Manual check

Manual check with default `info` level:
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/88dc893e-255b-4afc-aecb-6f05e4dbf8ea">



Manual check with log level set to `debug` via AWS Console:
<img width="752" alt="image" src="https://github.com/user-attachments/assets/0f976357-0646-4f99-b046-2735545964fa">
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/8bd1e0ec-463c-4d90-b11b-0b9e63737c1b">


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
