### PR TITLE
fix: add a required input prompt for use in region input

### DIFF
--- a/.changeset/shaggy-pens-sort.md
+++ b/.changeset/shaggy-pens-sort.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/cli-core': patch
+'@aws-amplify/backend-cli': patch
+---
+
+add a required input prompt for use in region input

--- a/packages/cli-core/API.md
+++ b/packages/cli-core/API.md
@@ -15,6 +15,9 @@ export class AmplifyPrompter {
         message: string;
         defaultValue?: string;
     }) => Promise<string>;
+    static requiredInput: (options: {
+        message: string;
+    }) => Promise<string>;
     static secretValue: (promptMessage?: string) => Promise<string>;
     static yesOrNo: (options: {
         message: string;

--- a/packages/cli-core/src/prompter/amplify_prompts.ts
+++ b/packages/cli-core/src/prompter/amplify_prompts.ts
@@ -55,4 +55,21 @@ export class AmplifyPrompter {
     });
     return response;
   };
+
+  /**
+   * An input style prompt that mandates a non-empty value.
+   * @param options for displaying the prompt
+   * @param options.message display for the prompt
+   * @returns Promise<string> the user input
+   */
+  static requiredInput = async (options: {
+    message: string;
+  }): Promise<string> => {
+    const response = await input({
+      message: options.message,
+      validate: (val: string) =>
+        val && val.length > 0 ? true : 'Cannot be empty',
+    });
+    return response;
+  };
 }

--- a/packages/cli/src/commands/configure/configure_profile_command.test.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.test.ts
@@ -42,7 +42,7 @@ void describe('configure command', () => {
     emitSuccessMock.mock.resetCalls();
   });
 
-  void it('configures a profile with an IAM user', async (contextual) => {
+  void it('fails to configure a profile with a name that already has a profile', async (contextual) => {
     const mockProfileExists = mock.method(
       profileController,
       'profileExists',
@@ -65,7 +65,7 @@ void describe('configure command', () => {
     });
   });
 
-  void it('configures a profile with an IAM user', async (contextual) => {
+  void it('configures a profile with an existing IAM user credentials', async (contextual) => {
     const mockProfileExists = mock.method(
       profileController,
       'profileExists',
@@ -84,10 +84,10 @@ void describe('configure command', () => {
       }
     );
 
-    const mockInput = contextual.mock.method(
+    const mockRequiredInput = contextual.mock.method(
       AmplifyPrompter,
-      'input',
-      (options: { message: string; defaultValue?: string }) => {
+      'requiredInput',
+      (options: { message: string }) => {
         if (options.message.includes('Enter the AWS region to use')) {
           return Promise.resolve(testRegion);
         }
@@ -105,7 +105,7 @@ void describe('configure command', () => {
 
     assert.equal(mockProfileExists.mock.callCount(), 1);
     assert.equal(mockSecretValue.mock.callCount(), 2);
-    assert.equal(mockInput.mock.callCount(), 1);
+    assert.equal(mockRequiredInput.mock.callCount(), 1);
     assert.equal(mockHasIAMUser.mock.callCount(), 1);
     assert.equal(mockAppendAWSFiles.mock.callCount(), 1);
     assert.deepStrictEqual(mockAppendAWSFiles.mock.calls[0].arguments[0], {
@@ -121,7 +121,7 @@ void describe('configure command', () => {
     });
   });
 
-  void it('configures a profile without an IAM user', async (contextual) => {
+  void it('configures a profile without an existing IAM user', async (contextual) => {
     const mockProfileExists = mock.method(
       profileController,
       'profileExists',
@@ -146,7 +146,16 @@ void describe('configure command', () => {
       (options: { message: string; defaultValue?: string }) => {
         if (options.message.includes('[enter] when complete')) {
           return Promise.resolve('anything');
-        } else if (options.message.includes('Enter the AWS region to use')) {
+        }
+        assert.fail(`Do not expect prompt message: '${options.message}'`);
+      }
+    );
+
+    const mockRequiredInput = contextual.mock.method(
+      AmplifyPrompter,
+      'requiredInput',
+      (options: { message: string }) => {
+        if (options.message.includes('Enter the AWS region to use')) {
           return Promise.resolve(testRegion);
         }
         assert.fail(`Do not expect prompt message: '${options.message}'`);
@@ -167,7 +176,8 @@ void describe('configure command', () => {
 
     assert.equal(mockProfileExists.mock.callCount(), 1);
     assert.equal(mockSecretValue.mock.callCount(), 2);
-    assert.equal(mockInput.mock.callCount(), 2);
+    assert.equal(mockInput.mock.callCount(), 1);
+    assert.equal(mockRequiredInput.mock.callCount(), 1);
     assert.equal(mockHasIAMUser.mock.callCount(), 1);
     assert.equal(mockOpen.mock.callCount(), 1);
     assert.equal(

--- a/packages/cli/src/commands/configure/configure_profile_command.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.ts
@@ -71,7 +71,7 @@ export class ConfigureProfileCommand
       'Enter Secret Access Key:'
     );
 
-    const region = await AmplifyPrompter.input({
+    const region = await AmplifyPrompter.requiredInput({
       message: `Enter the AWS region to use with the '${profileName}' profile (eg us-east-1, us-west-2, etc):`,
     });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Currently we accept "Enter" as acceptable input for region while configuring the profile. This results in `""` value to be stored as region which later fails validation

## Changes

fix: add a required input prompt for use in region input

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
