### PR TITLE
Exclude FromJSONSchema from api checks due to its complexity

### DIFF
--- a/scripts/components/api-changes-validator/api_changes_validator.test.ts
+++ b/scripts/components/api-changes-validator/api_changes_validator.test.ts
@@ -61,6 +61,7 @@ void describe('Api changes validator', { concurrency: true }, () => {
         latestPackagePath,
         baselinePackageApiReportPath,
         workingDirectory,
+        [],
         'npmLocalLink'
       );
 
@@ -92,6 +93,7 @@ void describe('Api changes validator', { concurrency: true }, () => {
         latestPackagePath,
         baselinePackageApiReportPath,
         workingDirectory,
+        ['SampleIgnoredType'],
         'npmLocalLink'
       );
 

--- a/scripts/components/api-changes-validator/api_changes_validator.ts
+++ b/scripts/components/api-changes-validator/api_changes_validator.ts
@@ -30,6 +30,7 @@ export class ApiChangesValidator {
     private readonly latestPackagePath: string,
     private readonly baselinePackageApiReportPath: string,
     private readonly workingDirectory: string,
+    private readonly excludedTypes: Array<string> = [],
     private readonly latestPackageDependencyDeclarationStrategy:
       | 'npmRegistry'
       | 'npmLocalLink' = 'npmRegistry'
@@ -103,7 +104,8 @@ export class ApiChangesValidator {
     const apiReportAST = ApiReportParser.parse(apiReportContent);
     const usage = new ApiUsageGenerator(
       latestPackageJson.name,
-      apiReportAST
+      apiReportAST,
+      this.excludedTypes
     ).generate();
     await fsp.writeFile(path.join(this.testProjectPath, 'index.ts'), usage);
     await execa('npm', ['install'], { cwd: this.testProjectPath });

--- a/scripts/components/api-changes-validator/api_usage_generator.test.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.test.ts
@@ -337,6 +337,15 @@ const someTypeUnderSubNamespaceUsageFunction = (someTypeUnderSubNamespaceFunctio
 }
     `,
   },
+  {
+    description: 'Skips ignored type',
+    apiReportCode: `
+export type SampleIgnoredType = {
+  someProperty: string;
+}
+    `,
+    expectedApiUsage: '',
+  },
 ];
 
 const nestInMarkdownCodeBlock = (apiReportCode: string) => {
@@ -351,7 +360,8 @@ void describe('Api usage generator', () => {
       );
       const apiUsage = new ApiUsageGenerator(
         'samplePackageName',
-        apiReportAST
+        apiReportAST,
+        ['SampleIgnoredType']
       ).generate();
       assert.strictEqual(
         // .replace() removes EOL differences between Windows and other OS so output matches for all

--- a/scripts/components/api-changes-validator/api_usage_generator.ts
+++ b/scripts/components/api-changes-validator/api_usage_generator.ts
@@ -25,7 +25,8 @@ export class ApiUsageGenerator {
    */
   constructor(
     private readonly packageName: string,
-    private readonly apiReportAST: ts.SourceFile
+    private readonly apiReportAST: ts.SourceFile,
+    private readonly excludedTypes: Array<string>
   ) {
     this.namespaceDefinitions = this.getNamespaceDefinitions();
   }
@@ -65,7 +66,8 @@ export class ApiUsageGenerator {
       case ts.SyntaxKind.TypeAliasDeclaration:
         return new TypeUsageStatementsGenerator(
           node as ts.TypeAliasDeclaration,
-          this.packageName
+          this.packageName,
+          this.excludedTypes
         ).generate();
       case ts.SyntaxKind.EnumDeclaration:
         return new EnumUsageStatementsGenerator(

--- a/scripts/components/api-changes-validator/api_usage_statements_generators.ts
+++ b/scripts/components/api-changes-validator/api_usage_statements_generators.ts
@@ -122,10 +122,14 @@ export class TypeUsageStatementsGenerator implements UsageStatementsGenerator {
    */
   constructor(
     private readonly typeAliasDeclaration: ts.TypeAliasDeclaration,
-    private readonly packageName: string
+    private readonly packageName: string,
+    private readonly excludedTypes: Array<string>
   ) {}
   generate = (): UsageStatementsGeneratorOutput => {
     const typeName = this.typeAliasDeclaration.name.getText();
+    if (this.excludedTypes.includes(typeName)) {
+      return {};
+    }
     const constName = toLowerCamelCase(typeName);
     const genericTypeParametersDeclaration =
       new GenericTypeParameterDeclarationUsageStatementsGenerator(

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/API.md
@@ -79,4 +79,9 @@ export type SampleTypeUsingClass = {
 export type SampleTypeThatReferencesFunction<T extends typeof someFunction1> = {
   sampleProperty: T;
 };
+
+// This type is intentionally different from what's in sources
+export type SampleIgnoredType = {
+  someProperty: string;
+};
 ```

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/src/index.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/src/index.ts
@@ -110,3 +110,8 @@ export type SampleTypeUsingClass = {
 export type SampleTypeThatReferencesFunction<T extends typeof someFunction1> = {
   sampleProperty: T;
 };
+
+// This type is intentionally different from what's in api report
+export type SampleIgnoredType = {
+  someProperty: number;
+};


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

The way we test types assignment (attempt to assign to older copy of type) makes compiler fail for `FromJSONSchema`. This can be attributed to the way we test it rather than actual usage of the type. The attempt to compare current type to older copy of `FromJSONSchema` triggers it's deep computation mentioned in https://github.com/ThomasAribart/json-schema-to-ts/blob/main/documentation/FAQs/i-get-a-type-instantiation-is-excessively-deep-and-potentially-infinite-error-what-should-i-do.md .

Fixes:
```
AggregateError: Breaking API changes detected. See below for details.
    If these changes are intentional, this is okay.
    Otherwise, update the PR to remove the unintentional breaks
    at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:87:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  [errors]: [
    Error: Validation of @aws-amplify/ai-constructs failed, compiler output:
    index.ts(113,9): error TS2589: Type instantiation is excessively deep and possibly infinite.
    index.ts(113,87): error TS2589: Type instantiation is excessively deep and possibly infinite.
    index.ts(113,87): error TS2590: Expression produces a union type that is too complex to represent.
        at ApiChangesValidator.validate (/home/runner/work/amplify-backend/amplify-backend/scripts/components/api-changes-validator/api_changes_validator.ts:61:13)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:70:5)
        at async Promise.allSettled (index 26)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:50:27)
  ]
```

## Changes

Since there isn't much we can do about this. I.e. we can't find better way to assert type assignability nor we can simplify this type. We exclude it from checks.

This PR:
1. adds mechanism to exclude certain types from api checks.
2. excludes `FromJSONSchema`

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
