### PR TITLE
updates layer to also use layername:version

### DIFF
--- a/.changeset/real-yaks-bow.md
+++ b/.changeset/real-yaks-bow.md
@@ -1,5 +1,0 @@
----
-'@aws-amplify/backend-function': minor
----
-
-updates layer to use shorthand version

--- a/.changeset/real-yaks-bow.md
+++ b/.changeset/real-yaks-bow.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': minor
+---
+
+updates layer to use shorthand version

--- a/.changeset/silent-files-appear.md
+++ b/.changeset/silent-files-appear.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-function': minor
+'@aws-amplify/backend': minor
+---
+
+updates layer to also use layername:version

--- a/packages/backend-function/src/layer_parser.test.ts
+++ b/packages/backend-function/src/layer_parser.test.ts
@@ -10,12 +10,12 @@ import {
   ResourceNameValidator,
 } from '@aws-amplify/plugin-types';
 import { App, Stack } from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import fsp from 'fs/promises';
 import assert from 'node:assert';
+import path from 'node:path';
 import { after, beforeEach, describe, it } from 'node:test';
 import { defineFunction } from './factory.js';
-import path from 'node:path';
-import fsp from 'fs/promises';
 
 const createStackAndSetContext = (): Stack => {
   const app = new App();
@@ -115,7 +115,7 @@ void describe('AmplifyFunctionFactory - Layers', () => {
       (error: AmplifyUserError) => {
         assert.strictEqual(
           error.message,
-          `Invalid ARN format for layer: ${invalidLayerArn}`
+          `Invalid format for layer: ${invalidLayerArn}`
         );
         assert.ok(error.resolution);
         return true;
@@ -182,6 +182,79 @@ void describe('AmplifyFunctionFactory - Layers', () => {
     template.hasResourceProperties('AWS::Lambda::Function', {
       Handler: 'index.handler',
       Layers: [duplicateArn],
+    });
+  });
+
+  void it('accepts and converts name:version format to ARN', () => {
+    const functionFactory = defineFunction({
+      entry: './test-assets/default-lambda/handler.ts',
+      name: 'lambdaWithNameVersionLayer',
+      layers: {
+        myLayer: 'my-layer:1',
+      },
+    });
+    const lambda = functionFactory.getInstance(getInstanceProps);
+    const template = Template.fromStack(Stack.of(lambda.resources.lambda));
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Handler: 'index.handler',
+      Layers: [
+        {
+          'Fn::Join': [
+            '',
+            [
+              'arn:aws:lambda:',
+              { Ref: 'AWS::Region' },
+              ':',
+              { Ref: 'AWS::AccountId' },
+              ':layer:my-layer:1',
+            ],
+          ],
+        },
+      ],
+    });
+  });
+
+  void it('throws an error for invalid name:version format', () => {
+    const invalidFormat = 'my-layer'; // missing version number
+    const functionFactory = defineFunction({
+      entry: './test-assets/default-lambda/handler.ts',
+      name: 'lambdaWithInvalidNameVersion',
+      layers: {
+        myLayer: invalidFormat,
+      },
+    });
+
+    assert.throws(
+      () => functionFactory.getInstance(getInstanceProps),
+      (error: AmplifyUserError) => {
+        assert.strictEqual(
+          error.message,
+          `Invalid format for layer: ${invalidFormat}`
+        );
+        assert.ok(error.resolution);
+        return true;
+      }
+    );
+  });
+
+  void it('accepts mixed format of ARNs and name:version', () => {
+    const fullArn =
+      'arn:aws:lambda:us-east-1:123456789012:layer:full-arn-layer:1';
+    const functionFactory = defineFunction({
+      entry: './test-assets/default-lambda/handler.ts',
+      name: 'lambdaWithMixedLayerFormats',
+      layers: {
+        fullArnLayer: fullArn,
+        nameVersionLayer: 'name-version-layer:2',
+      },
+    });
+    const lambda = functionFactory.getInstance(getInstanceProps);
+    const template = Template.fromStack(Stack.of(lambda.resources.lambda));
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Handler: 'index.handler',
+      Layers: Match.arrayWith([fullArn]),
     });
   });
 });

--- a/packages/backend-function/src/layer_parser.ts
+++ b/packages/backend-function/src/layer_parser.ts
@@ -7,13 +7,26 @@ export class FunctionLayerArnParser {
   private arnPattern = new RegExp(
     'arn:[a-zA-Z0-9-]+:lambda:[a-zA-Z0-9-]+:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+'
   );
+  private nameVersionPattern = new RegExp('^[a-zA-Z0-9-_]+:[0-9]+$');
+
+  /**
+   * Creates a new FunctionLayerArnParser
+   * @param region - AWS region
+   * @param account - AWS account ID
+   */
+  constructor(
+    private readonly region: string,
+    private readonly account: string
+  ) {}
 
   /**
    * Parse the layers for a function
-   * @param layers - Layers to be attached to the function
+   * @param layers - Layers to be attached to the function. Each layer can be specified as either:
+   *                - A full ARN (arn:aws:lambda:<region>:<account>:layer:<name>:<version>)
+   *                - A name:version format (e.g., "my-layer:1")
    * @param functionName - Name of the function
-   * @returns Valid layers for the function
-   * @throws AmplifyUserError if the layer ARN is invalid
+   * @returns Valid layers for the function with resolved ARNs
+   * @throws AmplifyUserError if the layer ARN or name:version format is invalid
    * @throws AmplifyUserError if the number of layers exceeds the limit
    */
   parseLayers(
@@ -23,36 +36,56 @@ export class FunctionLayerArnParser {
     const validLayers: Record<string, string> = {};
     const uniqueArns = new Set<string>();
 
-    for (const [key, arn] of Object.entries(layers)) {
-      if (!this.isValidLayerArn(arn)) {
-        throw new AmplifyUserError('InvalidLayerArnFormatError', {
-          message: `Invalid ARN format for layer: ${arn}`,
-          resolution: `Update the layer ARN with the expected format: arn:aws:lambda:<current-region>:<account-id>:layer:<layer-name>:<version> for function: ${functionName}`,
+    for (const [key, value] of Object.entries(layers)) {
+      let arn: string;
+
+      if (this.isValidLayerArn(value)) {
+        // If it's already a valid ARN, use it as is
+        arn = value;
+      } else if (this.isValidNameVersion(value)) {
+        // If it's in name:version format, construct the ARN using provided region and account
+        const [name, version] = value.split(':');
+        arn = `arn:aws:lambda:${this.region}:${this.account}:layer:${name}:${version}`;
+      } else {
+        throw new AmplifyUserError('InvalidLayerFormatError', {
+          message: `Invalid format for layer: ${value}`,
+          resolution: `Layer must be either a full ARN (arn:aws:lambda:<region>:<account>:layer:<name>:<version>) or name:version format for function: ${functionName}`,
         });
       }
 
-      // Add to validLayers and uniqueArns only if the ARN hasn't been added already
+      // Ensure we don't add duplicate ARNs
       if (!uniqueArns.has(arn)) {
         uniqueArns.add(arn);
         validLayers[key] = arn;
       }
     }
 
-    // Validate the number of unique layers
     this.validateLayerCount(uniqueArns);
-
     return validLayers;
   }
 
   /**
    * Validate the ARN format for a Lambda Layer
+   * @param arn - The ARN string to validate
+   * @returns boolean indicating if the ARN format is valid
    */
   private isValidLayerArn(arn: string): boolean {
     return this.arnPattern.test(arn);
   }
 
   /**
+   * Validate the name:version format for a Lambda Layer
+   * @param value - The string to validate in format "name:version"
+   * @returns boolean indicating if the format is valid
+   */
+  private isValidNameVersion(value: string): boolean {
+    return this.nameVersionPattern.test(value);
+  }
+
+  /**
    * Validate the number of layers attached to a function
+   * @param uniqueArns - Set of unique layer ARNs
+   * @throws AmplifyUserError if the number of layers exceeds 5
    * @see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html#function-configuration-deployment-and-execution
    */
   private validateLayerCount(uniqueArns: Set<string>): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**


## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

We can currently use an ARN to add a layer. This PR would add support for just providing the `layerName:version` where the account-id and region are auto inferred using cdk improving DX. 

example:

```
   layers: {
   "sharp": "SharpLayerGen2:1", 
   "@aws-lambda-powertools/logger":
      "arn:aws:lambda:us-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12",
    },
```


**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
