### PR TITLE
fix: detect deploymentType from Stack Tags

### DIFF
--- a/.changeset/purple-dodos-kneel.md
+++ b/.changeset/purple-dodos-kneel.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/deployed-backend-client': patch
+---
+
+fix: detect deploymentType from Stack Tags

--- a/packages/deployed-backend-client/src/deployed_backend_client_list_sandboxes.test.ts
+++ b/packages/deployed-backend-client/src/deployed_backend_client_list_sandboxes.test.ts
@@ -7,14 +7,8 @@ import {
   StackStatus,
 } from '@aws-sdk/client-cloudformation';
 import { BackendDeploymentStatus } from './deployed_backend_client_factory.js';
-import { platformOutputKey } from '@aws-amplify/backend-output-schemas';
 import { DefaultBackendOutputClient } from './backend_output_client.js';
 import { DefaultDeployedBackendClient } from './deployed_backend_client.js';
-import {
-  BackendOutputClientError,
-  BackendOutputClientErrorType,
-  StackIdentifier,
-} from './index.js';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { S3 } from '@aws-sdk/client-s3';
 import { DeployedResourcesEnumerator } from './deployed-backend-client/deployed_resources_enumerator.js';
@@ -34,14 +28,6 @@ const listStacksMock = {
   ],
 };
 
-const getOutputMockResponse = {
-  [platformOutputKey]: {
-    payload: {
-      deploymentType: 'sandbox',
-    },
-  },
-};
-
 void describe('Deployed Backend Client list sandboxes', () => {
   const mockCfnClient = new CloudFormation();
   const mockS3Client = new S3();
@@ -56,9 +42,18 @@ void describe('Deployed Backend Client list sandboxes', () => {
         const matchingStack = listStacksMock.StackSummaries.find((stack) => {
           return stack.StackName === request.input.StackName;
         });
-        const stack = matchingStack;
         return {
-          Stacks: [stack],
+          Stacks: [
+            {
+              ...matchingStack,
+              Tags: [
+                {
+                  Key: 'amplify:deployment-type',
+                  Value: 'sandbox',
+                },
+              ],
+            },
+          ],
         };
       }
       throw request;
@@ -84,23 +79,7 @@ void describe('Deployed Backend Client list sandboxes', () => {
     mockCfnClient,
     new AmplifyClient()
   );
-  const getOutputMock = mock.method(
-    mockBackendOutputClient,
-    'getOutput',
-    (backendIdentifier: StackIdentifier) => {
-      if (backendIdentifier.stackName === 'amplify-test-not-a-sandbox') {
-        return {
-          ...getOutputMockResponse,
-          [platformOutputKey]: {
-            payload: {
-              deploymentType: 'branch',
-            },
-          },
-        };
-      }
-      return getOutputMockResponse;
-    }
-  );
+
   const returnedSandboxes = [
     {
       deploymentType: 'sandbox',
@@ -117,7 +96,6 @@ void describe('Deployed Backend Client list sandboxes', () => {
   ];
 
   beforeEach(() => {
-    getOutputMock.mock.resetCalls();
     listStacksMockFn.mock.resetCalls();
     cfnClientSendMock.mock.resetCalls();
     const deployedResourcesEnumerator = new DeployedResourcesEnumerator(
@@ -207,59 +185,5 @@ void describe('Deployed Backend Client list sandboxes', () => {
     );
 
     assert.equal(listStacksMockFn.mock.callCount(), 2);
-  });
-
-  void it('paginates listBackends when one page contains a stack, but it gets filtered due to not having gen2 outputs', async () => {
-    getOutputMock.mock.mockImplementationOnce(() => {
-      throw new BackendOutputClientError(
-        BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR,
-        'Test metadata retrieval error'
-      );
-    });
-    listStacksMockFn.mock.mockImplementationOnce(() => {
-      return {
-        StackSummaries: [
-          {
-            StackName: 'amplify-test-name-sandbox-testHash',
-            StackStatus: StackStatus.CREATE_COMPLETE,
-            CreationTime: new Date(0),
-            LastUpdatedTime: new Date(1),
-          },
-        ],
-        NextToken: 'abc',
-      };
-    });
-    const sandboxes = deployedBackendClient.listBackends({
-      deploymentType: 'sandbox',
-    });
-    assert.deepEqual(
-      (await sandboxes.getBackendSummaryByPage().next()).value,
-      returnedSandboxes
-    );
-
-    assert.equal(listStacksMockFn.mock.callCount(), 2);
-  });
-
-  void it('does not paginate listBackends when one page throws an unexpected error fetching gen2 outputs', async () => {
-    getOutputMock.mock.mockImplementationOnce(() => {
-      throw new Error('Unexpected Error!');
-    });
-    listStacksMockFn.mock.mockImplementationOnce(() => {
-      return {
-        StackSummaries: [
-          {
-            StackName: 'amplify-test-name-sandbox-testHash',
-            StackStatus: StackStatus.CREATE_COMPLETE,
-            CreationTime: new Date(0),
-            LastUpdatedTime: new Date(1),
-          },
-        ],
-        NextToken: 'abc',
-      };
-    });
-    const listBackendsPromise = deployedBackendClient.listBackends({
-      deploymentType: 'sandbox',
-    });
-    await assert.rejects(listBackendsPromise.getBackendSummaryByPage().next());
   });
 });


### PR DESCRIPTION
## Problem

`listBackends` [calls](https://github.com/aws-amplify/amplify-backend/blob/fb3538c58cfb25b6ae8aa5d4036be05bf1ee2181/packages/deployed-backend-client/src/deployed_backend_client.ts#L166-L167) `tryGetDeploymentType` to load the entire stack metadata and then infer deployment type from it.

This creates issue if the stack is being created or deleted and the metadata is not available causing the `fetchBackendOutput` to throw causing the `listBackends` call to fail.

**Issue number, if available:**

## Changes

Infer `deploymentType` from stack tags instead. If we can't we don't include that stack/backend in the result.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
