### PR TITLE
add error mapping for lambda exceeding max size

### DIFF
--- a/.changeset/new-mails-speak.md
+++ b/.changeset/new-mails-speak.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+add error mapping for lambda exceeding max size

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -609,6 +609,18 @@ npm error enoent`,
     errorName: 'CloudFormationDeletionError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage: `Error: some-stack failed: InvalidParameterValueException: Unzipped size must be smaller than 262144000 bytes`,
+    expectedTopLevelErrorMessage: 'Maximum Lambda size exceeded',
+    errorName: 'LambdaMaxSizeExceededError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage: `Error: some-stack failed: InvalidParameterValueException: Function code combined with layers exceeds the maximum allowed size of 262144000 bytes. The actual size is 306703523 bytes.`,
+    expectedTopLevelErrorMessage: 'Maximum Lambda size exceeded',
+    errorName: 'LambdaMaxSizeExceededError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -206,10 +206,10 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
-        /InvalidParameterValueException:(.*) (size must be smaller than|exceeds the maximum allowed size of) (?<maxSize>.*) bytes/,
+        /InvalidParameterValueException:(.*) (size must be smaller than|exceeds the maximum allowed size of) (?<maxSize>\d+) bytes/,
       humanReadableErrorMessage: 'Maximum Lambda size exceeded',
       resolutionMessage:
-        'Make sure Lambda code is smaller than {maxSize} bytes unzipped',
+        'Make sure your Lambda bundled packages with layers and dependencies is smaller than {maxSize} bytes unzipped.',
       errorName: 'LambdaMaxSizeExceededError',
       classification: 'ERROR',
     },

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -206,6 +206,15 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
+        /InvalidParameterValueException:(.*) (size must be smaller than|exceeds the maximum allowed size of) (?<maxSize>.*) bytes/,
+      humanReadableErrorMessage: 'Maximum Lambda size exceeded',
+      resolutionMessage:
+        'Make sure Lambda code is smaller than {maxSize} bytes unzipped',
+      errorName: 'LambdaMaxSizeExceededError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
         /User:(.*) is not authorized to perform: lambda:GetLayerVersion on resource:(.*) because no resource-based policy allows the lambda:GetLayerVersion action/,
       humanReadableErrorMessage: 'Unable to get Lambda layer version',
       resolutionMessage:
@@ -476,4 +485,5 @@ export type CDKDeploymentError =
   | 'InvalidPackageJsonError'
   | 'SecretNotSetError'
   | 'SyntaxError'
-  | 'GetLambdaLayerVersionError';
+  | 'GetLambdaLayerVersionError'
+  | 'LambdaMaxSizeExceededError';


### PR DESCRIPTION
## Problem

When trying to deploy a Lambda that exceeds the 250 MB size quota, deployment will fail with one of the following errors:
```
Error: <stack> failed: InvalidParameterValueException: Function code combined with layers exceeds the maximum allowed size of 262144000 bytes. The actual size is <size-above-max> bytes.
```
```
Error: <stack> failed: InvalidParameterValueException: Unzipped size must be smaller than 262144000 bytes
```

**Issue number, if available:**

## Changes

Capture both of these errors in the CDK error mapper.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
