### PR TITLE
Option 1: Inject MIS via SSM (possibly S3 url)

### DIFF
--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -183,17 +183,20 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
     resourceNameValidator,
   }: ConstructFactoryGetInstanceProps): AmplifyFunction => {
     if (!this.generator) {
-      const dataResources = constructContainer
-        .getConstructFactory<never>('DataResources')
-        ?.getInstance({
-          constructContainer,
-          outputStorageStrategy,
-          resourceNameValidator,
-        });
 
-      // Need something to use dataResources
-      // eslint-disable-next-line no-console
-      console.log(dataResources);
+      // This unfortunately creates a cycle if combined with access grants.
+
+      // const dataResources = constructContainer
+      //   .getConstructFactory<never>('DataResources')
+      //   ?.getInstance({
+      //     constructContainer,
+      //     outputStorageStrategy,
+      //     resourceNameValidator,
+      //   });
+      //
+      // // Need something to use dataResources
+      // // eslint-disable-next-line no-console
+      // console.log(dataResources);
 
       this.generator = new FunctionGenerator(
         this.hydrateDefaults(resourceNameValidator),

--- a/test-projects/lambda-client/amplify/functions/todo-count/handler.ts
+++ b/test-projects/lambda-client/amplify/functions/todo-count/handler.ts
@@ -1,14 +1,17 @@
 import type { Handler } from "aws-lambda";
-import { Amplify } from "aws-amplify";
-import { generateClient } from "aws-amplify/data";
-import type { Schema } from "../../data/resource";
-import { resourceConfig, libraryOptions } from "$amplify/client-config/todo-count"
+// import { Amplify } from "aws-amplify";
+// import { generateClient } from "aws-amplify/data";
+// import type { Schema } from "../../data/resource";
+// import { resourceConfig, libraryOptions } from "$amplify/client-config/todo-count"
 
-Amplify.configure(resourceConfig, libraryOptions);
-
-const client = generateClient<Schema>();
+// Amplify.configure(resourceConfig, libraryOptions);
+//
+// const client = generateClient<Schema>();
 
 export const handler: Handler = async () => {
-  const todos = (await client.models.Todo.list()).data;
-  return todos.length;
+
+  console.log(JSON.stringify(process.env, null, 2));
+
+  // const todos = (await client.models.Todo.list()).data;
+  // return todos.length;
 };


### PR DESCRIPTION
I was looking at old PR that explains cyclic dependency problem https://github.com/aws-amplify/amplify-backend/pull/969 .
See that PR description.

This POC is using a fact that access rules between data and function expose a way to inject anything from data into function env vars.
We seem to be already injecting GQL url in existing implementation so we'd be following an established pattern here.

The downside is that MIS read in function requires network call.

