### PR TITLE
add error mapping for role is invalid or cannot be assumed error

### DIFF
--- a/.changeset/brown-mayflies-turn.md
+++ b/.changeset/brown-mayflies-turn.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+add error mapping for role is invalid or cannot be assumed error'

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -659,6 +659,13 @@ npm error enoent`,
     errorName: 'LambdaEmptyZipFault',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage: `Error: some-stack failed: ValidationError: Role role-arn is invalid or cannot be assumed`,
+    expectedTopLevelErrorMessage:
+      'Role role-arn is invalid or cannot be assumed',
+    errorName: 'InvalidOrCannotAssumeRoleError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -165,6 +165,16 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex:
+        /ValidationError: Role (?<roleArn>.*) is invalid or cannot be assumed/,
+      humanReadableErrorMessage:
+        'Role {roleArn} is invalid or cannot be assumed',
+      resolutionMessage:
+        'Ensure the role exists and AWS credentials have an IAM policy that grants sts:AssumeRole for the role',
+      errorName: 'InvalidOrCannotAssumeRoleError',
+      classification: 'ERROR',
+    },
+    {
       errorRegex: new RegExp(
         `(SyntaxError|ReferenceError|TypeError)( \\[[A-Z_]+])?:((?:.|${this.multiLineEolRegex})*?at .*)`
       ),
@@ -523,6 +533,7 @@ export type CDKDeploymentError =
   | 'ExpiredTokenError'
   | 'FileConventionError'
   | 'ModuleNotFoundError'
+  | 'InvalidOrCannotAssumeRoleError'
   | 'InvalidPackageJsonError'
   | 'SecretNotSetError'
   | 'SyntaxError'


### PR DESCRIPTION
## Problem

If the role does not exist or permissions don't allow `sts:AssumeRole` for the role in question, sandbox throws with:
```
Error: ❌  <stack> failed: ValidationError: Role <role-arn> is invalid or cannot be assumed
```

This can be due to many reasons, one is if the CDK bootstrap exec role is deleted.

**Issue number, if available:**

## Changes

Add this error message to the CDK error mapper with resolution.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
