### PR TITLE
fix: internally paginate list secret calls

### DIFF
--- a/.changeset/chilly-snakes-accept.md
+++ b/.changeset/chilly-snakes-accept.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-secret': patch
+---
+
+fix: internally paginate list secret calls


### PR DESCRIPTION
## Problem

GetParametersByPath API only supports returning at [max 10 results](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html#systemsmanager-GetParametersByPath-request-MaxResults) at a time and requires pagination for further results.

**Issue number, if available:**

## Changes

Internally paginate the calls to return all secrets at once.

Out of scope: Updating the public API to paginate calls to `listSecrets`. This can be added in future if the need arises.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests and manually testing `ampx sandbox secrets list` command with more than 10 secrets in the sandbox.

## Checklist


- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
