### PR TITLE
Base64 encode amplify errors in serialized form

### DIFF
--- a/.changeset/metal-taxis-sing.md
+++ b/.changeset/metal-taxis-sing.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+Base64 encode serialized Amplify Errors

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -85,67 +85,113 @@ and some after the error message
     assert.deepStrictEqual(actual?.cause?.message, testError.cause?.message);
   });
 
-  void it('deserialize when string is encoded with single quote and has double quotes in it', () => {
-    const sampleStderr = `some random stderr
+  void describe('V1 deserialization', () => {
+    void it('deserialize when string is encoded with single quote and has double quotes in it', () => {
+      const sampleStderr = `some random stderr
     ${util.inspect({
       serializedError:
         '{"name":"SyntaxError","classification":"ERROR","options":{"message":"test error message","resolution":"test resolution"}}',
     })}
 and some after the error message
     `;
-    const actual = AmplifyError.fromStderr(sampleStderr);
-    assert.deepStrictEqual(actual?.name, 'SyntaxError');
-    assert.deepStrictEqual(actual?.classification, 'ERROR');
-    assert.deepStrictEqual(actual?.message, 'test error message');
-    assert.deepStrictEqual(actual?.resolution, 'test resolution');
-  });
+      const actual = AmplifyError.fromStderr(sampleStderr);
+      assert.deepStrictEqual(actual?.name, 'SyntaxError');
+      assert.deepStrictEqual(actual?.classification, 'ERROR');
+      assert.deepStrictEqual(actual?.message, 'test error message');
+      assert.deepStrictEqual(actual?.resolution, 'test resolution');
+    });
 
-  void it('deserialize when string is encoded with single quote and has double quotes escaped in between', () => {
-    const sampleStderr = `some random stderr
+    void it('deserialize when string is encoded with single quote and has double quotes escaped in between', () => {
+      const sampleStderr = `some random stderr
     ${util.inspect({
       serializedError:
         '{"name":"SyntaxError","classification":"ERROR","options":{"message":"paths must start with \\"/\\" and end with \\"/*","resolution":"test resolution"}}',
     })}
 and some after the error message
     `;
-    const actual = AmplifyError.fromStderr(sampleStderr);
-    assert.deepStrictEqual(actual?.name, 'SyntaxError');
-    assert.deepStrictEqual(actual?.classification, 'ERROR');
-    assert.deepStrictEqual(
-      actual?.message,
-      'paths must start with "/" and end with "/*'
-    );
-    assert.deepStrictEqual(actual?.resolution, 'test resolution');
-  });
+      const actual = AmplifyError.fromStderr(sampleStderr);
+      assert.deepStrictEqual(actual?.name, 'SyntaxError');
+      assert.deepStrictEqual(actual?.classification, 'ERROR');
+      assert.deepStrictEqual(
+        actual?.message,
+        'paths must start with "/" and end with "/*'
+      );
+      assert.deepStrictEqual(actual?.resolution, 'test resolution');
+    });
 
-  void it('deserialize when string is encoded with double quote and has double quotes string in it', () => {
-    const sampleStderr = `some random stderr
+    void it('deserialize when string is encoded with double quote and has double quotes string in it', () => {
+      const sampleStderr = `some random stderr
     serializedError: "{\\"name\\":\\"SyntaxError\\",\\"classification\\":\\"ERROR\\",\\"options\\":{\\"message\\":\\"test error message\\",\\"resolution\\":\\"test resolution\\"}}"
 and some after the error message
     `;
-    const actual = AmplifyError.fromStderr(sampleStderr);
-    assert.deepStrictEqual(actual?.name, 'SyntaxError');
-    assert.deepStrictEqual(actual?.classification, 'ERROR');
-    assert.deepStrictEqual(actual?.message, 'test error message');
-    assert.deepStrictEqual(actual?.resolution, 'test resolution');
-  });
+      const actual = AmplifyError.fromStderr(sampleStderr);
+      assert.deepStrictEqual(actual?.name, 'SyntaxError');
+      assert.deepStrictEqual(actual?.classification, 'ERROR');
+      assert.deepStrictEqual(actual?.message, 'test error message');
+      assert.deepStrictEqual(actual?.resolution, 'test resolution');
+    });
 
-  void it('deserialize when string has single quotes in between', () => {
-    const sampleStderr = `some random stderr
+    void it('deserialize when string has single quotes in between', () => {
+      const sampleStderr = `some random stderr
     ${util.inspect({
       serializedError:
         '{"name":"SyntaxError","classification":"ERROR","options":{"message":"Cannot read properties of undefined (reading \'data\')","resolution":"test resolution"}}',
     })}
 and some after the error message
     `;
-    const actual = AmplifyError.fromStderr(sampleStderr);
-    assert.deepStrictEqual(actual?.name, 'SyntaxError');
-    assert.deepStrictEqual(actual?.classification, 'ERROR');
-    assert.deepStrictEqual(
-      actual?.message,
-      `Cannot read properties of undefined (reading 'data')`
-    );
-    assert.deepStrictEqual(actual?.resolution, 'test resolution');
+      const actual = AmplifyError.fromStderr(sampleStderr);
+      assert.deepStrictEqual(actual?.name, 'SyntaxError');
+      assert.deepStrictEqual(actual?.classification, 'ERROR');
+      assert.deepStrictEqual(
+        actual?.message,
+        `Cannot read properties of undefined (reading 'data')`
+      );
+      assert.deepStrictEqual(actual?.resolution, 'test resolution');
+    });
+  });
+
+  void describe('V2 deserialization', () => {
+    void it('deserialize when string is encoded with single quote', () => {
+      const sampleStderr = `some random stderr
+      serializedError: '${Buffer.from(
+        '{"name":"SyntaxError","classification":"ERROR","options":{"message":"test error message","resolution":"test resolution"}}'
+      ).toString('base64')}',
+and some after the error message
+    `;
+      const actual = AmplifyError.fromStderr(sampleStderr);
+      assert.deepStrictEqual(actual?.name, 'SyntaxError');
+      assert.deepStrictEqual(actual?.classification, 'ERROR');
+      assert.deepStrictEqual(actual?.message, 'test error message');
+      assert.deepStrictEqual(actual?.resolution, 'test resolution');
+    });
+
+    void it('deserialize when string is encoded with double quote', () => {
+      const sampleStderr = `some random stderr
+      serializedError: "${Buffer.from(
+        '{"name":"SyntaxError","classification":"ERROR","options":{"message":"test error message","resolution":"test resolution"}}'
+      ).toString('base64')}",
+and some after the error message
+    `;
+      const actual = AmplifyError.fromStderr(sampleStderr);
+      assert.deepStrictEqual(actual?.name, 'SyntaxError');
+      assert.deepStrictEqual(actual?.classification, 'ERROR');
+      assert.deepStrictEqual(actual?.message, 'test error message');
+      assert.deepStrictEqual(actual?.resolution, 'test resolution');
+    });
+
+    void it('deserialize when string is encoded with back ticks', () => {
+      const sampleStderr = `some random stderr
+      serializedError: \`${Buffer.from(
+        '{"name":"SyntaxError","classification":"ERROR","options":{"message":"test error message","resolution":"test resolution"}}'
+      ).toString('base64')}\`,
+and some after the error message
+    `;
+      const actual = AmplifyError.fromStderr(sampleStderr);
+      assert.deepStrictEqual(actual?.name, 'SyntaxError');
+      assert.deepStrictEqual(actual?.classification, 'ERROR');
+      assert.deepStrictEqual(actual?.message, 'test error message');
+      assert.deepStrictEqual(actual?.resolution, 'test resolution');
+    });
   });
 });
 

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -47,55 +47,41 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     if (cause && AmplifyError.isAmplifyError(cause)) {
       cause.serializedError = undefined;
     }
-    this.serializedError = JSON.stringify(
-      {
-        name,
-        classification,
-        options,
-        cause,
-      },
-      errorSerializer
-    );
+    this.serializedError = Buffer.from(
+      JSON.stringify(
+        {
+          name,
+          classification,
+          options,
+          cause,
+        },
+        errorSerializer
+      )
+    ).toString('base64');
   }
 
   static fromStderr = (_stderr: string): AmplifyError | undefined => {
-    /**
-     * `["']?serializedError["']?:[ ]?` captures the start of the serialized error. The quotes depend on which OS is being used
-     * `(?:`(.+?)`|'(.+?)'|"((?:\\"|[^"])*?)")` captures the rest of the serialized string enclosed in either single quote,
-     * double quotes or back-ticks.
-     */
-    const extractionRegex =
-      /["']?serializedError["']?:[ ]?(?:`(.+?)`|'(.+?)'|"((?:\\"|[^"])*?)")/;
-    const serialized = _stderr.match(extractionRegex);
-    if (serialized && serialized.length === 4) {
-      // 4 because 1 match and 3 capturing groups
-      try {
-        const serializedString = serialized
-          .slice(1)
-          .find((item) => item && item.length > 0)
-          ?.replaceAll('\\"', '"')
-          .replaceAll("\\'", "'");
+    try {
+      const serializedString = tryFindSerializedErrorJSONString(_stderr);
 
-        if (!serializedString) {
-          return undefined;
-        }
-
-        const { name, classification, options, cause } =
-          JSON.parse(serializedString);
-
-        let serializedCause = cause;
-        if (cause && ErrorSerializerDeserializer.isSerializedErrorType(cause)) {
-          serializedCause = ErrorSerializerDeserializer.deserialize(cause);
-        }
-        return classification === 'ERROR'
-          ? new AmplifyUserError(name, options, serializedCause)
-          : new AmplifyFault(name, options, serializedCause);
-      } catch (error) {
-        // cannot deserialize
+      if (!serializedString) {
         return undefined;
       }
+
+      const { name, classification, options, cause } =
+        JSON.parse(serializedString);
+
+      let serializedCause = cause;
+      if (cause && ErrorSerializerDeserializer.isSerializedErrorType(cause)) {
+        serializedCause = ErrorSerializerDeserializer.deserialize(cause);
+      }
+      return classification === 'ERROR'
+        ? new AmplifyUserError(name, options, serializedCause)
+        : new AmplifyFault(name, options, serializedCause);
+    } catch (error) {
+      // cannot deserialize
+      return undefined;
     }
-    return undefined;
   };
 
   /**
@@ -206,6 +192,68 @@ export abstract class AmplifyError<T extends string = string> extends Error {
     );
   };
 }
+
+const tryFindSerializedErrorJSONString = (
+  _stderr: string
+): string | undefined => {
+  let errorJSONString = tryFindSerializedErrorJSONStringV2(_stderr);
+  if (!errorJSONString) {
+    errorJSONString = tryFindSerializedErrorJSONStringV1(_stderr);
+  }
+  return errorJSONString;
+};
+
+/**
+ * Tries to find serialized string assuming that it is in a form of serialized JSON encoded with base64.
+ */
+const tryFindSerializedErrorJSONStringV2 = (
+  _stderr: string
+): string | undefined => {
+  /**
+   * `["']?serializedError["']?:[ ]?` captures the start of the serialized error. The quotes depend on which OS is being used
+   * `(?:`([a-zA-Z0-9+/=]+?)`|'([a-zA-Z0-9+/=]+?)'|"([a-zA-Z0-9+/=]+?)")` captures the rest of the serialized string enclosed in either single quote,
+   * double quotes or back-ticks.
+   */
+  const extractionRegex =
+    /["']?serializedError["']?:[ ]?(?:`([a-zA-Z0-9+/=]+?)`|'([a-zA-Z0-9+/=]+?)'|"([a-zA-Z0-9+/=]+?)")/;
+  const serialized = _stderr.match(extractionRegex);
+  if (serialized && serialized.length === 4) {
+    // 4 because 1 match and 3 capturing groups
+    const base64SerializedString = serialized
+      .slice(1)
+      .find((item) => item && item.length > 0);
+    if (base64SerializedString) {
+      return Buffer.from(base64SerializedString, 'base64').toString('utf-8');
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Tries to find serialized string assuming that it is in a form of serialized JSON.
+ * @deprecated This is old format left for backwards compatibility in case that synth-time components are using older version of platform-core.
+ */
+const tryFindSerializedErrorJSONStringV1 = (
+  _stderr: string
+): string | undefined => {
+  /**
+   * `["']?serializedError["']?:[ ]?` captures the start of the serialized error. The quotes depend on which OS is being used
+   * `(?:`(.+?)`|'(.+?)'|"((?:\\"|[^"])*?)")` captures the rest of the serialized string enclosed in either single quote,
+   * double quotes or back-ticks.
+   */
+  const extractionRegex =
+    /["']?serializedError["']?:[ ]?(?:`(.+?)`|'(.+?)'|"((?:\\"|[^"])*?)")/;
+  const serialized = _stderr.match(extractionRegex);
+  if (serialized && serialized.length === 4) {
+    // 4 because 1 match and 3 capturing groups
+    return serialized
+      .slice(1)
+      .find((item) => item && item.length > 0)
+      ?.replaceAll('\\"', '"')
+      .replaceAll("\\'", "'");
+  }
+  return undefined;
+};
 
 const isCredentialsError = (err?: Error): boolean => {
   return (


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Sometimes serialized form of Amplify Error may contain quotes in unexpected places.
For example
```
  serializedError: '{"name":"NodeJSFunctionConstructInitializationError","classification":"ERROR","options":{"message":"Failed to instantiate nodejs function construct","resolution":"See the underlying error message for more details. Use `--debug` for additional debugging information."},"cause":{"name":"Error","message":"ENOTEMPTY: directory not empty, rmdir \'C:\\\\Users\\\\Desktop\\\\Documents\\\\testapp\\\\.amplify\\\\artifacts\\\\cdk.out\\\\bundling-temp-abcderf\'"}}',
 ```

It makes the extraction regex hard to maintain and catch up with these edge cases.

The current regex is defined here https://github.com/aws-amplify/amplify-backend/blob/f20e8a3c09bfde6799cfaa4c25e8773c372bd403/packages/platform-core/src/errors/amplify_error.ts#L62-L68 .

## Changes

This PR adds Base64 encoding on top of JSON serialization to reduce possible set of possible characters in `serializedError` . This making the extraction from stderr stream resilient to unexpected content.

## Validation

Added tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
