### PR TITLE
fix: add cdk error mapping for error 'command cdk not found'

### DIFF
--- a/.changeset/rude-moles-attack.md
+++ b/.changeset/rude-moles-attack.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+add cdk error mapping for error "cdk command not found"

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -369,6 +369,12 @@ const testErrorMappings = [
       (Cloud assembly schema version mismatch: Maximum schema version supported is 36.0.0, but found 36.1.1)`,
   },
   {
+    errorMessage: `error Command cdk not found. Did you mean cdl?`,
+    expectedTopLevelErrorMessage: 'Unable to detect cdk installation',
+    errorName: 'CDKNotFoundError',
+    expectedDownstreamErrorMessage: `error Command cdk not found. Did you mean cdl?`,
+  },
+  {
     errorMessage: `[31m  amplify-some-stack failed: ValidationError: Stack:stack-arn is in UPDATE_ROLLBACK_FAILED state and can not be updated.`,
     expectedTopLevelErrorMessage:
       'The CloudFormation deployment failed due to amplify-some-stack being in UPDATE_ROLLBACK_FAILED state.',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -160,7 +160,7 @@ export class CdkErrorMapper {
       errorRegex: /Command cdk not found/,
       humanReadableErrorMessage: 'Unable to detect cdk installation',
       resolutionMessage:
-        "Install the dependencies in your project by running 'yarn install' or 'npm install'",
+        "Ensure dependencies in your project are installed with your package manager. For example, by running 'yarn install' or 'npm install'",
       errorName: 'CDKNotFoundError',
       classification: 'ERROR',
     },

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -157,6 +157,14 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex: /Command cdk not found/,
+      humanReadableErrorMessage: 'Unable to detect cdk installation',
+      resolutionMessage:
+        "Install the dependencies in your project by running 'yarn install' or 'npm install'",
+      errorName: 'CDKNotFoundError',
+      classification: 'ERROR',
+    },
+    {
       errorRegex: new RegExp(
         `(SyntaxError|ReferenceError|TypeError)( \\[[A-Z_]+])?:((?:.|${this.multiLineEolRegex})*?at .*)`
       ),
@@ -460,6 +468,7 @@ export type CDKDeploymentError =
   | 'BootstrapDetectionError'
   | 'BootstrapOutdatedError'
   | 'CDKAssetPublishError'
+  | 'CDKNotFoundError'
   | 'CDKResolveAWSAccountError'
   | 'CDKVersionMismatchError'
   | 'CFNUpdateNotSupportedError'


### PR DESCRIPTION
## Problem

Sometimes yarn customers are running into this issue during sandbox run. I'm able to reproduce this by having sandbox running with yarn and deleting node_modules (or perhaps a custom clean script) and making a file change in the backend.

## Changes

Add error mapping to let customers know to install their dependencies again.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
