### PR TITLE
feat: Add mis build to the data factory

### DIFF
--- a/.changeset/rare-kiwis-live.md
+++ b/.changeset/rare-kiwis-live.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/model-generator': patch
+---
+
+feat: Add mis build to S3 from the data construct factory

--- a/package-lock.json
+++ b/package-lock.json
@@ -31840,12 +31840,12 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.3",
-        "@aws-amplify/plugin-types": "^1.3.1",
+        "@aws-amplify/plugin-types": "^1.4.0",
         "@aws-sdk/util-arn-parser": "^3.568.0"
       },
       "peerDependencies": {
@@ -31855,12 +31855,12 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^1.3.0",
-        "@aws-amplify/backend-data": "^1.1.7",
-        "@aws-amplify/backend-function": "^1.7.4",
+        "@aws-amplify/backend-auth": "^1.4.0",
+        "@aws-amplify/backend-data": "^1.2.0",
+        "@aws-amplify/backend-function": "^1.7.5",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.3",
         "@aws-amplify/backend-secret": "^1.1.4",
@@ -31868,7 +31868,7 @@
         "@aws-amplify/client-config": "^1.5.2",
         "@aws-amplify/data-schema": "^1.0.0",
         "@aws-amplify/platform-core": "^1.2.0",
-        "@aws-amplify/plugin-types": "^1.3.1",
+        "@aws-amplify/plugin-types": "^1.4.0",
         "@aws-sdk/client-amplify": "^3.624.0",
         "lodash.snakecase": "^4.1.1"
       },
@@ -31901,13 +31901,13 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/auth-construct": "^1.4.0",
+        "@aws-amplify/auth-construct": "^1.5.0",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.3",
-        "@aws-amplify/plugin-types": "^1.3.1"
+        "@aws-amplify/plugin-types": "^1.4.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.6",
@@ -31924,14 +31924,15 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.1.7",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.3",
         "@aws-amplify/data-construct": "^1.10.1",
         "@aws-amplify/data-schema-types": "^1.2.0",
-        "@aws-amplify/plugin-types": "^1.3.1"
+        "@aws-amplify/graphql-generator": "^0.5.0",
+        "@aws-amplify/plugin-types": "^1.4.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.6",
@@ -31945,11 +31946,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.2.0",
-        "@aws-amplify/plugin-types": "^1.3.1",
+        "@aws-amplify/plugin-types": "^1.4.0",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -31960,12 +31961,12 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.3",
-        "@aws-amplify/plugin-types": "^1.3.1",
+        "@aws-amplify/plugin-types": "^1.4.0",
         "execa": "^8.0.1"
       },
       "devDependencies": {
@@ -32061,19 +32062,19 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.1.8",
+        "@aws-amplify/backend-deployer": "^1.1.9",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-secret": "^1.1.2",
         "@aws-amplify/cli-core": "^1.2.0",
         "@aws-amplify/client-config": "^1.5.1",
         "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/form-generator": "^1.0.3",
-        "@aws-amplify/model-generator": "^1.0.8",
+        "@aws-amplify/model-generator": "^1.0.9",
         "@aws-amplify/platform-core": "^1.2.0",
-        "@aws-amplify/plugin-types": "^1.3.1",
+        "@aws-amplify/plugin-types": "^1.4.0",
         "@aws-amplify/sandbox": "^1.2.5",
         "@aws-amplify/schema-generator": "^1.2.5",
         "@aws-sdk/client-amplify": "^3.624.0",
@@ -32461,7 +32462,7 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
@@ -32469,7 +32470,7 @@
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
         "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/plugin-types": "^1.3.0",
+        "@aws-amplify/plugin-types": "^1.4.0",
         "@aws-sdk/client-appsync": "^3.624.0",
         "@aws-sdk/client-s3": "^3.624.0",
         "@aws-sdk/credential-providers": "^3.624.0",
@@ -32515,7 +32516,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "execa": "^5.1.1"

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -31,7 +31,8 @@
     "@aws-amplify/backend-output-storage": "^1.1.3",
     "@aws-amplify/backend-output-schemas": "^1.4.0",
     "@aws-amplify/data-construct": "^1.10.1",
-    "@aws-amplify/plugin-types": "^1.4.0",
-    "@aws-amplify/data-schema-types": "^1.2.0"
+    "@aws-amplify/data-schema-types": "^1.2.0",
+    "@aws-amplify/graphql-generator": "^0.5.1",
+    "@aws-amplify/plugin-types": "^1.4.0"
   }
 }

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -85,7 +85,6 @@ const createConstructContainerWithUserPoolAuthRegistered = (
         authenticatedUserIamRole: new Role(stack, 'testAuthRole', {
           assumedBy: new ServicePrincipal('test.amazon.com'),
         }),
-        identityPoolId: 'identityPoolId',
         cfnResources: {
           cfnUserPool: new CfnUserPool(stack, 'CfnUserPool', {}),
           cfnUserPoolClient: new CfnUserPoolClient(stack, 'CfnUserPoolClient', {
@@ -101,6 +100,7 @@ const createConstructContainerWithUserPoolAuthRegistered = (
           ),
         },
         groups: {},
+        identityPoolId: 'identityPool',
       },
     }),
   });
@@ -567,6 +567,23 @@ void describe('DataFactory', () => {
                 },
               ],
             },
+            {
+              Action: 's3:GetObject',
+              Resource: {
+                'Fn::Join': [
+                  '',
+                  [
+                    {
+                      'Fn::GetAtt': [
+                        'modelIntrospectionSchemaBucketF566B665',
+                        'Arn',
+                      ],
+                    },
+                    '/modelIntrospectionSchema.json',
+                  ],
+                ],
+              },
+            },
           ],
         },
         Roles: [
@@ -675,6 +692,23 @@ void describe('DataFactory', () => {
                 ],
               },
             },
+            {
+              Action: 's3:GetObject',
+              Resource: {
+                'Fn::Join': [
+                  '',
+                  [
+                    {
+                      'Fn::GetAtt': [
+                        'modelIntrospectionSchemaBucketF566B665',
+                        'Arn',
+                      ],
+                    },
+                    '/modelIntrospectionSchema.json',
+                  ],
+                ],
+              },
+            },
           ],
         },
         Roles: [
@@ -697,6 +731,23 @@ void describe('DataFactory', () => {
                       'Fn::GetAtt': ['amplifyDataGraphQLAPI42A6FA33', 'Arn'],
                     },
                     '/types/Query/*',
+                  ],
+                ],
+              },
+            },
+            {
+              Action: 's3:GetObject',
+              Resource: {
+                'Fn::Join': [
+                  '',
+                  [
+                    {
+                      'Fn::GetAtt': [
+                        'modelIntrospectionSchemaBucketF566B665',
+                        'Arn',
+                      ],
+                    },
+                    '/modelIntrospectionSchema.json',
                   ],
                 ],
               },


### PR DESCRIPTION
## Problem

Users would like to use the Gen2 data client interface to access their APIs from application functions (lambda's).

Our [docs offer instructions on this experience](https://docs.amplify.aws/react/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/#access-the-api-using-aws-amplify), which stop short of indicating how the customer should provide the model introspection schema needed to make the whole experience work.

## Change

1. Build the Model Introspection Schema (MIS) in the data factory
2. Construct an S3 bucket with the MIS as an object
3. Grant get permission to the MIS to any function that is granted `resource` permissions to the data schema
4. Add the bucket name and object key for the MIS to SSM (where it will be read

**Corresponding docs PR, if applicable:**
TODO

## Validation
- Unit tests added
- Manually tested in an example application
- TODO - Add E2E testing

## Checklist
- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
