### PR TITLE
Fix case when multiple tools are requested by Bedrock.

### DIFF
--- a/.changeset/tender-camels-agree.md
+++ b/.changeset/tender-camels-agree.md
@@ -2,4 +2,4 @@
 '@aws-amplify/ai-constructs': patch
 ---
 
-Limit tool usage in conversation turn
+Fix multi tool usage in single turn.

--- a/.changeset/tender-camels-agree.md
+++ b/.changeset/tender-camels-agree.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Limit tool usage in conversation turn

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.test.ts
@@ -174,7 +174,14 @@ void describe('Bedrock converse adapter', () => {
               toolUse: {
                 toolUseId: randomUUID().toString(),
                 name: additionalTool.name,
-                input: 'additionalToolInput',
+                input: 'additionalToolInput1',
+              },
+            },
+            {
+              toolUse: {
+                toolUseId: randomUUID().toString(),
+                name: additionalTool.name,
+                input: 'additionalToolInput2',
               },
             },
           ],
@@ -195,7 +202,14 @@ void describe('Bedrock converse adapter', () => {
               toolUse: {
                 toolUseId: randomUUID().toString(),
                 name: eventTool.name,
-                input: 'eventToolToolInput',
+                input: 'eventToolToolInput1',
+              },
+            },
+            {
+              toolUse: {
+                toolUseId: randomUUID().toString(),
+                name: eventTool.name,
+                input: 'eventToolToolInput2',
               },
             },
           ],
@@ -289,6 +303,10 @@ void describe('Bedrock converse adapter', () => {
       additionalToolUseBedrockResponse.output?.message?.content[0].toolUse
         ?.toolUseId
     );
+    assert.ok(
+      additionalToolUseBedrockResponse.output?.message?.content[1].toolUse
+        ?.toolUseId
+    );
     const expectedBedrockInput2: ConverseCommandInput = {
       messages: [
         ...(messages as Array<Message>),
@@ -305,6 +323,15 @@ void describe('Bedrock converse adapter', () => {
                     .toolUse.toolUseId,
               },
             },
+            {
+              toolResult: {
+                content: [additionalToolOutput],
+                status: 'success',
+                toolUseId:
+                  additionalToolUseBedrockResponse.output?.message.content[1]
+                    .toolUse.toolUseId,
+              },
+            },
           ],
         },
       ],
@@ -316,6 +343,9 @@ void describe('Bedrock converse adapter', () => {
     assert.ok(eventToolUseBedrockResponse.output?.message?.content);
     assert.ok(
       eventToolUseBedrockResponse.output?.message?.content[0].toolUse?.toolUseId
+    );
+    assert.ok(
+      eventToolUseBedrockResponse.output?.message?.content[1].toolUse?.toolUseId
     );
     assert.ok(expectedBedrockInput2.messages);
     const expectedBedrockInput3: ConverseCommandInput = {
@@ -331,6 +361,15 @@ void describe('Bedrock converse adapter', () => {
                 status: 'success',
                 toolUseId:
                   eventToolUseBedrockResponse.output?.message.content[0].toolUse
+                    .toolUseId,
+              },
+            },
+            {
+              toolResult: {
+                content: [eventToolOutput],
+                status: 'success',
+                toolUseId:
+                  eventToolUseBedrockResponse.output?.message.content[1].toolUse
                     .toolUseId,
               },
             },

--- a/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
+++ b/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
@@ -30,7 +30,7 @@ import { NormalizedCacheObject } from '@apollo/client';
 import {
   bedrockModelId,
   expectedTemperatureInDataToolScenario,
-  expectedTemperatureInProgrammaticToolScenario,
+  expectedTemperaturesInProgrammaticToolScenario,
 } from '../test-projects/conversation-handler/amplify/constants.js';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -581,7 +581,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
       role: 'user',
       content: [
         {
-          text: 'What is the temperature in Seattle?',
+          text: 'What is the temperature in Seattle, Boston and Miami?',
         },
       ],
     };
@@ -605,7 +605,21 @@ class ConversationHandlerTestProject extends TestProjectBase {
     // Assert that tool was used. I.e. LLM used value provided by the tool.
     assert.match(
       response.content,
-      new RegExp(expectedTemperatureInProgrammaticToolScenario.toString())
+      new RegExp(
+        expectedTemperaturesInProgrammaticToolScenario.Seattle.toString()
+      )
+    );
+    assert.match(
+      response.content,
+      new RegExp(
+        expectedTemperaturesInProgrammaticToolScenario.Boston.toString()
+      )
+    );
+    assert.match(
+      response.content,
+      new RegExp(
+        expectedTemperaturesInProgrammaticToolScenario.Miami.toString()
+      )
     );
   };
 

--- a/packages/integration-tests/src/test-projects/conversation-handler/amplify/constants.ts
+++ b/packages/integration-tests/src/test-projects/conversation-handler/amplify/constants.ts
@@ -8,6 +8,10 @@
  */
 export const bedrockModelId = 'anthropic.claude-3-haiku-20240307-v1:0';
 
-export const expectedTemperatureInProgrammaticToolScenario = 75;
+export const expectedTemperaturesInProgrammaticToolScenario = {
+  Seattle: 75,
+  Boston: 58,
+  Miami: 97,
+};
 
 export const expectedTemperatureInDataToolScenario = 85;

--- a/packages/integration-tests/src/test-projects/conversation-handler/amplify/custom-conversation-handler/custom_handler.ts
+++ b/packages/integration-tests/src/test-projects/conversation-handler/amplify/custom-conversation-handler/custom_handler.ts
@@ -3,7 +3,7 @@ import {
   createExecutableTool,
   handleConversationTurnEvent,
 } from '@aws-amplify/backend-ai/conversation/runtime';
-import { expectedTemperatureInProgrammaticToolScenario } from '../constants.js';
+import { expectedTemperaturesInProgrammaticToolScenario } from '../constants.js';
 
 const thermometerInputSchema = {
   type: 'object',
@@ -20,12 +20,13 @@ const thermometer = createExecutableTool(
     json: thermometerInputSchema,
   },
   (input) => {
-    if (input.city === 'Seattle') {
+    const city = input.city;
+    if (city === 'Seattle' || city === 'Boston' || city === 'Miami') {
       return Promise.resolve({
         // We use this value in test assertion.
         // LLM uses tool to get temperature and serves this value in final response.
         // We're matching number only as LLM may translate unit to something more descriptive.
-        text: `${expectedTemperatureInProgrammaticToolScenario}F`,
+        text: `${expectedTemperaturesInProgrammaticToolScenario[city]}F`,
       });
     }
     throw new Error(`Unknown city ${input.city}`);


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Currently. We append a new message if bedrock emits multiple tool use blocks in single bedrock response.
However, bedrock then validates that we return it a single array with tool responses. NOT multiple messages with tool responses.

I.e. we want to fix this error.
![image](https://github.com/user-attachments/assets/9490a293-a964-4154-be1c-4ab2417a8cf2)


## Changes

Accumulate tool responses into single "user message" instead of multiple messages.

## Validation

Enhanced both unit and e2e test to be sensitive to this scenario.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
