### PR TITLE
add permission to write to pull request for handle version update job

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -275,6 +275,9 @@ jobs:
     needs:
       - install
       - resolve_inputs
+    permissions:
+      # This is required so that this job can add the 'run-e2e' label on the pull request
+      pull-requests: write
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
         with:


### PR DESCRIPTION
## Problem

`handle_dependabot_version_update` job does not have the permission to write to Dependabot PRs, see https://github.com/aws-amplify/amplify-backend/actions/runs/12590013366/job/35090960677?pr=2387

**Issue number, if available:**

## Changes

Add permission mentioned in https://github.com/aws-amplify/amplify-backend/actions/runs/12590013366/job/35090960677?pr=2387#step:5:41 for the `handle_dependabot_version_update` job.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
