### PR TITLE
Fix a bug where $ sign in dart outputs would fail compilation

### DIFF
--- a/.changeset/new-buckets-mix.md
+++ b/.changeset/new-buckets-mix.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+Fix a bug where $ sign in dart outputs would fail compilation

--- a/packages/client-config/src/client-config-writer/client_config_formatter_default.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter_default.test.ts
@@ -50,7 +50,7 @@ void describe('client config formatter', () => {
       ClientConfigFormat.DART
     );
 
-    assert.ok(formattedConfig.startsWith("const amplifyConfig = '''"));
+    assert.ok(formattedConfig.startsWith("const amplifyConfig = r'''"));
     assert.ok(
       formattedConfig.includes(JSON.stringify(expectedConfigReturned, null, 2))
     );

--- a/packages/client-config/src/client-config-writer/client_config_formatter_default.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter_default.ts
@@ -16,7 +16,9 @@ export class ClientConfigFormatterDefault implements ClientConfigFormatter {
   format = (clientConfig: ClientConfig, format: ClientConfigFormat): string => {
     switch (format) {
       case ClientConfigFormat.DART: {
-        return `const amplifyConfig = '''${JSON.stringify(
+        // Using raw string, i.e. r''' to disable Dart's interpolations
+        // because we're using special characters like $ in some outputs.
+        return `const amplifyConfig = r'''${JSON.stringify(
           clientConfig,
           null,
           2

--- a/packages/client-config/src/client-config-writer/client_config_formatter_legacy.test.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter_legacy.test.ts
@@ -109,7 +109,7 @@ void describe('client config formatter', () => {
       expectedLegacyConfig.aws_user_pools_id
     );
 
-    assert.ok(formattedConfig.startsWith("const amplifyConfig = '''"));
+    assert.ok(formattedConfig.startsWith("const amplifyConfig = r'''"));
     assert.ok(
       formattedConfig.includes(JSON.stringify(clientConfigMobile, null, 2))
     );

--- a/packages/client-config/src/client-config-writer/client_config_formatter_legacy.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter_legacy.ts
@@ -29,7 +29,9 @@ export class ClientConfigFormatterLegacy implements ClientConfigFormatter {
         }export default amplifyConfig;${os.EOL}`;
       }
       case ClientConfigFormat.DART: {
-        return `const amplifyConfig = '''${JSON.stringify(
+        // Using raw string, i.e. r''' to disable Dart's interpolations
+        // because we're using special characters like $ in some outputs.
+        return `const amplifyConfig = r'''${JSON.stringify(
           this.configConverter.convertToMobileConfig(legacyConfig),
           null,
           2


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Fixes https://github.com/aws-amplify/amplify-backend/issues/2173 .

`$` is special characters in Dart. We're emitting outputs that contain `$` signs. That fails compilation.

## Changes

Use raw Dart strings to disable interpolation.

## Validation

1. Added tests.
2. Manual validation.

**Before**
![image](https://github.com/user-attachments/assets/d1196107-bfe1-4162-94dc-f90d5c956689)

**After**
![image](https://github.com/user-attachments/assets/96f6d21b-32cc-4f19-8cf0-f5dc7713c8c0)


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
