### PR TITLE
Use AiModel from data-schema-types as possible input

### DIFF
--- a/.changeset/happy-jokes-double.md
+++ b/.changeset/happy-jokes-double.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': patch
+---
+
+Update data-schema-types

--- a/.changeset/tough-taxis-tan.md
+++ b/.changeset/tough-taxis-tan.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-ai': patch
+---
+
+Use AiModel from data-schema-types as possible input

--- a/package-lock.json
+++ b/package-lock.json
@@ -2796,10 +2796,9 @@
       }
     },
     "node_modules/@aws-amplify/data-schema-types": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.1.1.tgz",
-      "integrity": "sha512-WhWEEsztpSSxIY0lJ3Ge5iA4g3PBm66SQmy1fBH1FBq0T+cxUBijifOU8MNwf+tf6lGpArMX0RS54HRVF5fUSA==",
-      "license": "Apache-2.0",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.2.0.tgz",
+      "integrity": "sha512-1hy2r7jl3hQ5J/CGjhmPhFPcdGSakfme1ZLjlTMJZILfYifZLSlGRKNCelMb3J5N9203hyeT5XDi5yR47JL1TQ==",
       "dependencies": {
         "graphql": "15.8.0",
         "rxjs": "^7.8.1"
@@ -31455,7 +31454,7 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "0.4.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.3.0",
@@ -31495,15 +31494,15 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.2.0",
         "@aws-amplify/backend-data": "^1.1.4",
-        "@aws-amplify/backend-function": "^1.6.0",
+        "@aws-amplify/backend-function": "^1.7.0",
         "@aws-amplify/backend-output-schemas": "^1.3.0",
         "@aws-amplify/backend-output-storage": "^1.1.2",
-        "@aws-amplify/backend-secret": "^1.1.2",
+        "@aws-amplify/backend-secret": "^1.1.4",
         "@aws-amplify/backend-storage": "^1.2.1",
         "@aws-amplify/client-config": "^1.4.0",
         "@aws-amplify/data-schema": "^1.0.0",
@@ -31524,12 +31523,13 @@
     },
     "packages/backend-ai": {
       "name": "@aws-amplify/backend-ai",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^0.4.0",
+        "@aws-amplify/ai-constructs": "^0.6.0",
         "@aws-amplify/backend-output-schemas": "^1.3.0",
         "@aws-amplify/backend-output-storage": "^1.0.2",
+        "@aws-amplify/data-schema-types": "^1.2.0",
         "@aws-amplify/platform-core": "^1.1.0",
         "@aws-amplify/plugin-types": "^1.0.1"
       },
@@ -31564,7 +31564,7 @@
         "@aws-amplify/backend-output-schemas": "^1.1.0",
         "@aws-amplify/backend-output-storage": "^1.1.2",
         "@aws-amplify/data-construct": "^1.10.1",
-        "@aws-amplify/data-schema-types": "^1.1.1",
+        "@aws-amplify/data-schema-types": "^1.2.0",
         "@aws-amplify/plugin-types": "^1.2.2"
       },
       "devDependencies": {
@@ -31579,7 +31579,7 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.6",
@@ -31594,7 +31594,7 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -31664,7 +31664,7 @@
     },
     "packages/backend-secret": {
       "name": "@aws-amplify/backend-secret",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.5",
@@ -31986,7 +31986,7 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
@@ -32038,11 +32038,11 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
-        "@aws-amplify/ai-constructs": "^0.4.0",
+        "@aws-amplify/ai-constructs": "^0.6.0",
         "@aws-amplify/auth-construct": "^1.3.1",
-        "@aws-amplify/backend": "^1.4.0",
-        "@aws-amplify/backend-ai": "^0.3.0",
-        "@aws-amplify/backend-secret": "^1.1.2",
+        "@aws-amplify/backend": "^1.5.0",
+        "@aws-amplify/backend-ai": "^0.3.2",
+        "@aws-amplify/backend-secret": "^1.1.4",
         "@aws-amplify/client-config": "^1.4.0",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/deployed-backend-client": "^1.4.1",

--- a/packages/backend-ai/API.md
+++ b/packages/backend-ai/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AiModel } from '@aws-amplify/data-schema-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { ConversationTurnEventVersion } from '@aws-amplify/ai-constructs/conversation';
 import { FunctionResources } from '@aws-amplify/plugin-types';
@@ -49,9 +50,7 @@ type DefineConversationHandlerFunctionProps = {
     name: string;
     entry?: string;
     models: Array<{
-        modelId: string | {
-            resourcePath: string;
-        };
+        modelId: string | AiModel;
         region?: string;
     }>;
 };

--- a/packages/backend-ai/package.json
+++ b/packages/backend-ai/package.json
@@ -25,6 +25,7 @@
     "@aws-amplify/ai-constructs": "^0.6.0",
     "@aws-amplify/backend-output-schemas": "^1.3.0",
     "@aws-amplify/backend-output-storage": "^1.0.2",
+    "@aws-amplify/data-schema-types": "^1.2.0",
     "@aws-amplify/platform-core": "^1.1.0",
     "@aws-amplify/plugin-types": "^1.0.1"
   },

--- a/packages/backend-ai/src/conversation/factory.ts
+++ b/packages/backend-ai/src/conversation/factory.ts
@@ -15,6 +15,7 @@ import {
 } from '@aws-amplify/ai-constructs/conversation';
 import path from 'path';
 import { CallerDirectoryExtractor } from '@aws-amplify/platform-core';
+import { AiModel } from '@aws-amplify/data-schema-types';
 
 class ConversationHandlerFunctionGenerator
   implements ConstructContainerEntryGenerator
@@ -115,12 +116,7 @@ export type DefineConversationHandlerFunctionProps = {
   name: string;
   entry?: string;
   models: Array<{
-    modelId:
-      | string
-      | {
-          // This is to match return of 'a.ai.model.anthropic.claude3Haiku()'
-          resourcePath: string;
-        };
+    modelId: string | AiModel;
     region?: string;
   }>;
 };

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -32,6 +32,6 @@
     "@aws-amplify/backend-output-schemas": "^1.1.0",
     "@aws-amplify/data-construct": "^1.10.1",
     "@aws-amplify/plugin-types": "^1.2.2",
-    "@aws-amplify/data-schema-types": "^1.1.1"
+    "@aws-amplify/data-schema-types": "^1.2.0"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Changes

The `AiModel` was moved to `data-schema-types`. Now we can use it instead of defining mirror type.

## Validation

There are already existing tests that cover previously mirrored type. The shape of data doesn't change, only type name.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
