### PR TITLE
chore: wraps no outputs found error from backend output client

### DIFF
--- a/.changeset/chilly-pillows-live.md
+++ b/.changeset/chilly-pillows-live.md
@@ -1,0 +1,8 @@
+---
+'@aws-amplify/model-generator': patch
+'@aws-amplify/client-config': patch
+'@aws-amplify/sandbox': patch
+'@aws-amplify/backend-cli': patch
+---
+
+wraps no outputs found error from backend output client

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -82,64 +82,64 @@ export class GenerateFormsCommand
     try {
       output = await backendOutputClient.getOutput(backendIdentifier);
     } catch (error) {
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.DEPLOYMENT_IN_PROGRESS
-      ) {
-        throw new AmplifyUserError(
-          'DeploymentInProgressError',
-          {
-            message: 'Deployment is currently in progress.',
-            resolution: 'Re-run this command once the deployment completes.',
-          },
-          error
-        );
+      if (BackendOutputClientError.isBackendOutputClientError(error)) {
+        switch (error.code) {
+          case BackendOutputClientErrorType.DEPLOYMENT_IN_PROGRESS:
+            throw new AmplifyUserError(
+              'DeploymentInProgressError',
+              {
+                message: 'Deployment is currently in progress.',
+                resolution:
+                  'Re-run this command once the deployment completes.',
+              },
+              error
+            );
+          case BackendOutputClientErrorType.NO_STACK_FOUND:
+            throw new AmplifyUserError(
+              'StackDoesNotExistError',
+              {
+                message: 'Stack does not exist.',
+                resolution:
+                  'Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists, then re-run this command.',
+              },
+              error
+            );
+          case BackendOutputClientErrorType.NO_OUTPUTS_FOUND:
+            throw new AmplifyUserError(
+              'AmplifyOutputsNotFoundError',
+              {
+                message: 'Amplify outputs not found in stack metadata',
+                resolution: `Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists.
+        If this is a new sandbox or branch deployment, wait for the deployment to be successfully finished and try again.`,
+              },
+              error
+            );
+          case BackendOutputClientErrorType.CREDENTIALS_ERROR:
+            throw new AmplifyUserError(
+              'CredentialsError',
+              {
+                message:
+                  'Unable to get backend outputs due to invalid credentials.',
+                resolution:
+                  'Ensure your AWS credentials are correctly set and refreshed.',
+              },
+              error
+            );
+          case BackendOutputClientErrorType.ACCESS_DENIED:
+            throw new AmplifyUserError(
+              'AccessDeniedError',
+              {
+                message:
+                  'Unable to get backend outputs due to insufficient permissions.',
+                resolution:
+                  'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
+              },
+              error
+            );
+          default:
+            throw error;
+        }
       }
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.NO_STACK_FOUND
-      ) {
-        throw new AmplifyUserError(
-          'StackDoesNotExistError',
-          {
-            message: 'Stack does not exist.',
-            resolution:
-              'Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists, then re-run this command.',
-          },
-          error
-        );
-      }
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.CREDENTIALS_ERROR
-      ) {
-        throw new AmplifyUserError(
-          'CredentialsError',
-          {
-            message:
-              'Unable to get backend outputs due to invalid credentials.',
-            resolution:
-              'Ensure your AWS credentials are correctly set and refreshed.',
-          },
-          error
-        );
-      }
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.ACCESS_DENIED
-      ) {
-        throw new AmplifyUserError(
-          'AccessDeniedError',
-          {
-            message:
-              'Unable to get backend outputs due to insufficient permissions.',
-            resolution:
-              'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
-          },
-          error
-        );
-      }
-
       throw error;
     }
 

--- a/packages/client-config/src/unified_client_config_generator.test.ts
+++ b/packages/client-config/src/unified_client_config_generator.test.ts
@@ -692,6 +692,39 @@ void describe('UnifiedClientConfigGenerator', () => {
       );
     });
 
+    void it('throws user error if the stack outputs are undefined', async () => {
+      const outputRetrieval = mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.NO_OUTPUTS_FOUND,
+          'stack outputs are undefined'
+        );
+      });
+      const modelSchemaAdapter = new ModelIntrospectionSchemaAdapter(
+        stubClientProvider
+      );
+
+      const configContributors = new ClientConfigContributorFactory(
+        modelSchemaAdapter
+      ).getContributors('1.3');
+
+      const clientConfigGenerator = new UnifiedClientConfigGenerator(
+        outputRetrieval,
+        configContributors
+      );
+
+      await assert.rejects(
+        () => clientConfigGenerator.generateClientConfig(),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(
+            error.message,
+            'Amplify outputs not found in stack metadata'
+          );
+          assert.ok(error.resolution);
+          return true;
+        }
+      );
+    });
+
     void it('throws user error if the stack is missing metadata', async () => {
       const outputRetrieval = mock.fn(() => {
         throw new BackendOutputClientError(

--- a/packages/client-config/src/unified_client_config_generator.ts
+++ b/packages/client-config/src/unified_client_config_generator.ts
@@ -39,78 +39,72 @@ export class UnifiedClientConfigGenerator implements ClientConfigGenerator {
     try {
       output = await this.fetchOutput();
     } catch (error) {
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.DEPLOYMENT_IN_PROGRESS
-      ) {
-        throw new AmplifyUserError(
-          'DeploymentInProgressError',
-          {
-            message: 'Deployment is currently in progress.',
-            resolution: 'Re-run this command once the deployment completes.',
-          },
-          error
-        );
+      if (BackendOutputClientError.isBackendOutputClientError(error)) {
+        switch (error.code) {
+          case BackendOutputClientErrorType.DEPLOYMENT_IN_PROGRESS:
+            throw new AmplifyUserError(
+              'DeploymentInProgressError',
+              {
+                message: 'Deployment is currently in progress.',
+                resolution:
+                  'Re-run this command once the deployment completes.',
+              },
+              error
+            );
+          case BackendOutputClientErrorType.NO_STACK_FOUND:
+            throw new AmplifyUserError(
+              'StackDoesNotExistError',
+              {
+                message: 'Stack does not exist.',
+                resolution:
+                  'Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists, then re-run this command.',
+              },
+              error
+            );
+          case BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR:
+            throw new AmplifyUserError(
+              'NonAmplifyStackError',
+              {
+                message: 'Stack was not created with Amplify.',
+                resolution:
+                  'Ensure the CloudFormation stack ID references a main stack created with Amplify, then re-run this command.',
+              },
+              error
+            );
+          case BackendOutputClientErrorType.NO_OUTPUTS_FOUND:
+            throw new AmplifyUserError(
+              'AmplifyOutputsNotFoundError',
+              {
+                message: 'Amplify outputs not found in stack metadata',
+                resolution: `Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists.
+        If this is a new sandbox or branch deployment, wait for the deployment to be successfully finished and try again.`,
+              },
+              error
+            );
+          case BackendOutputClientErrorType.CREDENTIALS_ERROR:
+            throw new AmplifyUserError(
+              'CredentialsError',
+              {
+                message:
+                  'Unable to get backend outputs due to invalid credentials.',
+                resolution:
+                  'Ensure your AWS credentials are correctly set and refreshed.',
+              },
+              error
+            );
+          case BackendOutputClientErrorType.ACCESS_DENIED:
+            throw new AmplifyUserError(
+              'AccessDeniedError',
+              {
+                message:
+                  'Unable to get backend outputs due to insufficient permissions.',
+                resolution:
+                  'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
+              },
+              error
+            );
+        }
       }
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.NO_STACK_FOUND
-      ) {
-        throw new AmplifyUserError(
-          'StackDoesNotExistError',
-          {
-            message: 'Stack does not exist.',
-            resolution:
-              'Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists, then re-run this command.',
-          },
-          error
-        );
-      }
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.METADATA_RETRIEVAL_ERROR
-      ) {
-        throw new AmplifyUserError(
-          'NonAmplifyStackError',
-          {
-            message: 'Stack was not created with Amplify.',
-            resolution:
-              'Ensure the CloudFormation stack ID references a main stack created with Amplify, then re-run this command.',
-          },
-          error
-        );
-      }
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.CREDENTIALS_ERROR
-      ) {
-        throw new AmplifyUserError(
-          'CredentialsError',
-          {
-            message:
-              'Unable to get backend outputs due to invalid credentials.',
-            resolution:
-              'Ensure your AWS credentials are correctly set and refreshed.',
-          },
-          error
-        );
-      }
-      if (
-        BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.ACCESS_DENIED
-      ) {
-        throw new AmplifyUserError(
-          'AccessDeniedError',
-          {
-            message:
-              'Unable to get backend outputs due to insufficient permissions.',
-            resolution:
-              'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
-          },
-          error
-        );
-      }
-
       throw error;
     }
     const backendOutput = unifiedBackendOutputSchema.parse(output);

--- a/packages/model-generator/src/create_graphql_document_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_document_generator.test.ts
@@ -100,6 +100,37 @@ void describe('model generator factory', () => {
     );
   });
 
+  void it('throws an error if outputs do not exist', async () => {
+    const fakeBackendOutputClient = {
+      getOutput: mock.fn(() => {
+        throw new BackendOutputClientError(
+          BackendOutputClientErrorType.NO_OUTPUTS_FOUND,
+          'stack outputs are undefined'
+        );
+      }),
+    };
+    mock.method(
+      BackendOutputClientFactory,
+      'getInstance',
+      () => fakeBackendOutputClient
+    );
+    const generator = createGraphqlDocumentGenerator({
+      backendIdentifier: { stackName: 'stackThatDoesNotHaveOutputs' },
+      awsClientProvider,
+    });
+    await assert.rejects(
+      () => generator.generateModels({ targetFormat: 'javascript' }),
+      (error: AmplifyUserError) => {
+        assert.strictEqual(
+          error.message,
+          'Amplify outputs not found in stack metadata'
+        );
+        assert.ok(error.resolution);
+        return true;
+      }
+    );
+  });
+
   void it('throws an error if credentials are expired when getting backend outputs', async () => {
     const fakeBackendOutputClient = {
       getOutput: mock.fn(() => {

--- a/packages/model-generator/src/create_graphql_models_generator.test.ts
+++ b/packages/model-generator/src/create_graphql_models_generator.test.ts
@@ -105,6 +105,37 @@ void describe('models generator factory', () => {
       );
     });
 
+    void it('throws an error if stack outputs are undefined', async () => {
+      const fakeBackendOutputClient = {
+        getOutput: mock.fn(() => {
+          throw new BackendOutputClientError(
+            BackendOutputClientErrorType.NO_OUTPUTS_FOUND,
+            'stack outputs are undefined'
+          );
+        }),
+      };
+      mock.method(
+        BackendOutputClientFactory,
+        'getInstance',
+        () => fakeBackendOutputClient
+      );
+      const generator = createGraphqlModelsGenerator({
+        backendIdentifier: { stackName: 'stackThatDoesNotHaveOutputs' },
+        awsClientProvider,
+      });
+      await assert.rejects(
+        () => generator.generateModels({ target: 'javascript' }),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(
+            error.message,
+            'Amplify outputs not found in stack metadata'
+          );
+          assert.ok(error.resolution);
+          return true;
+        }
+      );
+    });
+
     void it('throws an error if credentials are expired when getting backend outputs', async () => {
       const fakeBackendOutputClient = {
         getOutput: mock.fn(() => {

--- a/packages/model-generator/src/get_backend_output_with_error_handling.ts
+++ b/packages/model-generator/src/get_backend_output_with_error_handling.ts
@@ -16,63 +16,63 @@ export const getBackendOutputWithErrorHandling = async (
   try {
     return await backendOutputClient.getOutput(backendIdentifier);
   } catch (error) {
-    if (
-      BackendOutputClientError.isBackendOutputClientError(error) &&
-      error.code === BackendOutputClientErrorType.DEPLOYMENT_IN_PROGRESS
-    ) {
-      throw new AmplifyUserError(
-        'DeploymentInProgressError',
-        {
-          message: 'Deployment is currently in progress.',
-          resolution: 'Re-run this command once the deployment completes.',
-        },
-        error
-      );
+    if (BackendOutputClientError.isBackendOutputClientError(error)) {
+      switch (error.code) {
+        case BackendOutputClientErrorType.DEPLOYMENT_IN_PROGRESS:
+          throw new AmplifyUserError(
+            'DeploymentInProgressError',
+            {
+              message: 'Deployment is currently in progress.',
+              resolution: 'Re-run this command once the deployment completes.',
+            },
+            error
+          );
+        case BackendOutputClientErrorType.NO_STACK_FOUND:
+          throw new AmplifyUserError(
+            'StackDoesNotExistError',
+            {
+              message: 'Stack does not exist.',
+              resolution:
+                'Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists, then re-run this command.',
+            },
+            error
+          );
+        case BackendOutputClientErrorType.NO_OUTPUTS_FOUND:
+          throw new AmplifyUserError(
+            'AmplifyOutputsNotFoundError',
+            {
+              message: 'Amplify outputs not found in stack metadata',
+              resolution: `Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists.
+      If this is a new sandbox or branch deployment, wait for the deployment to be successfully finished and try again.`,
+            },
+            error
+          );
+        case BackendOutputClientErrorType.CREDENTIALS_ERROR:
+          throw new AmplifyUserError(
+            'CredentialsError',
+            {
+              message:
+                'Unable to get backend outputs due to invalid credentials.',
+              resolution:
+                'Ensure your AWS credentials are correctly set and refreshed.',
+            },
+            error
+          );
+        case BackendOutputClientErrorType.ACCESS_DENIED:
+          throw new AmplifyUserError(
+            'AccessDeniedError',
+            {
+              message:
+                'Unable to get backend outputs due to insufficient permissions.',
+              resolution:
+                'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
+            },
+            error
+          );
+        default:
+          throw error;
+      }
     }
-    if (
-      BackendOutputClientError.isBackendOutputClientError(error) &&
-      error.code === BackendOutputClientErrorType.NO_STACK_FOUND
-    ) {
-      throw new AmplifyUserError(
-        'StackDoesNotExistError',
-        {
-          message: 'Stack does not exist.',
-          resolution:
-            'Ensure the CloudFormation stack ID or Amplify App ID and branch specified are correct and exists, then re-run this command.',
-        },
-        error
-      );
-    }
-    if (
-      BackendOutputClientError.isBackendOutputClientError(error) &&
-      error.code === BackendOutputClientErrorType.CREDENTIALS_ERROR
-    ) {
-      throw new AmplifyUserError(
-        'CredentialsError',
-        {
-          message: 'Unable to get backend outputs due to invalid credentials.',
-          resolution:
-            'Ensure your AWS credentials are correctly set and refreshed.',
-        },
-        error
-      );
-    }
-    if (
-      BackendOutputClientError.isBackendOutputClientError(error) &&
-      error.code === BackendOutputClientErrorType.ACCESS_DENIED
-    ) {
-      throw new AmplifyUserError(
-        'AccessDeniedError',
-        {
-          message:
-            'Unable to get backend outputs due to insufficient permissions.',
-          resolution:
-            'Ensure you have permissions to call cloudformation:GetTemplateSummary.',
-        },
-        error
-      );
-    }
-
     throw error;
   }
 };

--- a/packages/sandbox/src/lambda_function_log_streamer.test.ts
+++ b/packages/sandbox/src/lambda_function_log_streamer.test.ts
@@ -168,6 +168,23 @@ void describe('LambdaFunctionLogStreamer', () => {
     assert.strictEqual(lambdaClientSendMock.mock.callCount(), 0);
   });
 
+  void it('return early if backend output client throws with outputs do not exist', async () => {
+    backendOutputClientMock.getOutput.mock.mockImplementationOnce(() => {
+      return Promise.reject(
+        new BackendOutputClientError(
+          BackendOutputClientErrorType.NO_OUTPUTS_FOUND,
+          'Stack outputs are undefined'
+        )
+      );
+    });
+    await classUnderTest.startStreamingLogs(testSandboxBackendId, {
+      enabled: true,
+    });
+
+    // No lambda calls to retrieve tags
+    assert.strictEqual(lambdaClientSendMock.mock.callCount(), 0);
+  });
+
   void it('calls logs monitor with all the customer defined functions and conversation handlers if no function name filter is provided', async () => {
     await classUnderTest.startStreamingLogs(testSandboxBackendId, {
       enabled: true,

--- a/packages/sandbox/src/lambda_function_log_streamer.ts
+++ b/packages/sandbox/src/lambda_function_log_streamer.ts
@@ -47,10 +47,13 @@ export class LambdaFunctionLogStreamer {
         sandboxBackendId
       );
     } catch (error) {
-      // If stack does not exist, we do not want to go further to start streaming logs
+      // If stack does not exist or hasn't deployed successfully, we do not want to go further to start streaming logs
       if (
         BackendOutputClientError.isBackendOutputClientError(error) &&
-        error.code === BackendOutputClientErrorType.NO_STACK_FOUND
+        [
+          BackendOutputClientErrorType.NO_STACK_FOUND,
+          BackendOutputClientErrorType.NO_OUTPUTS_FOUND,
+        ].some((code) => (error as BackendOutputClientError).code === code)
       ) {
         this.enabled = false;
         return;


### PR DESCRIPTION
## Problem

If the first deployment (sandbox/branch) is unsuccessful, the stack ends up getting created but stays in `CREATE_FAILED` state and doesn't have any outputs or metadata associated with it. This passes the check/error `NO_STACK_FOUND` since there is indeed a stack, but no outputs.

**Issue number, if available:**

## Changes

Add the new case of `NO_OUTPUTS_FOUND` and refactor bunch of `if` to a `switch`.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
