### PR TITLE
import named export from parcel/watcher

### DIFF
--- a/.changeset/chilled-pants-kiss.md
+++ b/.changeset/chilled-pants-kiss.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+move from importing the default export from the commonjs distribution of parcle/watcher to named export

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -1,5 +1,5 @@
 import debounce from 'debounce-promise';
-import parcelWatcher, { subscribe } from '@parcel/watcher';
+import { subscribe } from '@parcel/watcher';
 import { AmplifySandboxExecutor } from './sandbox_executor.js';
 import {
   BackendIdSandboxResolver,
@@ -197,7 +197,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
     });
 
     if (watchForChanges) {
-      this.watcherSubscription = await parcelWatcher.subscribe(
+      this.watcherSubscription = await subscribe(
         watchDir,
         async (_, events) => {
           // Log and track file changes.


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

in a limited env like WebContainers we're seeing issues related to the import of the "default" export from the commonjs distribution of parcel/watcher. "default" exports are a concept in ESM, where commonjs will export on `module.exports` or `exports`. Depending on the build process these are sometimes rebound to a named `default` -> `module.exports.default = "something"` or merged onto `module.exports`

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

This change removes the import of parcel/watchers default export in favor of the named `subscribe` export. `subscribe` was already in use for typing, so this change is small

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

validated by re-running the sandbox command in the limited WebContainers env
![CleanShot 2024-12-13 at 16 30 07](https://github.com/user-attachments/assets/e35a72b3-6af8-4feb-8b6a-c9760a8012f5)


<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
