### PR TITLE
fix(backend-deployer): improve handling of expired AWS credentials

### DIFF
--- a/.changeset/cool-pumpkins-dream.md
+++ b/.changeset/cool-pumpkins-dream.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+reclassify as error, UnknownFault, Error: The security token included in the request is expired

--- a/package-lock.json
+++ b/package-lock.json
@@ -31455,7 +31455,7 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
@@ -31495,12 +31495,12 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.2.0",
         "@aws-amplify/backend-data": "^1.1.5",
-        "@aws-amplify/backend-function": "^1.7.1",
+        "@aws-amplify/backend-function": "^1.7.2",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.2",
         "@aws-amplify/backend-secret": "^1.1.4",
@@ -31524,10 +31524,10 @@
     },
     "packages/backend-ai": {
       "name": "@aws-amplify/backend-ai",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^0.6.2",
+        "@aws-amplify/ai-constructs": "^0.7.0",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.0.2",
         "@aws-amplify/data-schema-types": "^1.2.0",
@@ -31595,7 +31595,7 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
@@ -32039,10 +32039,10 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
-        "@aws-amplify/ai-constructs": "^0.6.0",
+        "@aws-amplify/ai-constructs": "^0.7.0",
         "@aws-amplify/auth-construct": "^1.3.1",
-        "@aws-amplify/backend": "^1.5.0",
-        "@aws-amplify/backend-ai": "^0.3.2",
+        "@aws-amplify/backend": "^1.5.2",
+        "@aws-amplify/backend-ai": "^0.3.4",
         "@aws-amplify/backend-secret": "^1.1.4",
         "@aws-amplify/client-config": "^1.4.0",
         "@aws-amplify/data-schema": "^1.0.0",

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -23,6 +23,15 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: 'ExpiredToken',
   },
   {
+    errorMessage:
+      'Error: The security token included in the request is expired',
+    expectedTopLevelErrorMessage:
+      'The security token included in the request is invalid.',
+    errorName: 'ExpiredTokenError',
+    expectedDownstreamErrorMessage:
+      'Error: The security token included in the request is expired',
+  },
+  {
     errorMessage: 'Access Denied',
     expectedTopLevelErrorMessage:
       'The deployment role does not have sufficient permissions to perform this deployment.',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -90,10 +90,12 @@ export class CdkErrorMapper {
     classification: AmplifyErrorClassification;
   }> => [
     {
-      errorRegex: /ExpiredToken/,
+      errorRegex:
+        /ExpiredToken|Error: The security token included in the request is expired/,
       humanReadableErrorMessage:
         'The security token included in the request is invalid.',
-      resolutionMessage: 'Ensure your local AWS credentials are valid.',
+      resolutionMessage:
+        "Please update your AWS credentials. You can do this by running `aws configure` or by updating your AWS credentials file. If you're using temporary credentials, you may need to obtain new ones.",
       errorName: 'ExpiredTokenError',
       classification: 'ERROR',
     },


### PR DESCRIPTION
## Problem

The CdkErrorMapper was not properly handling the "Error: The security token included in the request is expired" error message, leading to potentially confusing error output for users with expired AWS credentials.

## Changes

- Updated the CdkErrorMapper to catch both "ExpiredToken" and "Error: The security token included in the request is expired" errors
- Modified the error message to be more descriptive and user-friendly
- Added a new test case to cover the expanded error handling
- Updated the existing test to align with the current implementation

**Corresponding docs PR, if applicable:** N/A

## Validation

- Updated and added unit tests in `cdk_error_mapper.test.ts` to cover the new error handling

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._