### PR TITLE
chore: add error mappings and resolutions for circular dependency failures

### DIFF
--- a/.changeset/early-dodos-pull.md
+++ b/.changeset/early-dodos-pull.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+add mapping for circular dependency failures with resolution

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -665,6 +665,20 @@ npm error enoent`,
     errorName: 'InvalidOrCannotAssumeRoleError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage: `some-stack failed: ValidationError: Circular dependency between resources: [storage1, data1, function1] `,
+    expectedTopLevelErrorMessage:
+      'The CloudFormation deployment failed due to circular dependency found between nested stacks [storage1, data1, function1]',
+    errorName: 'CloudformationStackCircularDependencyError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage: `The stack named named-stack failed to deploy: UPDATE_ROLLBACK_COMPLETE: Circular dependency between resources: [resource1, resource2] `,
+    expectedTopLevelErrorMessage:
+      'The CloudFormation deployment failed due to circular dependency found between resources [resource1, resource2] in a single stack',
+    errorName: 'CloudformationResourceCircularDependencyError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {


### PR DESCRIPTION
## Problem

A workaround for customers running into circular dependency was implemented here https://github.com/aws-amplify/amplify-backend/pull/2233 but the discoverability is still an issue for customers running into it.

**Issue number, if available:**

## Changes

Start with giving a detailed resolution step and for next steps, create a dedicated documentation page to handle circular dependencies. 

**Corresponding docs PR, if applicable:**

## Validation

Unit tests and manual testing

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
