### PR TITLE
fix: allow apiKeyAuthorizationMode to be undefined if defaultAuthorizationMode is apiKey

### DIFF
--- a/.changeset/itchy-flowers-reply.md
+++ b/.changeset/itchy-flowers-reply.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-data': patch
+'@aws-amplify/backend': patch
+---
+
+Allow apiKeyAuthorizationMode to be undefined if defaultAuthorizationMode is apiKey

--- a/packages/backend-data/src/convert_authorization_modes.test.ts
+++ b/packages/backend-data/src/convert_authorization_modes.test.ts
@@ -87,6 +87,7 @@ void describe('convertAuthorizationModesToCDK', () => {
       defaultAuthorizationMode: 'API_KEY',
       apiKeyConfig: {
         expires: Duration.days(7),
+        description: undefined,
       },
       iamConfig: {
         enableIamAuthorizationMode: true,
@@ -99,6 +100,26 @@ void describe('convertAuthorizationModesToCDK', () => {
         undefined,
         undefined
       ),
+      expectedOutput
+    );
+  });
+
+  void it('defaults api key expiry if default auth mode is api key and apiKeyConfig is undefined', () => {
+    const expectedOutput: CDKAuthorizationModes = {
+      defaultAuthorizationMode: 'API_KEY',
+      apiKeyConfig: {
+        expires: Duration.days(7),
+        description: undefined,
+      },
+      iamConfig: {
+        enableIamAuthorizationMode: true,
+      },
+    };
+
+    assert.deepStrictEqual(
+      convertAuthorizationModesToCDK(getInstancePropsStub, undefined, {
+        defaultAuthorizationMode: 'apiKey',
+      }),
       expectedOutput
     );
   });

--- a/packages/backend-data/src/convert_authorization_modes.ts
+++ b/packages/backend-data/src/convert_authorization_modes.ts
@@ -60,7 +60,7 @@ export const buildConstructFactoryProvidedAuthConfig = (
 const convertApiKeyAuthConfigToCDK = ({
   description,
   expiresInDays = DEFAULT_API_KEY_EXPIRATION_DAYS,
-}: ApiKeyAuthorizationModeProps): CDKApiKeyAuthorizationConfig => ({
+}: ApiKeyAuthorizationModeProps = {}): CDKApiKeyAuthorizationConfig => ({
   description,
   expires: Duration.days(expiresInDays),
 });
@@ -207,9 +207,12 @@ export const convertAuthorizationModesToCDK = (
   const cdkAuthorizationMode = convertAuthorizationModeToCDK(
     defaultAuthorizationMode
   );
-  const apiKeyConfig = authModes?.apiKeyAuthorizationMode
-    ? convertApiKeyAuthConfigToCDK(authModes.apiKeyAuthorizationMode)
-    : computeApiKeyAuthFromResource(authResources, authModes);
+  const apiKeyConfig =
+    authModes?.apiKeyAuthorizationMode ||
+    // If default auth mode is apiKey, don't require apiKeyAuthorizationMode to be defined
+    defaultAuthorizationMode === 'apiKey'
+      ? convertApiKeyAuthConfigToCDK(authModes?.apiKeyAuthorizationMode)
+      : computeApiKeyAuthFromResource(authResources, authModes);
   const userPoolConfig = computeUserPoolAuthFromResource(authResources);
   const identityPoolConfig = computeIdentityPoolAuthFromResource(authResources);
   const lambdaConfig = authModes?.lambdaAuthorizationMode


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

If `defaultAuthorizationMode` is set to `"apiKey"` and `apiKeyAuthorizationMode` is not defined the deploy will fail with an error. On the data construct side `apiKeyConfig` is required if `defaultAuthorizationMode` is `API_KEY`. The `convertAuthorizationModesToCDK` should provide `apiKeyConfig` in this case.

```
Failed to instantiate data construct
Caused By: Cannot read properties of undefined (reading 'authenticationType')

Resolution: See the underlying error message for more details.
```

```typescript
import { type ClientSchema, a, defineData } from "@aws-amplify/backend";

const schema = a.schema({
  Supermarket: a
    .model({
      name: a.string().required(),
      address: a.string(),
    })
    .authorization((allow) => [allow.publicApiKey()]),
});

export type Schema = ClientSchema<typeof schema>;

export const data = defineData({
  schema,
  authorizationModes: {
    defaultAuthorizationMode: "apiKey",
  },
});
```

**Issue number, if available:** https://github.com/aws-amplify/amplify-category-api/issues/2994

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Allow `apiKeyAuthorizationMode` to be undefined if `defaultAuthorizationMode` is `"apiKey"`.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

* Add unit test
* Test in sample app

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
