### PR TITLE
Mapping for more EPERM errors

### DIFF
--- a/.changeset/fuzzy-squids-raise.md
+++ b/.changeset/fuzzy-squids-raise.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+added mapping for additional EPERM errors

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -360,19 +360,19 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: `EACCES: permission denied, unlink '.amplify/artifacts/cdk.out/synth.lock'`,
   },
   {
-    errorMessage: `EPERM: operation not permitted, rename 'C:/Users/someUser/.amplify/artifacts/cdk.out/synth.lock.6785_1' → 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock'`,
+    errorMessage: `[31mEPERM: operation not permitted, rename 'C:/Users/someUser/.amplify/artifacts/cdk.out/synth.lock.6785_1' → 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock' [31m`,
     expectedTopLevelErrorMessage: `Not permitted to rename file: 'C:/Users/someUser/.amplify/artifacts/cdk.out/synth.lock.6785_1'`,
     errorName: 'FilePermissionsError',
     expectedDownstreamErrorMessage: undefined,
   },
   {
-    errorMessage: `[31mEPERM: operation not permitted, unlink '.amplify/artifacts/cdk.out/read.4276_1.lock' [39m`,
+    errorMessage: `[31mEPERM: operation not permitted, unlink '.amplify/artifacts/cdk.out/read.4276_1.lock' [31m`,
     expectedTopLevelErrorMessage: `Operation not permitted on file: '.amplify/artifacts/cdk.out/read.4276_1.lock'`,
     errorName: 'FilePermissionsError',
     expectedDownstreamErrorMessage: undefined,
   },
   {
-    errorMessage: `EPERM: operation not permitted, open '.amplify/artifacts/cdk.out/synth.lock.6785_1'`,
+    errorMessage: `[31mEPERM: operation not permitted, open '.amplify/artifacts/cdk.out/synth.lock.6785_1' [31m`,
     expectedTopLevelErrorMessage: `Operation not permitted on file: '.amplify/artifacts/cdk.out/synth.lock.6785_1'`,
     errorName: 'FilePermissionsError',
     expectedDownstreamErrorMessage: undefined,

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -360,8 +360,26 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: `EACCES: permission denied, unlink '.amplify/artifacts/cdk.out/synth.lock'`,
   },
   {
-    errorMessage: `EPERM: operation not permitted, rename 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock.6785_1' → 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock'`,
-    expectedTopLevelErrorMessage: `Not permitted to rename file: 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock.6785_1'`,
+    errorMessage: `EPERM: operation not permitted, rename 'C:/Users/someUser/.amplify/artifacts/cdk.out/synth.lock.6785_1' → 'C:/Users/someUser/amplify/artifacts/cdk.out/synth.lock'`,
+    expectedTopLevelErrorMessage: `Not permitted to rename file: 'C:/Users/someUser/.amplify/artifacts/cdk.out/synth.lock.6785_1'`,
+    errorName: 'FilePermissionsError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage: `[31mEPERM: operation not permitted, unlink '.amplify/artifacts/cdk.out/read.4276_1.lock' [39m`,
+    expectedTopLevelErrorMessage: `Operation not permitted on file: '.amplify/artifacts/cdk.out/read.4276_1.lock'`,
+    errorName: 'FilePermissionsError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage: `EPERM: operation not permitted, open '.amplify/artifacts/cdk.out/synth.lock.6785_1'`,
+    expectedTopLevelErrorMessage: `Operation not permitted on file: '.amplify/artifacts/cdk.out/synth.lock.6785_1'`,
+    errorName: 'FilePermissionsError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage: `Could not create output directory .amplify/artifacts/cdk.out (EPERM: operation not permitted, mkdir '.amplify/artifacts/cdk.out')`,
+    expectedTopLevelErrorMessage: `Not permitted to create the directory '.amplify/artifacts/cdk.out'`,
     errorName: 'FilePermissionsError',
     expectedDownstreamErrorMessage: undefined,
   },

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -201,6 +201,22 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex:
+        /EPERM: operation not permitted, mkdir '(.*).amplify\/artifacts\/cdk.out'/,
+      humanReadableErrorMessage: `Not permitted to create the directory '.amplify/artifacts/cdk.out'`,
+      resolutionMessage: `Check the permissions of '.amplify' folder and try running the command again`,
+      errorName: 'FilePermissionsError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
+        /EPERM: operation not permitted, (unlink|open) (?<fileName>(.*)\.lock\S+)/,
+      humanReadableErrorMessage: 'Operation not permitted on file: {fileName}',
+      resolutionMessage: `Check the permissions of '.amplify' folder and try running the command again`,
+      errorName: 'FilePermissionsError',
+      classification: 'ERROR',
+    },
+    {
       errorRegex: new RegExp(
         `\\[ERR_MODULE_NOT_FOUND\\]:(.*)${this.multiLineEolRegex}|Error: Cannot find module (.*)`
       ),


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
Many EPERM errors are not captured by CDK mapping
<!--
Describe the issue this PR is solving
-->

**Issue number, if available:** N/A

## Changes
With this update the vast majority of EPERM errors should now be properly mapped. 
Catches errors like: `EPERM: operation not permitted, open '[...]\.amplify\artifacts\cdk.out\synth.lock.25580_1'`, `EPERM: operation not permitted, unlink '.amplify/artifacts/cdk.out/read.19603.1.lock'`, and `Could not create output directory .amplify/artifacts/cdk.out (EPERM: operation not permitted, mkdir '[...]\.amplify\artifacts\cdk.out')`
Was able to reproduce all these errors by removing permissions from .amplify folder.
<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
