### PR TITLE
validate branch and app id inputs for pipeline-deploy command

### DIFF
--- a/.changeset/flat-donkeys-wonder.md
+++ b/.changeset/flat-donkeys-wonder.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+validate branch and app id inputs for pipeline-deploy command

--- a/.changeset/olive-singers-tease.md
+++ b/.changeset/olive-singers-tease.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+update logic for falling back to sandbox resolver for backend id

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.test.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.test.ts
@@ -79,3 +79,30 @@ void it('does not use sandbox id if the default identifier resolver fails and th
   });
   assert.deepEqual(resolvedId, undefined);
 });
+
+// stack, appId and branch can be empty string if option is added to command but no value is present (eg. 'ampx generate outputs --stack')
+// this shows intent for deployed backend id so we should not fallback to sandbox id
+void it('does not use sandbox id if the default identifier resolver fails and stack, appId or branch are empty strings', async () => {
+  const appName = 'testAppName';
+  const namespaceResolver = {
+    resolve: () => Promise.resolve(appName),
+  };
+
+  const defaultResolver = new AppBackendIdentifierResolver(namespaceResolver);
+  const username = 'test-user';
+  const sandboxResolver = new SandboxBackendIdResolver(
+    namespaceResolver,
+    () =>
+      ({
+        username,
+      } as never)
+  );
+  const backendIdResolver = new BackendIdentifierResolverWithFallback(
+    defaultResolver,
+    sandboxResolver
+  );
+  const resolvedId = await backendIdResolver.resolveDeployedBackendIdentifier({
+    stack: '',
+  });
+  assert.deepEqual(resolvedId, undefined);
+});

--- a/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
+++ b/packages/cli/src/backend-identifier/backend_identifier_with_sandbox_fallback.ts
@@ -23,7 +23,11 @@ export class BackendIdentifierResolverWithFallback
   resolveDeployedBackendIdentifier = async (
     args: BackendIdentifierParameters
   ) => {
-    if (args.stack || args.appId || args.branch) {
+    if (
+      args.stack !== undefined ||
+      args.appId !== undefined ||
+      args.branch !== undefined
+    ) {
       return this.defaultResolver.resolveDeployedBackendIdentifier(args);
     }
 
@@ -33,7 +37,11 @@ export class BackendIdentifierResolverWithFallback
    * Resolves deployed backend id to backend id, falling back to the sandbox id if stack or appId and branch inputs are not provided
    */
   resolveBackendIdentifier = async (args: BackendIdentifierParameters) => {
-    if (args.stack || args.appId || args.branch) {
+    if (
+      args.stack !== undefined ||
+      args.appId !== undefined ||
+      args.branch !== undefined
+    ) {
       return this.defaultResolver.resolveBackendIdentifier(args);
     }
 

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -246,11 +246,8 @@ void describe('deploy command', () => {
           'pipeline-deploy --app-id abc --branch'
         ),
       (error: TestCommandError) => {
-        assert.strictEqual(error.error.name, 'MissingCommandInputError');
-        assert.strictEqual(
-          error.error.message,
-          'Missing --branch and/or --app-id'
-        );
+        assert.strictEqual(error.error.name, 'InvalidCommandInputError');
+        assert.strictEqual(error.error.message, 'Invalid --branch or --app-id');
         return true;
       }
     );
@@ -263,11 +260,8 @@ void describe('deploy command', () => {
           'pipeline-deploy --app-id --branch testBranch'
         ),
       (error: TestCommandError) => {
-        assert.strictEqual(error.error.name, 'MissingCommandInputError');
-        assert.strictEqual(
-          error.error.message,
-          'Missing --branch and/or --app-id'
-        );
+        assert.strictEqual(error.error.name, 'InvalidCommandInputError');
+        assert.strictEqual(error.error.message, 'Invalid --branch or --app-id');
         return true;
       }
     );

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -238,4 +238,38 @@ void describe('deploy command', () => {
       ClientConfigFormat.DART,
     ]);
   });
+
+  void it('throws when --branch argument has no input', async () => {
+    await assert.rejects(
+      async () =>
+        await getCommandRunner(true).runCommand(
+          'pipeline-deploy --app-id abc --branch'
+        ),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'MissingCommandInputError');
+        assert.strictEqual(
+          error.error.message,
+          'Missing --branch and/or --app-id'
+        );
+        return true;
+      }
+    );
+  });
+
+  void it('throws when --app-id argument has no input', async () => {
+    await assert.rejects(
+      async () =>
+        await getCommandRunner(true).runCommand(
+          'pipeline-deploy --app-id --branch testBranch'
+        ),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'MissingCommandInputError');
+        assert.strictEqual(
+          error.error.message,
+          'Missing --branch and/or --app-id'
+        );
+        return true;
+      }
+    );
+  });
 });

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -122,9 +122,9 @@ export class PipelineDeployCommand
       })
       .check(async (argv) => {
         if (argv['branch'].length === 0 || argv['app-id'].length === 0) {
-          throw new AmplifyUserError('MissingCommandInputError', {
-            message: 'Missing --branch and/or --app-id',
-            resolution: 'Branch/app id must be at least 1 character',
+          throw new AmplifyUserError('InvalidCommandInputError', {
+            message: 'Invalid --branch or --app-id',
+            resolution: '--branch and --app-id must be at least 1 character',
           });
         }
       });

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -119,6 +119,14 @@ export class PipelineDeployCommand
         type: 'string',
         array: false,
         choices: Object.values(ClientConfigFormat),
+      })
+      .check(async (argv) => {
+        if (argv['branch'].length === 0 || argv['app-id'].length === 0) {
+          throw new AmplifyUserError('MissingCommandInputError', {
+            message: 'Missing --branch and/or --app-id',
+            resolution: 'Branch/app id must be at least 1 character',
+          });
+        }
       });
   };
 }


### PR DESCRIPTION
## Problem

This PR addresses 2 problems:

1. There is no validation to confirm `--branch` and `--app-id` have inputs for the `pipeline-deploy` command. So something like this can be passed `npx ampx pipeline-deploy --branch --app-id` which results in the following error when we start tagging the root stack:
```
ValidationError: 2 validation errors detected: Value '' at 'tags.1.member.value' failed to satisfy constraint: Member must have length greater than or equal to 1; Value '' at 'tags.2.member.value' failed to satisfy constraint: Member must have length greater than or equal to 1
```

2. For `generate` commands, if `--branch`, `--app-id`, or `--stack` have no inputs (eg. `generate outputs --stack`) we incorrectly fallback to sandbox resolver.

**Issue number, if available:**

## Changes

- Validate that `--branch` and `--app-id` options have an input with a length of at least 1 for pipeline-deploy command.
- Make fallback logic more strict for when we fallback to sandbox resolver for backend id

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
