### PR TITLE
Handle errors when checking CDK bootstrap

### DIFF
--- a/.changeset/eleven-numbers-hide.md
+++ b/.changeset/eleven-numbers-hide.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Handle errors when checking CDK bootstrap.

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -97,6 +97,26 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: 'Is this account bootstrapped',
   },
   {
+    errorMessage:
+      // eslint-disable-next-line spellcheck/spell-checker
+      "This CDK deployment requires bootstrap stack version '6', but during the confirmation via SSM parameter /cdk-bootstrap/hnb659fds/version the following error occurred: AccessDeniedException",
+    expectedTopLevelErrorMessage:
+      'Unable to detect CDK bootstrap stack due to permission issues.',
+    errorName: 'BootstrapDetectionError',
+    expectedDownstreamErrorMessage:
+      // eslint-disable-next-line spellcheck/spell-checker
+      "This CDK deployment requires bootstrap stack version '6', but during the confirmation via SSM parameter /cdk-bootstrap/hnb659fds/version the following error occurred: AccessDeniedException",
+  },
+  {
+    errorMessage:
+      "This CDK deployment requires bootstrap stack version '6', found '5'. Please run 'cdk bootstrap'.",
+    expectedTopLevelErrorMessage:
+      'This AWS account and region has outdated CDK bootstrap stack.',
+    errorName: 'BootstrapOutdatedError',
+    expectedDownstreamErrorMessage:
+      "This CDK deployment requires bootstrap stack version '6', found '5'. Please run 'cdk bootstrap'.",
+  },
+  {
     errorMessage: 'Amplify Backend not found in amplify/backend.ts',
     expectedTopLevelErrorMessage:
       'Backend definition could not be found in amplify directory.',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -120,6 +120,26 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
+        /This CDK deployment requires bootstrap stack version \S+, found \S+\. Please run 'cdk bootstrap'\./,
+      humanReadableErrorMessage:
+        'This AWS account and region has outdated CDK bootstrap stack.',
+      resolutionMessage:
+        'Run `cdk bootstrap aws://{YOUR_ACCOUNT_ID}/{YOUR_REGION}` locally to re-bootstrap.',
+      errorName: 'BootstrapOutdatedError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
+        /This CDK deployment requires bootstrap stack version \S+, but during the confirmation via SSM parameter \S+ the following error occurred: AccessDeniedException/,
+      humanReadableErrorMessage:
+        'Unable to detect CDK bootstrap stack due to permission issues.',
+      resolutionMessage:
+        "Ensure that AWS credentials have an IAM policy that grants read access to 'arn:aws:ssm:*:*:parameter/cdk-bootstrap/*' SSM parameters.",
+      errorName: 'BootstrapDetectionError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
         /This CDK CLI is not compatible with the CDK library used by your application\. Please upgrade the CLI to the latest version\./,
       humanReadableErrorMessage:
         "Installed 'aws-cdk' is not compatible with installed 'aws-cdk-lib'.",
@@ -326,6 +346,8 @@ export type CDKDeploymentError =
   | 'BackendBuildError'
   | 'BackendSynthError'
   | 'BootstrapNotDetectedError'
+  | 'BootstrapDetectionError'
+  | 'BootstrapOutdatedError'
   | 'CDKResolveAWSAccountError'
   | 'CDKVersionMismatchError'
   | 'CFNUpdateNotSupportedError'


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

There are 2 new edge cases around CDK boostrap.
1. The stack might be outdated.
2. AWS creds might lack permissions to check parameter.

## Changes

Map errors and provide resolution steps.

## Validation

Added tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
