### PR TITLE
Fix intermittent credential problem on Windows

### DIFF
--- a/.github/actions/setup_profile/action.yml
+++ b/.github/actions/setup_profile/action.yml
@@ -19,8 +19,15 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
-        output-credentials: true # places the credentials in the GH context object rather than setting env vars
-      # the AWS credentials action does not have an option to configure a profile, so this manually configures one
+        # Credentials with special characters are not handled correctly on Windows
+        # when put into profile files. This forces action to retry until credentials without special characters
+        # are retrieved
+        # See: https://github.com/aws-actions/configure-aws-credentials/issues/599
+        # and https://github.com/aws-actions/configure-aws-credentials/issues/528
+        special-characters-workaround: ${{ contains(runner.os, 'Windows') }}
+        # places the credentials in the GH context object rather than setting env vars
+        # the AWS credentials action does not have an option to configure a profile, so this manually configures one
+        output-credentials: true
     - shell: bash
       run: |
         aws configure set aws_access_key_id ${{ steps.credentials.outputs.aws-access-key-id }} --profile ${{ inputs.profile-name }}


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

We're getting intermittent `InvalidSignatureException` exception in our e2e tests.
This seems to happen:
1. On Windows only.
2. With `e2e-tooling` profile only.
3. First SDK call with `e2e-tooling` profile seems to be failing, regardless of scenario.

This has been triaged to match:
https://github.com/aws-actions/configure-aws-credentials/issues/599
and 
https://github.com/aws-actions/configure-aws-credentials/issues/528

Example
![image](https://github.com/user-attachments/assets/f3148bd0-3f98-4e96-80dc-e375e6d94f9d)


## Changes

Use `special-characters-workaround` which was added to handle this particular case.

Docs: https://github.com/aws-actions/configure-aws-credentials/blob/97834a484a5ab3c40fa9e2eb40fcf8041105a573/action.yml#L73-L75

## Validation

This PR run.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
