### PR TITLE
Handle ENOENT error from npm

### DIFF
--- a/.changeset/nasty-jars-peel.md
+++ b/.changeset/nasty-jars-peel.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Handle ENOENT error from npm

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -513,6 +513,52 @@ for your current platform.
     errorName: 'ESBuildError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage:
+      // eslint-disable-next-line spellcheck/spell-checker
+      `Error: npm ERR! code ENOENT
+npm ERR! syscall lstat
+npm ERR! path /opt/homebrew/Cellar/node/22.2.0/lib
+npm ERR! errno -2
+npm ERR! enoent ENOENT: no such file or directory, lstat '/opt/homebrew/Cellar/node/22.2.0/lib'
+npm ERR! enoent This is related to npm not being able to find a file.
+npm ERR! enoent
+`,
+    expectedTopLevelErrorMessage:
+      // eslint-disable-next-line spellcheck/spell-checker
+      `NPM error occurred: npm ERR! code ENOENT
+npm ERR! syscall lstat
+npm ERR! path /opt/homebrew/Cellar/node/22.2.0/lib
+npm ERR! errno -2
+npm ERR! enoent ENOENT: no such file or directory, lstat '/opt/homebrew/Cellar/node/22.2.0/lib'
+npm ERR! enoent This is related to npm not being able to find a file.
+npm ERR! enoent`,
+    errorName: 'CommonNPMError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage:
+      // eslint-disable-next-line spellcheck/spell-checker
+      `Error: npm error code ENOENT
+npm error syscall lstat
+npm error path C:\\Users\testUser\\AppData\\Roaming\\npm
+npm error errno -4058
+npm error enoent ENOENT: no such file or directory, lstat 'C:\\Users\\testUser\\AppData\\Roaming\\npm'
+npm error enoent This is related to npm not being able to find a file.
+npm error enoent
+`,
+    expectedTopLevelErrorMessage:
+      // eslint-disable-next-line spellcheck/spell-checker
+      `NPM error occurred: npm error code ENOENT
+npm error syscall lstat
+npm error path C:\\Users\testUser\\AppData\\Roaming\\npm
+npm error errno -4058
+npm error enoent ENOENT: no such file or directory, lstat 'C:\\Users\\testUser\\AppData\\Roaming\\npm'
+npm error enoent This is related to npm not being able to find a file.
+npm error enoent`,
+    errorName: 'CommonNPMError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -325,6 +325,15 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex: new RegExp(
+        `(?<npmError>(npm error|npm ERR!) code ENOENT${this.multiLineEolRegex}((npm error|npm ERR!) (.*)${this.multiLineEolRegex})*)`
+      ),
+      humanReadableErrorMessage: 'NPM error occurred: {npmError}',
+      resolutionMessage: `See https://docs.npmjs.com/common-errors for resolution.`,
+      errorName: 'CommonNPMError',
+      classification: 'ERROR',
+    },
+    {
       // Error: .* is printed to stderr during cdk synth
       // Also extracts the first line in the stack where the error happened
       errorRegex: new RegExp(
@@ -407,6 +416,7 @@ export type CDKDeploymentError =
   | 'CDKVersionMismatchError'
   | 'CFNUpdateNotSupportedError'
   | 'CloudFormationDeploymentError'
+  | 'CommonNPMError'
   | 'FilePermissionsError'
   | 'MissingDefineBackendError'
   | 'MultipleSandboxInstancesError'


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

`ENOENT` coming from npm indicate broken installation or workspace.

## Changes

1. Introduce `CommonNpmError`.
2. Map just `ENOENT` errors for now.
3. Direct customer to https://docs.npmjs.com/common-errors in resolution.

## Validation

Added tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
