### PR TITLE
Fix case where bedrock content blocks would be populated with 'null' instead of 'undefined.

### DIFF
--- a/.changeset/early-starfishes-impress.md
+++ b/.changeset/early-starfishes-impress.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Fix case where bedrock content blocks would be populated with 'null' instead of 'undefined.

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -72,6 +72,12 @@ type ConversationMessageContentBlock = bedrock.ContentBlock | {
             bytes: string;
         };
     };
+    text?: never;
+    document?: never;
+    toolUse?: never;
+    toolResult?: never;
+    guardContent?: never;
+    $unknown?: never;
 };
 
 // @public (undocumented)

--- a/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.test.ts
@@ -342,6 +342,58 @@ void describe('Conversation message history retriever', () => {
         },
       ],
     },
+    {
+      name: 'Replaces null values with undefined',
+      mockListResponseMessages: [
+        {
+          id: event.currentMessageId,
+          conversationId: event.conversationId,
+          role: 'user',
+          content: [
+            {
+              text: 'some_text',
+              // @ts-expect-error Intentionally providing null outside of typing
+              image: null,
+              // @ts-expect-error Intentionally providing null outside of typing
+              document: null,
+              // @ts-expect-error Intentionally providing null outside of typing
+              toolUse: null,
+              // @ts-expect-error Intentionally providing null outside of typing
+              toolResult: null,
+              // @ts-expect-error Intentionally providing null outside of typing
+              guardContent: null,
+              // @ts-expect-error Intentionally providing null outside of typing
+              $unknown: null,
+            },
+            {
+              // @ts-expect-error Intentionally providing null outside of typing
+              text: null,
+              document: { format: 'csv', name: 'test_name', source: undefined },
+            },
+          ],
+        },
+      ],
+      expectedMessages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'some_text',
+              image: undefined,
+              document: undefined,
+              toolUse: undefined,
+              toolResult: undefined,
+              guardContent: undefined,
+              $unknown: undefined,
+            },
+            {
+              text: undefined,
+              document: { format: 'csv', name: 'test_name', source: undefined },
+            },
+          ],
+        },
+      ],
+    },
   ];
 
   for (const testCase of testCases) {

--- a/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
@@ -235,6 +235,24 @@ export class ConversationMessageHistoryRetriever {
       variables,
     });
 
-    return response.data[this.event.messageHistoryQuery.listQueryName].items;
+    const items =
+      response.data[this.event.messageHistoryQuery.listQueryName].items;
+
+    items.forEach((item) => {
+      item.content?.forEach((contentBlock) => {
+        let property: keyof typeof contentBlock;
+        for (property in contentBlock) {
+          // Deserialization of GraphQl query result sets these properties to 'null'
+          // This can trigger Bedrock SDK validation as it expects 'undefined' if properties are not set.
+          // We can't fix how GraphQl response is deserialized.
+          // Therefore, we apply this transformation to fix the data.
+          if (contentBlock[property] === null) {
+            contentBlock[property] = undefined;
+          }
+        }
+      });
+    });
+
+    return items;
   };
 }

--- a/packages/ai-constructs/src/conversation/runtime/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/types.ts
@@ -26,6 +26,14 @@ export type ConversationMessageContentBlock =
         // Upstream (Appsync) may send images in a form of Base64 encoded strings
         source: { bytes: string };
       };
+      // These are needed so that union with other content block types works.
+      // See https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-bedrock-runtime/TypeAlias/ContentBlock/.
+      text?: never;
+      document?: never;
+      toolUse?: never;
+      toolResult?: never;
+      guardContent?: never;
+      $unknown?: never;
     };
 
 export type ToolDefinition<TJSONSchema extends JSONSchema = JSONSchema> = {


### PR DESCRIPTION


<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

1. GraphQL query returns `null` for fields that are not populated in a sparse block models.
2. Bedrock doesn't like `nulls` it likes `undefined`. I.e. fails with `"errorMessage": "ContentBlock object at messages.5.content.0 must set one of the following keys: text, image, toolUse, toolResult, document.",` when seeing `{text: null, image: null, toolUse: {...}}`


![image](https://github.com/user-attachments/assets/508816bf-f7e0-4d36-ad40-ffb396d63d80)
Source: https://www.reddit.com/r/ProgrammerHumor/comments/mqt9br/null_vs_undefined/

**Issue number, if available:**

## Changes

Add logic in message history retrieval to replace `null` with `undefined`

## Validation

Added unit test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
