### PR TITLE
[POC] add breakCircularDependency prop to defineFunction

### DIFF
--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -38,6 +38,7 @@ export type FunctionProps = {
     schedule?: FunctionSchedule | FunctionSchedule[];
     layers?: Record<string, string>;
     bundling?: FunctionBundlingOptions;
+    breakCircularDependencies?: boolean;
 };
 
 // @public (undocumented)


### PR DESCRIPTION
## Changes

Adds `breakCircularDependency` (naming can change) to `defineFunction` props. If this is set to true, splits function into its own stack based on the function's name.

```ts
// amplify/auth/resource.ts
export const preSignUp = defineFunction({
   name: 'preSignUp',
   entry: './presignup/handler.ts',
  breakCircularDependency: true,
});

export const randomFunction = defineFunction({
   name: 'randomFunction',
   entry: './randomefunction/handler.ts',
});

export const auth = defineAuth({
   ...
   triggers: { preSignUp },
});
```
```ts
// amplify/backend.ts
export const backend = defineBackend({
  auth,
  data,
  randomFunction,
  preSignUp,
});

const randomFunctionStack = backend.randomFunction.stack; // function stack
const preSignUpStack = backend.preSignUp.stack; // presignup stack
```

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
