### PR TITLE
Allow Node 22 functions

### DIFF
--- a/.changeset/forty-bulldogs-end.md
+++ b/.changeset/forty-bulldogs-end.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-function': minor
+---
+
+Add support to `@aws-amplify/backend-function` for Node 22
+
+Add support to `@aws-amplify/backend-function` for Node 22, which is a [supported Lambda runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-deprecation-levels) that was added in [`aws-cdk-lib/aws-lambda` version `2.168.0`](https://github.com/aws/aws-cdk/releases/tag/v2.168.0) on November 20th, 2024

--- a/.changeset/forty-bulldogs-end.md
+++ b/.changeset/forty-bulldogs-end.md
@@ -1,5 +1,6 @@
 ---
 '@aws-amplify/backend-function': minor
+'@aws-amplify/backend': minor
 ---
 
 Add support to `@aws-amplify/backend-function` for Node 22

--- a/.changeset/new-rings-suffer.md
+++ b/.changeset/new-rings-suffer.md
@@ -1,0 +1,20 @@
+---
+'@aws-amplify/backend-platform-test-stubs': patch
+'@aws-amplify/backend-output-storage': patch
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/schema-generator': patch
+'@aws-amplify/backend-storage': patch
+'@aws-amplify/auth-construct': patch
+'@aws-amplify/ai-constructs': patch
+'@aws-amplify/client-config': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/plugin-types': patch
+'@aws-amplify/backend-ai': patch
+'@aws-amplify/backend': patch
+'@aws-amplify/sandbox': patch
+---
+
+update aws-cdk lib to ^2.168.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -19581,9 +19581,9 @@
       "license": "0BSD"
     },
     "node_modules/aws-cdk": {
-      "version": "2.164.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.164.1.tgz",
-      "integrity": "sha512-dWRViQgHLe7GHkPIQGA+8EQSm8TBcxemyCC3HHW3wbLMWUDbspio9Dktmw5EmWxlFjjWh86Dk1JWf1zKQo8C5g==",
+      "version": "2.171.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.171.0.tgz",
+      "integrity": "sha512-tVo4hYS0iAbiCFxUh2/7KoDL6EHEIUAurCJaBs2BOUAB9DfBuUAPp8DGUK4iVF8XzrQQ4f3a5ivN7DteQrGBEQ==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -31526,7 +31526,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -31545,7 +31545,7 @@
         "@aws-sdk/util-arn-parser": "^3.568.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -31574,7 +31574,7 @@
         "aws-lambda": "^1.0.7"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -31591,7 +31591,7 @@
         "@aws-amplify/plugin-types": "^1.5.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -31614,7 +31614,7 @@
         "aws-lambda": "^1.0.7"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -31635,7 +31635,7 @@
         "@aws-amplify/platform-core": "^1.2.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -31650,7 +31650,7 @@
         "tsx": "^4.6.1"
       },
       "peerDependencies": {
-        "aws-cdk": "^2.158.0",
+        "aws-cdk": "^2.168.0",
         "typescript": "^5.0.0"
       }
     },
@@ -31711,7 +31711,7 @@
         "@aws-amplify/plugin-types": "^1.3.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0"
+        "aws-cdk-lib": "^2.168.0"
       }
     },
     "packages/backend-platform-test-stubs": {
@@ -31720,7 +31720,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.3.1",
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -31751,7 +31751,7 @@
         "@aws-amplify/platform-core": "^1.2.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -32128,7 +32128,7 @@
         "@zip.js/zip.js": "^2.7.52",
         "aws-amplify": "^6.0.16",
         "aws-appsync-auth-link": "^3.0.7",
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0",
         "execa": "^8.0.1",
         "fs-extra": "^11.1.1",
@@ -32218,7 +32218,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.609.0",
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -32366,7 +32366,7 @@
         "@types/parse-gitignore": "^1.0.0"
       },
       "peerDependencies": {
-        "aws-cdk": "^2.158.0"
+        "aws-cdk": "^2.168.0"
       }
     },
     "packages/schema-generator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6159,15 +6159,15 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.202",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
+      "version": "2.2.213",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.213.tgz",
+      "integrity": "sha512-crm1yDJmORJF2Y9gDvNUX4Q3iQXVhWrL7oaZfpx3QDqrvVz5UEgWGpJdysqDuWFZTmIgtrI5Svq3UfdwCNNpsg==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
+      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -19597,9 +19597,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.164.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.164.1.tgz",
-      "integrity": "sha512-jNvVmfZJbZoAYU94b5dzTlF2z6JXJ204NgcYY5haOa6mq3m2bzdYPXnPtB5kpAX3oBi++yoRdmLhqgckdEhUZA==",
+      "version": "2.171.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.171.0.tgz",
+      "integrity": "sha512-N0O0mWI+S8PAbiED7eV05qVfbJgHkdh+jQS4BOG6CUAc/i2s9U4w+XDRkK8auO0HgTM9+ahEaFfucMuQ4abRWQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -19615,10 +19615,10 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-awscli-v1": "^2.2.208",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
@@ -19742,9 +19742,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.1",
+      "version": "3.0.3",
       "inBundle": true,
-      "license": "MIT"
+      "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.2.0",
@@ -31641,10 +31641,10 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.2.0",
+        "@aws-amplify/platform-core": "^1.2.2",
         "@aws-amplify/plugin-types": "^1.4.0",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
@@ -31672,7 +31672,7 @@
         "uuid": "^9.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -32179,7 +32179,7 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.5.0",

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/auth-construct/package.json
+++ b/packages/auth-construct/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/util-arn-parser": "^3.568.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-ai/package.json
+++ b/packages/backend-ai/package.json
@@ -30,7 +30,7 @@
     "@aws-amplify/plugin-types": "^1.5.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-auth/package.json
+++ b/packages/backend-auth/package.json
@@ -33,7 +33,7 @@
     "aws-lambda": "^1.0.7"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -24,7 +24,7 @@
     "@aws-amplify/platform-core": "^1.2.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   },
   "dependencies": {

--- a/packages/backend-deployer/package.json
+++ b/packages/backend-deployer/package.json
@@ -25,7 +25,7 @@
     "tsx": "^4.6.1"
   },
   "peerDependencies": {
-    "aws-cdk": "^2.158.0",
+    "aws-cdk": "^2.168.0",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -46,7 +46,7 @@ export type FunctionProps = {
 export type FunctionSchedule = TimeInterval | CronSchedule;
 
 // @public (undocumented)
-export type NodeVersion = 16 | 18 | 20;
+export type NodeVersion = 16 | 18 | 20 | 22;
 
 // @public (undocumented)
 export type TimeInterval = `every ${number}m` | `every ${number}h` | `every day` | `every week` | `every month` | `every year`;

--- a/packages/backend-function/package.json
+++ b/packages/backend-function/package.json
@@ -32,7 +32,7 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -335,7 +335,7 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             runtime: 14 as NodeVersion,
           }).getInstance(getInstanceProps),
-        new Error('runtime must be one of the following: 16, 18, 20')
+        new Error('runtime must be one of the following: 16, 18, 20, 22')
       );
     });
 

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -308,12 +308,12 @@ void describe('AmplifyFunctionFactory', () => {
     void it('sets valid runtime', () => {
       const lambda = defineFunction({
         entry: './test-assets/default-lambda/handler.ts',
-        runtime: 16,
+        runtime: 22,
       }).getInstance(getInstanceProps);
       const template = Template.fromStack(lambda.stack);
 
       template.hasResourceProperties('AWS::Lambda::Function', {
-        Runtime: Runtime.NODEJS_16_X.name,
+        Runtime: Runtime.NODEJS_22_X.name,
       });
     });
 

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -570,10 +570,11 @@ const isWholeNumberBetweenInclusive = (
   max: number
 ) => min <= test && test <= max && test % 1 === 0;
 
-export type NodeVersion = 16 | 18 | 20;
+export type NodeVersion = 16 | 18 | 20 | 22;
 
 const nodeVersionMap: Record<NodeVersion, Runtime> = {
   16: Runtime.NODEJS_16_X,
   18: Runtime.NODEJS_18_X,
   20: Runtime.NODEJS_20_X,
+  22: Runtime.NODEJS_22_X,
 };

--- a/packages/backend-output-storage/package.json
+++ b/packages/backend-output-storage/package.json
@@ -24,6 +24,6 @@
     "@aws-amplify/plugin-types": "^1.3.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0"
+    "aws-cdk-lib": "^2.168.0"
   }
 }

--- a/packages/backend-platform-test-stubs/package.json
+++ b/packages/backend-platform-test-stubs/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-amplify/plugin-types": "^1.3.1",
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-storage/package.json
+++ b/packages/backend-storage/package.json
@@ -28,7 +28,7 @@
     "@aws-amplify/platform-core": "^1.2.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,7 +40,7 @@
     "lodash.snakecase": "^4.1.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/client-config/API.md
+++ b/packages/client-config/API.md
@@ -627,7 +627,7 @@ export type CustomClientConfig = {
 export const DEFAULT_CLIENT_CONFIG_VERSION: ClientConfigVersion;
 
 // @public
-export const generateClientConfig: <T extends "1" | "1.1" | "1.2" | "1.3" | "0">(backendIdentifier: DeployedBackendIdentifier, version: T, awsClientProvider?: AWSClientProvider<{
+export const generateClientConfig: <T extends "1.2" | "1.3" | "1.1" | "1" | "0">(backendIdentifier: DeployedBackendIdentifier, version: T, awsClientProvider?: AWSClientProvider<{
     getS3Client: S3Client;
     getAmplifyClient: AmplifyClient;
     getCloudFormationClient: CloudFormationClient;

--- a/packages/client-config/API.md
+++ b/packages/client-config/API.md
@@ -627,7 +627,7 @@ export type CustomClientConfig = {
 export const DEFAULT_CLIENT_CONFIG_VERSION: ClientConfigVersion;
 
 // @public
-export const generateClientConfig: <T extends "1.2" | "1.3" | "1.1" | "1" | "0">(backendIdentifier: DeployedBackendIdentifier, version: T, awsClientProvider?: AWSClientProvider<{
+export const generateClientConfig: <T extends "1" | "1.1" | "1.2" | "1.3" | "0">(backendIdentifier: DeployedBackendIdentifier, version: T, awsClientProvider?: AWSClientProvider<{
     getS3Client: S3Client;
     getAmplifyClient: AmplifyClient;
     getCloudFormationClient: CloudFormationClient;

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -33,7 +33,7 @@
     "@zip.js/zip.js": "^2.7.52",
     "aws-amplify": "^6.0.16",
     "aws-appsync-auth-link": "^3.0.7",
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0",
     "execa": "^8.0.1",
     "fs-extra": "^11.1.1",

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -166,12 +166,12 @@ export const packageJsonSchema: z.ZodObject<{
     type: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"module">, z.ZodLiteral<"commonjs">]>>;
 }, "strip", z.ZodTypeAny, {
     name?: string | undefined;
-    version?: string | undefined;
     type?: "module" | "commonjs" | undefined;
+    version?: string | undefined;
 }, {
     name?: string | undefined;
-    version?: string | undefined;
     type?: "module" | "commonjs" | undefined;
+    version?: string | undefined;
 }>;
 
 // @public

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -166,12 +166,12 @@ export const packageJsonSchema: z.ZodObject<{
     type: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"module">, z.ZodLiteral<"commonjs">]>>;
 }, "strip", z.ZodTypeAny, {
     name?: string | undefined;
-    type?: "module" | "commonjs" | undefined;
     version?: string | undefined;
+    type?: "module" | "commonjs" | undefined;
 }, {
     name?: string | undefined;
-    type?: "module" | "commonjs" | undefined;
     version?: string | undefined;
+    type?: "module" | "commonjs" | undefined;
 }>;
 
 // @public

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -11,7 +11,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.158.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0",
     "@aws-sdk/types": "^3.609.0"
   },

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -42,6 +42,6 @@
     "@types/parse-gitignore": "^1.0.0"
   },
   "peerDependencies": {
-    "aws-cdk": "^2.158.0"
+    "aws-cdk": "^2.168.0"
   }
 }


### PR DESCRIPTION
## Problem

Closes #2268

## Changes

Add support to `@aws-amplify/backend-function` for Node 22, which is a [supported Lambda runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-deprecation-levels) that was added in [`aws-cdk-lib/aws-lambda` version `2.168.0`](https://github.com/aws/aws-cdk/releases/tag/v2.168.0) on November 20th, 2024

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
