### PR TITLE
remove the workaround for no-misused-promises as it broke lambdas execution

### DIFF
--- a/.changeset/popular-insects-listen.md
+++ b/.changeset/popular-insects-listen.md
@@ -1,5 +1,6 @@
 ---
 '@aws-amplify/backend-function': patch
+'@aws-amplify/backend': patch
 ---
 
 remove the workaround for no-misused-promises as it broke lambdas execution

--- a/.changeset/popular-insects-listen.md
+++ b/.changeset/popular-insects-listen.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': patch
+---
+
+remove the workaround for no-misused-promises as it broke lambdas execution

--- a/packages/backend-function/src/lambda-shims/invoke_ssm_shim.ts
+++ b/packages/backend-function/src/lambda-shims/invoke_ssm_shim.ts
@@ -9,7 +9,8 @@ await internalAmplifyFunctionResolveSsmParams();
 const SSM_PARAMETER_REFRESH_MS = 1000 * 60;
 
 setInterval(
-  void (async () => {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  async () => {
     try {
       await internalAmplifyFunctionResolveSsmParams();
     } catch (error) {
@@ -21,6 +22,6 @@ setInterval(
         // Do nothing if logging fails
       }
     }
-  }),
+  },
   SSM_PARAMETER_REFRESH_MS
 );


### PR DESCRIPTION
## Problem

After the recent change of https://github.com/aws-amplify/amplify-backend/pull/2438, health checks are failing as lambda execution is failing with error

```console
"TypeError [ERR_INVALID_ARG_TYPE]: The \"callback\" argument must be of type function. Received undefined",
        "    at setInterval (node:timers:212:3)",
        "    at file:///var/task/index.mjs:1:1769",
        "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
```

I tried changing it to use IIFE as well and then instead I got the following error from lambda

```console
  "TypeError [ERR_INVALID_ARG_TYPE]: The \"callback\" argument must be of type function. Received an instance of Promise",
        "    at setInterval (node:timers:212:3)",
        "    at file:///var/task/index.mjs:1:1769",
        "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
```

**Issue number, if available:**

## Changes

Reverting the workaround and turning off eslint to unblock the pipeline

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
