### PR TITLE
add resourceGroupName prop to function

### DIFF
--- a/.changeset/bright-guests-marry.md
+++ b/.changeset/bright-guests-marry.md
@@ -1,0 +1,11 @@
+---
+'@aws-amplify/backend-function': minor
+'@aws-amplify/backend-storage': minor
+'@aws-amplify/plugin-types': minor
+'@aws-amplify/backend': minor
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/backend-ai': patch
+---
+
+add resourceGroupName prop to function and storage

--- a/.changeset/bright-guests-marry.md
+++ b/.changeset/bright-guests-marry.md
@@ -8,4 +8,4 @@
 '@aws-amplify/backend-ai': patch
 ---
 
-add resourceGroupName prop to function and storage
+add resourceGroupName prop to function

--- a/.changeset/bright-guests-marry.md
+++ b/.changeset/bright-guests-marry.md
@@ -1,6 +1,6 @@
 ---
 '@aws-amplify/backend-function': minor
-'@aws-amplify/backend-storage': minor
+'@aws-amplify/backend-storage': patch
 '@aws-amplify/plugin-types': minor
 '@aws-amplify/backend': minor
 '@aws-amplify/backend-auth': patch

--- a/packages/backend-ai/src/conversation/factory.ts
+++ b/packages/backend-ai/src/conversation/factory.ts
@@ -1,5 +1,6 @@
 import { AIConversationOutput } from '@aws-amplify/backend-output-schemas';
 import {
+  AmplifyResourceGroupName,
   BackendOutputStorageStrategy,
   ConstructContainerEntryGenerator,
   ConstructFactory,
@@ -20,7 +21,8 @@ import { AiModel } from '@aws-amplify/data-schema-types';
 class ConversationHandlerFunctionGenerator
   implements ConstructContainerEntryGenerator
 {
-  readonly resourceGroupName = 'conversationHandlerFunction';
+  readonly resourceGroupName: AmplifyResourceGroupName =
+    'conversationHandlerFunction';
 
   constructor(
     private readonly props: DefineConversationHandlerFunctionProps,

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -12,6 +12,7 @@ import {
   TriggerEvent,
 } from '@aws-amplify/auth-construct';
 import {
+  AmplifyResourceGroupName,
   AuthResources,
   AuthRoleName,
   ConstructContainerEntryGenerator,
@@ -134,7 +135,7 @@ export class AmplifyAuthFactory implements ConstructFactory<BackendAuth> {
 }
 
 class AmplifyAuthGenerator implements ConstructContainerEntryGenerator {
-  readonly resourceGroupName = 'auth';
+  readonly resourceGroupName: AmplifyResourceGroupName = 'auth';
   private readonly name: string;
 
   constructor(

--- a/packages/backend-auth/src/reference_factory.ts
+++ b/packages/backend-auth/src/reference_factory.ts
@@ -1,4 +1,5 @@
 import {
+  AmplifyResourceGroupName,
   AuthRoleName,
   BackendOutputStorageStrategy,
   ConstructContainerEntryGenerator,
@@ -129,7 +130,7 @@ export class AmplifyReferenceAuthFactory
 class AmplifyReferenceAuthGenerator
   implements ConstructContainerEntryGenerator
 {
-  readonly resourceGroupName = 'auth';
+  readonly resourceGroupName: AmplifyResourceGroupName = 'auth';
   private readonly name: string;
 
   constructor(

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -1,6 +1,7 @@
 import { IConstruct } from 'constructs';
 import {
   AmplifyFunction,
+  AmplifyResourceGroupName,
   AuthResources,
   BackendOutputStorageStrategy,
   ConstructContainerEntryGenerator,
@@ -112,7 +113,7 @@ export class DataFactory implements ConstructFactory<AmplifyData> {
 }
 
 class DataGenerator implements ConstructContainerEntryGenerator {
-  readonly resourceGroupName = 'data';
+  readonly resourceGroupName: AmplifyResourceGroupName = 'data';
   private readonly name: string;
 
   constructor(

--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AmplifyResourceGroupName } from '@aws-amplify/plugin-types';
 import { BackendSecret } from '@aws-amplify/plugin-types';
 import { ConstructFactory } from '@aws-amplify/plugin-types';
 import { FunctionResources } from '@aws-amplify/plugin-types';
@@ -38,6 +39,7 @@ export type FunctionProps = {
     schedule?: FunctionSchedule | FunctionSchedule[];
     layers?: Record<string, string>;
     bundling?: FunctionBundlingOptions;
+    resourceGroupName?: AmplifyResourceGroupName;
 };
 
 // @public (undocumented)

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -155,6 +155,8 @@ export type FunctionProps = {
   /**
    * Group the function with existing Amplify resources or separate the function into its own group.
    * @default 'function' // grouping with other Amplify functions
+   * @example
+   * resourceGroupName: 'auth' // to group an auth trigger with an auth resource
    */
   resourceGroupName?: AmplifyResourceGroupName;
 };

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -9,6 +9,7 @@ import {
   TagName,
 } from '@aws-amplify/platform-core';
 import {
+  AmplifyResourceGroupName,
   BackendOutputStorageStrategy,
   BackendSecret,
   BackendSecretResolver,
@@ -150,6 +151,12 @@ export type FunctionProps = {
    * Options for bundling the function code.
    */
   bundling?: FunctionBundlingOptions;
+
+  /**
+   * Group the function with existing Amplify resources or separate the function into its own group.
+   * @default 'function' // grouping with other Amplify functions
+   */
+  resourceGroupName?: AmplifyResourceGroupName;
 };
 
 export type FunctionBundlingOptions = {
@@ -208,6 +215,7 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
       schedule: this.resolveSchedule(),
       bundling: this.resolveBundling(),
       layers,
+      resourceGroupName: this.props.resourceGroupName ?? 'function',
     };
   };
 
@@ -339,12 +347,14 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
 type HydratedFunctionProps = Required<FunctionProps>;
 
 class FunctionGenerator implements ConstructContainerEntryGenerator {
-  readonly resourceGroupName = 'function';
+  readonly resourceGroupName: AmplifyResourceGroupName;
 
   constructor(
     private readonly props: HydratedFunctionProps,
     private readonly outputStorageStrategy: BackendOutputStorageStrategy<FunctionOutput>
-  ) {}
+  ) {
+    this.resourceGroupName = props.resourceGroupName;
+  }
 
   generateContainerEntry = ({
     scope,

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AmplifyResourceGroupName } from '@aws-amplify/plugin-types';
 import { AmplifyUserErrorOptions } from '@aws-amplify/platform-core';
 import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { CfnBucket } from 'aws-cdk-lib/aws-s3';
@@ -30,7 +29,6 @@ export type AmplifyStorageProps = {
     versioned?: boolean;
     outputStorageStrategy?: BackendOutputStorageStrategy<StorageOutput>;
     triggers?: Partial<Record<AmplifyStorageTriggerEvent, ConstructFactory<ResourceProvider<FunctionResources>>>>;
-    resourceGroupName?: AmplifyResourceGroupName;
 };
 
 // @public (undocumented)

--- a/packages/backend-storage/API.md
+++ b/packages/backend-storage/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AmplifyResourceGroupName } from '@aws-amplify/plugin-types';
 import { AmplifyUserErrorOptions } from '@aws-amplify/platform-core';
 import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { CfnBucket } from 'aws-cdk-lib/aws-s3';
@@ -29,6 +30,7 @@ export type AmplifyStorageProps = {
     versioned?: boolean;
     outputStorageStrategy?: BackendOutputStorageStrategy<StorageOutput>;
     triggers?: Partial<Record<AmplifyStorageTriggerEvent, ConstructFactory<ResourceProvider<FunctionResources>>>>;
+    resourceGroupName?: AmplifyResourceGroupName;
 };
 
 // @public (undocumented)

--- a/packages/backend-storage/src/construct.ts
+++ b/packages/backend-storage/src/construct.ts
@@ -8,6 +8,7 @@ import {
   IBucket,
 } from 'aws-cdk-lib/aws-s3';
 import {
+  AmplifyResourceGroupName,
   BackendOutputStorageStrategy,
   ConstructFactory,
   FunctionResources,
@@ -63,6 +64,13 @@ export type AmplifyStorageProps = {
       ConstructFactory<ResourceProvider<FunctionResources>>
     >
   >;
+  /**
+   * Group the storage resource with existing Amplify resources or separate the storage resource into its own group.
+   *
+   * Warning: Changing this is a destructive change for the storage resource.
+   * @default 'storage' // grouping with other storage resources
+   */
+  resourceGroupName?: AmplifyResourceGroupName;
 };
 
 export type StorageResources = {

--- a/packages/backend-storage/src/construct.ts
+++ b/packages/backend-storage/src/construct.ts
@@ -8,7 +8,6 @@ import {
   IBucket,
 } from 'aws-cdk-lib/aws-s3';
 import {
-  AmplifyResourceGroupName,
   BackendOutputStorageStrategy,
   ConstructFactory,
   FunctionResources,
@@ -64,13 +63,6 @@ export type AmplifyStorageProps = {
       ConstructFactory<ResourceProvider<FunctionResources>>
     >
   >;
-  /**
-   * Group the storage resource with existing Amplify resources or separate the storage resource into its own group.
-   *
-   * Warning: Changing this is a destructive change for the storage resource.
-   * @default 'storage' // grouping with other storage resources
-   */
-  resourceGroupName?: AmplifyResourceGroupName;
 };
 
 export type StorageResources = {

--- a/packages/backend-storage/src/storage_container_entry_generator.ts
+++ b/packages/backend-storage/src/storage_container_entry_generator.ts
@@ -18,7 +18,7 @@ import { TagName } from '@aws-amplify/platform-core';
 export class StorageContainerEntryGenerator
   implements ConstructContainerEntryGenerator
 {
-  readonly resourceGroupName: AmplifyResourceGroupName;
+  readonly resourceGroupName: AmplifyResourceGroupName = 'storage';
 
   /**
    * Initialize with context from storage factory
@@ -27,9 +27,7 @@ export class StorageContainerEntryGenerator
     private readonly props: AmplifyStorageFactoryProps,
     private readonly getInstanceProps: ConstructFactoryGetInstanceProps,
     private readonly storageAccessOrchestratorFactory: StorageAccessOrchestratorFactory = new StorageAccessOrchestratorFactory()
-  ) {
-    this.resourceGroupName = props.resourceGroupName ?? 'storage';
-  }
+  ) {}
 
   generateContainerEntry = ({
     scope,

--- a/packages/backend-storage/src/storage_container_entry_generator.ts
+++ b/packages/backend-storage/src/storage_container_entry_generator.ts
@@ -1,4 +1,5 @@
 import {
+  AmplifyResourceGroupName,
   ConstructContainerEntryGenerator,
   ConstructFactoryGetInstanceProps,
   GenerateContainerEntryProps,
@@ -17,7 +18,7 @@ import { TagName } from '@aws-amplify/platform-core';
 export class StorageContainerEntryGenerator
   implements ConstructContainerEntryGenerator
 {
-  readonly resourceGroupName = 'storage';
+  readonly resourceGroupName: AmplifyResourceGroupName;
 
   /**
    * Initialize with context from storage factory
@@ -26,7 +27,9 @@ export class StorageContainerEntryGenerator
     private readonly props: AmplifyStorageFactoryProps,
     private readonly getInstanceProps: ConstructFactoryGetInstanceProps,
     private readonly storageAccessOrchestratorFactory: StorageAccessOrchestratorFactory = new StorageAccessOrchestratorFactory()
-  ) {}
+  ) {
+    this.resourceGroupName = props.resourceGroupName ?? 'storage';
+  }
 
   generateContainerEntry = ({
     scope,

--- a/packages/integration-tests/src/test-e2e/deployment/circular_dep_auth_data_func.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/circular_dep_auth_data_func.deployment.test.ts
@@ -1,0 +1,4 @@
+import { CircularDepAuthDataFuncTestProjectCreator } from '../../test-project-setup/circular_dep_auth_data_func.js';
+import { defineDeploymentTest } from './deployment.test.template.js';
+
+defineDeploymentTest(new CircularDepAuthDataFuncTestProjectCreator());

--- a/packages/integration-tests/src/test-e2e/deployment/circular_dep_data_func.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/circular_dep_data_func.deployment.test.ts
@@ -1,0 +1,4 @@
+import { CircularDepDataFuncTestProjectCreator } from '../../test-project-setup/circular_dep_data_func.js';
+import { defineDeploymentTest } from './deployment.test.template.js';
+
+defineDeploymentTest(new CircularDepDataFuncTestProjectCreator());

--- a/packages/integration-tests/src/test-e2e/sandbox/circular_dep_auth_data_func.sandbox.test.ts
+++ b/packages/integration-tests/src/test-e2e/sandbox/circular_dep_auth_data_func.sandbox.test.ts
@@ -1,0 +1,4 @@
+import { CircularDepAuthDataFuncTestProjectCreator } from '../../test-project-setup/circular_dep_auth_data_func.js';
+import { defineSandboxTest } from './sandbox.test.template.js';
+
+defineSandboxTest(new CircularDepAuthDataFuncTestProjectCreator());

--- a/packages/integration-tests/src/test-e2e/sandbox/circular_dep_data_func.sandbox.test.ts
+++ b/packages/integration-tests/src/test-e2e/sandbox/circular_dep_data_func.sandbox.test.ts
@@ -1,0 +1,4 @@
+import { CircularDepDataFuncTestProjectCreator } from '../../test-project-setup/circular_dep_data_func.js';
+import { defineSandboxTest } from './sandbox.test.template.js';
+
+defineSandboxTest(new CircularDepDataFuncTestProjectCreator());

--- a/packages/integration-tests/src/test-project-setup/circular_dep_auth_data_func.ts
+++ b/packages/integration-tests/src/test-project-setup/circular_dep_auth_data_func.ts
@@ -1,0 +1,83 @@
+import { TestProjectBase } from './test_project_base.js';
+import fs from 'fs/promises';
+import { createEmptyAmplifyProject } from './create_empty_amplify_project.js';
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { TestProjectCreator } from './test_project_creator.js';
+import { AmplifyClient } from '@aws-sdk/client-amplify';
+import { e2eToolingClientConfig } from '../e2e_tooling_client_config.js';
+
+/**
+ * Creates test projects with circular dependency between auth, data, and functions
+ */
+export class CircularDepAuthDataFuncTestProjectCreator
+  implements TestProjectCreator
+{
+  readonly name = 'circular-dep-auth-data-func';
+
+  /**
+   * Creates project creator.
+   */
+  constructor(
+    private readonly cfnClient: CloudFormationClient = new CloudFormationClient(
+      e2eToolingClientConfig
+    ),
+    private readonly amplifyClient: AmplifyClient = new AmplifyClient(
+      e2eToolingClientConfig
+    )
+  ) {}
+
+  createProject = async (e2eProjectDir: string): Promise<TestProjectBase> => {
+    const { projectName, projectRoot, projectAmplifyDir } =
+      await createEmptyAmplifyProject(this.name, e2eProjectDir);
+
+    const project = new CircularDepAuthDataFuncTestProject(
+      projectName,
+      projectRoot,
+      projectAmplifyDir,
+      this.cfnClient,
+      this.amplifyClient
+    );
+    await fs.cp(
+      project.sourceProjectAmplifyDirURL,
+      project.projectAmplifyDirPath,
+      {
+        recursive: true,
+      }
+    );
+    return project;
+  };
+}
+
+/**
+ * Test project with circular dependency between auth, data, and functions
+ */
+class CircularDepAuthDataFuncTestProject extends TestProjectBase {
+  readonly sourceProjectDirPath =
+    '../../src/test-projects/circular-dep-auth-data-func';
+
+  readonly sourceProjectAmplifyDirSuffix = `${this.sourceProjectDirPath}/amplify`;
+
+  readonly sourceProjectAmplifyDirURL: URL = new URL(
+    this.sourceProjectAmplifyDirSuffix,
+    import.meta.url
+  );
+
+  /**
+   * Create a test project instance.
+   */
+  constructor(
+    name: string,
+    projectDirPath: string,
+    projectAmplifyDirPath: string,
+    cfnClient: CloudFormationClient,
+    amplifyClient: AmplifyClient
+  ) {
+    super(
+      name,
+      projectDirPath,
+      projectAmplifyDirPath,
+      cfnClient,
+      amplifyClient
+    );
+  }
+}

--- a/packages/integration-tests/src/test-project-setup/circular_dep_data_func.ts
+++ b/packages/integration-tests/src/test-project-setup/circular_dep_data_func.ts
@@ -1,0 +1,83 @@
+import { TestProjectBase } from './test_project_base.js';
+import fs from 'fs/promises';
+import { createEmptyAmplifyProject } from './create_empty_amplify_project.js';
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { TestProjectCreator } from './test_project_creator.js';
+import { AmplifyClient } from '@aws-sdk/client-amplify';
+import { e2eToolingClientConfig } from '../e2e_tooling_client_config.js';
+
+/**
+ * Creates test projects with circular dependency between data, and functions
+ */
+export class CircularDepDataFuncTestProjectCreator
+  implements TestProjectCreator
+{
+  readonly name = 'circular-dep-data-func';
+
+  /**
+   * Creates project creator.
+   */
+  constructor(
+    private readonly cfnClient: CloudFormationClient = new CloudFormationClient(
+      e2eToolingClientConfig
+    ),
+    private readonly amplifyClient: AmplifyClient = new AmplifyClient(
+      e2eToolingClientConfig
+    )
+  ) {}
+
+  createProject = async (e2eProjectDir: string): Promise<TestProjectBase> => {
+    const { projectName, projectRoot, projectAmplifyDir } =
+      await createEmptyAmplifyProject(this.name, e2eProjectDir);
+
+    const project = new CircularDepDataFuncTestProject(
+      projectName,
+      projectRoot,
+      projectAmplifyDir,
+      this.cfnClient,
+      this.amplifyClient
+    );
+    await fs.cp(
+      project.sourceProjectAmplifyDirURL,
+      project.projectAmplifyDirPath,
+      {
+        recursive: true,
+      }
+    );
+    return project;
+  };
+}
+
+/**
+ * Test project with circular dependency between data, and functions
+ */
+class CircularDepDataFuncTestProject extends TestProjectBase {
+  readonly sourceProjectDirPath =
+    '../../src/test-projects/circular-dep-data-func';
+
+  readonly sourceProjectAmplifyDirSuffix = `${this.sourceProjectDirPath}/amplify`;
+
+  readonly sourceProjectAmplifyDirURL: URL = new URL(
+    this.sourceProjectAmplifyDirSuffix,
+    import.meta.url
+  );
+
+  /**
+   * Create a test project instance.
+   */
+  constructor(
+    name: string,
+    projectDirPath: string,
+    projectAmplifyDirPath: string,
+    cfnClient: CloudFormationClient,
+    amplifyClient: AmplifyClient
+  ) {
+    super(
+      name,
+      projectDirPath,
+      projectAmplifyDirPath,
+      cfnClient,
+      amplifyClient
+    );
+  }
+}

--- a/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/auth/resource.ts
@@ -1,0 +1,11 @@
+import { defineAuth } from '@aws-amplify/backend';
+import { preSignUp } from '../functions/pre-sign-up/resource.js';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+  },
+  triggers: {
+    preSignUp,
+  },
+});

--- a/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/backend.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/backend.ts
@@ -1,0 +1,23 @@
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource.js';
+import { data } from './data/resource.js';
+import { apiFunction } from './functions/api-function/resource.js';
+import { preSignUp } from './functions/pre-sign-up/resource.js';
+import { DynamoEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { StartingPosition } from 'aws-cdk-lib/aws-lambda';
+
+const backend = defineBackend({
+  auth,
+  data,
+  apiFunction,
+  preSignUp,
+});
+
+const eventSource = new DynamoEventSource(
+  backend.data.resources.tables['Todo'],
+  {
+    startingPosition: StartingPosition.LATEST,
+  }
+);
+
+backend.apiFunction.resources.lambda.addEventSource(eventSource);

--- a/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/data/resource.ts
@@ -1,0 +1,25 @@
+import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
+
+const schema = a.schema({
+  Todo: a
+    .model({
+      content: a.string(),
+    })
+    .authorization((allow) => [allow.publicApiKey()]),
+}) as never; // Not 100% sure why TS is complaining here. The error I'm getting is "The inferred type of 'schema' references an inaccessible 'unique symbol' type. A type annotation is necessary."
+
+// ^ appears to be caused by these 2 rules in tsconfig.base.json: https://github.com/aws-amplify/amplify-backend/blob/8d9a7a4c3033c474b0fc78379cdd4c1854d890ce/tsconfig.base.json#L7-L8
+// Possibly something to do with all the `references` in the nested configs. Using the same tsconfig in a new amplify app doesn't cause the error.
+
+export type Schema = ClientSchema<typeof schema>;
+
+export const data = defineData({
+  schema,
+  authorizationModes: {
+    defaultAuthorizationMode: 'apiKey',
+    // API Key is used for a.allow.public() rules
+    apiKeyAuthorizationMode: {
+      expiresInDays: 30,
+    },
+  },
+});

--- a/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/functions/api-function/resource.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/functions/api-function/resource.ts
@@ -1,0 +1,7 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const apiFunction = defineFunction({
+  name: 'apiFunction',
+  entry: '../handler.ts',
+  resourceGroupName: 'data',
+});

--- a/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/functions/handler.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/functions/handler.ts
@@ -1,0 +1,1 @@
+export const handler = () => {};

--- a/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/functions/pre-sign-up/resource.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-auth-data-func/amplify/functions/pre-sign-up/resource.ts
@@ -1,0 +1,7 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const preSignUp = defineFunction({
+  name: 'preSignUp',
+  entry: '../handler.ts',
+  resourceGroupName: 'auth',
+});

--- a/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/auth/resource.ts
@@ -1,0 +1,7 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+  },
+});

--- a/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/backend.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/backend.ts
@@ -1,0 +1,23 @@
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource.js';
+import { data } from './data/resource.js';
+import { apiFunction } from './functions/api-function/resource.js';
+import { DynamoEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { StartingPosition } from 'aws-cdk-lib/aws-lambda';
+import { queryFunction } from './functions/query-function/resource.js';
+
+const backend = defineBackend({
+  auth,
+  data,
+  apiFunction,
+  queryFunction,
+});
+
+const eventSource = new DynamoEventSource(
+  backend.data.resources.tables['Todo'],
+  {
+    startingPosition: StartingPosition.LATEST,
+  }
+);
+
+backend.apiFunction.resources.lambda.addEventSource(eventSource);

--- a/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/data/resource.ts
@@ -1,0 +1,32 @@
+import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
+import { queryFunction } from '../functions/query-function/resource.js';
+
+const schema = a.schema({
+  Todo: a
+    .model({
+      content: a.string(),
+    })
+    .authorization((allow) => [allow.publicApiKey()]),
+  query: a
+    .query()
+    .arguments({ content: a.string() })
+    .returns(a.string())
+    .authorization((allow) => [allow.publicApiKey()])
+    .handler(a.handler.function(queryFunction)),
+}) as never; // Not 100% sure why TS is complaining here. The error I'm getting is "The inferred type of 'schema' references an inaccessible 'unique symbol' type. A type annotation is necessary."
+
+// ^ appears to be caused by these 2 rules in tsconfig.base.json: https://github.com/aws-amplify/amplify-backend/blob/8d9a7a4c3033c474b0fc78379cdd4c1854d890ce/tsconfig.base.json#L7-L8
+// Possibly something to do with all the `references` in the nested configs. Using the same tsconfig in a new amplify app doesn't cause the error.
+
+export type Schema = ClientSchema<typeof schema>;
+
+export const data = defineData({
+  schema,
+  authorizationModes: {
+    defaultAuthorizationMode: 'apiKey',
+    // API Key is used for a.allow.public() rules
+    apiKeyAuthorizationMode: {
+      expiresInDays: 30,
+    },
+  },
+});

--- a/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/functions/api-function/resource.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/functions/api-function/resource.ts
@@ -1,0 +1,7 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const apiFunction = defineFunction({
+  name: 'apiFunction',
+  entry: '../handler.ts',
+  resourceGroupName: 'data',
+});

--- a/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/functions/handler.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/functions/handler.ts
@@ -1,0 +1,1 @@
+export const handler = () => {};

--- a/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/functions/query-function/resource.ts
+++ b/packages/integration-tests/src/test-projects/circular-dep-data-func/amplify/functions/query-function/resource.ts
@@ -1,0 +1,7 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const queryFunction = defineFunction({
+  name: 'queryFunction',
+  entry: '../handler.ts',
+  resourceGroupName: 'data',
+});

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -27,7 +27,7 @@ import { Stack } from 'aws-cdk-lib';
 export type AmplifyFunction = ResourceProvider<FunctionResources>;
 
 // @public
-export type AmplifyResourceGroupName = 'auth' | 'conversationHandlerFunction' | 'data' | 'function' | 'storage' | (string & {
+export type AmplifyResourceGroupName = 'auth' | 'data' | 'storage' | (string & {
     resourceGroupNameLike?: any;
 });
 

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -27,6 +27,11 @@ import { Stack } from 'aws-cdk-lib';
 export type AmplifyFunction = ResourceProvider<FunctionResources>;
 
 // @public
+export type AmplifyResourceGroupName = 'auth' | 'conversationHandlerFunction' | 'data' | 'function' | 'storage' | (string & {
+    resourceGroupNameLike?: any;
+});
+
+// @public
 export type AppId = string;
 
 // @public

--- a/packages/plugin-types/src/amplify_resource_group_name.ts
+++ b/packages/plugin-types/src/amplify_resource_group_name.ts
@@ -3,9 +3,7 @@
  */
 export type AmplifyResourceGroupName =
   | 'auth'
-  | 'conversationHandlerFunction'
   | 'data'
-  | 'function'
   | 'storage'
   // eslint-disable-next-line spellcheck/spell-checker
   // `(string & { resourceGroupNameLike?: any} )` is a workaround to allow default resource group names to show up in IntelliSense while allowing any string to be passed.

--- a/packages/plugin-types/src/amplify_resource_group_name.ts
+++ b/packages/plugin-types/src/amplify_resource_group_name.ts
@@ -1,0 +1,14 @@
+/**
+ * Represents the types of resource group name
+ */
+export type AmplifyResourceGroupName =
+  | 'auth'
+  | 'conversationHandlerFunction'
+  | 'data'
+  | 'function'
+  | 'storage'
+  // eslint-disable-next-line spellcheck/spell-checker
+  // `(string & { resourceGroupNameLike?: any} )` is a workaround to allow default resource group names to show up in IntelliSense while allowing any string to be passed.
+  // See https://github.com/microsoft/TypeScript/issues/29729#issuecomment-460346421.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | (string & { resourceGroupNameLike?: any });

--- a/packages/plugin-types/src/index.ts
+++ b/packages/plugin-types/src/index.ts
@@ -21,3 +21,4 @@ export * from './stable_backend_identifiers.js';
 export * from './resource_name_validator.js';
 export * from './aws_client_provider.js';
 export * from './stack_provider.js';
+export * from './amplify_resource_group_name.js';


### PR DESCRIPTION
## Problem

Certain usage patterns with functions end up with `Caused By: ❌ Deployment failed: Error [ValidationError]: Circular dependency between resources: ...`

This happens in scenarios where it could be avoided if functions created with `defineFunction` were not in the same stack.

**Issue number, if available:**

## Changes

Add `resourceGroupName` prop to `defineFunction` in order to provide the flexibility to designate a stack for a function resource.

Also introduces `AmplifyResourceGroupName` type which has default Amplify resource group names for each resource (example: `defineData`'s resourceGroupName = 'data') that will show up in IntelliSense:
<img width="609" alt="Screenshot 2024-11-14 at 4 36 49 PM" src="https://github.com/user-attachments/assets/275911e4-b39c-4b62-83e7-d04b7568d455">

So with `defineFunction` it will be possible to:
- Group with existing Amplify resources (example: group auth triggers with auth resources by setting `resourceGroupName = 'auth'`)
- Be in its own group with a custom string

**Corresponding docs PR, if applicable:**

## Validation

Two new E2E test projects for common use cases that run into circular dependency issues: `circular-dep-auth-data-func` and `circular-dep-data-func`. I have them in two separate projects instead of one to isolate use cases. I also considered using `TestProjectBase.getUpdates` to swap out all files from one use case to another to keep things in one project but this will take longer to run.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
