### PR TITLE
fix dependabot version update workflow

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -277,6 +277,8 @@ jobs:
       - resolve_inputs
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup_node
         with:
           node-version: 18
@@ -285,10 +287,9 @@ jobs:
           node-version: 18
           cdk-version: ${{ needs.resolve_inputs.outputs.cdk_version }}
       - name: Handle Dependabot version update pull request
-        run: npx tsx scripts/dependabot_handle_version_update.ts "$BASE_SHA" "$HEAD_SHA"
+        run: npx tsx scripts/dependabot_handle_version_update.ts "$BASE_SHA"
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # The dependabot_handler_version_update script needs to add the 'run-e2e' pull request label
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   do_include_e2e:

--- a/scripts/components/dependabot_version_update_handler.test.ts
+++ b/scripts/components/dependabot_version_update_handler.test.ts
@@ -117,6 +117,10 @@ void describe('dependabot version update handler', async () => {
         pull_request: {
           number: 1,
           body: pullRequestBody,
+          head: {
+            ref: 'dependabot/test_version_update_branch',
+            sha: 'abcd1234', // used for naming the changeset file
+          },
         },
       },
       issue: {
@@ -131,15 +135,13 @@ void describe('dependabot version update handler', async () => {
     };
 
     // Update package.json files for both packages and commit to match what Dependabot will do for a version update PR
-    await gitClient.switchToBranch('dependabot/test_update');
+    await gitClient.switchToBranch('dependabot/test_version_update_branch');
     await setPackageDependencies(cantaloupePackagePath, { testDep: '^1.1.0' });
     await setPackageDependencies(platypusPackagePath, { testDep: '^1.1.0' });
     await gitClient.commitAllChanges('Bump dependencies');
-    const headRef = await gitClient.getHashForCurrentCommit();
 
     const dependabotVersionUpdateHandler = new DependabotVersionUpdateHandler(
       baseRef,
-      headRef,
       gitClient,
       githubClient,
       testWorkingDir,
@@ -150,7 +152,7 @@ void describe('dependabot version update handler', async () => {
 
     const changesetFilePath = path.join(
       testWorkingDir,
-      `.changeset/dependabot-${headRef}.md`
+      '.changeset/dependabot-abcd1234.md'
     );
 
     await assertChangesetFile(

--- a/scripts/components/dependabot_version_update_handler.test.ts
+++ b/scripts/components/dependabot_version_update_handler.test.ts
@@ -119,6 +119,7 @@ void describe('dependabot version update handler', async () => {
           body: pullRequestBody,
           head: {
             ref: 'dependabot/test_version_update_branch',
+            // eslint-disable-next-line spellcheck/spell-checker
             sha: 'abcd1234', // used for naming the changeset file
           },
         },
@@ -152,6 +153,7 @@ void describe('dependabot version update handler', async () => {
 
     const changesetFilePath = path.join(
       testWorkingDir,
+      // eslint-disable-next-line spellcheck/spell-checker
       '.changeset/dependabot-abcd1234.md'
     );
 

--- a/scripts/components/dependabot_version_update_handler.ts
+++ b/scripts/components/dependabot_version_update_handler.ts
@@ -16,7 +16,6 @@ export class DependabotVersionUpdateHandler {
    */
   constructor(
     private readonly baseRef: string,
-    private readonly headRef: string,
     private readonly gitClient: GitClient,
     private readonly ghClient: GithubClient,
     private readonly _rootDir: string = process.cwd(),
@@ -40,7 +39,8 @@ export class DependabotVersionUpdateHandler {
       return;
     }
 
-    const branch = await this.gitClient.getCurrentBranch();
+    const branch = this._ghContext.payload.pull_request.head.ref;
+    await this.gitClient.switchToBranch(branch);
     if (!branch.startsWith('dependabot/')) {
       // if branch is not a dependabot branch, return early
       return;
@@ -78,7 +78,7 @@ export class DependabotVersionUpdateHandler {
     // Create and commit the changeset file, then add the 'run-e2e' label and force push to the PR
     const fileName = path.join(
       this._rootDir,
-      `.changeset/dependabot-${this.headRef}.md`
+      `.changeset/dependabot-${this._ghContext.payload.pull_request.head.sha}.md`
     );
     const versionUpdates = await this.getVersionUpdates();
     await this.createChangesetFile(fileName, versionUpdates, packageNames);

--- a/scripts/dependabot_handle_version_update.ts
+++ b/scripts/dependabot_handle_version_update.ts
@@ -4,17 +4,13 @@ import { DependabotVersionUpdateHandler } from './components/dependabot_version_
 
 const baseRef = process.argv[2];
 if (baseRef === undefined) {
-  throw new Error('No base ref specified for generate changeset check');
-}
-
-const headRef = process.argv[3];
-if (headRef === undefined) {
-  throw new Error('No head ref specified for generate changeset check');
+  throw new Error(
+    'No base ref specified for handle dependabot version update check'
+  );
 }
 
 const dependabotVersionUpdateHandler = new DependabotVersionUpdateHandler(
   baseRef,
-  headRef,
   new GitClient(),
   new GithubClient()
 );


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

There were some issues and the `handle_dependabot_version_update` workflow was not able to add a changeset file to Dependabot PRs.

**Issue number, if available:**

## Changes

- Update getting the branch name and sha from GitHub context (this removed the need for HEAD_SHA input for the script)
- Added fetch depth to `checkout` step so we can properly get the updated files

**Corresponding docs PR, if applicable:**

## Validation

This PR https://github.com/aws-amplify/amplify-backend/pull/2393 that has these changes and is based off of this Dependabot version update PR https://github.com/aws-amplify/amplify-backend/pull/2387.
https://github.com/aws-amplify/amplify-backend/actions/runs/12588139778/job/35085511871

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
