### PR TITLE
Fix case where tool use does not have input while streaming

### DIFF
--- a/.changeset/clean-hounds-exercise.md
+++ b/.changeset/clean-hounds-exercise.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Fix case where tool use does not have input while streaming

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
@@ -232,8 +232,9 @@ export class BedrockConverseAdapter {
           if (chunk.contentBlockDelta.delta?.toolUse) {
             if (!chunk.contentBlockDelta.delta.toolUse.input) {
               toolUseInput = '';
+            } else {
+              toolUseInput += chunk.contentBlockDelta.delta.toolUse.input;
             }
-            toolUseInput += chunk.contentBlockDelta.delta.toolUse.input;
           } else if (chunk.contentBlockDelta.delta?.text) {
             text += chunk.contentBlockDelta.delta.text;
             yield {
@@ -249,7 +250,9 @@ export class BedrockConverseAdapter {
           }
         } else if (chunk.contentBlockStop) {
           if (toolUseBlock) {
-            toolUseBlock.toolUse.input = JSON.parse(toolUseInput);
+            if (toolUseInput) {
+              toolUseBlock.toolUse.input = JSON.parse(toolUseInput);
+            }
             accumulatedAssistantMessage.content?.push(toolUseBlock);
             if (
               toolUseBlock.toolUse.name &&


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Bedrock Tools might be parameterless.

In that case bedrock either returns undefined input or blank.

## Changes

Conditionally parse tool input.

## Validation

added tests 

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
