### PR TITLE
add error mapping for lambda bundling into an empty zip

### DIFF
--- a/.changeset/brave-walls-thank.md
+++ b/.changeset/brave-walls-thank.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+add error mapping for lambda bundling into an empty zip

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -633,6 +633,12 @@ npm error enoent`,
     errorName: 'LambdaMaxSizeExceededError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage: `Error: some-stack failed: InvalidParameterValueException: Uploaded file must be a non-empty zip`,
+    expectedTopLevelErrorMessage: 'Lambda bundled into an empty zip',
+    errorName: 'LambdaEmptyZipError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -636,7 +636,7 @@ npm error enoent`,
   {
     errorMessage: `Error: some-stack failed: InvalidParameterValueException: Uploaded file must be a non-empty zip`,
     expectedTopLevelErrorMessage: 'Lambda bundled into an empty zip',
-    errorName: 'LambdaEmptyZipError',
+    errorName: 'LambdaEmptyZipFault',
     expectedDownstreamErrorMessage: undefined,
   },
 ];

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -234,8 +234,8 @@ export class CdkErrorMapper {
         /InvalidParameterValueException: Uploaded file must be a non-empty zip/,
       humanReadableErrorMessage: 'Lambda bundled into an empty zip',
       resolutionMessage: `Try removing '.amplify/artifacts' then running the command again. If it still doesn't work, see https://github.com/aws/aws-cdk/issues/18459 for more methods.`,
-      errorName: 'LambdaEmptyZipError',
-      classification: 'ERROR',
+      errorName: 'LambdaEmptyZipFault',
+      classification: 'FAULT',
     },
     {
       errorRegex:
@@ -511,5 +511,5 @@ export type CDKDeploymentError =
   | 'SecretNotSetError'
   | 'SyntaxError'
   | 'GetLambdaLayerVersionError'
-  | 'LambdaEmptyZipError'
+  | 'LambdaEmptyZipFault'
   | 'LambdaMaxSizeExceededError';

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -231,6 +231,14 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
+        /InvalidParameterValueException: Uploaded file must be a non-empty zip/,
+      humanReadableErrorMessage: 'Lambda bundled into an empty zip',
+      resolutionMessage: `Try removing '.amplify/artifacts' then running the command again. If it still doesn't work, see https://github.com/aws/aws-cdk/issues/18459 for more methods.`,
+      errorName: 'LambdaEmptyZipError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
         /User:(.*) is not authorized to perform: lambda:GetLayerVersion on resource:(.*) because no resource-based policy allows the lambda:GetLayerVersion action/,
       humanReadableErrorMessage: 'Unable to get Lambda layer version',
       resolutionMessage:
@@ -503,4 +511,5 @@ export type CDKDeploymentError =
   | 'SecretNotSetError'
   | 'SyntaxError'
   | 'GetLambdaLayerVersionError'
+  | 'LambdaEmptyZipError'
   | 'LambdaMaxSizeExceededError';


### PR DESCRIPTION
## Problem

For several reasons Lambda bundling results in an empty zip file and we see
```
Error: some-stack failed: InvalidParameterValueException: Uploaded file must be a non-empty zip
```

**Issue number, if available:**

## Changes

Add to the CDK error mapper to capture this with a generic resolution message of removing artifacts and trying again. Also includes a link to a GitHub issue with other scenarios and resolutions.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
