### PR TITLE
fix: extract generic cdk asset publish failures

### DIFF
--- a/.changeset/poor-phones-attend.md
+++ b/.changeset/poor-phones-attend.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+extract generic cdk asset publish failures

--- a/package-lock.json
+++ b/package-lock.json
@@ -31647,6 +31647,7 @@
         "@aws-amplify/platform-core": "^1.2.0",
         "@aws-amplify/plugin-types": "^1.4.0",
         "execa": "^8.0.1",
+        "strip-ansi": "^6.0.1",
         "tsx": "^4.6.1"
       },
       "peerDependencies": {

--- a/packages/backend-deployer/package.json
+++ b/packages/backend-deployer/package.json
@@ -22,7 +22,8 @@
     "@aws-amplify/platform-core": "^1.2.2",
     "@aws-amplify/plugin-types": "^1.4.0",
     "execa": "^8.0.1",
-    "tsx": "^4.6.1"
+    "tsx": "^4.6.1",
+    "strip-ansi": "^6.0.1"
   },
   "peerDependencies": {
     "aws-cdk": "^2.158.0",

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -430,6 +430,24 @@ npm error A complete log of this run can be found in: /home/some-path/.npm/_logs
     expectedDownstreamErrorMessage: undefined,
   },
   {
+    // eslint-disable-next-line spellcheck/spell-checker
+    errorMessage: `[31m[1mamplify-stack-sandbox-11[22m: fail: Bucket named 'cdk-abc-assets-11-us-west-2' exists, but we do not have access to it.[39m
+[31m[1mamplify-stack-sandbox-11[22m: fail: Bucket named 'cdk-abc-assets-11-us-west-2' exists, but we do not have access to it.[39m
+[31mFailed to publish asset abc:current_account-current_region[39m`,
+    expectedTopLevelErrorMessage: `CDK failed to publish assets due to 'Bucket named 'cdk-abc-assets-11-us-west-2' exists, but we do not have access to it.'`,
+    errorName: 'CDKAssetPublishError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    // eslint-disable-next-line spellcheck/spell-checker
+    errorMessage: `[31m[1mamplify-user-sandbox-c71414864a[22m: fail: socket hang up[39m
+
+[31mFailed to publish asset abc:current_account-current_region[39m`,
+    expectedTopLevelErrorMessage: `CDK failed to publish assets due to 'socket hang up'`,
+    errorName: 'CDKAssetPublishError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
     errorMessage:
       `Error: Transform failed with 1 error:` +
       EOL +


### PR DESCRIPTION
## Problem

generic cdk asset publish failures are categorized as unknown faults


**Issue number, if available:**

## Changes

extract the actual error and display more meaningful error message to customer.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
