### PR TITLE
add validation for environment prop

### DIFF
--- a/.changeset/shy-lions-smash.md
+++ b/.changeset/shy-lions-smash.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+change errors in FunctionFactory to AmplifyUserError

--- a/.changeset/weak-nails-change.md
+++ b/.changeset/weak-nails-change.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+add validation for environment prop

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -304,6 +304,75 @@ void describe('AmplifyFunctionFactory', () => {
     });
   });
 
+  void describe('environment property', () => {
+    void it('sets valid environment', () => {
+      const functionFactory = defineFunction({
+        entry: './test-assets/default-lambda/handler.ts',
+        name: 'myCoolLambda',
+        environment: {
+          TEST_ENV: 'testValue',
+        },
+      });
+      const lambda = functionFactory.getInstance(getInstanceProps);
+      const stack = lambda.stack;
+      const template = Template.fromStack(stack);
+      template.resourceCountIs('AWS::Lambda::Function', 1);
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        Environment: {
+          Variables: {
+            TEST_ENV: 'testValue',
+          },
+        },
+      });
+    });
+
+    void it('sets default environment', () => {
+      const functionFactory = defineFunction({
+        entry: './test-assets/default-lambda/handler.ts',
+        name: 'myCoolLambda',
+      });
+      const lambda = functionFactory.getInstance(getInstanceProps);
+      const stack = lambda.stack;
+      const template = Template.fromStack(stack);
+      template.resourceCountIs('AWS::Lambda::Function', 1);
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        Environment: {},
+      });
+    });
+
+    void it('throws when adding environment variables with invalid key', () => {
+      assert.throws(
+        () =>
+          defineFunction({
+            entry: './test-assets/default-lambda/handler.ts',
+            name: 'myCoolLambda',
+            environment: {
+              ['this.is.wrong']: 'testValue',
+            },
+          }).getInstance(getInstanceProps),
+        new Error(
+          `environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters`
+        )
+      );
+    });
+
+    void it('throws when adding environment variables with key less than 2 characters', () => {
+      assert.throws(
+        () =>
+          defineFunction({
+            entry: './test-assets/default-lambda/handler.ts',
+            name: 'myCoolLambda',
+            environment: {
+              A: 'testValue',
+            },
+          }).getInstance(getInstanceProps),
+        new Error(
+          `environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters`
+        )
+      );
+    });
+  });
+
   void describe('runtime property', () => {
     void it('sets valid runtime', () => {
       const lambda = defineFunction({

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -19,6 +19,7 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import fsp from 'fs/promises';
 import path from 'node:path';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -207,9 +208,10 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             timeoutSeconds: 0,
           }).getInstance(getInstanceProps),
-        new Error(
-          'timeoutSeconds must be a whole number between 1 and 900 inclusive'
-        )
+        new AmplifyUserError('InvalidTimeoutError', {
+          message: `Invalid function timeout of 0`,
+          resolution: `timeoutSeconds must be a whole number between 1 and 900 inclusive`,
+        })
       );
     });
 
@@ -220,9 +222,10 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             timeoutSeconds: 901,
           }).getInstance(getInstanceProps),
-        new Error(
-          'timeoutSeconds must be a whole number between 1 and 900 inclusive'
-        )
+        new AmplifyUserError('InvalidTimeoutError', {
+          message: `Invalid function timeout of 901`,
+          resolution: `timeoutSeconds must be a whole number between 1 and 900 inclusive`,
+        })
       );
     });
 
@@ -233,9 +236,10 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             timeoutSeconds: 10.5,
           }).getInstance(getInstanceProps),
-        new Error(
-          'timeoutSeconds must be a whole number between 1 and 900 inclusive'
-        )
+        new AmplifyUserError('InvalidTimeoutError', {
+          message: `Invalid function timeout of 10.5`,
+          resolution: `timeoutSeconds must be a whole number between 1 and 900 inclusive`,
+        })
       );
     });
   });
@@ -271,9 +275,10 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             memoryMB: 127,
           }).getInstance(getInstanceProps),
-        new Error(
-          'memoryMB must be a whole number between 128 and 10240 inclusive'
-        )
+        new AmplifyUserError('InvalidMemoryMBError', {
+          message: `Invalid function memoryMB of 127`,
+          resolution: `memoryMB must be a whole number between 128 and 10240 inclusive`,
+        })
       );
     });
 
@@ -284,9 +289,10 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             memoryMB: 10241,
           }).getInstance(getInstanceProps),
-        new Error(
-          'memoryMB must be a whole number between 128 and 10240 inclusive'
-        )
+        new AmplifyUserError('InvalidMemoryMBError', {
+          message: `Invalid function memoryMB of 10241`,
+          resolution: `memoryMB must be a whole number between 128 and 10240 inclusive`,
+        })
       );
     });
 
@@ -297,9 +303,10 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             memoryMB: 256.2,
           }).getInstance(getInstanceProps),
-        new Error(
-          'memoryMB must be a whole number between 128 and 10240 inclusive'
-        )
+        new AmplifyUserError('InvalidMemoryMBError', {
+          message: `Invalid function memoryMB of 256.2`,
+          resolution: `memoryMB must be a whole number between 128 and 10240 inclusive`,
+        })
       );
     });
   });
@@ -347,12 +354,14 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             name: 'myCoolLambda',
             environment: {
-              ['this.is.wrong']: 'testValue',
+              'this.is.wrong': 'testValue',
             },
           }).getInstance(getInstanceProps),
-        new Error(
-          `environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters`
-        )
+        new AmplifyUserError('InvalidEnvironmentKeyError', {
+          message: `Invalid function environment key(s): this.is.wrong`,
+          resolution:
+            'Environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters',
+        })
       );
     });
 
@@ -366,9 +375,31 @@ void describe('AmplifyFunctionFactory', () => {
               A: 'testValue',
             },
           }).getInstance(getInstanceProps),
-        new Error(
-          `environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters`
-        )
+        new AmplifyUserError('InvalidEnvironmentKeyError', {
+          message: `Invalid function environment key(s): A`,
+          resolution:
+            'Environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters',
+        })
+      );
+    });
+
+    void it('throws when multiple environment variables are invalid', () => {
+      assert.throws(
+        () =>
+          defineFunction({
+            entry: './test-assets/default-lambda/handler.ts',
+            name: 'lambdaWithMultipleEnvVars',
+            environment: {
+              A: 'testValueA',
+              TEST_ENV: 'envValue',
+              'this.is.wrong': 'testValue',
+            },
+          }).getInstance(getInstanceProps),
+        new AmplifyUserError('InvalidEnvironmentKeyError', {
+          message: `Invalid function environment key(s): A, this.is.wrong`,
+          resolution:
+            'Environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters',
+        })
       );
     });
   });
@@ -404,7 +435,10 @@ void describe('AmplifyFunctionFactory', () => {
             entry: './test-assets/default-lambda/handler.ts',
             runtime: 14 as NodeVersion,
           }).getInstance(getInstanceProps),
-        new Error('runtime must be one of the following: 16, 18, 20, 22')
+        new AmplifyUserError('InvalidRuntimeError', {
+          message: `Invalid function runtime of 14`,
+          resolution: 'runtime must be one of the following: 16, 18, 20, 22',
+        })
       );
     });
 

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -325,7 +325,7 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
 
     Object.keys(this.props.environment).forEach((key) => {
       // validate using key pattern from https://docs.aws.amazon.com/lambda/latest/api/API_Environment.html
-      if (!key.match(/^[a-zA-Z]([a-zA-Z0-9_])+$/) || key.length < 2) {
+      if (!key.match(/^[a-zA-Z]([a-zA-Z0-9_])+$/)) {
         throw new Error(
           `environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters`
         );

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -294,9 +294,10 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
         timeoutMax
       )
     ) {
-      throw new Error(
-        `timeoutSeconds must be a whole number between ${timeoutMin} and ${timeoutMax} inclusive`
-      );
+      throw new AmplifyUserError('InvalidTimeoutError', {
+        message: `Invalid function timeout of ${this.props.timeoutSeconds}`,
+        resolution: `timeoutSeconds must be a whole number between ${timeoutMin} and ${timeoutMax} inclusive`,
+      });
     }
     return this.props.timeoutSeconds;
   };
@@ -311,9 +312,10 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
     if (
       !isWholeNumberBetweenInclusive(this.props.memoryMB, memoryMin, memoryMax)
     ) {
-      throw new Error(
-        `memoryMB must be a whole number between ${memoryMin} and ${memoryMax} inclusive`
-      );
+      throw new AmplifyUserError('InvalidMemoryMBError', {
+        message: `Invalid function memoryMB of ${this.props.memoryMB}`,
+        resolution: `memoryMB must be a whole number between ${memoryMin} and ${memoryMax} inclusive`,
+      });
     }
     return this.props.memoryMB;
   };
@@ -323,14 +325,24 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
       return {};
     }
 
+    const invalidKeys: string[] = [];
+
     Object.keys(this.props.environment).forEach((key) => {
       // validate using key pattern from https://docs.aws.amazon.com/lambda/latest/api/API_Environment.html
       if (!key.match(/^[a-zA-Z]([a-zA-Z0-9_])+$/)) {
-        throw new Error(
-          `environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters`
-        );
+        invalidKeys.push(key);
       }
     });
+
+    if (invalidKeys.length > 0) {
+      throw new AmplifyUserError('InvalidEnvironmentKeyError', {
+        message: `Invalid function environment key(s): ${invalidKeys.join(
+          ', '
+        )}`,
+        resolution:
+          'Environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters',
+      });
+    }
 
     return this.props.environment;
   };
@@ -344,11 +356,12 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
     }
 
     if (!(this.props.runtime in nodeVersionMap)) {
-      throw new Error(
-        `runtime must be one of the following: ${Object.keys(
+      throw new AmplifyUserError('InvalidRuntimeError', {
+        message: `Invalid function runtime of ${this.props.runtime}`,
+        resolution: `runtime must be one of the following: ${Object.keys(
           nodeVersionMap
-        ).join(', ')}`
-      );
+        ).join(', ')}`,
+      });
     }
 
     return this.props.runtime;

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -232,7 +232,7 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
       entry: this.resolveEntry(),
       timeoutSeconds: this.resolveTimeout(),
       memoryMB: this.resolveMemory(),
-      environment: this.props.environment ?? {},
+      environment: this.resolveEnvironment(),
       runtime: this.resolveRuntime(),
       schedule: this.resolveSchedule(),
       bundling: this.resolveBundling(),
@@ -316,6 +316,23 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
       );
     }
     return this.props.memoryMB;
+  };
+
+  private resolveEnvironment = () => {
+    if (this.props.environment === undefined) {
+      return {};
+    }
+
+    Object.keys(this.props.environment).forEach((key) => {
+      // validate using key pattern from https://docs.aws.amazon.com/lambda/latest/api/API_Environment.html
+      if (!key.match(/^[a-zA-Z]([a-zA-Z0-9_])+$/) || key.length < 2) {
+        throw new Error(
+          `environment keys must match [a-zA-Z]([a-zA-Z0-9_])+ and be at least 2 characters`
+        );
+      }
+    });
+
+    return this.props.environment;
   };
 
   private resolveRuntime = () => {


### PR DESCRIPTION
## Problem

Deployment can fail with the following error message when function environment keys are invalid:
```
1 validation error detected: Value at <environment-key> failed to satisfy constraint: Map keys must satisfy constraint: [Member must satisfy regular expression pattern: [a-zA-Z]([a-zA-Z0-9_])+]
```

**Issue number, if available:**

## Changes

Add validation for `defineFunction` environment prop.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
