### PR TITLE
Handle case when AWS region is configured as blank string

### DIFF
--- a/.changeset/short-dryers-tell.md
+++ b/.changeset/short-dryers-tell.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Handle case when AWS region is configured as blank string

--- a/packages/cli/src/command_middleware.test.ts
+++ b/packages/cli/src/command_middleware.test.ts
@@ -122,6 +122,19 @@ void describe('commandMiddleware', () => {
         }
       });
 
+      void it('throws error if region is blank', async () => {
+        process.env.AWS_REGION = '';
+        delete process.env.AWS_DEFAULT_REGION;
+        try {
+          await commandMiddleware.ensureAwsCredentialAndRegion(
+            {} as ArgumentsCamelCase<{ profile: string | undefined }>
+          );
+          assert.fail('expect to throw error');
+        } catch (err) {
+          assert.match((err as Error).message, /The AWS region is blank/);
+        }
+      });
+
       void it('throws error if a profile is provided and no other credential providers', async () => {
         try {
           await commandMiddleware.ensureAwsCredentialAndRegion({

--- a/packages/cli/src/command_middleware.ts
+++ b/packages/cli/src/command_middleware.ts
@@ -60,8 +60,9 @@ export class CommandMiddleware {
     }
 
     // Check region.
+    let region: string | undefined = undefined;
     try {
-      await loadConfig(NODE_REGION_CONFIG_OPTIONS, {
+      region = await loadConfig(NODE_REGION_CONFIG_OPTIONS, {
         ignoreCache: true,
       })();
     } catch (err) {
@@ -76,6 +77,13 @@ export class CommandMiddleware {
         },
         err as Error
       );
+    }
+    if (!region.trim()) {
+      throw new AmplifyUserError('InvalidCredentialError', {
+        message: 'The AWS region is blank',
+        resolution:
+          'Ensure that a valid AWS region is provided in profile configuration or AWS_REGION environment variable.',
+      });
     }
   };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

When

```
export AWS_REGION=""
```

And running
```
npx ampx sandbox --debug
```

CLI throws:
```
Error: expected `region` to be configured for `aws.auth#sigv4`
[DEBUG] 2024-11-06T22:20:26.927Z: Error: expected `region` to be configured for `aws.auth#sigv4`
    at /Users/sobkamil/playground/testapp059/node_modules/@aws-sdk/client-ssm/dist-cjs/auth/httpAuthSchemeProvider.js:11:23
    at Object.defaultSSMHttpAuthSchemeParametersProvider [as httpAuthSchemeParametersProvider] (/Users/sobkamil/playground/testapp059/node_modules/@aws-sdk/client-ssm/dist-cjs/auth/httpAuthSchemeProvider.js:12:15)
    at async /Users/sobkamil/playground/testapp059/node_modules/@smithy/core/dist-cjs/index.js:61:5
    at async /Users/sobkamil/playground/testapp059/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:34:22
    at async FileWatchingSandbox.isBootstrapped (file:///Users/sobkamil/playground/testapp059/node_modules/@aws-amplify/sandbox/lib/file_watching_sandbox.js:241:46)
    at async FileWatchingSandbox.start (file:///Users/sobkamil/playground/testapp059/node_modules/@aws-amplify/sandbox/lib/file_watching_sandbox.js:87:30)
    at async Object.handler (file:///Users/sobkamil/playground/testapp059/node_modules/@aws-amplify/backend-cli/lib/commands/sandbox/sandbox_command.js:80:9)
```

## Changes

Detect blank region and throw user error.


After change:
```
npx ampx sandbox --debug

...
InvalidCredentialError: The AWS region is blank
Resolution: Ensure that a valid AWS region is provided in profile configuration or AWS_REGION environment variable.
```

## Validation

1. Added test.
2. Manual validation




## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
