### PR TITLE
Handle type predicates in api check.

### DIFF
--- a/scripts/components/api-changes-validator/api_usage_statements_generators.ts
+++ b/scripts/components/api-changes-validator/api_usage_statements_generators.ts
@@ -566,7 +566,18 @@ export class CallableUsageStatementsGenerator
       ).generate().usageStatement ?? '';
     let returnValueAssignmentTarget = '';
     if (this.functionType.type.kind !== ts.SyntaxKind.VoidKeyword) {
-      returnValueAssignmentTarget = `const returnValue: ${this.functionType.type.getText()} = `;
+      let returnType;
+      if (this.functionType.type.kind === ts.SyntaxKind.TypePredicate) {
+        // Example type predicate looks like this
+        // '(input: unknown) => input is SampleType;'
+        // It's a special syntax that tells compiler that it's safe to assume
+        // type after invoking the check.
+        // But when it comes to value assignment this is treated as boolean.
+        returnType = 'boolean';
+      } else {
+        returnType = this.functionType.type.getText();
+      }
+      returnValueAssignmentTarget = `const returnValue: ${returnType} = `;
     }
     const minParameterUsage =
       new CallableParameterUsageStatementsGenerator(

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/API.md
@@ -84,4 +84,10 @@ export type SampleTypeThatReferencesFunction<T extends typeof someFunction1> = {
 export type SampleIgnoredType = {
   someProperty: string;
 };
+
+export const sampleTypePredicate: (input: unknown) => input is SampleType;
+
+export class SampleClassWithTypePredicate {
+  static sampleTypePredicate: (input: unknown) => input is SampleType;
+}
 ```

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/src/index.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-without-breaks/src/index.ts
@@ -115,3 +115,13 @@ export type SampleTypeThatReferencesFunction<T extends typeof someFunction1> = {
 export type SampleIgnoredType = {
   someProperty: number;
 };
+
+export const sampleTypePredicate = (input: unknown): input is SampleType => {
+  throw new Error();
+};
+
+export class SampleClassWithTypePredicate {
+  static sampleTypePredicate = (input: unknown): input is SampleType => {
+    throw new Error();
+  };
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Fixes type predicate handling in api check.

New syntax was introduced in https://github.com/aws-amplify/amplify-backend/pull/2200 .

## Changes

1. Treat type predicate return type as boolean.

## Validation

Added tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
