### PR TITLE
enforce branch option implying app id for generate commands

### DIFF
--- a/.changeset/happy-pianos-destroy.md
+++ b/.changeset/happy-pianos-destroy.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+enforce branch option implying app id for generate commands

--- a/packages/cli/src/commands/generate/forms/generate_forms_command.ts
+++ b/packages/cli/src/commands/generate/forms/generate_forms_command.ts
@@ -190,7 +190,7 @@ export class GenerateFormsCommand
         type: 'string',
         array: false,
         group: 'Project identifier',
-        implies: 'appId',
+        implies: 'app-id',
       })
       .option('out-dir', {
         describe: 'A path to directory where generated forms are written.',

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
@@ -93,23 +93,6 @@ void describe('generate graphql-client-code command', () => {
     );
   });
 
-  void it('generates and writes graphql client code for branch', async () => {
-    await commandRunner.runCommand('graphql-client-code --branch branch_name');
-    assert.equal(invokeGenerateApiCodeMock.mock.callCount(), 1);
-    assert.deepEqual(invokeGenerateApiCodeMock.mock.calls[0].arguments[0], {
-      appName: 'testAppName',
-      branchName: 'branch_name',
-      format: GenerateApiCodeFormat.GRAPHQL_CODEGEN,
-      statementTarget: GenerateApiCodeStatementTarget.TYPESCRIPT,
-      typeTarget: GenerateApiCodeTypeTarget.TYPESCRIPT,
-    });
-    assert.equal(writeToDirectoryMock.mock.callCount(), 1);
-    assert.equal(
-      writeToDirectoryMock.mock.calls[0].arguments[0],
-      process.cwd()
-    );
-  });
-
   void it('generates and writes graphql client code for appID and branch', async () => {
     await commandRunner.runCommand(
       'graphql-client-code --branch branch_name --app-id app_id'

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.test.ts
@@ -331,6 +331,14 @@ void describe('generate graphql-client-code command', () => {
     );
   });
 
+  void it('fails if branch is present but not app id', async () => {
+    const output = await commandRunner.runCommand(
+      'graphql-client-code --branch baz'
+    );
+    assert.match(output, /Missing dependent arguments:/);
+    assert.match(output, /branch -> app-id/);
+  });
+
   // Note: after this test, future tests seem to be in a weird state, leaving this at the end
   void it('fails if both stack and branch are present', async () => {
     const output = await commandRunner.runCommand(

--- a/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
+++ b/packages/cli/src/commands/generate/graphql-client-code/generate_graphql_client_code_command.ts
@@ -130,6 +130,7 @@ export class GenerateGraphqlClientCodeCommand
         describe: 'A git branch of the Amplify project',
         type: 'string',
         array: false,
+        implies: 'app-id',
         group: 'Project identifier',
       })
       .option('out', {

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -82,29 +82,6 @@ void describe('generate outputs command', () => {
     );
   });
 
-  void it('generates and writes config for branch', async () => {
-    await commandRunner.runCommand(
-      'outputs --branch branch_name --out-dir /foo/bar'
-    );
-    assert.equal(generateClientConfigMock.mock.callCount(), 1);
-    assert.deepEqual(generateClientConfigMock.mock.calls[0].arguments[0], {
-      appName: 'testAppName',
-      branchName: 'branch_name',
-    });
-    // I can't find any open node:test or yargs issues that would explain why this is necessary
-    // but for some reason the mock call count does not update without this 0ms wait
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    assert.equal(generateClientConfigMock.mock.callCount(), 1);
-    assert.deepEqual(
-      generateClientConfigMock.mock.calls[0].arguments[1],
-      '1.3' // default version
-    );
-    assert.deepStrictEqual(
-      generateClientConfigMock.mock.calls[0].arguments[2],
-      '/foo/bar'
-    );
-  });
-
   void it('generates and writes config for appID and branch', async () => {
     await commandRunner.runCommand(
       'outputs --branch branch_name --app-id app_id --out-dir /foo/bar'

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -225,4 +225,10 @@ void describe('generate outputs command', () => {
     );
     assert.match(output, /Arguments .* mutually exclusive/);
   });
+
+  void it('fails if branch is present but not app id', async () => {
+    const output = await commandRunner.runCommand('outputs --branch baz');
+    assert.match(output, /Missing dependent arguments:/);
+    assert.match(output, /branch -> app-id/);
+  });
 });

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -101,6 +101,7 @@ export class GenerateOutputsCommand
         describe: 'A git branch of the Amplify project',
         type: 'string',
         array: false,
+        implies: 'app-id',
         group: 'Project identifier',
       })
       .option('format', {

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.test.ts
@@ -165,6 +165,14 @@ void describe('generate graphql-client-code command', () => {
     assert.match(output, /Arguments .* are mutually exclusive/);
   });
 
+  void it('fails if branch is present but not app id', async () => {
+    const output = await commandRunner.runCommand(
+      'schema-from-database --branch baz'
+    );
+    assert.match(output, /Missing dependent arguments:/);
+    assert.match(output, /branch -> app-id/);
+  });
+
   void it('shows available options in help output', async () => {
     const output = await commandRunner.runCommand(
       'schema-from-database --help'

--- a/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
+++ b/packages/cli/src/commands/generate/schema-from-database/generate_schema_command.ts
@@ -123,7 +123,7 @@ export class GenerateSchemaCommand
         type: 'string',
         array: false,
         group: 'Project identifier',
-        implies: 'appId',
+        implies: 'app-id',
       })
       .option('out', {
         describe: 'A path to directory where generated schema is written.',


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

I've found that we don't enforce passing both `--app-id` and `--branch` for all generate commands.

It is possible to run `npx ampx generate outputs --branch <branch>`, when this happens we look at `name` in `package.json` but if this name does not match an existing Amplify app then we will get `Error: No apps found with name <app-name> in region <region>`.

**Issue number, if available:**

## Changes

Enforce passing both `--app-id` and `--branch` options for `generate outputs` and `generate graphql-client-code`, this aligns with `generate forms` and `generate schema-from-database` and our [docs](https://docs.amplify.aws/react/reference/cli-commands/#npx-ampx-generate).

**Corresponding docs PR, if applicable:**

## Validation

Unit tests. Locally and in Amplify console.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
