### PR TITLE
add validation for sandbox set command secret-name

### DIFF
--- a/.changeset/old-hornets-type.md
+++ b/.changeset/old-hornets-type.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+add validation for sandbox set command secret-name


### PR DESCRIPTION
## Problem

When attempting to set a secret with an invalid character in the secret name, the following error appears:
```
SetSecretsFailedFault: Failed to set secrets. ValidationException: Parameter name: can't be prefixed with "ssm" (case-insensitive). If formed as a path, it can consist of sub-paths divided by slash symbol; each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_
Cause: {"name":"ValidationException","$fault":"client","$metadata":{"httpStatusCode":400,"requestId":"f5206be8-b8a6-411e-a959-979676f439af","attempts":1,"totalRetryDelay":0},"__type":"ValidationException","message":"Parameter name: can't be prefixed with \"ssm\" (case-insensitive). If formed as a path, it can consist of sub-paths divided by slash symbol; each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_"}
```

**Issue number, if available:**

## Changes

Add check for `secret-name` arg that matches valid characters but does not:
- validate for length at this time as this can vary widely based on other parts of the resulting parameter arn (mainly name and namespace)
- allow for the slash character as setting a secret name with `/` does not show up in `ampx sandbox secret list`

**Corresponding docs PR, if applicable:**

## Validation

Unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
