### PR TITLE
Add information about event version to conversation components

### DIFF
--- a/.changeset/sixty-cycles-happen.md
+++ b/.changeset/sixty-cycles-happen.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ai-constructs': minor
+'@aws-amplify/backend-ai': minor
+---
+
+Add information about event version to conversation components

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -17,7 +17,8 @@ import { ResourceProvider } from '@aws-amplify/plugin-types';
 declare namespace __export__conversation {
     export {
         ConversationHandlerFunction,
-        ConversationHandlerFunctionProps
+        ConversationHandlerFunctionProps,
+        ConversationTurnEventVersion
     }
 }
 export { __export__conversation }
@@ -42,6 +43,8 @@ export { __export__conversation__runtime }
 // @public
 class ConversationHandlerFunction extends Construct implements ResourceProvider<FunctionResources> {
     constructor(scope: Construct, id: string, props: ConversationHandlerFunctionProps);
+    // (undocumented)
+    static readonly eventVersion: ConversationTurnEventVersion;
     // (undocumented)
     resources: FunctionResources;
 }
@@ -115,6 +118,9 @@ type ConversationTurnEvent = {
         clientTools?: Array<ToolDefinition>;
     };
 };
+
+// @public (undocumented)
+type ConversationTurnEventVersion = `1.${number}`;
 
 // @public
 const createExecutableTool: <TJSONSchema extends JSONSchema = JSONSchema, TToolInput = FromJSONSchema<TJSONSchema>>(name: string, description: string, inputSchema: ToolInputSchema<TJSONSchema>, handler: (input: TToolInput) => Promise<bedrock.ToolResultContentBlock>) => ExecutableTool<TJSONSchema, TToolInput>;

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
@@ -40,6 +40,11 @@ export type ConversationHandlerFunctionProps = {
   outputStorageStrategy?: BackendOutputStorageStrategy<AIConversationOutput>;
 };
 
+// Event is a protocol between AppSync and Lambda handler. Therefore, X.Y subset of semver is enough.
+// Typing this as 1.X so that major version changes are caught by compiler if consumer of this construct inspects
+// event version.
+export type ConversationTurnEventVersion = `1.${number}`;
+
 /**
  * Conversation Handler Function CDK construct.
  * This construct deploys resources that integrate conversation routes
@@ -54,6 +59,7 @@ export class ConversationHandlerFunction
   extends Construct
   implements ResourceProvider<FunctionResources>
 {
+  static readonly eventVersion: ConversationTurnEventVersion = '1.0';
   resources: FunctionResources;
 
   /**

--- a/packages/ai-constructs/src/conversation/index.ts
+++ b/packages/ai-constructs/src/conversation/index.ts
@@ -1,6 +1,11 @@
 import {
   ConversationHandlerFunction,
   ConversationHandlerFunctionProps,
+  ConversationTurnEventVersion,
 } from './conversation_handler_construct.js';
 
-export { ConversationHandlerFunction, ConversationHandlerFunctionProps };
+export {
+  ConversationHandlerFunction,
+  ConversationHandlerFunctionProps,
+  ConversationTurnEventVersion,
+};

--- a/packages/backend-ai/API.md
+++ b/packages/backend-ai/API.md
@@ -5,12 +5,14 @@
 ```ts
 
 import { ConstructFactory } from '@aws-amplify/plugin-types';
+import { ConversationTurnEventVersion } from '@aws-amplify/ai-constructs/conversation';
 import { FunctionResources } from '@aws-amplify/plugin-types';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
 import * as runtime from '@aws-amplify/ai-constructs/conversation/runtime';
 
 declare namespace __export__conversation {
     export {
+        ConversationHandlerFunctionFactory,
         DefineConversationHandlerFunctionProps,
         defineConversationHandlerFunction
     }
@@ -29,13 +31,18 @@ declare namespace __export__conversation__runtime {
 export { __export__conversation__runtime }
 
 // @public (undocumented)
+type ConversationHandlerFunctionFactory = ConstructFactory<ResourceProvider<FunctionResources>> & {
+    readonly eventVersion: ConversationTurnEventVersion;
+};
+
+// @public (undocumented)
 type ConversationTurnEvent = runtime.ConversationTurnEvent;
 
 // @public (undocumented)
 const createExecutableTool: <TJSONSchema extends runtime.JSONSchema = runtime.JSONSchema, TToolInput = runtime.FromJSONSchema<TJSONSchema>>(name: string, description: string, inputSchema: runtime.ToolInputSchema<TJSONSchema>, handler: (input: TToolInput) => Promise<ToolResultContentBlock>) => ExecutableTool<TJSONSchema, TToolInput>;
 
 // @public
-const defineConversationHandlerFunction: (props: DefineConversationHandlerFunctionProps) => ConstructFactory<ResourceProvider<FunctionResources>>;
+const defineConversationHandlerFunction: (props: DefineConversationHandlerFunctionProps) => ConversationHandlerFunctionFactory;
 
 // @public (undocumented)
 type DefineConversationHandlerFunctionProps = {

--- a/packages/backend-ai/src/conversation/factory.test.ts
+++ b/packages/backend-ai/src/conversation/factory.test.ts
@@ -15,6 +15,7 @@ import { defaultEntryHandler } from './test-assets/with-default-entry/resource.j
 import { customEntryHandler } from './test-assets/with-custom-entry/resource.js';
 import { Template } from 'aws-cdk-lib/assertions';
 import { defineConversationHandlerFunction } from './factory.js';
+import { ConversationHandlerFunction } from '@aws-amplify/ai-constructs/conversation';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -55,6 +56,14 @@ void describe('ConversationHandlerFactory', () => {
     const instance1 = factory.getInstance(getInstanceProps);
     const instance2 = factory.getInstance(getInstanceProps);
     assert.strictEqual(instance1, instance2);
+  });
+
+  void it('has event version corresponding to construct', () => {
+    const factory = defaultEntryHandler;
+    assert.strictEqual(
+      factory.eventVersion,
+      ConversationHandlerFunction.eventVersion
+    );
   });
 
   void it('resolves default entry when not specified', () => {

--- a/packages/backend-ai/src/conversation/factory.ts
+++ b/packages/backend-ai/src/conversation/factory.ts
@@ -11,6 +11,7 @@ import {
 import {
   ConversationHandlerFunction,
   ConversationHandlerFunctionProps,
+  ConversationTurnEventVersion,
 } from '@aws-amplify/ai-constructs/conversation';
 import path from 'path';
 import { CallerDirectoryExtractor } from '@aws-amplify/platform-core';
@@ -51,9 +52,17 @@ class ConversationHandlerFunctionGenerator
   };
 }
 
-class ConversationHandlerFunctionFactory
-  implements ConstructFactory<ConversationHandlerFunction>
+export type ConversationHandlerFunctionFactory = ConstructFactory<
+  ResourceProvider<FunctionResources>
+> & {
+  readonly eventVersion: ConversationTurnEventVersion;
+};
+
+class DefaultConversationHandlerFunctionFactory
+  implements ConversationHandlerFunctionFactory
 {
+  readonly eventVersion: ConversationTurnEventVersion =
+    ConversationHandlerFunction.eventVersion;
   private generator: ConstructContainerEntryGenerator;
 
   constructor(
@@ -121,6 +130,6 @@ export type DefineConversationHandlerFunctionProps = {
  */
 export const defineConversationHandlerFunction = (
   props: DefineConversationHandlerFunctionProps
-): ConstructFactory<ResourceProvider<FunctionResources>> =>
+): ConversationHandlerFunctionFactory =>
   // eslint-disable-next-line amplify-backend-rules/prefer-amplify-errors
-  new ConversationHandlerFunctionFactory(props, new Error().stack);
+  new DefaultConversationHandlerFunctionFactory(props, new Error().stack);

--- a/packages/backend-ai/src/conversation/index.ts
+++ b/packages/backend-ai/src/conversation/index.ts
@@ -1,9 +1,11 @@
 import {
+  ConversationHandlerFunctionFactory,
   DefineConversationHandlerFunctionProps,
   defineConversationHandlerFunction,
 } from './factory.js';
 
 export {
+  ConversationHandlerFunctionFactory,
   DefineConversationHandlerFunctionProps,
   defineConversationHandlerFunction,
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

This PR solves two problems:
1. Defines type for conversation handler factory. This is to narrow down what `a.conversation({ ..., handler: })` can take. I.e. prevent using raw defineFunction.
2. Define and expose information about event version.

## Changes

1. Adds return type for `defineConversationHandlerFunction`.
2. Adds information about conversation turn even version to both `ai-constructs` and `backend-ai`.
    1. Event is a protocol/schema. Therefore `major.minor` is sufficient.
    2. Typing is defined as `1.x` for the version.
        1. This will trigger compiler when we introduce `2.x` and attempt to use incompatible version is made.
        2. This surfaces a version value at runtime. So that upstream component is aware of which feature set of event is supported.

## Validation

Added test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
