### PR TITLE
Handle parameter not found error while deleting secret

### DIFF
--- a/.changeset/tidy-chicken-notice.md
+++ b/.changeset/tidy-chicken-notice.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-secret': patch
+---
+
+Handle parameter not found error while deleting secret

--- a/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
+++ b/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
@@ -69,7 +69,7 @@ export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
         secretName
       );
     } catch (e) {
-      throw this.translateToAmplifyError(e, 'Remove');
+      throw this.translateToAmplifyError(e, 'Remove', { name: secretName });
     }
   };
 
@@ -87,6 +87,7 @@ export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
           'ExpiredTokenException',
           'ExpiredToken',
           'CredentialsProviderError',
+          'IncompleteSignatureException',
           'InvalidSignatureException',
         ].includes(error.cause.name)
       ) {
@@ -105,6 +106,16 @@ export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
       ) {
         return new AmplifyUserError('SSMParameterNotFoundError', {
           message: `Failed to get ${secretIdentifier.name} secret. ${error.cause.name}: ${error.cause?.message}`,
+          resolution: `Make sure that ${secretIdentifier.name} has been set. See https://docs.amplify.aws/react/deploy-and-host/fullstack-branching/secrets-and-vars/.`,
+        });
+      }
+      if (
+        error.cause.name === 'ParameterNotFound' &&
+        apiName === 'Remove' &&
+        secretIdentifier
+      ) {
+        return new AmplifyUserError('SSMParameterNotFoundError', {
+          message: `Failed to remove ${secretIdentifier.name} secret. ${error.cause.name}: ${error.cause?.message}`,
           resolution: `Make sure that ${secretIdentifier.name} has been set. See https://docs.amplify.aws/react/deploy-and-host/fullstack-branching/secrets-and-vars/.`,
         });
       }

--- a/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
+++ b/packages/backend-secret/src/ssm_secret_with_amplify_error_handling.ts
@@ -101,21 +101,13 @@ export class SSMSecretClientWithAmplifyErrorHandling implements SecretClient {
       }
       if (
         error.cause.name === 'ParameterNotFound' &&
-        apiName === 'Get' &&
+        (apiName === 'Get' || apiName === 'Remove') &&
         secretIdentifier
       ) {
         return new AmplifyUserError('SSMParameterNotFoundError', {
-          message: `Failed to get ${secretIdentifier.name} secret. ${error.cause.name}: ${error.cause?.message}`,
-          resolution: `Make sure that ${secretIdentifier.name} has been set. See https://docs.amplify.aws/react/deploy-and-host/fullstack-branching/secrets-and-vars/.`,
-        });
-      }
-      if (
-        error.cause.name === 'ParameterNotFound' &&
-        apiName === 'Remove' &&
-        secretIdentifier
-      ) {
-        return new AmplifyUserError('SSMParameterNotFoundError', {
-          message: `Failed to remove ${secretIdentifier.name} secret. ${error.cause.name}: ${error.cause?.message}`,
+          message: `Failed to ${apiName.toLowerCase()} ${
+            secretIdentifier.name
+          } secret. ${error.cause.name}: ${error.cause?.message}`,
           resolution: `Make sure that ${secretIdentifier.name} has been set. See https://docs.amplify.aws/react/deploy-and-host/fullstack-branching/secrets-and-vars/.`,
         });
       }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Two errors are misclassified as faults while removing secrets:
1. When ssm parameter does not exist.
2. Another variant of invalid credentials.

## Changes

Added handling logic.

## Validation

Existing tests + new test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
