### PR TITLE
Adds Architecture Property on defineFunction

### DIFF
--- a/.changeset/tall-parrots-sort.md
+++ b/.changeset/tall-parrots-sort.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': minor
+---
+
+adds support for architecture property on defineFunction

--- a/.changeset/tall-parrots-sort.md
+++ b/.changeset/tall-parrots-sort.md
@@ -1,5 +1,6 @@
 ---
 '@aws-amplify/backend-function': minor
+'@aws-amplify/backend': minor
 ---
 
 adds support for architecture property on defineFunction

--- a/packages/backend-function/API.md
+++ b/packages/backend-function/API.md
@@ -65,6 +65,9 @@ type DataClientReturn<T> = T extends DataClientEnv ? DataClientConfig : DataClie
 export const defineFunction: (props?: FunctionProps) => ConstructFactory<ResourceProvider<FunctionResources> & ResourceAccessAcceptorFactory & AddEnvironmentFactory & StackProvider>;
 
 // @public (undocumented)
+export type FunctionArchitecture = 'x86_64' | 'arm64';
+
+// @public (undocumented)
 export type FunctionBundlingOptions = {
     minify?: boolean;
 };
@@ -94,6 +97,7 @@ export type FunctionProps = {
     ephemeralStorageSizeMB?: number;
     environment?: Record<string, string | BackendSecret>;
     runtime?: NodeVersion;
+    architecture?: FunctionArchitecture;
     schedule?: FunctionSchedule | FunctionSchedule[];
     layers?: Record<string, string>;
     bundling?: FunctionBundlingOptions;

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -481,7 +481,7 @@ void describe('AmplifyFunctionFactory', () => {
         }).getInstance(getInstanceProps),
       new AmplifyUserError('InvalidArchitectureError', {
         message: `Invalid function architecture of invalid`,
-        resolution: 'runtime must be one of the following: arm64, x86_64',
+        resolution: 'architecture must be one of the following: arm64, x86_64',
       })
     );
   });

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -13,9 +13,13 @@ import {
 } from '@aws-amplify/backend-platform-test-stubs';
 import { defaultLambda } from './test-assets/default-lambda/resource.js';
 import { Template } from 'aws-cdk-lib/assertions';
-import { NodeVersion, defineFunction } from './factory.js';
+import {
+  FunctionArchitecture,
+  NodeVersion,
+  defineFunction,
+} from './factory.js';
 import { lambdaWithDependencies } from './test-assets/lambda-with-dependencies/resource.js';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import fsp from 'fs/promises';
 import path from 'node:path';
@@ -452,6 +456,34 @@ void describe('AmplifyFunctionFactory', () => {
 
       assert.ok(endDate > currentDate);
     });
+  });
+
+  void describe('architecture property', () => {
+    void it('sets valid architecture', () => {
+      const lambda = defineFunction({
+        entry: './test-assets/default-lambda/handler.ts',
+        architecture: 'arm64',
+      }).getInstance(getInstanceProps);
+      const template = Template.fromStack(lambda.stack);
+
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        Architecture: Architecture.ARM_64.name,
+      });
+    });
+  });
+
+  void it('throws on invalid architecture', () => {
+    assert.throws(
+      () =>
+        defineFunction({
+          entry: './test-assets/default-lambda/handler.ts',
+          architecture: 'invalid' as FunctionArchitecture,
+        }).getInstance(getInstanceProps),
+      new AmplifyUserError('InvalidArchitectureError', {
+        message: `Invalid function architecture of invalid`,
+        resolution: 'runtime must be one of the following: arm64, x86_64',
+      })
+    );
   });
 
   void describe('schedule property', () => {

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -467,7 +467,7 @@ void describe('AmplifyFunctionFactory', () => {
       const template = Template.fromStack(lambda.stack);
 
       template.hasResourceProperties('AWS::Lambda::Function', {
-        Architecture: Architecture.ARM_64.name,
+        Architectures: [Architecture.ARM_64.name],
       });
     });
   });

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -31,6 +31,7 @@ import { Rule } from 'aws-cdk-lib/aws-events';
 import * as targets from 'aws-cdk-lib/aws-events-targets';
 import { Policy } from 'aws-cdk-lib/aws-iam';
 import {
+  Architecture,
   CfnFunction,
   ILayerVersion,
   LayerVersion,
@@ -133,6 +134,12 @@ export type FunctionProps = {
    * Defaults to the oldest NodeJS LTS version. See https://nodejs.org/en/about/previous-releases
    */
   runtime?: NodeVersion;
+
+  /**
+   * The architecture of the target platform for the lambda environment.
+   * Defaults to X86_64.
+   */
+  architecture?: FunctionArchitecture;
 
   /**
    * A time interval string to periodically run the function.
@@ -246,6 +253,7 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
       ephemeralStorageSizeMB: this.resolveEphemeralStorageSize(),
       environment: this.resolveEnvironment(),
       runtime: this.resolveRuntime(),
+      architecture: this.resolveArchitecture(),
       schedule: this.resolveSchedule(),
       bundling: this.resolveBundling(),
       layers: this.props.layers ?? {},
@@ -401,6 +409,25 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
     return this.props.runtime;
   };
 
+  private resolveArchitecture = () => {
+    const architectureDefault = 'x86_64';
+
+    if (!this.props.architecture) {
+      return architectureDefault;
+    }
+
+    if (!(this.props.architecture in architectureMap)) {
+      throw new AmplifyUserError('InvalidArchitectureError', {
+        message: `Invalid function architecture of ${this.props.architecture}`,
+        resolution: `architecture must be one of the following: ${Object.keys(
+          architectureMap
+        ).join(', ')}`,
+      });
+    }
+
+    return this.props.architecture;
+  };
+
   private resolveSchedule = () => {
     if (!this.props.schedule) {
       return [];
@@ -539,6 +566,7 @@ class AmplifyFunction
         entry: props.entry,
         timeout: Duration.seconds(props.timeoutSeconds),
         memorySize: props.memoryMB,
+        architecture: architectureMap[props.architecture],
         ephemeralStorageSize: Size.mebibytes(props.ephemeralStorageSizeMB),
         runtime: nodeVersionMap[props.runtime],
         layers: props.resolvedLayers,
@@ -677,4 +705,11 @@ const nodeVersionMap: Record<NodeVersion, Runtime> = {
   18: Runtime.NODEJS_18_X,
   20: Runtime.NODEJS_20_X,
   22: Runtime.NODEJS_22_X,
+};
+
+export type FunctionArchitecture = 'x86_64' | 'arm64';
+
+const architectureMap: Record<FunctionArchitecture, Architecture> = {
+  arm64: Architecture.ARM_64,
+  x86_64: Architecture.X86_64,
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Allows the users to choose between the available Lambda runtime architectures (`x86_64` and `arm64`).

**Issue number, if available:** 1820

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

This is a relatively simple change, which only adds the architecture field to the `defineFunction` function, with `x86_64` as its default value to keep backwards compatibility, and converts it to the corresponding CDK API `Architecture` value.

This change also introduced a new Architecture validation to guarantee that only valid values are used. Tests and documentation changes are also included.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
