### PR TITLE
fix: return amplify user error as it is from `AmplifyError.fromError`

### DIFF
--- a/.changeset/five-comics-beg.md
+++ b/.changeset/five-comics-beg.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+return amplify user error as it is from `AmplifyError.fromError`

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -33,7 +33,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     // (undocumented)
     readonly details?: string;
     // (undocumented)
-    static fromError: (error: unknown) => AmplifyError<'UnknownFault' | 'CredentialsError' | 'InsufficientDiskSpaceError' | 'InvalidCommandInputError' | 'DomainNotFoundError' | 'SyntaxError'>;
+    static fromError: (error: unknown) => AmplifyError;
     // (undocumented)
     static fromStderr: (_stderr: string) => AmplifyError | undefined;
     static isAmplifyError: (error: unknown) => error is AmplifyError<string>;

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -205,4 +205,13 @@ void describe('AmplifyError.fromError', async () => {
       );
     });
   });
+  void it('return amplify user errors as it is', () => {
+    const error = new AmplifyUserError('DeploymentInProgressError', {
+      message: 'Deployment already in progress',
+      resolution: 'wait for it',
+    });
+    const actual = AmplifyError.fromError(error);
+    assert.deepStrictEqual(error, actual);
+    assert.strictEqual(actual.resolution, error.resolution);
+  });
 });

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -119,6 +119,10 @@ export abstract class AmplifyError<T extends string = string> extends Error {
   };
 
   static fromError = (error: unknown): AmplifyError => {
+    if (AmplifyError.isAmplifyError(error)) {
+      return error;
+    }
+
     const errorMessage =
       error instanceof Error
         ? `${error.name}: ${error.message}`
@@ -182,9 +186,6 @@ export abstract class AmplifyError<T extends string = string> extends Error {
         error
       );
     }
-    if (error instanceof Error && isAmplifyUserError(error)) {
-      return error;
-    }
     return new AmplifyFault(
       'UnknownFault',
       {
@@ -233,10 +234,6 @@ const isInsufficientDiskSpaceError = (err?: Error): boolean => {
       err.message.includes(message)
     )
   );
-};
-
-const isAmplifyUserError = (err?: Error): err is AmplifyUserError => {
-  return !!err && 'classification' in err && err.classification === 'ERROR';
 };
 
 /**

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -118,16 +118,7 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     );
   };
 
-  static fromError = (
-    error: unknown
-  ): AmplifyError<
-    | 'UnknownFault'
-    | 'CredentialsError'
-    | 'InsufficientDiskSpaceError'
-    | 'InvalidCommandInputError'
-    | 'DomainNotFoundError'
-    | 'SyntaxError'
-  > => {
+  static fromError = (error: unknown): AmplifyError => {
     const errorMessage =
       error instanceof Error
         ? `${error.name}: ${error.message}`
@@ -191,6 +182,9 @@ export abstract class AmplifyError<T extends string = string> extends Error {
         error
       );
     }
+    if (error instanceof Error && isAmplifyUserError(error)) {
+      return error;
+    }
     return new AmplifyFault(
       'UnknownFault',
       {
@@ -239,6 +233,10 @@ const isInsufficientDiskSpaceError = (err?: Error): boolean => {
       err.message.includes(message)
     )
   );
+};
+
+const isAmplifyUserError = (err?: Error): err is AmplifyUserError => {
+  return !!err && 'classification' in err && err.classification === 'ERROR';
 };
 
 /**


### PR DESCRIPTION
## Problem

`AmplifyUserError`s were getting wrapped as UnknownFaults in `AmplifyError.fromError`

**Issue number, if available:**

## Changes

return amplify user error as it is from `AmplifyError.fromError`

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
