### PR TITLE
chore: catch and wrap deployment in progress when deleting the backend

### DIFF
--- a/.changeset/new-maps-lay.md
+++ b/.changeset/new-maps-lay.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+catch and wrap deployment in progress when deleting the backend

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -679,6 +679,13 @@ npm error enoent`,
     errorName: 'CloudformationResourceCircularDependencyError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage: `destroy failed Error: Stack [someStackArn] cannot be deleted while in status UPDATE_COMPLETE_CLEANUP_IN_PROGRESS`,
+    expectedTopLevelErrorMessage:
+      'Backend failed to be deleted since the previous deployment is still in progress.',
+    errorName: 'DeleteFailedWhileDeploymentInProgressError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -471,6 +471,15 @@ export class CdkErrorMapper {
       errorName: 'CDKAssetPublishError',
       classification: 'ERROR',
     },
+    {
+      // We capture the parameter name to show relevant error message
+      errorRegex:
+        /destroy failed Error: Stack \[(?<stackArn>.*)\] cannot be deleted while in status /,
+      humanReadableErrorMessage: `Backend failed to be deleted since the previous deployment is still in progress.`,
+      resolutionMessage: `Wait for the previous deployment for stack {stackArn} to be completed before attempting to delete again.`,
+      errorName: 'DeleteFailedWhileDeploymentInProgressError',
+      classification: 'ERROR',
+    },
     // Generic error printed by CDK. Order matters so keep this towards the bottom of this list
     {
       // Error: .* is printed to stderr during cdk synth
@@ -554,6 +563,7 @@ export type CDKDeploymentError =
   | 'CloudFormationDeletionError'
   | 'CloudFormationDeploymentError'
   | 'CommonNPMError'
+  | 'DeleteFailedWhileDeploymentInProgressError'
   | 'FilePermissionsError'
   | 'MissingDefineBackendError'
   | 'MultipleSandboxInstancesError'


### PR DESCRIPTION
## Problem

When customers try to delete a sandbox, but a previous deployment is still in progress, CFN throws an error destroy failed Error: Stack [id] cannot be deleted while in status UPDATE_COMPLETE_CLEANUP_IN_PROGRESS

**Issue number, if available:**

## Changes

catch and wrap deployment in progress when deleting the backend

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
