### PR TITLE
Shows region being used when starting sandbox

### DIFF
--- a/.changeset/thirty-weeks-whisper.md
+++ b/.changeset/thirty-weeks-whisper.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+shows region on sandbox start

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -353,17 +353,36 @@ void describe('Sandbox using local project name resolver', () => {
       undefined,
       false
     ));
-    assert.strictEqual(printer.log.mock.callCount(), 7);
+    assert.strictEqual(printer.log.mock.callCount(), 8);
 
     assert.strictEqual(
       printer.log.mock.calls[1].arguments[0],
       format.indent(`${format.bold('Identifier:')} \ttestSandboxName`)
     );
     assert.strictEqual(
-      printer.log.mock.calls[3].arguments[0],
+      printer.log.mock.calls[4].arguments[0],
       `${format.indent(
         format.dim('\nTo specify a different sandbox identifier, use ')
       )}${format.bold('--identifier')}`
+    );
+  });
+
+  void it('correctly displays the region at the startup', async () => {
+    ({ sandboxInstance } = await setupAndStartSandbox(
+      {
+        executor: sandboxExecutor,
+        ssmClient: ssmClientMock,
+        functionsLogStreamer:
+          functionsLogStreamerMock as unknown as LambdaFunctionLogStreamer,
+      },
+      undefined,
+      false
+    ));
+    assert.strictEqual(printer.log.mock.callCount(), 8);
+
+    assert.strictEqual(
+      printer.log.mock.calls[3].arguments[0],
+      format.indent(`${format.bold('Region:')} \ttest-region`)
     );
   });
 

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -442,6 +442,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
     );
     const stackName =
       BackendIdentifierConversions.toStackName(sandboxBackendId);
+    const region = await this.ssmClient.config.region();
     this.printer.log(
       format.indent(format.highlight(format.bold('\nAmplify Sandbox\n')))
     );
@@ -449,6 +450,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
       format.indent(`${format.bold('Identifier:')} \t${sandboxBackendId.name}`)
     );
     this.printer.log(format.indent(`${format.bold('Stack:')} \t${stackName}`));
+    this.printer.log(format.indent(`${format.bold('Region:')} \t${region}`));
     if (!sandboxIdentifier) {
       this.printer.log(
         `${format.indent(


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

When working with multiple profile or a region env variable set on a terminal session the sandbox can get deployed to a different region that what a user may be expecting. Showing the region at the start would help see what region is currently being used. 

example:

![image](https://github.com/user-attachments/assets/f9c5a115-121e-4883-978d-dd604107d818)
![image](https://github.com/user-attachments/assets/922615a1-ba9e-4dfc-aadf-b948f94d9c5e)


<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
