### PR TITLE
Update permissions tests in `ProfileController` to use mock

### DIFF
--- a/.changeset/sweet-sheep-march.md
+++ b/.changeset/sweet-sheep-march.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+updated tests and constructor for profileController

--- a/packages/cli/src/commands/configure/profile_controller.test.ts
+++ b/packages/cli/src/commands/configure/profile_controller.test.ts
@@ -1,11 +1,10 @@
 import path from 'node:path';
-import { after, before, beforeEach, describe, it } from 'node:test';
+import { after, before, beforeEach, describe, it, mock } from 'node:test';
 import fs from 'fs/promises';
 import { ProfileController } from './profile_controller.js';
 import assert from 'node:assert';
 import { loadSharedConfigFiles } from '@smithy/shared-ini-file-loader';
 import { EOL } from 'node:os';
-import { chmodSync } from 'node:fs';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 const testAccessKeyId = 'testAccessKeyId';
@@ -220,64 +219,6 @@ void describe('profile controller', () => {
       );
     });
 
-    void it('throws error if config file already exists and is missing read permissions', async () => {
-      if (process.platform.startsWith('win')) {
-        // Windows does not have the same behavior when files are missing permissions
-        return;
-      }
-
-      const expectedErr = new AmplifyUserError('PermissionsError', {
-        message: `You do not have the permissions to read this file: ${configFilePath}.`,
-        resolution: `Ensure that you have the right permissions to read from ${configFilePath}.`,
-      });
-      chmodSync(configFilePath, 0o000);
-      await assert.rejects(
-        async () =>
-          await profileController.createOrAppendAWSFiles({
-            profile: testProfile2,
-            region: testRegion2,
-            accessKeyId: testAccessKeyId2,
-            secretAccessKey: testSecretAccessKey2,
-          }),
-        (error: AmplifyUserError) => {
-          assert.strictEqual(error.name, expectedErr.name);
-          assert.strictEqual(error.message, expectedErr.message);
-          assert.strictEqual(error.resolution, expectedErr.resolution);
-          return true;
-        }
-      );
-    });
-
-    void it('throws error if config file already exists and is missing write permissions', async () => {
-      if (process.platform.startsWith('win')) {
-        // Windows does not have the same behavior when files are missing permissions
-        return;
-      }
-
-      const expectedErr = new AmplifyUserError('PermissionsError', {
-        message: `You do not have the permissions to write to this file: ${configFilePath}`,
-        resolution: `Ensure that you have the right permissions to write to ${configFilePath}.`,
-      });
-
-      chmodSync(configFilePath, 0o444);
-
-      await assert.rejects(
-        async () =>
-          await profileController.createOrAppendAWSFiles({
-            profile: testProfile2,
-            region: testRegion2,
-            accessKeyId: testAccessKeyId2,
-            secretAccessKey: testSecretAccessKey2,
-          }),
-        (error: AmplifyUserError) => {
-          assert.strictEqual(error.name, expectedErr.name);
-          assert.strictEqual(error.message, expectedErr.message);
-          assert.strictEqual(error.resolution, expectedErr.resolution);
-          return true;
-        }
-      );
-    });
-
     void it('creates directory if does not exist', async () => {
       // delete directory
       await fs.rm(testDir, { recursive: true, force: true });
@@ -352,6 +293,98 @@ void describe('profile controller', () => {
         'utf-8'
       );
       assert.equal(await profileController.profileExists(testProfile), true);
+    });
+  });
+
+  void describe('Missing permissions on config file', () => {
+    let testDir: string;
+    let configFilePath: string;
+    let credFilePath: string;
+
+    const fsMock = {
+      readFile: mock.fn<
+        (path: string, encoding: BufferEncoding) => Promise<void | string>
+      >(() => Promise.resolve()),
+      appendFile: mock.fn<() => Promise<void>>(() => Promise.resolve()),
+    };
+
+    const profileController = new ProfileController(
+      fsMock as unknown as typeof fs
+    );
+
+    before(async () => {
+      testDir = await fs.mkdtemp('amplify_cmd_test');
+      configFilePath = path.join(process.cwd(), testDir, 'config');
+      credFilePath = path.join(process.cwd(), testDir, 'credentials');
+
+      process.env.AWS_CONFIG_FILE = configFilePath;
+      process.env.AWS_SHARED_CREDENTIALS_FILE = credFilePath;
+
+      fsMock.readFile.mock.resetCalls();
+      fsMock.appendFile.mock.resetCalls();
+    });
+
+    after(async () => {
+      await fs.rm(testDir, { recursive: true, force: true });
+      delete process.env.AWS_CONFIG_FILE;
+      delete process.env.AWS_SHARED_CREDENTIALS_FILE;
+    });
+
+    void it('throws error if config file already exists and is missing read permissions', async () => {
+      const expectedErr = new AmplifyUserError('PermissionsError', {
+        message: `You do not have the permissions to read this file: ${configFilePath}.`,
+        resolution: `Ensure that you have the right permissions to read from ${configFilePath}.`,
+      });
+
+      fsMock.readFile.mock.mockImplementationOnce(() =>
+        Promise.reject(new Error('EACCES: Permission denied'))
+      );
+
+      await assert.rejects(
+        async () =>
+          profileController.createOrAppendAWSFiles({
+            profile: testProfile2,
+            region: testRegion2,
+            accessKeyId: testAccessKeyId2,
+            secretAccessKey: testSecretAccessKey2,
+          }),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(error.name, expectedErr.name);
+          assert.strictEqual(error.message, expectedErr.message);
+          assert.strictEqual(error.resolution, expectedErr.resolution);
+          return true;
+        }
+      );
+    });
+
+    void it('throws error if config file already exists and is missing write permissions', async () => {
+      const expectedErr = new AmplifyUserError('PermissionsError', {
+        message: `You do not have the permissions to write to this file: ${configFilePath}`,
+        resolution: `Ensure that you have the right permissions to write to ${configFilePath}.`,
+      });
+
+      fsMock.readFile.mock.mockImplementationOnce(
+        (path: string, encoding: BufferEncoding) => fs.readFile(path, encoding)
+      );
+      fsMock.appendFile.mock.mockImplementationOnce(() =>
+        Promise.reject(new Error('EACCES: Permission denied'))
+      );
+
+      await assert.rejects(
+        async () =>
+          profileController.createOrAppendAWSFiles({
+            profile: testProfile2,
+            region: testRegion2,
+            accessKeyId: testAccessKeyId2,
+            secretAccessKey: testSecretAccessKey2,
+          }),
+        (error: AmplifyUserError) => {
+          assert.strictEqual(error.name, expectedErr.name);
+          assert.strictEqual(error.message, expectedErr.message);
+          assert.strictEqual(error.resolution, expectedErr.resolution);
+          return true;
+        }
+      );
     });
   });
 });

--- a/packages/cli/src/commands/configure/profile_controller.ts
+++ b/packages/cli/src/commands/configure/profile_controller.ts
@@ -5,7 +5,7 @@ import {
 } from '@smithy/shared-ini-file-loader';
 import { fromIni } from '@aws-sdk/credential-providers';
 import { EOL } from 'os';
-import fs from 'fs/promises';
+import _fs from 'fs/promises';
 import path from 'path';
 import { existsSync } from 'fs';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
@@ -37,6 +37,10 @@ export type ProfileOptions = ConfigProfileOptions & CredentialProfileOptions;
  */
 export class ProfileController {
   /**
+   * constructor
+   */
+  constructor(private readonly fs = _fs) {}
+  /**
    * Return true if the provided profile exists in the aws config and/or credential file.
    */
   profileExists = async (profile: string): Promise<boolean> => {
@@ -66,7 +70,7 @@ export class ProfileController {
 
     const dirName = path.dirname(filePath);
     if (!existsSync(dirName)) {
-      await fs.mkdir(dirName, { recursive: true });
+      await this.fs.mkdir(dirName, { recursive: true });
     }
 
     const fileEndsWithEOL = await this.isFileEndsWithEOL(filePath);
@@ -79,7 +83,7 @@ export class ProfileController {
     configData += `region = ${options.region}${EOL}`;
 
     try {
-      await fs.appendFile(filePath, configData, { mode: '600' });
+      await this.fs.appendFile(filePath, configData, { mode: '600' });
     } catch (err) {
       const error = err as Error;
       if (error.message.includes('EACCES')) {
@@ -115,7 +119,7 @@ export class ProfileController {
 
     const dirName = path.dirname(filePath);
     if (!existsSync(dirName)) {
-      await fs.mkdir(dirName, { recursive: true });
+      await this.fs.mkdir(dirName, { recursive: true });
     }
 
     const fileEndsWithEOL = await this.isFileEndsWithEOL(filePath);
@@ -125,7 +129,7 @@ export class ProfileController {
     credentialData += `aws_access_key_id = ${options.accessKeyId}${EOL}`;
     credentialData += `aws_secret_access_key = ${options.secretAccessKey}${EOL}`;
 
-    await fs.appendFile(filePath, credentialData, { mode: '600' });
+    await this.fs.appendFile(filePath, credentialData, { mode: '600' });
 
     // validate after write. It is to ensure this function is compatible with the current AWS format.
     const provider = fromIni({
@@ -144,7 +148,7 @@ export class ProfileController {
 
   private isFileEndsWithEOL = async (filePath: string): Promise<boolean> => {
     try {
-      const data = await fs.readFile(filePath, 'utf-8');
+      const data = await this.fs.readFile(filePath, 'utf-8');
       return data.length > 0 && data.slice(-EOL.length) === EOL;
     } catch (err) {
       const error = err as Error;


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Permissions tests with `chmod` were failing on CodeBuild

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Updated the `chmod` tests to use mock instead


## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
tests work locally
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
