### PR TITLE
Print bootstrap url when browser cannot be opened

### DIFF
--- a/.changeset/seven-chefs-trade.md
+++ b/.changeset/seven-chefs-trade.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+Print bootstrap url when browser cannot be opened

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -37,6 +37,7 @@ import {
   BackendIdentifierConversions,
 } from '@aws-amplify/platform-core';
 import { LambdaFunctionLogStreamer } from './lambda_function_log_streamer.js';
+
 /**
  * CDK stores bootstrap version in parameter store. Example parameter name looks like /cdk-bootstrap/<qualifier>/version.
  * The default value for qualifier is hnb659fds, i.e. default parameter path is /cdk-bootstrap/hnb659fds/version.
@@ -125,7 +126,23 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       );
       // get region from an available sdk client;
       const region = await this.ssmClient.config.region();
-      await this.open(getBootstrapUrl(region));
+      const bootstrapUrl = getBootstrapUrl(region);
+      try {
+        await this.open(bootstrapUrl);
+      } catch (e) {
+        // If opening the link fails for any reason we fall back to
+        // printing the url in the console.
+        // This might happen:
+        // - in headless environments
+        // - if user does not have any app to open URL
+        // - if browser crashes
+        let logEntry = 'Unable to open bootstrap url';
+        if (e instanceof Error) {
+          logEntry = `${logEntry}, ${e.message}`;
+        }
+        this.printer.log(logEntry, LogLevel.DEBUG);
+        this.printer.log(`Open ${bootstrapUrl} in the browser.`);
+      }
       return;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

There are legit cases when bootstrap url cannot be opened.
E.g.
- in headless environments
- if user does not have any app to open URL or lacks permissions to open it
- if browser crashes

## Changes

Catch open errors, eat and log them (as debug logs), print url to the console.

## Validation

added test

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
