### PR TITLE
cdk error mapping EPERM errors relating to synth.lock

### DIFF
--- a/.changeset/purple-news-do.md
+++ b/.changeset/purple-news-do.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Catches most common EPERM error and update to resolution message for stack in failed state

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -360,6 +360,12 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: `EACCES: permission denied, unlink '.amplify/artifacts/cdk.out/synth.lock'`,
   },
   {
+    errorMessage: `EPERM: operation not permitted, rename 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock.6785_1' → 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock'`,
+    expectedTopLevelErrorMessage: `Not permitted to rename file: 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock.6785_1'`,
+    errorName: 'FilePermissionsError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
     errorMessage: `This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
       (Cloud assembly schema version mismatch: Maximum schema version supported is 36.0.0, but found 36.1.1)`,
     expectedTopLevelErrorMessage:

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -188,8 +188,7 @@ export class CdkErrorMapper {
       errorRegex:
         /EPERM: operation not permitted, rename (?<fileName>(.*)\/synth\.lock\.\S+) → '(.*)\/synth\.lock'/,
       humanReadableErrorMessage: 'Not permitted to rename file: {fileName}',
-      resolutionMessage:
-        'Try running the command again and check that no other process has this file open and that you have the right permissions to rename this file',
+      resolutionMessage: `Try running the command again and ensure that only one instance of sandbox is running. If it still doesn't work check the permissions of '.amplify' folder`,
       errorName: 'FilePermissionsError',
       classification: 'ERROR',
     },

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -229,7 +229,7 @@ export class CdkErrorMapper {
       humanReadableErrorMessage:
         'The CloudFormation deletion failed due to {stackName} being in DELETE_FAILED state. Ensure all your resources are able to be deleted',
       resolutionMessage:
-        'The following resource(s) failed to delete: {resources}. Ensure they are in a state where they can be deleted. Find more information in the CloudFormation AWS Console for this stack.',
+        'The following resource(s) failed to delete: {resources}. Check the error message for more details and ensure your resources are in a state where they can be deleted. Check the CloudFormation AWS Console for this stack to find additional information.',
       errorName: 'CloudFormationDeletionError',
       classification: 'ERROR',
     },

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -185,6 +185,15 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex:
+        /EPERM: operation not permitted, rename (?<fileName>.*) → 'C:(.*)synth.lock(.*)/,
+      humanReadableErrorMessage: 'Not permitted to rename file: {fileName}',
+      resolutionMessage:
+        'Check that you have the right permissions to rename this file and try running the command again',
+      errorName: 'FilePermissionsError',
+      classification: 'ERROR',
+    },
+    {
       errorRegex: new RegExp(
         `\\[ERR_MODULE_NOT_FOUND\\]:(.*)${this.multiLineEolRegex}|Error: Cannot find module (.*)`
       ),

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -186,10 +186,10 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
-        /EPERM: operation not permitted, rename (?<fileName>.*) → 'C:(.*)synth.lock(.*)/,
+        /EPERM: operation not permitted, rename (?<fileName>(.*)\/synth\.lock\.\S+) → '(.*)\/synth\.lock'/,
       humanReadableErrorMessage: 'Not permitted to rename file: {fileName}',
       resolutionMessage:
-        'Check that you have the right permissions to rename this file and try running the command again',
+        'Try running the command again and check that no other process has this file open and that you have the right permissions to rename this file',
       errorName: 'FilePermissionsError',
       classification: 'ERROR',
     },


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
Error like `EPERM: operation not permitted, rename 'C:\Users\[...]\.amplify\artifacts\cdk.out\synth.lock.45040_1' → 'C:\Users\[...]\.amplify\artifacts\cdk.out\synth.lock'` not mapped properly. 
Updated `The stack named _stackName_ is in a failed state. You may need to delete it from the AWS console : DELETE_FAILED` resolution message to suggest looking at original error message, has additional info about cause of error.
<!--
Describe the issue this PR is solving
-->

**Issue number, if available:** N/A

## Changes
Handles errors like `EPERM: operation not permitted, rename 'C:\Users\[...]\.amplify\artifacts\cdk.out\synth.lock.45040_1' → 'C:\Users\[...]\.amplify\artifacts\cdk.out\synth.lock'`.
<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
