### PR TITLE
allow trailing dot when applying namespace.

### DIFF
--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
@@ -16,6 +16,10 @@ type SomeOtherTypeUnderSubNamespace = {
   someProperty: SomeTypeUnderSubNamespace;
 };
 
+class SomeClassUnderNamespace {
+  static readonly someStaticProperty: string;
+}
+
 declare namespace someSubNamespace {
   export {
     SomeTypeUnderSubNamespace,
@@ -28,6 +32,7 @@ export const functionUsingTypes2: (props: SomeTypeUnderNamespace, extraArg: stri
 
 declare namespace someNamespace {
   export {
+    SomeClassUnderNamespace,
     SomeTypeUnderNamespace,
     someSubNamespace,
     functionUsingTypes1,

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
@@ -20,6 +20,10 @@ class SomeClassUnderNamespace {
   static readonly someStaticProperty: string;
 }
 
+type SomeTypeUnderNamespaceWithGenerics<TPropertyType> = {
+  someGenericProperty: TPropertyType;
+};
+
 declare namespace someSubNamespace {
   export {
     SomeTypeUnderSubNamespace,
@@ -34,6 +38,7 @@ declare namespace someNamespace {
   export {
     SomeClassUnderNamespace,
     SomeTypeUnderNamespace,
+    SomeTypeUnderNamespaceWithGenerics,
     someSubNamespace,
     functionUsingTypes1,
     functionUsingTypes2

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
@@ -18,3 +18,7 @@ export const functionUsingTypes2 = (
 export class SomeClassUnderNamespace {
   static readonly someStaticProperty: string;
 }
+
+export type SomeTypeUnderNamespaceWithGenerics<TPropertyType> = {
+  someGenericProperty: TPropertyType;
+};

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_namespace.ts
@@ -14,3 +14,7 @@ export const functionUsingTypes2 = (
 ): Array<someSubNamespace.SomeTypeUnderSubNamespace> => {
   throw new Error();
 };
+
+export class SomeClassUnderNamespace {
+  static readonly someStaticProperty: string;
+}

--- a/scripts/components/api-changes-validator/usage_statemets_renderer.ts
+++ b/scripts/components/api-changes-validator/usage_statemets_renderer.ts
@@ -70,6 +70,9 @@ export class UsageStatementsRenderer {
       // characters that can be found before or after symbol
       // this is to prevent partial matches in case one symbol's characters are subset of longer one
       const possibleSymbolPrefix = '[\\s\\,\\(<;]';
+      // Notes about non-obvious suffixes:
+      // '.' is possible suffix if static class member is accessed
+      // '(' bracket is possible for callable like constructor calls.
       const possibleSymbolSuffix = '[\\s\\,\\(\\)>;\\.]';
       const regex = new RegExp(
         `(${possibleSymbolPrefix})(${symbolName})(${possibleSymbolSuffix})`,

--- a/scripts/components/api-changes-validator/usage_statemets_renderer.ts
+++ b/scripts/components/api-changes-validator/usage_statemets_renderer.ts
@@ -70,10 +70,7 @@ export class UsageStatementsRenderer {
       // characters that can be found before or after symbol
       // this is to prevent partial matches in case one symbol's characters are subset of longer one
       const possibleSymbolPrefix = '[\\s\\,\\(<;]';
-      // Notes about non-obvious suffixes:
-      // '.' is possible suffix if static class member is accessed
-      // '(' bracket is possible for callable like constructor calls.
-      const possibleSymbolSuffix = '[\\s\\,\\(\\)>;\\.]';
+      const possibleSymbolSuffix = '[\\s\\,\\(\\)<>;\\.]';
       const regex = new RegExp(
         `(${possibleSymbolPrefix})(${symbolName})(${possibleSymbolSuffix})`,
         'g'

--- a/scripts/components/api-changes-validator/usage_statemets_renderer.ts
+++ b/scripts/components/api-changes-validator/usage_statemets_renderer.ts
@@ -69,9 +69,10 @@ export class UsageStatementsRenderer {
 
       // characters that can be found before or after symbol
       // this is to prevent partial matches in case one symbol's characters are subset of longer one
-      const symbolTerminators = '[\\s\\,\\(\\)<>;]';
+      const possibleSymbolPrefix = '[\\s\\,\\(<;]';
+      const possibleSymbolSuffix = '[\\s\\,\\(\\)>;\\.]';
       const regex = new RegExp(
-        `(${symbolTerminators})(${symbolName})(${symbolTerminators})`,
+        `(${possibleSymbolPrefix})(${symbolName})(${possibleSymbolSuffix})`,
         'g'
       );
       usageStatements = usageStatements.replaceAll(


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

The usage snippets that are testing static symbols from namespaced class are not applying namespace correctly.

```
/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:100
  throw new AggregateError(
        ^


AggregateError: Breaking API changes detected. See below for details.
    If these changes are intentional, this is okay.
    Otherwise, update the PR to remove the unintentional breaks
    at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:100:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  [errors]: [
    Error: Validation of @aws-amplify/ai-constructs failed, compiler output:
    index.ts(16,78): error TS2304: Cannot find name 'ConversationHandlerFunction'.
        at ApiChangesValidator.validate (/home/runner/work/amplify-backend/amplify-backend/scripts/components/api-changes-validator/api_changes_validator.ts:62:13)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:82:5)
        at async Promise.allSettled (index 26)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/scripts/check_api_changes.ts:62:27)
  ]
}
```

## Changes

Allow `.` to be a suffix when searching symbols to replace.

Namespaced symbols look like this `<ns1>.<ns2>.<ns3>.<symbol>`.
Therefore:
1. it's safe to assume that anything after `<symbol>` is member acccess, for example `<ns1>.<ns2>.<ns3>.<symbol>.<some_static_field>`
2. Namespace replacing algorithm won't partial match `<ns3>.<symbol>` because we don't allow `.` as prefix.

## Validation

1. Test added.
2. This PR checks.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
