### PR TITLE
handle not authorized to perform on resource error

### DIFF
--- a/.changeset/slimy-sheep-wonder.md
+++ b/.changeset/slimy-sheep-wonder.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+handle not authorized to perform on resource error

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -399,6 +399,13 @@ npm error A complete log of this run can be found in: /home/some-path/.npm/_logs
     errorName: 'InvalidPackageJsonError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage: `Error: some-stack failed: ValidationError: User: <escaped ARN> is not authorized to perform: ssm:GetParameters on resource: <escaped ARN> because no identity-based policy allows the ssm:GetParameters action`,
+    expectedTopLevelErrorMessage:
+      'Unable to deploy due to insufficient permissions',
+    errorName: 'AccessDeniedError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -40,12 +40,18 @@ export class CdkErrorMapper {
         if (matchGroups.groups) {
           for (const [key, value] of Object.entries(matchGroups.groups)) {
             const placeHolder = `{${key}}`;
-            if (matchingError.humanReadableErrorMessage.includes(placeHolder)) {
+            if (
+              matchingError.humanReadableErrorMessage.includes(placeHolder) ||
+              matchingError.resolutionMessage.includes(placeHolder)
+            ) {
               matchingError.humanReadableErrorMessage =
                 matchingError.humanReadableErrorMessage.replace(
                   placeHolder,
                   value
                 );
+
+              matchingError.resolutionMessage =
+                matchingError.resolutionMessage.replace(placeHolder, value);
               // reset the stderr dump in the underlying error
               underlyingError = undefined;
             }
@@ -203,6 +209,15 @@ export class CdkErrorMapper {
       resolutionMessage:
         'Make sure layer ARNs are correct and layer regions match function region',
       errorName: 'GetLambdaLayerVersionError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
+        /User:(.*) is not authorized to perform:(.*) on resource:(.*) because no identity-based policy allows the (?<action>.*) action/,
+      humanReadableErrorMessage:
+        'Unable to deploy due to insufficient permissions',
+      resolutionMessage: 'Ensure you have permissions to call {action}',
+      errorName: 'AccessDeniedError',
       classification: 'ERROR',
     },
     {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -213,10 +213,11 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
-        /User:(.*) is not authorized to perform:(.*) on resource:(.*) because no identity-based policy allows the (?<action>.*) action/,
+        /User:(.*) is not authorized to perform:(.*) on resource:(?<resource>.*) because no identity-based policy allows the (?<action>.*) action/,
       humanReadableErrorMessage:
         'Unable to deploy due to insufficient permissions',
-      resolutionMessage: 'Ensure you have permissions to call {action}',
+      resolutionMessage:
+        'Ensure you have permissions to call {action} for {resource}',
       errorName: 'AccessDeniedError',
       classification: 'ERROR',
     },


### PR DESCRIPTION
## Problem

If the AWS account used does not have all permissions to perform deployment (not using the `AmplifyBackendDeployFullAccess` permission policy), deployment fails with an error like:
```
Error: Stack <stack> failed: ValidationError: User: <user-arn> is not authorized to perform: ssm:GetParameters on resource: <resource-arn> because no identity-based policy allows the ssm:GetParameters action
```

**Issue number, if available:**

## Changes

- Handle not authorized to perform on resource error
- Update so placeholders can be applied to resolution messages too (in this case to show the action in resolution)

**Corresponding docs PR, if applicable:**

## Validation

Added test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
