### PR TITLE
Fix detection of AmplifyErrors

### DIFF
--- a/.changeset/green-cups-jam.md
+++ b/.changeset/green-cups-jam.md
@@ -1,0 +1,9 @@
+---
+'@aws-amplify/platform-core': minor
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/sandbox': patch
+'@aws-amplify/backend-cli': patch
+---
+
+Fix detection of AmplifyErrors

--- a/.changeset/green-cups-jam.md
+++ b/.changeset/green-cups-jam.md
@@ -2,6 +2,7 @@
 '@aws-amplify/platform-core': minor
 '@aws-amplify/backend-deployer': patch
 '@aws-amplify/backend-data': patch
+'@aws-amplify/backend': patch
 '@aws-amplify/sandbox': patch
 '@aws-amplify/backend-cli': patch
 ---

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -81,6 +81,7 @@
   "idps",
   "implementors",
   "inheritdoc",
+  "instanceof",
   "interop",
   "invokable",
   "invoker",

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -184,7 +184,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
         this.props.authorizationModes
       );
     } catch (error) {
-      if (error instanceof AmplifyError) {
+      if (AmplifyError.isAmplifyError(error)) {
         throw error;
       }
       throw new AmplifyUserError<AmplifyDataError>(

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -86,7 +86,7 @@ export class CDKDeployer implements BackendDeployer {
     } catch (typeError: unknown) {
       if (
         synthError &&
-        typeError instanceof AmplifyError &&
+        AmplifyError.isAmplifyError(typeError) &&
         typeError.cause?.message.match(
           /Cannot find module '\$amplify\/env\/.*' or its corresponding type declarations/
         )

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -121,7 +121,7 @@ void describe('sandbox command', () => {
       () =>
         commandRunner.runCommand(`sandbox --identifier ${invalidIdentifier}`), // invalid identifier
       (err: TestCommandError) => {
-        assert.ok(err.error instanceof AmplifyError);
+        assert.ok(AmplifyError.isAmplifyError(err.error));
         assert.strictEqual(
           err.error.message,
           'Invalid --identifier provided: invalid@'

--- a/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_event_handler_factory.ts
@@ -64,7 +64,7 @@ export class SandboxEventHandlerFactory {
             return;
           }
           const deployError = args[0];
-          if (deployError && deployError instanceof AmplifyError) {
+          if (deployError && AmplifyError.isAmplifyError(deployError)) {
             await usageDataEmitter.emitFailure(deployError, {
               command: 'Sandbox',
             });

--- a/packages/cli/src/error_handler.ts
+++ b/packages/cli/src/error_handler.ts
@@ -111,7 +111,7 @@ const handleError = async ({
 
   printMessagePreamble?.();
 
-  if (error instanceof AmplifyError) {
+  if (AmplifyError.isAmplifyError(error)) {
     printer.print(format.error(`${error.name}: ${error.message}`));
 
     if (error.resolution) {
@@ -141,7 +141,7 @@ const handleError = async ({
   }
 
   await usageDataEmitter?.emitFailure(
-    error instanceof AmplifyError
+    AmplifyError.isAmplifyError(error)
       ? error
       : AmplifyError.fromError(
           error && error instanceof Error ? error : new Error(message)

--- a/packages/eslint-rules/src/index.ts
+++ b/packages/eslint-rules/src/index.ts
@@ -2,9 +2,11 @@ import { noEmptyCatchRule } from './rules/no_empty_catch.js';
 import { amplifyErrorNameRule } from './rules/amplify_error_name.js';
 import { preferAmplifyErrorsRule } from './rules/prefer_amplify_errors.js';
 import { noAmplifyErrors } from './rules/no_amplify_errors.js';
+import { amplifyErrorNoInstanceOf } from './rules/amplify_error_no_instance_of';
 
 export const rules: Record<string, unknown> = {
   'amplify-error-name': amplifyErrorNameRule,
+  'amplify-error-no-instanceof': amplifyErrorNoInstanceOf,
   'no-empty-catch': noEmptyCatchRule,
   'prefer-amplify-errors': preferAmplifyErrorsRule,
   'no-amplify-errors': noAmplifyErrors,
@@ -15,6 +17,7 @@ export const configs = {
     plugins: ['amplify-backend-rules'],
     rules: {
       'amplify-backend-rules/amplify-error-name': 'error',
+      'amplify-backend-rules/amplify-error-no-instanceof': 'error',
       'amplify-backend-rules/no-empty-catch': 'error',
       'amplify-backend-rules/prefer-amplify-errors': 'off',
       'amplify-backend-rules/no-amplify-errors': 'off',

--- a/packages/eslint-rules/src/rules/amplify_error_no_instance_of.test.ts
+++ b/packages/eslint-rules/src/rules/amplify_error_no_instance_of.test.ts
@@ -1,0 +1,28 @@
+import * as nodeTest from 'node:test';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { amplifyErrorNoInstanceOf } from './amplify_error_no_instance_of.js';
+
+RuleTester.afterAll = nodeTest.after;
+// See https://typescript-eslint.io/packages/rule-tester/#with-specific-frameworks
+// Node test runner methods return promises which are not relevant in the context of testing.
+// We do ignore them in other places with void keyword.
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+RuleTester.it = nodeTest.it;
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+RuleTester.describe = nodeTest.describe;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('amplify-error-no-instanceof', amplifyErrorNoInstanceOf, {
+  valid: ['e instanceof Error'],
+  invalid: [
+    {
+      code: 'e instanceof AmplifyError',
+      errors: [
+        {
+          messageId: 'noInstanceOfWithAmplifyError',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-rules/src/rules/amplify_error_no_instance_of.ts
+++ b/packages/eslint-rules/src/rules/amplify_error_no_instance_of.ts
@@ -1,0 +1,41 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+/**
+ * This rule flags empty catch blocks. Even if they contain comments.
+ *
+ * This rule differs from built in https://github.com/eslint/eslint/blob/main/lib/rules/no-empty.js
+ * in such a way that it uses typescript-eslint and typescript AST
+ * which does not include comments as statements in catch clause body block.
+ */
+export const amplifyErrorNoInstanceOf = ESLintUtils.RuleCreator.withoutDocs({
+  create(context) {
+    return {
+      // This naming comes from @typescript-eslint/utils types.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      BinaryExpression(node) {
+        if (
+          node.operator === 'instanceof' &&
+          node.right.type === 'Identifier' &&
+          node.right.name === 'AmplifyError'
+        ) {
+          context.report({
+            messageId: 'noInstanceOfWithAmplifyError',
+            node,
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description: 'Instanceof operator must not be used with AmplifyError.',
+    },
+    messages: {
+      noInstanceOfWithAmplifyError:
+        'Do not use instanceof with AmplifyError. Use AmplifyError.isAmplifyError instead.',
+    },
+    type: 'problem',
+    schema: [],
+  },
+  defaultOptions: [],
+});

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -166,12 +166,12 @@ export const packageJsonSchema: z.ZodObject<{
     type: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"module">, z.ZodLiteral<"commonjs">]>>;
 }, "strip", z.ZodTypeAny, {
     name?: string | undefined;
-    version?: string | undefined;
     type?: "module" | "commonjs" | undefined;
+    version?: string | undefined;
 }, {
     name?: string | undefined;
-    version?: string | undefined;
     type?: "module" | "commonjs" | undefined;
+    version?: string | undefined;
 }>;
 
 // @public

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -24,6 +24,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     static fromError: (error: unknown) => AmplifyError<'UnknownFault' | 'CredentialsError' | 'InvalidCommandInputError' | 'DomainNotFoundError' | 'SyntaxError'>;
     // (undocumented)
     static fromStderr: (_stderr: string) => AmplifyError | undefined;
+    static isAmplifyError: (error: unknown) => error is AmplifyError<string>;
     // (undocumented)
     readonly link?: string;
     // (undocumented)
@@ -165,12 +166,12 @@ export const packageJsonSchema: z.ZodObject<{
     type: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"module">, z.ZodLiteral<"commonjs">]>>;
 }, "strip", z.ZodTypeAny, {
     name?: string | undefined;
-    type?: "module" | "commonjs" | undefined;
     version?: string | undefined;
+    type?: "module" | "commonjs" | undefined;
 }, {
     name?: string | undefined;
-    type?: "module" | "commonjs" | undefined;
     version?: string | undefined;
+    type?: "module" | "commonjs" | undefined;
 }>;
 
 // @public

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -165,7 +165,7 @@ void describe('AmplifyError.fromError', async () => {
     yargsErrors.forEach((error) => {
       const actual = AmplifyError.fromError(error);
       assert.ok(
-        actual instanceof AmplifyError &&
+        AmplifyError.isAmplifyError(actual) &&
           actual.name === 'InvalidCommandInputError',
         `Failed the test for error ${error.message}`
       );
@@ -175,7 +175,8 @@ void describe('AmplifyError.fromError', async () => {
     const error = new Error('getaddrinfo ENOTFOUND some-domain.com');
     const actual = AmplifyError.fromError(error);
     assert.ok(
-      actual instanceof AmplifyError && actual.name === 'DomainNotFoundError',
+      AmplifyError.isAmplifyError(actual) &&
+        actual.name === 'DomainNotFoundError',
       `Failed the test for error ${error.message}`
     );
   });
@@ -184,7 +185,7 @@ void describe('AmplifyError.fromError', async () => {
     error.name = 'SyntaxError';
     const actual = AmplifyError.fromError(error);
     assert.ok(
-      actual instanceof AmplifyError && actual.name === 'SyntaxError',
+      AmplifyError.isAmplifyError(actual) && actual.name === 'SyntaxError',
       `Failed the test for error ${error.message}`
     );
   });

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -44,7 +44,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     this.code = options.code;
     this.link = options.link;
 
-    if (cause && cause instanceof AmplifyError) {
+    if (cause && AmplifyError.isAmplifyError(cause)) {
       cause.serializedError = undefined;
     }
     this.serializedError = JSON.stringify(
@@ -96,6 +96,26 @@ export abstract class AmplifyError<T extends string = string> extends Error {
       }
     }
     return undefined;
+  };
+
+  /**
+   * This function is a type predicate for AmplifyError.
+   * See https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates.
+   *
+   * Checks if error is an AmplifyError by inspecting if required properties are set.
+   * This is recommended instead of instanceof operator.
+   * The instance of operator does not work as expected if AmplifyError class is loaded
+   * from multiple sources, for example when package manager decides to not de-duplicate dependencies.
+   * See https://github.com/nodejs/node/issues/17943.
+   */
+  static isAmplifyError = (error: unknown): error is AmplifyError => {
+    return (
+      error instanceof Error &&
+      'classification' in error &&
+      (error.classification === 'ERROR' || error.classification === 'FAULT') &&
+      typeof error.name === 'string' &&
+      typeof error.message === 'string'
+    );
   };
 
   static fromError = (

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -273,7 +273,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-aliasattributes
       // offer to recreate the sandbox or revert the change
       if (
-        error instanceof AmplifyError &&
+        AmplifyError.isAmplifyError(error) &&
         error.name === 'CFNUpdateNotSupportedError'
       ) {
         await this.handleUnsupportedDestructiveChanges(options);
@@ -385,7 +385,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
         message = `${message}\nCaused By: ${error.cause.message}\n`;
       }
 
-      if (error instanceof AmplifyError && error.resolution) {
+      if (AmplifyError.isAmplifyError(error) && error.resolution) {
         message = `${message}\nResolution: ${error.resolution}\n`;
       }
     } else message = String(error);


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

`AmplifyError`s are used across multiple packages. When package manager does not de-deuplicate dependencies. I.e. there are multiple copies of `amplify_error.js` in `node_modules` then each class (and it's hierarchy) is a separate island in runtime memory. This causes `instanceof` check to be unreliable when testing if error is an amplify error.

## Changes

1. Add type predicate (see https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates)
2. Replace `instaceof` with type predicate.
3. Add lint rule to prevent `instanceof AmplifyError`

## Validation

PR checks.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
