### PR TITLE
Add log groups to e2e resource cleanup script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@actions/github": "^6.0.0",
         "@aws-sdk/client-amplify": "^3.624.0",
         "@aws-sdk/client-cloudformation": "^3.624.0",
+        "@aws-sdk/client-cloudwatch-logs": "^3.624.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.624.0",
         "@aws-sdk/client-dynamodb": "^3.624.0",
         "@aws-sdk/client-iam": "^3.624.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@actions/github": "^6.0.0",
     "@aws-sdk/client-amplify": "^3.624.0",
     "@aws-sdk/client-cloudformation": "^3.624.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.624.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.624.0",
     "@aws-sdk/client-dynamodb": "^3.624.0",
     "@aws-sdk/client-iam": "^3.624.0",

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -7,6 +7,13 @@ import {
   StackSummary,
 } from '@aws-sdk/client-cloudformation';
 import {
+  CloudWatchLogsClient,
+  DeleteLogGroupCommand,
+  DescribeLogGroupsCommand,
+  DescribeLogGroupsCommandOutput,
+  LogGroup,
+} from '@aws-sdk/client-cloudwatch-logs';
+import {
   Bucket,
   DeleteBucketCommand,
   DeleteObjectsCommand,
@@ -70,6 +77,9 @@ const amplifyClient = new AmplifyClient({
 const cfnClient = new CloudFormationClient({
   maxAttempts: 5,
 });
+const cloudWatchClient = new CloudWatchLogsClient({
+  maxAttempts: 5,
+});
 const cognitoClient = new CognitoIdentityProviderClient({
   maxAttempts: 5,
 });
@@ -91,6 +101,7 @@ const TEST_CDK_RESOURCE_PREFIX = 'test-cdk';
 
 /**
  * Stacks are considered stale after 2 hours.
+ * Log groups are considered stale after 7 days. For troubleshooting purposes.
  * Other resources are considered stale after 3 hours.
  *
  * Stack deletion triggers asynchronous resource deletion while this script is running.
@@ -100,6 +111,7 @@ const TEST_CDK_RESOURCE_PREFIX = 'test-cdk';
  */
 const stackStaleDurationInMilliseconds = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
 const staleDurationInMilliseconds = 3 * 60 * 60 * 1000; // 3 hours in milliseconds
+const logGroupStaleDurationInMilliseconds = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
 
 const isStackStale = (
   stackSummary: StackSummary | undefined
@@ -110,6 +122,17 @@ const isStackStale = (
   return (
     now.getTime() - stackSummary.CreationTime.getTime() >
     stackStaleDurationInMilliseconds
+  );
+};
+
+const isLogGroupStale = (
+  logGroup: LogGroup | undefined
+): boolean | undefined => {
+  if (!logGroup?.creationTime) {
+    return;
+  }
+  return (
+    now.getTime() - logGroup.creationTime > logGroupStaleDurationInMilliseconds
   );
 };
 
@@ -543,6 +566,53 @@ for (const staleDynamoDBTable of allStaleDynamoDBTables) {
     const errorMessage = e instanceof Error ? e.message : '';
     console.log(
       `Failed to delete ${staleDynamoDBTable.TableName} DDB table. ${errorMessage}`
+    );
+  }
+}
+
+const listAllStaleTestLogGroups = async (): Promise<Array<LogGroup>> => {
+  let nextToken: string | undefined = undefined;
+  const logGroups: Array<LogGroup> = [];
+  do {
+    const listLogGroupsResponse: DescribeLogGroupsCommandOutput =
+      await cloudWatchClient.send(
+        new DescribeLogGroupsCommand({
+          nextToken,
+        })
+      );
+    nextToken = listLogGroupsResponse.nextToken;
+    listLogGroupsResponse.logGroups
+      ?.filter(
+        (logGroup) =>
+          (logGroup.logGroupName?.startsWith(TEST_AMPLIFY_RESOURCE_PREFIX) ||
+            logGroup.logGroupName?.startsWith(
+              `/${TEST_AMPLIFY_RESOURCE_PREFIX}`
+            ) ||
+            logGroup.logGroupName?.startsWith(
+              `/aws/lambda/${TEST_AMPLIFY_RESOURCE_PREFIX}`
+            )) &&
+          isLogGroupStale(logGroup)
+      )
+      .forEach((item) => {
+        logGroups.push(item);
+      });
+  } while (nextToken);
+  return logGroups;
+};
+
+const allStaleLogGroups = await listAllStaleTestLogGroups();
+for (const logGroup of allStaleLogGroups) {
+  try {
+    await cloudWatchClient.send(
+      new DeleteLogGroupCommand({
+        logGroupName: logGroup.logGroupName,
+      })
+    );
+    console.log(`Successfully deleted ${logGroup.logGroupName} log group`);
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : '';
+    console.log(
+      `Failed to delete ${logGroup.logGroupName} log group. ${errorMessage}`
     );
   }
 }

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -584,9 +584,10 @@ const listAllStaleTestLogGroups = async (): Promise<Array<LogGroup>> => {
     listLogGroupsResponse.logGroups
       ?.filter(
         (logGroup) =>
-          // some log groups have form /aws/lambda/<prefix><rest>
-          // some have <prefix><rest>
-          logGroup.logGroupName?.includes(TEST_AMPLIFY_RESOURCE_PREFIX) &&
+          (logGroup.logGroupName?.startsWith(TEST_AMPLIFY_RESOURCE_PREFIX) ||
+            logGroup.logGroupName?.startsWith(
+              `/aws/lambda/${TEST_AMPLIFY_RESOURCE_PREFIX}`
+            )) &&
           isLogGroupStale(logGroup)
       )
       .forEach((item) => {

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -584,13 +584,9 @@ const listAllStaleTestLogGroups = async (): Promise<Array<LogGroup>> => {
     listLogGroupsResponse.logGroups
       ?.filter(
         (logGroup) =>
-          (logGroup.logGroupName?.startsWith(TEST_AMPLIFY_RESOURCE_PREFIX) ||
-            logGroup.logGroupName?.startsWith(
-              `/${TEST_AMPLIFY_RESOURCE_PREFIX}`
-            ) ||
-            logGroup.logGroupName?.startsWith(
-              `/aws/lambda/${TEST_AMPLIFY_RESOURCE_PREFIX}`
-            )) &&
+          // some log groups have form /aws/lambda/<prefix><rest>
+          // some have <prefix><rest>
+          logGroup.logGroupName?.includes(TEST_AMPLIFY_RESOURCE_PREFIX) &&
           isLogGroupStale(logGroup)
       )
       .forEach((item) => {

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -581,6 +581,7 @@ const listAllStaleTestLogGroups = async (): Promise<Array<LogGroup>> => {
         })
       );
     nextToken = listLogGroupsResponse.nextToken;
+    const logGroupsTmp: Array<LogGroup> = [];
     listLogGroupsResponse.logGroups
       ?.filter(
         (logGroup) =>
@@ -594,8 +595,24 @@ const listAllStaleTestLogGroups = async (): Promise<Array<LogGroup>> => {
           isLogGroupStale(logGroup)
       )
       .forEach((item) => {
-        logGroups.push(item);
+        //logGroups.push(item);
+        logGroupsTmp.push(item);
       });
+    for (const logGroup of logGroupsTmp) {
+      try {
+        await cloudWatchClient.send(
+          new DeleteLogGroupCommand({
+            logGroupName: logGroup.logGroupName,
+          })
+        );
+        console.log(`Successfully deleted ${logGroup.logGroupName} log group`);
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : '';
+        console.log(
+          `Failed to delete ${logGroup.logGroupName} log group. ${errorMessage}`
+        );
+      }
+    }
   } while (nextToken);
   return logGroups;
 };

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -581,7 +581,6 @@ const listAllStaleTestLogGroups = async (): Promise<Array<LogGroup>> => {
         })
       );
     nextToken = listLogGroupsResponse.nextToken;
-    const logGroupsTmp: Array<LogGroup> = [];
     listLogGroupsResponse.logGroups
       ?.filter(
         (logGroup) =>
@@ -595,24 +594,8 @@ const listAllStaleTestLogGroups = async (): Promise<Array<LogGroup>> => {
           isLogGroupStale(logGroup)
       )
       .forEach((item) => {
-        //logGroups.push(item);
-        logGroupsTmp.push(item);
+        logGroups.push(item);
       });
-    for (const logGroup of logGroupsTmp) {
-      try {
-        await cloudWatchClient.send(
-          new DeleteLogGroupCommand({
-            logGroupName: logGroup.logGroupName,
-          })
-        );
-        console.log(`Successfully deleted ${logGroup.logGroupName} log group`);
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : '';
-        console.log(
-          `Failed to delete ${logGroup.logGroupName} log group. ${errorMessage}`
-        );
-      }
-    }
   } while (nextToken);
   return logGroups;
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

When troubleshooting e2e test failures, sometimes it's good to look at lambda logs. However, old, not cleaned up log groups makes this impossible as AWS Console loads 10k log groups before allowing searching for relevant one and due to overflow sometimes the interesting log groups are not even loaded.

## Changes

Include log groups in e2e resource cleanup

## Validation

https://github.com/aws-amplify/amplify-backend/actions/runs/11481721215

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
