### PR TITLE
Adjustment for `copy_template.ts`

### DIFF
--- a/scripts/copy_template.ts
+++ b/scripts/copy_template.ts
@@ -24,14 +24,12 @@ if (!values?.name || !values?.template) {
 }
 
 const sourcePath = path.resolve(
-  new URL('.', import.meta.url).pathname,
-  '..',
+  new URL('.', import.meta.url).host,
   'templates',
   values.template as string
 );
 const destPath = path.resolve(
-  new URL('.', import.meta.url).pathname,
-  '..',
+  new URL('.', import.meta.url).host,
   'packages',
   values.name as string
 );


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
When Windows users attempt to use the command: `npm run new -- --template=<template> --name=<new name>`, it fails with `ENOENT: no such file or directory, lstat 'C:\C:\Users\[..]\amplify-backend\templates\empty-package'` -- specifically, the double C drive is a problem. 

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Changed URL to use `host` instead of `pathname` when pulling the source and destination paths of the file -- see https://nodejs.org/api/url.html#urlobjecthost
Which also means that the line to jump one level out (`'..'`) is no longer needed. 

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Tested on Windows and Linux dev desktop, was able to successfully make a new package using `npm run new -- --template=<template> --name=<new name>` on both. 
Results of running on Linux: 
![image](https://github.com/user-attachments/assets/b4469afc-f1d0-4af4-a623-f053d14e7783)

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
