### PR TITLE
Remove deprecated messages field from event

### DIFF
--- a/.changeset/dull-mugs-agree.md
+++ b/.changeset/dull-mugs-agree.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': minor
+---
+
+Remove deprecated messages field from event

--- a/packages/ai-constructs/API.md
+++ b/packages/ai-constructs/API.md
@@ -25,8 +25,6 @@ export { __export__conversation }
 
 declare namespace __export__conversation__runtime {
     export {
-        ConversationMessage,
-        ConversationMessageContentBlock,
         ConversationTurnEvent,
         createExecutableTool,
         ExecutableTool,
@@ -60,27 +58,6 @@ type ConversationHandlerFunctionProps = {
 };
 
 // @public (undocumented)
-type ConversationMessage = {
-    role: 'user' | 'assistant';
-    content: Array<ConversationMessageContentBlock>;
-};
-
-// @public (undocumented)
-type ConversationMessageContentBlock = bedrock.ContentBlock | {
-    image: Omit<bedrock.ImageBlock, 'source'> & {
-        source: {
-            bytes: string;
-        };
-    };
-    text?: never;
-    document?: never;
-    toolUse?: never;
-    toolResult?: never;
-    guardContent?: never;
-    $unknown?: never;
-};
-
-// @public (undocumented)
 type ConversationTurnEvent = {
     conversationId: string;
     currentMessageId: string;
@@ -103,7 +80,6 @@ type ConversationTurnEvent = {
     request: {
         headers: Record<string, string>;
     };
-    messages?: Array<ConversationMessage>;
     messageHistoryQuery: {
         getQueryName: string;
         getQueryInputTypeName: string;

--- a/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
@@ -108,10 +108,6 @@ export class ConversationMessageHistoryRetriever {
   ) {}
 
   getMessageHistory = async (): Promise<Array<ConversationMessage>> => {
-    if (this.event.messages?.length) {
-      // This is for backwards compatibility and should be removed with messages property.
-      return this.event.messages;
-    }
     const messages = await this.listMessages();
 
     let currentMessage = messages.find(

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_executor.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_executor.test.ts
@@ -11,7 +11,6 @@ void describe('Conversation turn executor', () => {
     conversationId: 'testConversationId',
     currentMessageId: 'testCurrentMessageId',
     graphqlApiEndpoint: '',
-    messages: [],
     messageHistoryQuery: {
       getQueryName: '',
       getQueryInputTypeName: '',

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
@@ -16,7 +16,6 @@ void describe('Conversation turn response sender', () => {
     conversationId: 'testConversationId',
     currentMessageId: 'testCurrentMessageId',
     graphqlApiEndpoint: 'http://fake.endpoint/',
-    messages: [],
     messageHistoryQuery: {
       getQueryName: '',
       getQueryInputTypeName: '',

--- a/packages/ai-constructs/src/conversation/runtime/event-tools-provider/event_tools_provider.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/event-tools-provider/event_tools_provider.test.ts
@@ -11,7 +11,6 @@ void describe('events tool provider', () => {
       conversationId: '',
       currentMessageId: '',
       graphqlApiEndpoint: '',
-      messages: [],
       messageHistoryQuery: {
         getQueryName: '',
         getQueryInputTypeName: '',
@@ -73,7 +72,6 @@ void describe('events tool provider', () => {
       conversationId: '',
       currentMessageId: '',
       graphqlApiEndpoint: '',
-      messages: [],
       messageHistoryQuery: {
         getQueryName: '',
         getQueryInputTypeName: '',

--- a/packages/ai-constructs/src/conversation/runtime/index.ts
+++ b/packages/ai-constructs/src/conversation/runtime/index.ts
@@ -1,6 +1,4 @@
 import {
-  ConversationMessage,
-  ConversationMessageContentBlock,
   ConversationTurnEvent,
   ExecutableTool,
   FromJSONSchema,
@@ -14,8 +12,6 @@ import { handleConversationTurnEvent } from './conversation_turn_executor.js';
 import { createExecutableTool } from './executable_tool_factory.js';
 
 export {
-  ConversationMessage,
-  ConversationMessageContentBlock,
   ConversationTurnEvent,
   createExecutableTool,
   ExecutableTool,

--- a/packages/ai-constructs/src/conversation/runtime/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/types.ts
@@ -66,10 +66,6 @@ export type ConversationTurnEvent = {
   request: {
     headers: Record<string, string>;
   };
-  /**
-   * @deprecated This field is going to be removed in upcoming releases.
-   */
-  messages?: Array<ConversationMessage>;
   messageHistoryQuery: {
     getQueryName: string;
     getQueryInputTypeName: string;

--- a/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
+++ b/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
@@ -7,10 +7,7 @@ import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import { DeployedResourcesFinder } from '../find_deployed_resource.js';
-import {
-  ConversationMessage,
-  ConversationTurnEvent,
-} from '@aws-amplify/ai-constructs/conversation/runtime';
+import { ConversationTurnEvent } from '@aws-amplify/ai-constructs/conversation/runtime';
 import { randomUUID } from 'crypto';
 import { generateClientConfig } from '@aws-amplify/client-config';
 import { AmplifyAuthCredentialsFactory } from '../amplify_auth_credentials_factory.js';
@@ -34,6 +31,7 @@ import {
 } from '../test-projects/conversation-handler/amplify/constants.js';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
+import * as bedrock from '@aws-sdk/client-bedrock-runtime';
 
 // TODO: this is a work around
 // it seems like as of amplify v6 , some of the code only runs in the browser ...
@@ -50,6 +48,28 @@ type ConversationTurnAppSyncResponse = {
   associatedUserMessageId: string;
   content: string;
 };
+
+type ConversationMessage = {
+  role: 'user' | 'assistant';
+  content: Array<ConversationMessageContentBlock>;
+};
+
+type ConversationMessageContentBlock =
+  | bedrock.ContentBlock
+  | {
+      image: Omit<bedrock.ImageBlock, 'source'> & {
+        // Upstream (Appsync) may send images in a form of Base64 encoded strings
+        source: { bytes: string };
+      };
+      // These are needed so that union with other content block types works.
+      // See https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-bedrock-runtime/TypeAlias/ContentBlock/.
+      text?: never;
+      document?: never;
+      toolUse?: never;
+      toolResult?: never;
+      guardContent?: never;
+      $unknown?: never;
+    };
 
 type CreateConversationMessageChatInput = ConversationMessage & {
   conversationId: string;
@@ -203,10 +223,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
       backendId,
       authenticatedUserCredentials.accessToken,
       clientConfig.data.url,
-      apolloClient,
-      // Does not use message history lookup.
-      // This case should be removed when event.messages field is removed.
-      false
+      apolloClient
     );
 
     await this.assertDefaultConversationHandlerCanExecuteTurn(
@@ -214,15 +231,6 @@ class ConversationHandlerTestProject extends TestProjectBase {
       authenticatedUserCredentials.accessToken,
       clientConfig.data.url,
       apolloClient,
-      true
-    );
-
-    await this.assertDefaultConversationHandlerCanExecuteTurn(
-      backendId,
-      authenticatedUserCredentials.accessToken,
-      clientConfig.data.url,
-      apolloClient,
-      true,
       // Simulate eventual consistency
       true
     );
@@ -252,16 +260,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
       backendId,
       authenticatedUserCredentials.accessToken,
       clientConfig.data.url,
-      apolloClient,
-      false
-    );
-
-    await this.assertDefaultConversationHandlerCanExecuteTurnWithImage(
-      backendId,
-      authenticatedUserCredentials.accessToken,
-      clientConfig.data.url,
-      apolloClient,
-      true
+      apolloClient
     );
   }
 
@@ -270,7 +269,6 @@ class ConversationHandlerTestProject extends TestProjectBase {
     accessToken: string,
     graphqlApiEndpoint: string,
     apolloClient: ApolloClient<NormalizedCacheObject>,
-    useMessageHistory: boolean,
     withoutMessageAvailableInTheMessageList = false
   ): Promise<void> => {
     const defaultConversationHandlerFunction = (
@@ -303,28 +301,13 @@ class ConversationHandlerTestProject extends TestProjectBase {
       ...commonEventProperties,
     };
 
-    if (useMessageHistory) {
-      if (withoutMessageAvailableInTheMessageList) {
-        // This tricks conversation handler to think that message is not available in the list.
-        // I.e. it simulates eventually consistency read at list operation where item is not yet visible.
-        // In this case handler should fall back to lookup by current message id.
-        message.conversationId = randomUUID().toString();
-      }
-      await this.insertMessage(apolloClient, message);
-    } else {
-      event.messageHistoryQuery = {
-        getQueryName: '',
-        getQueryInputTypeName: '',
-        listQueryName: '',
-        listQueryInputTypeName: '',
-      };
-      event.messages = [
-        {
-          role: message.role,
-          content: message.content,
-        },
-      ];
+    if (withoutMessageAvailableInTheMessageList) {
+      // This tricks conversation handler to think that message is not available in the list.
+      // I.e. it simulates eventually consistency read at list operation where item is not yet visible.
+      // In this case handler should fall back to lookup by current message id.
+      message.conversationId = randomUUID().toString();
     }
+    await this.insertMessage(apolloClient, message);
 
     const response = await this.executeConversationTurn(
       event,
@@ -338,8 +321,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
     backendId: BackendIdentifier,
     accessToken: string,
     graphqlApiEndpoint: string,
-    apolloClient: ApolloClient<NormalizedCacheObject>,
-    useMessageHistory: boolean
+    apolloClient: ApolloClient<NormalizedCacheObject>
   ): Promise<void> => {
     const defaultConversationHandlerFunction = (
       await this.resourceFinder.findByBackendIdentifier(
@@ -390,22 +372,8 @@ class ConversationHandlerTestProject extends TestProjectBase {
       },
       ...commonEventProperties,
     };
-    if (useMessageHistory) {
-      await this.insertMessage(apolloClient, message);
-    } else {
-      event.messageHistoryQuery = {
-        getQueryName: '',
-        getQueryInputTypeName: '',
-        listQueryName: '',
-        listQueryInputTypeName: '',
-      };
-      event.messages = [
-        {
-          role: message.role,
-          content: message.content,
-        },
-      ];
-    }
+
+    await this.insertMessage(apolloClient, message);
     const response = await this.executeConversationTurn(
       event,
       defaultConversationHandlerFunction,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

`event.messages` is deprecate and ready for removal after data construct shipped.

## Changes

1. Remove deprecated field
2. Adjust logic and tests.

## Validation

Existing tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
