### PR TITLE
bump verdaccio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13882,9 +13882,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.5.tgz",
-      "integrity": "sha512-v+XHd9XmWbufxF1/bTaVm2yhbxY+TB4YtWRqF2zaXBlDNMkls34KiATz0AVDLavL3iB6bQk9/7n3oY1EoLSWGA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.7.tgz",
+      "integrity": "sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13901,9 +13901,9 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "6.13.0",
+        "qs": "6.13.1",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "^4.1.3",
+        "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
@@ -18251,19 +18251,20 @@
       "license": "ISC"
     },
     "node_modules/@verdaccio/auth": {
-      "version": "8.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/auth/-/auth-8.0.0-next-8.4.tgz",
-      "integrity": "sha512-Bv+du+eIMK2/KU2wIjha2FHQrhBT5RuDOVi1nyRyjEyjmJrUt2RWU0Cb7ASxzQy61nkcJ3bs7kuu9dPHK/Z+jw==",
+      "version": "8.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/auth/-/auth-8.0.0-next-8.7.tgz",
+      "integrity": "sha512-CSLBAsCJT1oOpJ4OWnVGmN6o/ZilDNa7Aa5+AU1LI2lbRblqgr4BVRn07GFqimJ//6+tPzl8BHgyiCbBhh1ZiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/config": "8.0.0-next-8.4",
-        "@verdaccio/core": "8.0.0-next-8.4",
-        "@verdaccio/loaders": "8.0.0-next-8.3",
+        "@verdaccio/config": "8.0.0-next-8.7",
+        "@verdaccio/core": "8.0.0-next-8.7",
+        "@verdaccio/loaders": "8.0.0-next-8.4",
         "@verdaccio/signature": "8.0.0-next-8.1",
-        "@verdaccio/utils": "8.1.0-next-8.4",
-        "debug": "4.3.7",
+        "@verdaccio/utils": "8.1.0-next-8.7",
+        "debug": "4.4.0",
         "lodash": "4.17.21",
-        "verdaccio-htpasswd": "13.0.0-next-8.4"
+        "verdaccio-htpasswd": "13.0.0-next-8.7"
       },
       "engines": {
         "node": ">=18"
@@ -18274,12 +18275,13 @@
       }
     },
     "node_modules/@verdaccio/auth/node_modules/@verdaccio/utils": {
-      "version": "8.1.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.4.tgz",
-      "integrity": "sha512-mAEBWV5zsjtC4e/hfj1Q/eYtMlML5wxedk7mqqmvAydjw+ycSH/D/ksU+B10h4STX2NcBlcLtgLl7OI/wFzrgA==",
+      "version": "8.1.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.7.tgz",
+      "integrity": "sha512-4eqPCnPAJsL6gdVs0/oqZNgs2PnQW3HHBMgBHyEbb5A/ESI10TvRp+B7MRl9glUmy/aR5B6YSI68rgXvAFjdxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
+        "@verdaccio/core": "8.0.0-next-8.7",
         "lodash": "4.17.21",
         "minimatch": "7.4.6",
         "semver": "7.6.3"
@@ -18297,8 +18299,27 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@verdaccio/auth/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@verdaccio/auth/node_modules/minimatch": {
@@ -18306,6 +18327,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
       "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -18342,14 +18364,15 @@
       "license": "MIT"
     },
     "node_modules/@verdaccio/config": {
-      "version": "8.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-8.0.0-next-8.4.tgz",
-      "integrity": "sha512-9CTYYhaO4xrGbiYjLqRy8EMFPm0YL4a7P6ae8Zm4Dx85Dd6i8XqZ7tlU/+a6qf1g/qggYloolU8pcjaLWNDKAQ==",
+      "version": "8.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-8.0.0-next-8.7.tgz",
+      "integrity": "sha512-pA0WCWvvWY6vPRav+X0EuFmuK6M08zIpRzTKkqSriCWk6JUCZ07TDnN054AS8TSSOy6EaWgHxnUw3nTd34Z4Sg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
-        "@verdaccio/utils": "8.1.0-next-8.4",
-        "debug": "4.3.7",
+        "@verdaccio/core": "8.0.0-next-8.7",
+        "@verdaccio/utils": "8.1.0-next-8.7",
+        "debug": "4.4.0",
         "js-yaml": "4.1.0",
         "lodash": "4.17.21",
         "minimatch": "7.4.6"
@@ -18363,12 +18386,13 @@
       }
     },
     "node_modules/@verdaccio/config/node_modules/@verdaccio/utils": {
-      "version": "8.1.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.4.tgz",
-      "integrity": "sha512-mAEBWV5zsjtC4e/hfj1Q/eYtMlML5wxedk7mqqmvAydjw+ycSH/D/ksU+B10h4STX2NcBlcLtgLl7OI/wFzrgA==",
+      "version": "8.1.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.7.tgz",
+      "integrity": "sha512-4eqPCnPAJsL6gdVs0/oqZNgs2PnQW3HHBMgBHyEbb5A/ESI10TvRp+B7MRl9glUmy/aR5B6YSI68rgXvAFjdxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
+        "@verdaccio/core": "8.0.0-next-8.7",
         "lodash": "4.17.21",
         "minimatch": "7.4.6",
         "semver": "7.6.3"
@@ -18385,15 +18409,35 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/@verdaccio/config/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@verdaccio/config/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@verdaccio/config/node_modules/js-yaml": {
@@ -18401,6 +18445,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -18413,6 +18458,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
       "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -18424,10 +18470,11 @@
       }
     },
     "node_modules/@verdaccio/core": {
-      "version": "8.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-8.0.0-next-8.4.tgz",
-      "integrity": "sha512-TCaHwIpr97f4YQkU25E6pk1dbfWTQwYPos1tMb9Q7k6IapoxN0c1s+SyF5FBuMOIfJpTHoWJDo/z7QCouQC3lw==",
+      "version": "8.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-8.0.0-next-8.7.tgz",
+      "integrity": "sha512-pf8M2Z5EI/5Zdhdcm3aadb9Q9jiDsIredPD3+cIoDum8x3di2AIYvQD7i5BEramfzZlLXVICmFAulU7nUY11qg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "8.17.1",
         "core-js": "3.37.1",
@@ -18449,6 +18496,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18466,6 +18514,7 @@
       "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -18475,7 +18524,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@verdaccio/file-locking": {
       "version": "10.3.1",
@@ -18495,10 +18545,11 @@
       }
     },
     "node_modules/@verdaccio/loaders": {
-      "version": "8.0.0-next-8.3",
-      "resolved": "https://registry.npmjs.org/@verdaccio/loaders/-/loaders-8.0.0-next-8.3.tgz",
-      "integrity": "sha512-7bIOdi+U1xSLRu0s1XxQwrV3zzzFaVaTX7JKFgj2tQvMy9AgzlpjbW1CqaH8OTVEqq03Pwvwj5hQlcvyzCwm1A==",
+      "version": "8.0.0-next-8.4",
+      "resolved": "https://registry.npmjs.org/@verdaccio/loaders/-/loaders-8.0.0-next-8.4.tgz",
+      "integrity": "sha512-Powlqb4SuMbe6RVgxyyOXaCjuHCcK7oZA+lygaKZDpV9NSHJtbkkV4L+rXyCfTX3b0tKsBh7FzaIdgWc1rDeGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "4.3.7",
         "lodash": "4.17.21"
@@ -18568,13 +18619,14 @@
       "license": "MIT"
     },
     "node_modules/@verdaccio/logger": {
-      "version": "8.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger/-/logger-8.0.0-next-8.4.tgz",
-      "integrity": "sha512-zJIFpKYNR/api/mxj5HqJSlEMFh9J4sVKk+3QYlPmppW68beZLLzqwchb5+c/V559lnSrGy5HvDUEGLXvp6reA==",
+      "version": "8.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger/-/logger-8.0.0-next-8.7.tgz",
+      "integrity": "sha512-5EMPdZhz2V08BP2rjhtN/Fz5KxCfPJBkYDitbk/eo+FCZ9nVdMCQE3WRbHEaXyJQcIso/LJ6RnL/zKN20E/rPg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/logger-commons": "8.0.0-next-8.4",
-        "pino": "9.4.0"
+        "@verdaccio/logger-commons": "8.0.0-next-8.7",
+        "pino": "9.5.0"
       },
       "engines": {
         "node": ">=18"
@@ -18585,15 +18637,16 @@
       }
     },
     "node_modules/@verdaccio/logger-commons": {
-      "version": "8.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-8.0.0-next-8.4.tgz",
-      "integrity": "sha512-neDbq5IIRoidFT4Rv3zH9YydICDCJEybb06BzCGVOzlhZ7F+fBzJH1qlBhAEISfbONugDgfuUQ2jbRCKEkHezQ==",
+      "version": "8.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-8.0.0-next-8.7.tgz",
+      "integrity": "sha512-sXNx57G1LVp81xF4qHer3AOcMEZ90W4FjxtYF0vmULcVg3ybdtStKAT/9ocZtVMvLWTPAauhqylfnXoRZYf32A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
+        "@verdaccio/core": "8.0.0-next-8.7",
         "@verdaccio/logger-prettify": "8.0.0-next-8.1",
         "colorette": "2.0.20",
-        "debug": "4.3.7"
+        "debug": "4.4.0"
       },
       "engines": {
         "node": ">=18"
@@ -18603,11 +18656,30 @@
         "url": "https://opencollective.com/verdaccio"
       }
     },
+    "node_modules/@verdaccio/logger-commons/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@verdaccio/logger-prettify": {
       "version": "8.0.0-next-8.1",
       "resolved": "https://registry.npmjs.org/@verdaccio/logger-prettify/-/logger-prettify-8.0.0-next-8.1.tgz",
       "integrity": "sha512-vLhaGq0q7wtMCcqa0aQY6QOsMNarhTu/l4e6Z8mG/5LUH95GGLsBwpXLnKS94P3deIjsHhc9ycnEmG39txbQ1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "colorette": "2.0.20",
         "dayjs": "1.11.13",
@@ -18624,17 +18696,18 @@
       }
     },
     "node_modules/@verdaccio/middleware": {
-      "version": "8.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-8.0.0-next-8.4.tgz",
-      "integrity": "sha512-tzpfSpeLKUeyTsQ+fvUsokgdh1NrjDJX/oz2ya8wTYSInKAt1Ld9MRzRVSHJwIQc7wfg46zSjpcKZVLA/YkJ6w==",
+      "version": "8.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-8.0.0-next-8.7.tgz",
+      "integrity": "sha512-Zad7KcdOsI1DUBt1TjQb08rIi/IFFaJKdPhj7M6oy5BX9l/4OM0TtbBueHFNS1+aU+t5eo8ue7ZHbqmjDY/6VQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/config": "8.0.0-next-8.4",
-        "@verdaccio/core": "8.0.0-next-8.4",
-        "@verdaccio/url": "13.0.0-next-8.4",
-        "@verdaccio/utils": "8.1.0-next-8.4",
-        "debug": "4.3.7",
-        "express": "4.21.1",
+        "@verdaccio/config": "8.0.0-next-8.7",
+        "@verdaccio/core": "8.0.0-next-8.7",
+        "@verdaccio/url": "13.0.0-next-8.7",
+        "@verdaccio/utils": "8.1.0-next-8.7",
+        "debug": "4.4.0",
+        "express": "4.21.2",
         "express-rate-limit": "5.5.1",
         "lodash": "4.17.21",
         "lru-cache": "7.18.3",
@@ -18649,12 +18722,13 @@
       }
     },
     "node_modules/@verdaccio/middleware/node_modules/@verdaccio/utils": {
-      "version": "8.1.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.4.tgz",
-      "integrity": "sha512-mAEBWV5zsjtC4e/hfj1Q/eYtMlML5wxedk7mqqmvAydjw+ycSH/D/ksU+B10h4STX2NcBlcLtgLl7OI/wFzrgA==",
+      "version": "8.1.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.7.tgz",
+      "integrity": "sha512-4eqPCnPAJsL6gdVs0/oqZNgs2PnQW3HHBMgBHyEbb5A/ESI10TvRp+B7MRl9glUmy/aR5B6YSI68rgXvAFjdxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
+        "@verdaccio/core": "8.0.0-next-8.7",
         "lodash": "4.17.21",
         "minimatch": "7.4.6",
         "semver": "7.6.3"
@@ -18672,8 +18746,27 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@verdaccio/middleware/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@verdaccio/middleware/node_modules/lru-cache": {
@@ -18681,6 +18774,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -18690,6 +18784,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -18702,6 +18797,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
       "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -18730,6 +18826,7 @@
       "resolved": "https://registry.npmjs.org/@verdaccio/signature/-/signature-8.0.0-next-8.1.tgz",
       "integrity": "sha512-lHD/Z2FoPQTtDYz6ZlXhj/lrg0SFirHrwCGt/cibl1GlePpx78WPdo03tgAyl0Qf+I35n484/gR1l9eixBQqYw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "4.3.7",
         "jsonwebtoken": "9.0.2"
@@ -18758,15 +18855,16 @@
       }
     },
     "node_modules/@verdaccio/tarball": {
-      "version": "13.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-13.0.0-next-8.4.tgz",
-      "integrity": "sha512-zizQwACK+P9sHtArbuW5MJluRpc3lC6bilGTFNc0TLkHbwL73F8wxkKr5VLzWV7H54+sVKMDs1lCnaoHa0ygmw==",
+      "version": "13.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-13.0.0-next-8.7.tgz",
+      "integrity": "sha512-EWRuEOLgb3UETxUsYg6+Mml6DDRiwQqKIEsE4Ys6y6rcH2vgW6XMnTt+s/v5pFI+zlbi6fxjOgQB1e6IJAwxVA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
-        "@verdaccio/url": "13.0.0-next-8.4",
-        "@verdaccio/utils": "8.1.0-next-8.4",
-        "debug": "4.3.7",
+        "@verdaccio/core": "8.0.0-next-8.7",
+        "@verdaccio/url": "13.0.0-next-8.7",
+        "@verdaccio/utils": "8.1.0-next-8.7",
+        "debug": "4.4.0",
         "gunzip-maybe": "^1.4.2",
         "lodash": "4.17.21",
         "tar-stream": "^3.1.7"
@@ -18780,12 +18878,13 @@
       }
     },
     "node_modules/@verdaccio/tarball/node_modules/@verdaccio/utils": {
-      "version": "8.1.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.4.tgz",
-      "integrity": "sha512-mAEBWV5zsjtC4e/hfj1Q/eYtMlML5wxedk7mqqmvAydjw+ycSH/D/ksU+B10h4STX2NcBlcLtgLl7OI/wFzrgA==",
+      "version": "8.1.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-8.1.0-next-8.7.tgz",
+      "integrity": "sha512-4eqPCnPAJsL6gdVs0/oqZNgs2PnQW3HHBMgBHyEbb5A/ESI10TvRp+B7MRl9glUmy/aR5B6YSI68rgXvAFjdxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
+        "@verdaccio/core": "8.0.0-next-8.7",
         "lodash": "4.17.21",
         "minimatch": "7.4.6",
         "semver": "7.6.3"
@@ -18803,8 +18902,27 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@verdaccio/tarball/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@verdaccio/tarball/node_modules/minimatch": {
@@ -18812,6 +18930,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
       "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -18823,19 +18942,21 @@
       }
     },
     "node_modules/@verdaccio/ui-theme": {
-      "version": "8.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/ui-theme/-/ui-theme-8.0.0-next-8.4.tgz",
-      "integrity": "sha512-j3STxUuIgvn058LqfXWv+SwRi1fQ7HapMSfVKXAhi09+f4zlD2mtvKLth0WbuzU1NqJPTGLAP9ueBf1210C1Hw==",
-      "dev": true
+      "version": "8.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/ui-theme/-/ui-theme-8.0.0-next-8.7.tgz",
+      "integrity": "sha512-+7f7XqqIU+TVCHjsP6lWzCdsD4sM7MEhn4cu3mLW1kJZ7eenWKEltoqixQnoXJzaBjCiz+yXW1WkjMyEFLNbpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@verdaccio/url": {
-      "version": "13.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-13.0.0-next-8.4.tgz",
-      "integrity": "sha512-Xo+9DUcwYTBV6d0n4vjLAN2k92J33XM/9JNltWM6140oI8lz+VJKiajtejG/hRBi82RioRdWJ0RZDDY6FsbS3Q==",
+      "version": "13.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-13.0.0-next-8.7.tgz",
+      "integrity": "sha512-biFvwH3zIXYicA+SXNGvjMAe8oIQ5VddsfbO0ZXWlFs0lIz8cgI7QYPeSiCkU2VKpGzZ8pEKgqkxFsfFkU5kGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
-        "debug": "4.3.7",
+        "@verdaccio/core": "8.0.0-next-8.7",
+        "debug": "4.4.0",
         "lodash": "4.17.21",
         "validator": "13.12.0"
       },
@@ -18845,6 +18966,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/verdaccio"
+      }
+    },
+    "node_modules/@verdaccio/url/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@verdaccio/utils": {
@@ -20338,6 +20477,22 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -23449,9 +23604,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23474,7 +23629,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -23489,6 +23644,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-rate-limit": {
@@ -23514,6 +23673,22 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -27728,9 +27903,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -27899,16 +28074,16 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-      "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
+      "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
+        "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
         "process-warning": "^4.0.0",
         "quick-format-unescaped": "^4.0.3",
@@ -27989,9 +28164,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/pino-abstract-transport/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.6.0.tgz",
+      "integrity": "sha512-cbAdYt0VcnpN2Bekq7PU+k363ZRsPwJoEEJOEtSJQlJXzwaxt3FIo/uL+KeDSGIjJqtkwyge4KQgD2S2kd+CQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -28021,6 +28196,16 @@
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pino/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
     },
     "node_modules/pino/node_modules/process-warning": {
       "version": "4.0.0",
@@ -28301,13 +28486,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -28341,9 +28519,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -28365,13 +28543,6 @@
       "engines": {
         "node": ">=0.4.x"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -28739,13 +28910,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -29648,9 +29812,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz",
-      "integrity": "sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
+      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -30087,11 +30251,14 @@
       }
     },
     "node_modules/text-decoder": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.1.tgz",
-      "integrity": "sha512-x9v3H/lTKIJKQQe7RPQkLfKAnc9lUTkWDypIQgTzPJAq+5/GCDHonmshfvlsNSj58yyshbIJJDLmU15qNERrXQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -30157,6 +30324,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.70",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.70.tgz",
+      "integrity": "sha512-/W1YVgYVJd9ZDjey5NXadNh0mJXkiUMUue9Zebd0vpdo1sU+H4zFFTaJ1RKD4N6KFoHfcXy6l+Vu7bh+bdWCzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.70"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.70",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.70.tgz",
+      "integrity": "sha512-RNnIXDB1FD4T9cpQRErEqw6ZpjLlGdMOitdV+0xtbsnwr4YFka1zpc7D4KD+aAn8oSG5JyFrdasZTE04qDE9Yg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -30207,29 +30394,16 @@
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -30781,17 +30955,6 @@
         "querystring": "0.2.0"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -30902,32 +31065,33 @@
       }
     },
     "node_modules/verdaccio": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-6.0.2.tgz",
-      "integrity": "sha512-XthgJlF1hGW+GR/apRLZ7DQw26XpLI+xjMGb7dhJKxI4Pz2gSiEY1RXP9T9I/rlIBr9Zx6rYOgRk7A9Aeq/kpg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-6.0.5.tgz",
+      "integrity": "sha512-hv+v4mtG/rcNidGUHXAtNuVySiPE3/PM+7dYye5jCDrhCUmRJYOtnvDe/Ym1ZE/twti39g6izVRxEkjnSp52gA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cypress/request": "3.0.5",
-        "@verdaccio/auth": "8.0.0-next-8.4",
-        "@verdaccio/config": "8.0.0-next-8.4",
-        "@verdaccio/core": "8.0.0-next-8.4",
+        "@cypress/request": "3.0.7",
+        "@verdaccio/auth": "8.0.0-next-8.7",
+        "@verdaccio/config": "8.0.0-next-8.7",
+        "@verdaccio/core": "8.0.0-next-8.7",
         "@verdaccio/local-storage-legacy": "11.0.2",
-        "@verdaccio/logger": "8.0.0-next-8.4",
-        "@verdaccio/middleware": "8.0.0-next-8.4",
+        "@verdaccio/logger": "8.0.0-next-8.7",
+        "@verdaccio/middleware": "8.0.0-next-8.7",
         "@verdaccio/search-indexer": "8.0.0-next-8.2",
         "@verdaccio/signature": "8.0.0-next-8.1",
         "@verdaccio/streams": "10.2.1",
-        "@verdaccio/tarball": "13.0.0-next-8.4",
-        "@verdaccio/ui-theme": "8.0.0-next-8.4",
-        "@verdaccio/url": "13.0.0-next-8.4",
+        "@verdaccio/tarball": "13.0.0-next-8.7",
+        "@verdaccio/ui-theme": "8.0.0-next-8.7",
+        "@verdaccio/url": "13.0.0-next-8.7",
         "@verdaccio/utils": "7.0.1-next-8.1",
         "async": "3.2.6",
         "clipanion": "4.0.0-rc.4",
         "compression": "1.7.5",
         "cors": "2.8.5",
-        "debug": "4.3.7",
+        "debug": "4.4.0",
         "envinfo": "7.14.0",
-        "express": "4.21.1",
+        "express": "4.21.2",
         "express-rate-limit": "5.5.1",
         "fast-safe-stringify": "2.1.1",
         "handlebars": "4.7.8",
@@ -30942,8 +31106,8 @@
         "pkginfo": "0.4.1",
         "semver": "7.6.3",
         "validator": "13.12.0",
-        "verdaccio-audit": "13.0.0-next-8.4",
-        "verdaccio-htpasswd": "13.0.0-next-8.4"
+        "verdaccio-audit": "13.0.0-next-8.7",
+        "verdaccio-htpasswd": "13.0.0-next-8.7"
       },
       "bin": {
         "verdaccio": "bin/verdaccio"
@@ -30957,14 +31121,15 @@
       }
     },
     "node_modules/verdaccio-audit": {
-      "version": "13.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-13.0.0-next-8.4.tgz",
-      "integrity": "sha512-T4yi/46fLngllx5mvFtXsGcW3MxGZZ9IkHYPK1OQw9+Xj9aOuMec2eFdztTRo9SgqZfgblGSY1ESZYy19sQLvw==",
+      "version": "13.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-13.0.0-next-8.7.tgz",
+      "integrity": "sha512-kd6YdrDztkP1/GDZT7Ue2u41iGPvM9y+5aaUbIBUPvTY/YVv57K6MaCMfn9C/I+ZL4R7XOTSxTtWvz3JK4QrNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/config": "8.0.0-next-8.4",
-        "@verdaccio/core": "8.0.0-next-8.4",
-        "express": "4.21.1",
+        "@verdaccio/config": "8.0.0-next-8.7",
+        "@verdaccio/core": "8.0.0-next-8.7",
+        "express": "4.21.2",
         "https-proxy-agent": "5.0.1",
         "node-fetch": "cjs"
       },
@@ -30977,17 +31142,18 @@
       }
     },
     "node_modules/verdaccio-htpasswd": {
-      "version": "13.0.0-next-8.4",
-      "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-13.0.0-next-8.4.tgz",
-      "integrity": "sha512-w0knjKz8SdBGSv0Kt61LoUOCYBZ2/iig3bVbGFWTj4MwCUG6eNewMoQ6nbrk+kyHNFVq75IzT1eIhXDEysx15Q==",
+      "version": "13.0.0-next-8.7",
+      "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-13.0.0-next-8.7.tgz",
+      "integrity": "sha512-znyFnwt59mLKTAu6eHJrfWP07iaHUlYiQN7QoBo8KMAOT1AecUYreBqs93oKHdIOzjTI8j6tQLg57DpeVS5vgg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@verdaccio/core": "8.0.0-next-8.4",
+        "@verdaccio/core": "8.0.0-next-8.7",
         "@verdaccio/file-locking": "13.0.0-next-8.2",
         "apache-md5": "1.1.8",
         "bcryptjs": "2.4.3",
         "core-js": "3.37.1",
-        "debug": "4.3.7",
+        "debug": "4.4.0",
         "http-errors": "2.0.0",
         "unix-crypt-td-js": "1.1.4"
       },
@@ -31004,6 +31170,7 @@
       "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-13.0.0-next-8.2.tgz",
       "integrity": "sha512-TcHgN3I/N28WBSvtukpGrJhBljl4jyIXq0vEv94vXAG6nUE3saK+vtgo8PfYA3Ueo88v/1zyAbiZM4uxwojCmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lockfile": "1.0.4"
       },
@@ -31021,9 +31188,28 @@
       "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/verdaccio-htpasswd/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/verdaccio/node_modules/argparse": {
@@ -31032,6 +31218,24 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/verdaccio/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/verdaccio/node_modules/handlebars": {
       "version": "4.7.8",
@@ -31607,7 +31811,7 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
@@ -31647,11 +31851,11 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.4.2",
-        "@aws-amplify/backend-data": "^1.2.3",
+        "@aws-amplify/backend-data": "^1.3.0",
         "@aws-amplify/backend-function": "^1.10.0",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.4",
@@ -31675,10 +31879,10 @@
     },
     "packages/backend-ai": {
       "name": "@aws-amplify/backend-ai",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.1.0",
+        "@aws-amplify/ai-constructs": "^1.2.0",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.4",
         "@aws-amplify/data-schema-types": "^1.2.0",
@@ -31715,7 +31919,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
@@ -32092,7 +32296,7 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^1.1.12",
@@ -32102,7 +32306,7 @@
         "@aws-amplify/client-config": "^1.5.4",
         "@aws-amplify/deployed-backend-client": "^1.5.0",
         "@aws-amplify/form-generator": "^1.0.3",
-        "@aws-amplify/model-generator": "^1.0.10",
+        "@aws-amplify/model-generator": "^1.0.11",
         "@aws-amplify/platform-core": "^1.4.0",
         "@aws-amplify/plugin-types": "^1.6.0",
         "@aws-amplify/sandbox": "^1.2.8",
@@ -32973,7 +33177,7 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",


### PR DESCRIPTION
## Problem

Running `npm audit` we have a vulnerability from downstream dependency of `verdaccio`:
```
# npm audit report

path-to-regexp  <0.1.12
Severity: moderate
Unpatched `path-to-regexp` ReDoS in 0.1.x - https://github.com/advisories/GHSA-rhx6-c78j-4q9w
fix available via `npm audit fix`
node_modules/path-to-regexp
  express  4.0.0-rc1 - 4.21.1 || 5.0.0-alpha.1 - 5.0.0-beta.3
  Depends on vulnerable versions of path-to-regexp
  node_modules/express
    @verdaccio/middleware  <=8.0.0-next-8.6
    Depends on vulnerable versions of express
    node_modules/@verdaccio/middleware
      verdaccio  2.2.7-r - 2.7.2 || 3.0.0-alpha.1 - 6.0.4 || 7.0.0-next.0 - 8.0.0-next-8.6
      Depends on vulnerable versions of @verdaccio/middleware
      Depends on vulnerable versions of express
      Depends on vulnerable versions of verdaccio-audit
      node_modules/verdaccio
    verdaccio-audit  0.0.2 - 13.0.0-next-8.6
    Depends on vulnerable versions of express
    node_modules/verdaccio-audit
```

**Issue number, if available:**

## Changes

Bump `verdaccio` to patched version.

**Corresponding docs PR, if applicable:**

## Validation

After updating `verdaccio` to latest:
```
➜  amplify-backend git:(main) ✗ npm audit           
found 0 vulnerabilities
```

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
