### PR TITLE
wrap more instances of ENOENT type errors

### DIFF
--- a/.changeset/afraid-crabs-care.md
+++ b/.changeset/afraid-crabs-care.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/client-config': patch
+---
+
+wrap more instances of ENOENT type errors

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -693,6 +693,22 @@ npm error enoent`,
     errorName: 'InsufficientMemorySpaceError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage:
+      "ENOENT: no such file or directory, open '/Users/myUser/nonExistingFile'",
+    expectedTopLevelErrorMessage:
+      "Failed to open '/Users/myUser/nonExistingFile'",
+    errorName: 'FileNotFoundError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage:
+      "ENOENT: no such file or directory, open '/Users/myUser/.amplify/artifacts/cdk.out/manifest.json'",
+    expectedTopLevelErrorMessage:
+      'The Amplify backend definition is missing `defineBackend` call.',
+    errorName: 'MissingDefineBackendError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -434,12 +434,21 @@ export class CdkErrorMapper {
       // During 'cdk synth' CDK CLI attempts to read CDK assembly after calling customer's app.
       // But no files are rendered causing it to fail.
       errorRegex:
-        /ENOENT: no such file or directory, open '\.amplify.artifacts.cdk\.out.manifest\.json'/,
+        /ENOENT: no such file or directory, open '.*\.amplify.artifacts.cdk\.out.manifest\.json'/,
       humanReadableErrorMessage:
         'The Amplify backend definition is missing `defineBackend` call.',
       resolutionMessage:
         'Check your backend definition in the `amplify` folder. Ensure that `amplify/backend.ts` contains `defineBackend` call.',
       errorName: 'MissingDefineBackendError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
+        /^ENOENT: no such file or directory, (?<action_and_filepath>.*)$/,
+      humanReadableErrorMessage: 'Failed to {action_and_filepath}',
+      resolutionMessage:
+        'File or directory not found. Failed to {action_and_filepath}',
+      errorName: 'FileNotFoundError',
       classification: 'ERROR',
     },
     {
@@ -579,6 +588,7 @@ export type CDKDeploymentError =
   | 'ESBuildError'
   | 'ExpiredTokenError'
   | 'FileConventionError'
+  | 'FileNotFoundError'
   | 'ModuleNotFoundError'
   | 'InsufficientMemorySpaceError'
   | 'InvalidOrCannotAssumeRoleError'

--- a/packages/client-config/src/paths/get_client_config_path.test.ts
+++ b/packages/client-config/src/paths/get_client_config_path.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import assert from 'node:assert';
 import { getClientConfigPath } from './get_client_config_path.js';
 import { ClientConfigFileBaseName, ClientConfigFormat } from '../index.js';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 const testPath = 'some/path';
 
@@ -111,13 +112,18 @@ void describe('getClientConfigPath', () => {
         "ENOENT: no such file or directory, mkdir '/invalidPath'"
       );
     });
-    await assert.rejects(async () => {
-      await getClientConfigPath(
-        ClientConfigFileBaseName.DEFAULT,
-        nonExistingPath
-      );
-    }),
-      { message: 'Directory /invalidPath could not be created.' };
+    await assert.rejects(
+      () =>
+        getClientConfigPath(ClientConfigFileBaseName.DEFAULT, nonExistingPath),
+      (error: AmplifyUserError) => {
+        assert.strictEqual(
+          error.message,
+          'Directory /invalidPath could not be created.'
+        );
+        assert.ok(error.resolution);
+        return true;
+      }
+    );
   });
 
   void it('returns path to client config file with absolute path', async () => {

--- a/packages/client-config/src/paths/get_client_config_path.test.ts
+++ b/packages/client-config/src/paths/get_client_config_path.test.ts
@@ -7,7 +7,7 @@ import { ClientConfigFileBaseName, ClientConfigFormat } from '../index.js';
 
 const testPath = 'some/path';
 
-mock.method(fsp, 'mkdir', () => undefined);
+const mkdirMock = mock.method(fsp, 'mkdir', () => undefined);
 
 void describe('getClientConfigPath', () => {
   void it('returns path to legacy config file', async () => {
@@ -102,6 +102,19 @@ void describe('getClientConfigPath', () => {
         `${ClientConfigFileBaseName.DEFAULT}.${ClientConfigFormat.JSON}`
       )
     );
+  });
+
+  void it('fails when path is invalid or cannot be created', async () => {
+    const nonExistingPath = '/invalidPath';
+    mkdirMock.mock.mockImplementationOnce(() => {
+      throw new Error(
+        "ENOENT: no such file or directory, mkdir '/invalidPath'"
+      );
+    });
+    await assert.rejects(() =>
+      getClientConfigPath(ClientConfigFileBaseName.DEFAULT, nonExistingPath)
+    );
+    ('Directory /invalidPath could not be created.');
   });
 
   void it('returns path to client config file with absolute path', async () => {

--- a/packages/client-config/src/paths/get_client_config_path.test.ts
+++ b/packages/client-config/src/paths/get_client_config_path.test.ts
@@ -111,10 +111,13 @@ void describe('getClientConfigPath', () => {
         "ENOENT: no such file or directory, mkdir '/invalidPath'"
       );
     });
-    await assert.rejects(() =>
-      getClientConfigPath(ClientConfigFileBaseName.DEFAULT, nonExistingPath)
-    );
-    ('Directory /invalidPath could not be created.');
+    await assert.rejects(async () => {
+      await getClientConfigPath(
+        ClientConfigFileBaseName.DEFAULT,
+        nonExistingPath
+      );
+    }),
+      { message: 'Directory /invalidPath could not be created.' };
   });
 
   void it('returns path to client config file with absolute path', async () => {

--- a/packages/client-config/src/paths/get_client_config_path.ts
+++ b/packages/client-config/src/paths/get_client_config_path.ts
@@ -1,6 +1,7 @@
 import fsp from 'fs/promises';
 import path from 'path';
 import { ClientConfigFileBaseName, ClientConfigFormat } from '../index.js';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 /**
  * Get path to config file
@@ -32,7 +33,21 @@ export const getClientConfigPath = async (
     } catch (error) {
       // outDir does not exist, so create dir
       if (error instanceof Error && error.message.includes('ENOENT')) {
-        await fsp.mkdir(outDir, { recursive: true });
+        try {
+          await fsp.mkdir(outDir, { recursive: true });
+        } catch (error) {
+          if (error instanceof Error && error.message.includes('ENOENT')) {
+            throw new AmplifyUserError(
+              'InvalidPathError',
+              {
+                message: `Directory ${outDir} could not be created.`,
+                resolution:
+                  'Ensure that you have access for creating this file path and that the path is correct',
+              },
+              error
+            );
+          }
+        }
       } else {
         throw error;
       }


### PR DESCRIPTION
## Problem

Continuation of https://github.com/aws-amplify/amplify-backend/pull/2192 and https://github.com/aws-amplify/amplify-backend/pull/2267 we still see some instances of this error in telemetry. I've found three different causes

1. Customers using file paths in their backend definition that genuinely don't exist.
2. Customer providing a path for client config that cannot be created such as `/lib`
3. for `manifest.json` file in cdk.out directory. I believe this is similar issue as https://github.com/aws-amplify/amplify-backend/pull/2192 though I am not able to reproduce it by any means.

## Validation

Unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
