### PR TITLE
Fix a case when Bedrock throws validation error if tool input is not persisted in history

### DIFF
--- a/.changeset/clever-emus-hope.md
+++ b/.changeset/clever-emus-hope.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Fix a case when Bedrock throws validation error if tool input is not persisted in history

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.test.ts
@@ -901,8 +901,8 @@ void describe('Bedrock converse adapter', () => {
     assert.strictEqual(responseText, 'finalResponse');
 
     assert.strictEqual(toolExecuteMock.mock.calls.length, 2);
-    assert.strictEqual(toolExecuteMock.mock.calls[0].arguments[0], undefined);
-    assert.strictEqual(toolExecuteMock.mock.calls[1].arguments[0], undefined);
+    assert.deepStrictEqual(toolExecuteMock.mock.calls[0].arguments[0], {});
+    assert.deepStrictEqual(toolExecuteMock.mock.calls[1].arguments[0], {});
   });
 
   void it('throws if tool is duplicated', () => {

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
@@ -252,6 +252,10 @@ export class BedrockConverseAdapter {
           if (toolUseBlock) {
             if (toolUseInput) {
               toolUseBlock.toolUse.input = JSON.parse(toolUseInput);
+            } else {
+              // Bedrock API requires tool input to be non-null in message history.
+              // Therefore, falling back to empty object.
+              toolUseBlock.toolUse.input = {};
             }
             accumulatedAssistantMessage.content?.push(toolUseBlock);
             if (

--- a/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
+++ b/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
@@ -26,6 +26,7 @@ import assert from 'assert';
 import { NormalizedCacheObject } from '@apollo/client';
 import {
   bedrockModelId,
+  expectedRandomNumber,
   expectedTemperatureInDataToolScenario,
   expectedTemperaturesInProgrammaticToolScenario,
 } from '../test-projects/conversation-handler/amplify/constants.js';
@@ -270,6 +271,16 @@ class ConversationHandlerTestProject extends TestProjectBase {
 
     await this.executeWithRetry(() =>
       this.assertCustomConversationHandlerCanExecuteTurn(
+        backendId,
+        authenticatedUserCredentials.accessToken,
+        dataUrl,
+        apolloClient,
+        true
+      )
+    );
+
+    await this.executeWithRetry(() =>
+      this.assertCustomConversationHandlerCanExecuteTurnWithParameterLessTool(
         backendId,
         authenticatedUserCredentials.accessToken,
         dataUrl,
@@ -852,6 +863,56 @@ class ConversationHandlerTestProject extends TestProjectBase {
       )
     );
   };
+
+  private assertCustomConversationHandlerCanExecuteTurnWithParameterLessTool =
+    async (
+      backendId: BackendIdentifier,
+      accessToken: string,
+      graphqlApiEndpoint: string,
+      apolloClient: ApolloClient<NormalizedCacheObject>,
+      streamResponse: boolean
+    ): Promise<void> => {
+      const customConversationHandlerFunction = (
+        await this.resourceFinder.findByBackendIdentifier(
+          backendId,
+          'AWS::Lambda::Function',
+          (name) => name.includes('custom')
+        )
+      )[0];
+
+      const message: CreateConversationMessageChatInput = {
+        conversationId: randomUUID().toString(),
+        id: randomUUID().toString(),
+        role: 'user',
+        content: [
+          {
+            text: 'Generate and print random number',
+          },
+        ],
+      };
+      await this.insertMessage(apolloClient, message);
+
+      // send event
+      const event: ConversationTurnEvent = {
+        conversationId: message.conversationId,
+        currentMessageId: message.id,
+        graphqlApiEndpoint: graphqlApiEndpoint,
+        request: {
+          headers: { authorization: accessToken },
+        },
+        ...this.getCommonEventProperties(streamResponse),
+      };
+      const response = await this.executeConversationTurn(
+        event,
+        customConversationHandlerFunction,
+        apolloClient
+      );
+      // Assert that tool was used. I.e. LLM used value provided by the tool.
+      assert.match(
+        response.content,
+        new RegExp(expectedRandomNumber.toString())
+      );
+    };
 
   private assertDefaultConversationHandlerCanPropagateError = async (
     backendId: BackendIdentifier,

--- a/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
+++ b/packages/integration-tests/src/test-project-setup/conversation_handler_project.ts
@@ -886,7 +886,7 @@ class ConversationHandlerTestProject extends TestProjectBase {
         role: 'user',
         content: [
           {
-            text: 'Generate and print random number',
+            text: 'Give me a random number',
           },
         ],
       };

--- a/packages/integration-tests/src/test-projects/conversation-handler/amplify/constants.ts
+++ b/packages/integration-tests/src/test-projects/conversation-handler/amplify/constants.ts
@@ -14,3 +14,5 @@ export const expectedTemperaturesInProgrammaticToolScenario = {
 };
 
 export const expectedTemperatureInDataToolScenario = 85;
+
+export const expectedRandomNumber = 42;

--- a/packages/integration-tests/src/test-projects/conversation-handler/amplify/custom-conversation-handler/custom_handler.ts
+++ b/packages/integration-tests/src/test-projects/conversation-handler/amplify/custom-conversation-handler/custom_handler.ts
@@ -3,7 +3,10 @@ import {
   createExecutableTool,
   handleConversationTurnEvent,
 } from '@aws-amplify/backend-ai/conversation/runtime';
-import { expectedTemperaturesInProgrammaticToolScenario } from '../constants.js';
+import {
+  expectedRandomNumber,
+  expectedTemperaturesInProgrammaticToolScenario,
+} from '../constants.js';
 
 const thermometerInputSchema = {
   type: 'object',
@@ -33,11 +36,32 @@ const thermometer = createExecutableTool(
   }
 );
 
+// Parameter-less tool.
+const randomNumberGeneratorInputSchema = {
+  type: 'object',
+  properties: {},
+  required: [],
+} as const;
+
+const randomNumberGenerator = createExecutableTool(
+  'randomNumberGenerator',
+  'Generates random numbers',
+  {
+    json: randomNumberGeneratorInputSchema,
+  },
+  () => {
+    return Promise.resolve({
+      // We use this value in test assertion.
+      text: `${expectedRandomNumber}`,
+    });
+  }
+);
+
 /**
  * Handler with simple tool.
  */
 export const handler = async (event: ConversationTurnEvent) => {
   await handleConversationTurnEvent(event, {
-    tools: [thermometer],
+    tools: [randomNumberGenerator, thermometer],
   });
 };

--- a/packages/integration-tests/src/test-projects/conversation-handler/amplify/custom-conversation-handler/custom_handler.ts
+++ b/packages/integration-tests/src/test-projects/conversation-handler/amplify/custom-conversation-handler/custom_handler.ts
@@ -45,7 +45,7 @@ const randomNumberGeneratorInputSchema = {
 
 const randomNumberGenerator = createExecutableTool(
   'randomNumberGenerator',
-  'Generates random numbers',
+  'Returns a random number',
   {
     json: randomNumberGeneratorInputSchema,
   },


### PR DESCRIPTION
## Problem

This was missed in https://github.com/aws-amplify/amplify-backend/pull/2226

![image](https://github.com/user-attachments/assets/8389ebab-c6f2-416e-84a0-9dd7a1449872)

## Changes

Fall back to empty object when bedrock is sending empty input.

## Validation

Added e2e test for this particular case since problem was with bedrock runtime validation

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
