### PR TITLE
add sms configuration and custom sms sender to auth

### DIFF
--- a/.changeset/curly-bags-cheer.md
+++ b/.changeset/curly-bags-cheer.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/auth-construct': minor
+'@aws-amplify/backend-auth': minor
+---
+
+add sms configuration and custom sms sender to auth

--- a/.changeset/curly-bags-cheer.md
+++ b/.changeset/curly-bags-cheer.md
@@ -1,6 +1,7 @@
 ---
 '@aws-amplify/auth-construct': minor
 '@aws-amplify/backend-auth': minor
+'@aws-amplify/backend': minor
 ---
 
 add sms configuration and custom sms sender to auth

--- a/package-lock.json
+++ b/package-lock.json
@@ -33595,11 +33595,11 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
-        "@aws-amplify/platform-core": "^1.3.0",
+        "@aws-amplify/platform-core": "^1.5.1",
         "@aws-amplify/plugin-types": "^1.6.0",
         "@aws-sdk/client-bedrock-runtime": "^3.622.0",
         "@smithy/types": "^3.3.0",
@@ -33635,19 +33635,19 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.4.2",
         "@aws-amplify/backend-data": "^1.4.0",
-        "@aws-amplify/backend-function": "^1.11.0",
+        "@aws-amplify/backend-function": "^1.12.0",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.4",
         "@aws-amplify/backend-secret": "^1.1.4",
         "@aws-amplify/backend-storage": "^1.2.4",
         "@aws-amplify/client-config": "^1.5.5",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/platform-core": "^1.5.0",
+        "@aws-amplify/platform-core": "^1.5.1",
         "@aws-amplify/plugin-types": "^1.7.0",
         "@aws-sdk/client-amplify": "^3.624.0"
       },
@@ -33859,7 +33859,7 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
@@ -33870,7 +33870,7 @@
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.7",
-        "@aws-amplify/platform-core": "^1.5.0",
+        "@aws-amplify/platform-core": "^1.5.1",
         "@aws-sdk/client-s3": "^3.624.0",
         "@aws-sdk/client-ssm": "^3.624.0",
         "aws-sdk": "^2.1550.0",
@@ -34133,7 +34133,8 @@
         "@aws-amplify/platform-core": "^1.3.0",
         "@inquirer/prompts": "^3.0.0",
         "execa": "^9.5.1",
-        "kleur": "^4.1.5"
+        "kleur": "^4.1.5",
+        "zod": "^3.22.2"
       }
     },
     "packages/cli-core/node_modules/execa": {
@@ -34983,7 +34984,7 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.7.0",

--- a/packages/auth-construct/API.md
+++ b/packages/auth-construct/API.md
@@ -48,7 +48,8 @@ export type AuthProps = {
         externalProviders?: ExternalProviderOptions;
     };
     senders?: {
-        email: Pick<UserPoolSESOptions, 'fromEmail' | 'fromName' | 'replyTo'> | CustomEmailSender;
+        email?: Pick<UserPoolSESOptions, 'fromEmail' | 'fromName' | 'replyTo'> | CustomEmailSender;
+        sms?: UserPoolSnsOptions | CustomSmsSender;
     };
     userAttributes?: UserAttributes;
     multifactor?: MFA;
@@ -87,6 +88,12 @@ export type CustomAttributeString = CustomAttributeBase & StringAttributeConstra
 
 // @public
 export type CustomEmailSender = {
+    handler: IFunction;
+    kmsKeyArn?: string;
+};
+
+// @public
+export type CustomSmsSender = {
     handler: IFunction;
     kmsKeyArn?: string;
 };
@@ -179,6 +186,13 @@ export const triggerEvents: readonly ["createAuthChallenge", "customMessage", "d
 
 // @public
 export type UserAttributes = StandardAttributes & Record<`custom:${string}`, CustomAttribute>;
+
+// @public
+export type UserPoolSnsOptions = {
+    readonly externalId?: string;
+    readonly snsCallerArn?: string;
+    readonly snsRegion?: string;
+};
 
 // @public (undocumented)
 export type VerificationEmailWithCode = {

--- a/packages/auth-construct/src/index.ts
+++ b/packages/auth-construct/src/index.ts
@@ -27,6 +27,8 @@ export {
   CustomAttributeDateTime,
   CustomAttributeBase,
   CustomEmailSender,
+  CustomSmsSender,
+  UserPoolSnsOptions,
 } from './types.js';
 export { AmplifyAuth } from './construct.js';
 export { triggerEvents } from './trigger_events.js';

--- a/packages/auth-construct/src/test-assets/lambda/handler.js
+++ b/packages/auth-construct/src/test-assets/lambda/handler.js
@@ -1,0 +1,6 @@
+/**
+ * Hello world lambda used for testing defaults to `defineFunction`
+ */
+export const handler = async () => {
+  return 'hello world lambda';
+};

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -390,6 +390,40 @@ export type CustomEmailSender = {
 };
 
 /**
+ * CustomSmsSender type for configuring a custom Lambda function for sms sending
+ */
+export type CustomSmsSender = {
+  handler: IFunction;
+  kmsKeyArn?: string;
+};
+
+/**
+ * Options to enable and configure an IAM role to be used for calling SNS for sending SMS by cognito
+ */
+export type UserPoolSnsOptions = {
+  /**
+   * The external ID provides additional security for your IAM role.
+   * You can use an `ExternalId` with the IAM role that you use with Amazon SNS to send SMS messages for your user pool. If you provide an `ExternalId` , your Amazon Cognito user pool includes it in the request to assume your IAM role. You can configure the role trust policy to require that Amazon Cognito, and any principal, provide the `ExternalID` . If you use the Amazon Cognito Management Console to create a role for SMS multi-factor authentication (MFA), Amazon Cognito creates a role with the required permissions and a trust policy that demonstrates use of the `ExternalId` .
+   * For more information about the `ExternalId` of a role, see [How to use an external ID when granting access to your AWS resources to a third party](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) .
+   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-smsconfiguration.html#cfn-cognito-userpool-smsconfiguration-externalid
+   */
+  readonly externalId?: string;
+  /**
+   * The Amazon Resource Name (ARN) of the Amazon SNS caller.
+   * This is the ARN of the IAM role in your AWS account that Amazon Cognito will use to send SMS messages. SMS messages are subject to a [spending limit](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-email-phone-verification.html) .
+   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-smsconfiguration.html#cfn-cognito-userpool-smsconfiguration-snscallerarn
+   */
+  readonly snsCallerArn?: string;
+  /**
+   * The AWS Region to use with Amazon SNS integration.
+   * You can choose the same Region as your user pool, or a supported *Legacy Amazon SNS alternate Region* .
+   * Amazon Cognito resources in the Asia Pacific (Seoul) AWS Region must use your Amazon SNS configuration in the Asia Pacific (Tokyo) Region. For more information, see [SMS message settings for Amazon Cognito user pools](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-sms-settings.html) .
+   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-smsconfiguration.html#cfn-cognito-userpool-smsconfiguration-snsregion
+   */
+  readonly snsRegion?: string;
+};
+
+/**
  * Input props for the AmplifyAuth construct
  */
 export type AuthProps = {
@@ -432,9 +466,11 @@ export type AuthProps = {
      * @see https://docs.amplify.aws/react/build-a-backend/auth/moving-to-production/#email
      * @see https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-email-sender.html
      */
-    email:
+    email?:
       | Pick<UserPoolSESOptions, 'fromEmail' | 'fromName' | 'replyTo'>
       | CustomEmailSender;
+
+    sms?: UserPoolSnsOptions | CustomSmsSender;
   };
   /**
    * The set of attributes that are required for every user in the user pool. Read more on attributes here - https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html

--- a/packages/backend-auth/API.md
+++ b/packages/backend-auth/API.md
@@ -28,6 +28,7 @@ import { ResourceProvider } from '@aws-amplify/plugin-types';
 import { StackProvider } from '@aws-amplify/plugin-types';
 import { TriggerEvent } from '@aws-amplify/auth-construct';
 import { UserPoolSESOptions } from 'aws-cdk-lib/aws-cognito';
+import { UserPoolSnsOptions } from '@aws-amplify/auth-construct';
 
 // @public
 export type ActionIam = 'addUserToGroup' | 'createGroup' | 'createUser' | 'deleteGroup' | 'deleteUser' | 'deleteUserAttributes' | 'disableUser' | 'enableUser' | 'forgetDevice' | 'getDevice' | 'getGroup' | 'getUser' | 'listUsers' | 'listUsersInGroup' | 'listGroups' | 'listDevices' | 'listGroupsForUser' | 'removeUserFromGroup' | 'resetUserPassword' | 'setUserMfaPreference' | 'setUserPassword' | 'setUserSettings' | 'updateDeviceStatus' | 'updateGroup' | 'updateUserAttributes';
@@ -47,7 +48,8 @@ export type AmplifyAuthProps = Expand<Omit<AuthProps, 'outputStorageStrategy' | 
     triggers?: Partial<Record<TriggerEvent, ConstructFactory<ResourceProvider<FunctionResources>>>>;
     access?: AuthAccessGenerator;
     senders?: {
-        email: Pick<UserPoolSESOptions, 'fromEmail' | 'fromName' | 'replyTo'> | CustomEmailSender;
+        email?: Pick<UserPoolSESOptions, 'fromEmail' | 'fromName' | 'replyTo'> | CustomEmailSender;
+        sms?: UserPoolSnsOptions | CustomSmsSender;
     };
 }>;
 
@@ -99,6 +101,12 @@ export type BackendReferenceAuth = ResourceProvider<ReferenceAuthResources> & Re
 
 // @public
 export type CustomEmailSender = {
+    handler: ConstructFactory<AmplifyFunction> | IFunction;
+    kmsKeyArn?: string;
+};
+
+// @public
+export type CustomSmsSender = {
     handler: ConstructFactory<AmplifyFunction> | IFunction;
     kmsKeyArn?: string;
 };

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -10,6 +10,7 @@ import {
   AmplifyAuth,
   AuthProps,
   TriggerEvent,
+  UserPoolSnsOptions,
 } from '@aws-amplify/auth-construct';
 import {
   AmplifyResourceGroupName,
@@ -35,6 +36,7 @@ import {
   AuthAccessGenerator,
   AuthLoginWithFactoryProps,
   CustomEmailSender,
+  CustomSmsSender,
   Expand,
 } from './types.js';
 import { UserPoolAccessPolicyFactory } from './userpool_access_policy_factory.js';
@@ -73,9 +75,10 @@ export type AmplifyAuthProps = Expand<
      * Configure email sender options
      */
     senders?: {
-      email:
+      email?:
         | Pick<UserPoolSESOptions, 'fromEmail' | 'fromName' | 'replyTo'>
         | CustomEmailSender;
+      sms?: UserPoolSnsOptions | CustomSmsSender;
     };
   }
 >;

--- a/packages/backend-auth/src/types.ts
+++ b/packages/backend-auth/src/types.ts
@@ -262,3 +262,11 @@ export type CustomEmailSender = {
   handler: ConstructFactory<AmplifyFunction> | IFunction;
   kmsKeyArn?: string;
 };
+
+/**
+ * CustomSmsSender type for configuring a custom Lambda function for sms sending
+ */
+export type CustomSmsSender = {
+  handler: ConstructFactory<AmplifyFunction> | IFunction;
+  kmsKeyArn?: string;
+};

--- a/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/auth/resource.ts
@@ -1,15 +1,24 @@
 import { defineAuth } from '@aws-amplify/backend';
-import { funcCustomEmailSender } from '../function.js';
+import { funcCustomEmailSender, funcCustomSmsSender } from '../function.js';
 
 const customEmailSenderFunction = {
   handler: funcCustomEmailSender,
+};
+
+const customSmsSenderFunction = {
+  handler: funcCustomSmsSender,
 };
 
 export const auth = defineAuth({
   loginWith: {
     email: true,
   },
+  multifactor: {
+    sms: true,
+    mode: 'REQUIRED',
+  },
   senders: {
     email: customEmailSenderFunction,
+    sms: customSmsSenderFunction,
   },
 });

--- a/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/backend.ts
+++ b/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/backend.ts
@@ -24,7 +24,6 @@ if (scheduleFunctionLambdaRole) {
 backend.funcWithSchedule.addEnvironment('SQS_QUEUE_URL', queue.queueUrl);
 
 // Queue setup for customEmailSender
-
 const customEmailSenderLambda = backend.funcCustomEmailSender.resources.lambda;
 const customEmailSenderLambdaRole = customEmailSenderLambda.role;
 const customEmailSenderQueueStack = Stack.of(customEmailSenderLambda);
@@ -43,6 +42,29 @@ if (customEmailSenderLambdaRole) {
   );
 }
 backend.funcCustomEmailSender.addEnvironment(
-  'CUSTOM_EMAIL_SENDER_SQS_QUEUE_URL',
+  'CUSTOM_SENDER_SQS_QUEUE_URL',
   emailSenderQueue.queueUrl
+);
+
+// Queue setup for customSmsSender
+const customSmsSenderLambda = backend.funcCustomSmsSender.resources.lambda;
+const customSmsSenderLambdaRole = customSmsSenderLambda.role;
+const customSmsSenderQueueStack = Stack.of(customSmsSenderLambda);
+const smsSenderQueue = new Queue(
+  customSmsSenderQueueStack,
+  'amplify-customSmsSenderQueue'
+);
+
+if (customSmsSenderLambdaRole) {
+  smsSenderQueue.grantSendMessages(
+    Role.fromRoleArn(
+      customSmsSenderQueueStack,
+      'CustomSmsSenderLambdaExecutionRole',
+      customSmsSenderLambdaRole.roleArn
+    )
+  );
+}
+backend.funcCustomSmsSender.addEnvironment(
+  'CUSTOM_SENDER_SQS_QUEUE_URL',
+  smsSenderQueue.queueUrl
 );

--- a/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/func-src/handler_custom_sender.ts
+++ b/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/func-src/handler_custom_sender.ts
@@ -1,19 +1,19 @@
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
 
 /**
- * This function asserts that custom email sender function is working properly
+ * This function asserts that custom sender function is working properly
  */
 export const handler = async () => {
   const sqsClient = new SQSClient({ region: process.env.region });
 
-  const queueUrl = process.env.CUSTOM_EMAIL_SENDER_SQS_QUEUE_URL;
+  const queueUrl = process.env.CUSTOM_SENDER_SQS_QUEUE_URL;
 
   if (!queueUrl) {
     throw new Error('SQS_QUEUE_URL is not set in environment variables');
   }
 
   const messageBody = JSON.stringify({
-    message: 'Custom Email Sender is working',
+    message: 'Custom Sender is working',
     timeStamp: new Date().toISOString(),
   });
 

--- a/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/function.ts
+++ b/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/function.ts
@@ -42,5 +42,10 @@ export const funcProvided = defineFunction((scope) => {
 
 export const funcCustomEmailSender = defineFunction({
   name: 'funcCustomEmailSender',
-  entry: './func-src/handler_custom_email_sender.ts',
+  entry: './func-src/handler_custom_sender.ts',
+});
+
+export const funcCustomSmsSender = defineFunction({
+  name: 'funcCustomSmsSender',
+  entry: './func-src/handler_custom_sender.ts',
 });

--- a/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/test_factories.ts
+++ b/packages/integration-tests/src/test-projects/advanced-auth-and-functions/amplify/test_factories.ts
@@ -1,10 +1,11 @@
 import {
   funcCustomEmailSender,
+  funcCustomSmsSender,
   funcNoMinify,
+  funcProvided,
   funcWithAwsSdk,
   funcWithSchedule,
   funcWithSsm,
-  funcProvided,
 } from './function.js';
 import { auth } from './auth/resource.js';
 
@@ -15,5 +16,6 @@ export const authAndFunctions = {
   funcWithSchedule,
   funcNoMinify,
   funcCustomEmailSender,
+  funcCustomSmsSender,
   funcProvided,
 };


### PR DESCRIPTION
## Changes

Adds sms configuration and custom sms sender to auth. Some implementation decisions:
* `KMSKeyArn` is duplicated in both `sms` and `email` custom senders since extracting it out will involve a breaking change and cognito only accepts one key for both senders. This change will throw an exception if different keys are used in both sms and email senders.
* We rely on CDK to create the IAM role if customer wants to enable SMS but doesn't explicitly provide one.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
