### PR TITLE
fix: validate input stack name for generate commands

### DIFF
--- a/.changeset/shy-ladybugs-buy.md
+++ b/.changeset/shy-ladybugs-buy.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+validate input stack name for generate commands

--- a/packages/cli/src/commands/generate/generate_command.ts
+++ b/packages/cli/src/commands/generate/generate_command.ts
@@ -4,6 +4,7 @@ import { GenerateFormsCommand } from './forms/generate_forms_command.js';
 import { GenerateGraphqlClientCodeCommand } from './graphql-client-code/generate_graphql_client_code_command.js';
 import { CommandMiddleware } from '../../command_middleware.js';
 import { GenerateSchemaCommand } from './schema-from-database/generate_schema_command.js';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 /**
  * An entry point for generate command.
@@ -61,6 +62,20 @@ export class GenerateCommand implements CommandModule {
           describe: 'An AWS profile name.',
           type: 'string',
           array: false,
+        })
+        .check(async (argv) => {
+          const stackNameRegex =
+            /^[a-zA-Z][-a-zA-Z0-9]{1,127}$|^arn:[-a-zA-Z0-9:/._+]$/;
+          if (argv['stack'] && typeof argv['stack'] === 'string') {
+            if (!argv.stack.match(stackNameRegex)) {
+              throw new AmplifyUserError('InvalidCommandInputError', {
+                message: `Invalid --stack name provided: ${argv.stack}`,
+                resolution:
+                  'Check the value of the stack name provided and try again.',
+              });
+            }
+          }
+          return true;
         })
         .middleware([this.commandMiddleware.ensureAwsCredentialAndRegion])
     );

--- a/packages/cli/src/commands/generate/generate_command_factory.test.ts
+++ b/packages/cli/src/commands/generate/generate_command_factory.test.ts
@@ -1,7 +1,10 @@
 import yargs from 'yargs';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { TestCommandRunner } from '../../test-utils/command_runner.js';
+import {
+  TestCommandError,
+  TestCommandRunner,
+} from '../../test-utils/command_runner.js';
 import { createGenerateCommand } from './generate_command_factory.js';
 
 /**
@@ -29,6 +32,20 @@ void describe('top level generate command', () => {
   void it('fails if subcommand is not provided', async () => {
     const output = await commandRunner.runCommand('generate');
     assert.match(output, /Not enough non-option arguments/);
+  });
+
+  void it('fails if stack argument provided is invalid', async () => {
+    await assert.rejects(
+      () => commandRunner.runCommand('generate outputs --stack 3abcd'),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'InvalidCommandInputError');
+        assert.strictEqual(
+          error.error.message,
+          'Invalid --stack name provided: 3abcd'
+        );
+        return true;
+      }
+    );
   });
 
   void it('should throw if top level command handler is ever called', () => {

--- a/packages/cli/src/commands/generate/generate_command_factory.test.ts
+++ b/packages/cli/src/commands/generate/generate_command_factory.test.ts
@@ -36,12 +36,12 @@ void describe('top level generate command', () => {
 
   void it('fails if stack argument provided is invalid', async () => {
     await assert.rejects(
-      () => commandRunner.runCommand('generate outputs --stack 3abcd'),
+      () => commandRunner.runCommand('generate outputs --stack 3-Invalid'),
       (error: TestCommandError) => {
         assert.strictEqual(error.error.name, 'InvalidCommandInputError');
         assert.strictEqual(
           error.error.message,
-          'Invalid --stack name provided: 3abcd'
+          'Invalid --stack name provided: 3-Invalid'
         );
         return true;
       }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Currently there is no validation for stack name input in the generate commands. This fails later in CFN call with `ValidationError: 1 validation error detected: Value '@#$WDF@#R%' at 'stackName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*\|arn:[-a-zA-Z0-9:/._+]*`

Also from this [link](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html) we can deduce that the stack name (the one not starting from `arn`) has a limit of 128 characters.

**Issue number, if available:**

## Changes

validate input stack name for generate commands

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
