### PR TITLE
update error mapping to catch when Lambda layer ARN regions do not match function region

### DIFF
--- a/.changeset/violet-tools-clap.md
+++ b/.changeset/violet-tools-clap.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-function': patch
+---
+
+update error mapping to catch when Lambda layer ARN regions do not match function region

--- a/.changeset/violet-tools-clap.md
+++ b/.changeset/violet-tools-clap.md
@@ -1,4 +1,5 @@
 ---
+'@aws-amplify/backend': patch
 '@aws-amplify/backend-deployer': patch
 '@aws-amplify/backend-function': patch
 ---

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -380,6 +380,12 @@ const testErrorMappings = [
     errorName: 'MissingDefineBackendError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage: `User: <bootstrap-exec-role-arn> is not authorized to perform: lambda:GetLayerVersion on resource: <resource-arn> because no resource-based policy allows the lambda:GetLayerVersion action`,
+    expectedTopLevelErrorMessage: 'Unable to get Lambda layer version',
+    errorName: 'GetLambdaLayerVersionError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -197,6 +197,15 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex:
+        /User:(.*) is not authorized to perform: lambda:GetLayerVersion on resource:(.*) because no resource-based policy allows the lambda:GetLayerVersion action/,
+      humanReadableErrorMessage: 'Unable to get Lambda layer version',
+      resolutionMessage:
+        'Make sure layer ARNs are correct and layer regions match function region',
+      errorName: 'GetLambdaLayerVersionError',
+      classification: 'ERROR',
+    },
+    {
       // Also extracts the first line in the stack where the error happened
       errorRegex: new RegExp(
         `\\[esbuild Error\\]: ((?:.|${this.multiLineEolRegex})*?at .*)`
@@ -360,4 +369,5 @@ export type CDKDeploymentError =
   | 'FileConventionError'
   | 'ModuleNotFoundError'
   | 'SecretNotSetError'
-  | 'SyntaxError';
+  | 'SyntaxError'
+  | 'GetLambdaLayerVersionError';

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -17,7 +17,6 @@ import { NodeVersion, defineFunction } from './factory.js';
 import { lambdaWithDependencies } from './test-assets/lambda-with-dependencies/resource.js';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -409,38 +408,6 @@ void describe('AmplifyFunctionFactory', () => {
       const template = Template.fromStack(lambda.stack);
 
       template.resourceCountIs('AWS::Events::Rule', 0);
-    });
-  });
-
-  void describe('layers property', () => {
-    void it('defaults to no layers', () => {
-      const lambda = defineFunction({
-        entry: './test-assets/default-lambda/handler.ts',
-      }).getInstance(getInstanceProps);
-      const template = Template.fromStack(lambda.stack);
-
-      template.resourceCountIs('AWS::Lambda::LayerVersion', 0);
-    });
-
-    void it('throws if layer arn region is not the same as function region', () => {
-      assert.throws(
-        () =>
-          defineFunction({
-            entry: './test-assets/default-lambda/handler.ts',
-            layers: {
-              layer1:
-                'arn:aws:lambda:some-region:123456789012:layer:my-layer-1:1',
-            },
-          }).getInstance(getInstanceProps),
-        (error: AmplifyUserError) => {
-          assert.strictEqual(
-            error.message,
-            'Region in ARN does not match function region for layer: layer1'
-          );
-          assert.ok(error.resolution);
-          return true;
-        }
-      );
     });
   });
 

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -23,11 +23,16 @@ import {
   SsmEnvironmentEntry,
   StackProvider,
 } from '@aws-amplify/plugin-types';
-import { Duration, Lazy, Stack, Tags, Token } from 'aws-cdk-lib';
+import { Duration, Stack, Tags } from 'aws-cdk-lib';
 import { Rule } from 'aws-cdk-lib/aws-events';
 import * as targets from 'aws-cdk-lib/aws-events-targets';
 import { Policy } from 'aws-cdk-lib/aws-iam';
-import { CfnFunction, LayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
+import {
+  CfnFunction,
+  ILayerVersion,
+  LayerVersion,
+  Runtime,
+} from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Construct } from 'constructs';
 import { readFileSync } from 'fs';
@@ -345,10 +350,19 @@ class FunctionGenerator implements ConstructContainerEntryGenerator {
     scope,
     backendSecretResolver,
   }: GenerateContainerEntryProps) => {
+    // resolve layers to LayerVersion objects for the NodejsFunction constructor using the scope.
+    const resolvedLayers = Object.entries(this.props.layers).map(([key, arn]) =>
+      LayerVersion.fromLayerVersionArn(
+        scope,
+        `${this.props.name}-${key}-layer`,
+        arn
+      )
+    );
+
     return new AmplifyFunction(
       scope,
       this.props.name,
-      this.props,
+      { ...this.props, resolvedLayers },
       backendSecretResolver,
       this.outputStorageStrategy
     );
@@ -368,38 +382,13 @@ class AmplifyFunction
   constructor(
     scope: Construct,
     id: string,
-    props: HydratedFunctionProps,
+    props: HydratedFunctionProps & { resolvedLayers: ILayerVersion[] },
     backendSecretResolver: BackendSecretResolver,
     outputStorageStrategy: BackendOutputStorageStrategy<FunctionOutput>
   ) {
     super(scope, id);
 
     this.stack = Stack.of(scope);
-
-    // resolve layers to LayerVersion objects for the NodejsFunction constructor using the scope.
-    const resolvedLayers = Object.entries(props.layers).map(([key, arn]) => {
-      const layerRegion = arn.split(':')[3];
-      // If region is an unresolved token, use lazy to get region
-      const region = Token.isUnresolved(this.stack.region)
-        ? Lazy.string({
-            produce: () => this.stack.region,
-          })
-        : this.stack.region;
-
-      if (layerRegion !== region) {
-        throw new AmplifyUserError('InvalidLayerArnRegionError', {
-          message: `Region in ARN does not match function region for layer: ${key}`,
-          resolution:
-            'Update the layer ARN with the same region as the function',
-        });
-      }
-
-      return LayerVersion.fromLayerVersionArn(
-        scope,
-        `${props.name}-${key}-layer`,
-        arn
-      );
-    });
 
     const runtime = nodeVersionMap[props.runtime];
 
@@ -443,7 +432,7 @@ class AmplifyFunction
         timeout: Duration.seconds(props.timeoutSeconds),
         memorySize: props.memoryMB,
         runtime: nodeVersionMap[props.runtime],
-        layers: resolvedLayers,
+        layers: props.resolvedLayers,
         bundling: {
           ...props.bundling,
           banner: bannerCode,

--- a/packages/backend-function/src/layer_parser.test.ts
+++ b/packages/backend-function/src/layer_parser.test.ts
@@ -20,7 +20,7 @@ const createStackAndSetContext = (): Stack => {
   app.node.setContext('amplify-backend-name', 'testEnvName');
   app.node.setContext('amplify-backend-namespace', 'testBackendId');
   app.node.setContext('amplify-backend-type', 'branch');
-  const stack = new Stack(app, 'Stack', { env: { region: 'us-east-1' } });
+  const stack = new Stack(app);
   return stack;
 };
 


### PR DESCRIPTION
## Problem

Work done in https://github.com/aws-amplify/amplify-backend/pull/2188 was too eager (no solid way to validate layer arn region with function region during synthesis). Reverting this change leaves us with the original error when layer arn region is not the same as function region which is not great:

```
The CloudFormation deployment has failed.
Caused By: The stack named <stack> failed to deploy: UPDATE_ROLLBACK_COMPLETE: Resource handler returned message: "User: <user-arn> is not authorized to perform: lambda:GetLayerVersion on resource: <layer-arn> because no resource-based policy allows the lambda:GetLayerVersion action...

Resolution: Find more information in the CloudFormation AWS Console for this stack.
```

**Issue number, if available:**

## Changes

Update error mapping with instructions to check Lambda layer ARNs and make sure regions are correct. New error message:
```
Unable to get layer version
Caused By: User: <user-arn> is not authorized to perform: lambda:GetLayerVersion on resource: <layer-arn> because no resource-based policy allows the lambda:GetLayerVersion action

Resolution: Make sure layer ARNs are correct and regions match function region
```

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
