### PR TITLE
detect transform errors with multiple errors

### DIFF
--- a/.changeset/old-suns-float.md
+++ b/.changeset/old-suns-float.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+detect transform errors with multiple errors

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -223,6 +223,22 @@ const testErrorMappings = [
   },
   {
     errorMessage:
+      `Error [TransformError]: Transform failed with 2 errors:` +
+      EOL +
+      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Multiple exports with the same name auth` +
+      EOL +
+      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: The symbol auth has already been declared` +
+      EOL +
+      `    at failureErrorWithLog (/Users/user/work-space/amplify-app/node_modules/tsx/node_modules/esbuild/lib/main.js:1472:15)`,
+    expectedTopLevelErrorMessage:
+      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Multiple exports with the same name auth` +
+      EOL +
+      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: The symbol auth has already been declared`,
+    errorName: 'ESBuildError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage:
       `some rubbish before` +
       EOL +
       `Error: some cdk synth error` +

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -50,6 +50,12 @@ export class CdkErrorMapper {
               underlyingError = undefined;
             }
           }
+          // remove any trailing EOL
+          matchingError.humanReadableErrorMessage =
+            matchingError.humanReadableErrorMessage.replace(
+              new RegExp(`${this.multiLineEolRegex}$`),
+              ''
+            );
         } else {
           underlyingError.message = matchGroups[0];
         }
@@ -193,10 +199,9 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      // If there are multiple errors, capture all lines containing the errors and exclude the stack trace
+      // If there are multiple errors, capture all lines containing the errors
       errorRegex: new RegExp(
-        `\\[TransformError\\]: Transform failed with .* error(s?):${this.multiLineEolRegex}(?<esBuildErrorMessage>.*(?=${this.multiLineEolRegex}\\s*at\\s+))`,
-        's'
+        `\\[TransformError\\]: Transform failed with .* error(s?):${this.multiLineEolRegex}(?<esBuildErrorMessage>(.*ERROR:.*${this.multiLineEolRegex})+)`
       ),
       humanReadableErrorMessage: '{esBuildErrorMessage}',
       resolutionMessage:

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -193,8 +193,10 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      // If there are multiple errors, capture all lines containing the errors and exclude the stack trace
       errorRegex: new RegExp(
-        `\\[TransformError\\]: Transform failed with .* error:${this.multiLineEolRegex}(?<esBuildErrorMessage>.*)`
+        `\\[TransformError\\]: Transform failed with .* error(s?):${this.multiLineEolRegex}(?<esBuildErrorMessage>.*(?=${this.multiLineEolRegex}\\s*at\\s+))`,
+        's'
       ),
       humanReadableErrorMessage: '{esBuildErrorMessage}',
       resolutionMessage:


### PR DESCRIPTION
## Changes

Add ability for error mapper to detect `TransformError` with multiple errors.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
