### PR TITLE
catch errors during secret refreshes

### DIFF
--- a/.changeset/good-tigers-cover.md
+++ b/.changeset/good-tigers-cover.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+catch errors during secret refreshes

--- a/packages/backend-function/src/lambda-shims/invoke_ssm_shim.ts
+++ b/packages/backend-function/src/lambda-shims/invoke_ssm_shim.ts
@@ -9,5 +9,7 @@ await internalAmplifyFunctionResolveSsmParams();
 const SSM_PARAMETER_REFRESH_MS = 1000 * 60;
 
 setInterval(() => {
-  void internalAmplifyFunctionResolveSsmParams();
+  // Catch errors and do nothing in the case we are retrieving secrets when the Lambda starts shutting down
+  // eslint-disable-next-line promise/prefer-await-to-then
+  void internalAmplifyFunctionResolveSsmParams().catch(() => {});
 }, SSM_PARAMETER_REFRESH_MS);


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

For long running Lambda functions, there may be times when our SSM shim which gets secret values is running when the Lambda starts shutting down causing errors like:
```
ERROR	Unhandled Promise Rejection 	
{
    "errorType": "Runtime.UnhandledPromiseRejection",
    "errorMessage": "TimeoutError: Client network socket disconnected before secure TLS connection was established",
    "reason": {
        "errorType": "TimeoutError",
        "errorMessage": "Client network socket disconnected before secure TLS connection was established",
        "code": "ECONNRESET",
        "path": null,
        "host": "ssm.us-west-1.amazonaws.com",
        "port": 443,
        "name": "TimeoutError",
        "$metadata": {
            "attempts": 3,
            "totalRetryDelay": 182
        },
        "stack": [
            "Error: Client network socket disconnected before secure TLS connection was established",
            "    at connResetException (node:internal/errors:720:14)",
            "    at TLSSocket.onConnectEnd (node:_tls_wrap:1714:19)",
            "    at TLSSocket.emit (node:events:529:35)",
            "    at endReadableNT (node:internal/streams/readable:1400:12)",
            "    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)"
        ]
    },
    "promise": {},
    "stack": [
        "Runtime.UnhandledPromiseRejection: TimeoutError: Client network socket disconnected before secure TLS connection was established",
        "    at process.<anonymous> (file:///var/runtime/index.mjs:1276:17)",
        "    at process.emit (node:events:517:28)",
        "    at emit (node:internal/process/promises:149:20)",
        "    at processPromiseRejections (node:internal/process/promises:283:27)",
        "    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)"
    ]
}
```

**Issue number, if available:**

## Changes

Catch errors on subsequent calls to get secrets and do nothing so the Lambda function can shutdown gracefully.

**Corresponding docs PR, if applicable:**

## Validation

Lambda deployed to my account that is running on a schedule every minute:
<img width="530" alt="Screenshot 2025-01-21 at 12 43 13 PM" src="https://github.com/user-attachments/assets/25a79db9-ad2b-4db3-8749-96b275745ad1" />
Error spikes are the error message mentioned above.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
