### PR TITLE
set removal policy for resources to destroy in sandbox deployments

### DIFF
--- a/.changeset/hip-yaks-remain.md
+++ b/.changeset/hip-yaks-remain.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': patch
+---
+
+set removal policy for resources to destroy in sandbox deployments

--- a/packages/backend/src/engine/amplify_stack.test.ts
+++ b/packages/backend/src/engine/amplify_stack.test.ts
@@ -4,11 +4,19 @@ import { AmplifyStack } from './amplify_stack.js';
 import { Template } from 'aws-cdk-lib/assertions';
 import assert from 'node:assert';
 import { FederatedPrincipal, Role } from 'aws-cdk-lib/aws-iam';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+
+const branchBackendId: BackendIdentifier = {
+  namespace: 'testId',
+  name: 'testBranch',
+  type: 'branch',
+};
 
 void describe('AmplifyStack', () => {
   void it('renames nested stack logical IDs to non-redundant value', () => {
     const app = new App();
-    const rootStack = new AmplifyStack(app, 'test-id');
+    const rootStack = new AmplifyStack(app, branchBackendId);
     new NestedStack(rootStack, 'testName');
 
     const rootStackTemplate = Template.fromStack(rootStack);
@@ -23,7 +31,7 @@ void describe('AmplifyStack', () => {
 
   void it('allows roles with properly configured cognito trust policies', () => {
     const app = new App();
-    const rootStack = new AmplifyStack(app, 'test-id');
+    const rootStack = new AmplifyStack(app, branchBackendId);
     new Role(rootStack, 'correctRole', {
       assumedBy: new FederatedPrincipal(
         'cognito-identity.amazonaws.com',
@@ -43,7 +51,7 @@ void describe('AmplifyStack', () => {
 
   void it('throws on roles with cognito trust policy missing amr condition', () => {
     const app = new App();
-    const rootStack = new AmplifyStack(app, 'test-id');
+    const rootStack = new AmplifyStack(app, branchBackendId);
     new Role(rootStack, 'missingAmrCondition', {
       assumedBy: new FederatedPrincipal(
         'cognito-identity.amazonaws.com',
@@ -64,7 +72,7 @@ void describe('AmplifyStack', () => {
 
   void it('throws on roles with cognito trust policy missing aud condition', () => {
     const app = new App();
-    const rootStack = new AmplifyStack(app, 'test-id');
+    const rootStack = new AmplifyStack(app, branchBackendId);
     new Role(rootStack, 'missingAudCondition', {
       assumedBy: new FederatedPrincipal(
         'cognito-identity.amazonaws.com',
@@ -80,6 +88,34 @@ void describe('AmplifyStack', () => {
     assert.throws(() => Template.fromStack(rootStack), {
       message:
         'Cannot create a Role trust policy with Cognito that does not have a StringEquals condition for cognito-identity.amazonaws.com:aud',
+    });
+  });
+
+  void it('keeps default removal policy of retain for resources in branch deployments', () => {
+    const app = new App();
+    const rootStack = new AmplifyStack(app, branchBackendId);
+    // bucket has default removal policy to retain
+    new Bucket(rootStack, 'testBucket', { enforceSSL: true });
+    const template = Template.fromStack(rootStack);
+
+    template.hasResource('AWS::S3::Bucket', {
+      DeletionPolicy: 'Retain',
+    });
+  });
+
+  void it('sets removal policy to destroy for resources in sandbox deployments', () => {
+    const app = new App();
+    const rootStack = new AmplifyStack(app, {
+      namespace: 'testId',
+      name: 'testSandbox',
+      type: 'sandbox',
+    });
+    // bucket has default removal policy to retain
+    new Bucket(rootStack, 'testBucket', { enforceSSL: true });
+    const template = Template.fromStack(rootStack);
+
+    template.hasResource('AWS::S3::Bucket', {
+      DeletionPolicy: 'Delete',
     });
   });
 });

--- a/packages/backend/src/project_environment_main_stack_creator.ts
+++ b/packages/backend/src/project_environment_main_stack_creator.ts
@@ -2,7 +2,6 @@ import { BackendIdentifier, MainStackCreator } from '@aws-amplify/plugin-types';
 import { Construct } from 'constructs';
 import { Stack, Tags } from 'aws-cdk-lib';
 import { AmplifyStack } from './engine/amplify_stack.js';
-import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 
 /**
  * Creates stacks that are tied to a given project environment via an SSM parameter
@@ -22,10 +21,7 @@ export class ProjectEnvironmentMainStackCreator implements MainStackCreator {
    */
   getOrCreateMainStack = (): Stack => {
     if (this.mainStack === undefined) {
-      this.mainStack = new AmplifyStack(
-        this.scope,
-        BackendIdentifierConversions.toStackName(this.backendId)
-      );
+      this.mainStack = new AmplifyStack(this.scope, this.backendId);
     }
 
     const deploymentType = this.backendId.type;


### PR DESCRIPTION
## Problem

For sandbox, some resources are still retained even after running `ampx sandbox delete`.

**Issue number, if available:**

## Changes

Set `RemovalPolicy` on all sandbox resources to `DESTROY` to guarantee all resources are destroyed when deleting a sandbox.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests. Local project with a stateful resource (OpenSearch) and ensure all resources are deleted after running `ampx sandbox delete`.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
