### PR TITLE
Option 2: Split out schema generation.

### DIFF
--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -105,6 +105,14 @@ export class BackendFactory<
       if (typeof factory.provides === 'string') {
         constructContainer.registerConstructFactory(factory.provides, factory);
       }
+
+      if (factory.additionalProviders) {
+        Object.entries(factory.additionalProviders).forEach(
+          ([token, provider]) => {
+            constructContainer.registerAdditionalProvider(token, provider);
+          }
+        );
+      }
     });
 
     // now invoke all the factories and collect the constructs into this.resources

--- a/packages/plugin-types/src/construct_container.ts
+++ b/packages/plugin-types/src/construct_container.ts
@@ -1,5 +1,7 @@
 import { Construct } from 'constructs';
-import { ConstructFactory } from './construct_factory.js';
+import {
+  ConstructFactory,
+} from './construct_factory.js';
 import { BackendSecretResolver } from './backend_secret_resolver.js';
 import { ResourceProvider } from './resource_provider.js';
 import { SsmEnvironmentEntriesGenerator } from './ssm_environment_entries_generator.js';
@@ -40,4 +42,13 @@ export type ConstructContainer = {
   getConstructFactory: <T extends ResourceProvider>(
     token: string
   ) => ConstructFactory<T> | undefined;
+
+  // This naming is crap.
+  registerAdditionalProvider: (
+    token: string,
+    provider: (props: GenerateContainerEntryProps) => unknown
+  ) => void;
+  getAdditionalProvider: <T = unknown>(
+    token: string
+  ) => ((props: GenerateContainerEntryProps) => T) | undefined;
 };

--- a/packages/plugin-types/src/construct_factory.ts
+++ b/packages/plugin-types/src/construct_factory.ts
@@ -1,4 +1,7 @@
-import { ConstructContainer } from './construct_container.js';
+import {
+  ConstructContainer,
+  GenerateContainerEntryProps,
+} from './construct_container.js';
 import { BackendOutputStorageStrategy } from './output_storage_strategy.js';
 import { BackendOutputEntry } from './backend_output.js';
 import { ImportPathVerifier } from './import_path_verifier.js';
@@ -21,5 +24,9 @@ export type ConstructFactory<T extends ResourceProvider = ResourceProvider> = {
    * Registering as a provider allows other construct factories to fetch this one based on the provides token
    */
   readonly provides?: string;
+  readonly additionalProviders?: Record<
+    string,
+    (props: GenerateContainerEntryProps) => unknown
+  >;
   getInstance: (props: ConstructFactoryGetInstanceProps) => T;
 };

--- a/test-projects/lambda-client/amplify/functions/todo-count/handler.ts
+++ b/test-projects/lambda-client/amplify/functions/todo-count/handler.ts
@@ -1,14 +1,16 @@
 import type { Handler } from "aws-lambda";
-import { Amplify } from "aws-amplify";
-import { generateClient } from "aws-amplify/data";
-import type { Schema } from "../../data/resource";
-import { resourceConfig, libraryOptions } from "$amplify/client-config/todo-count"
-
-Amplify.configure(resourceConfig, libraryOptions);
-
-const client = generateClient<Schema>();
+// import { Amplify } from "aws-amplify";
+// import { generateClient } from "aws-amplify/data";
+// import type { Schema } from "../../data/resource";
+// import { resourceConfig, libraryOptions } from "$amplify/client-config/todo-count"
+//
+// Amplify.configure(resourceConfig, libraryOptions);
+//
+// const client = generateClient<Schema>();
 
 export const handler: Handler = async () => {
-  const todos = (await client.models.Todo.list()).data;
-  return todos.length;
+  // const todos = (await client.models.Todo.list()).data;
+  // return todos.length;
+
+  console.log(process.env.MIS);
 };


### PR DESCRIPTION
This is a (preferred?) alternative to https://github.com/aws-amplify/amplify-backend/pull/2167 .

The idea here is to split out schema computations from data construct creation. So that schema computation can become both input to function and data construct.

Elements:
1. Split schema generation logic.
2. Add new concept in construct container to register provider/factory method that can provide arbitrary piece of data.

The upside of this solution is that schema is can be bundling time asset without network calls from lambda.


The downside (if this is a downside at all?) is that we're inventing new way of how verticals can communicate and construct container becomes closer to be generic DI container (like syringe) where modules may register arbitrary logic. (which can be abused if contract between verticals established this way is not guarded with proper types/interfaces which become public api of a vertical).