### PR TITLE
expand handling of getaddrinfo ENOTFOUND errors

### DIFF
--- a/.changeset/hip-buses-clap.md
+++ b/.changeset/hip-buses-clap.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+expand handling of getaddrinfo ENOTFOUND errors

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -229,7 +229,7 @@ const isYargsValidationError = (err?: Error): boolean => {
 };
 
 const isENotFoundError = (err?: Error): boolean => {
-  return !!err && err.message.startsWith('getaddrinfo ENOTFOUND');
+  return !!err && err.message.includes('getaddrinfo ENOTFOUND');
 };
 
 const isSyntaxError = (err?: Error): boolean => {


### PR DESCRIPTION
## Problem

There are `getaddrinfo ENOTFOUND` errors that do not match our current error handling (error messages may not start with `getaddrinfo ENOTFOUND`)

**Issue number, if available:**

## Changes

Update error handling logic.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
