### PR TITLE
wrap instances of ResourceConflictException when resource update is in progress

### DIFF
--- a/.changeset/five-elephants-happen.md
+++ b/.changeset/five-elephants-happen.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+wrap instances of ResourceConflictException when resource update is in progress

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -709,6 +709,14 @@ npm error enoent`,
     errorName: 'MissingDefineBackendError',
     expectedDownstreamErrorMessage: undefined,
   },
+  {
+    errorMessage:
+      'Error: some-stack failed: ResourceConflictException: The operation cannot be performed at this time. An update is in progress for resource: test:resource:arn',
+    expectedTopLevelErrorMessage:
+      'Deployment failed because an update is in progress for test:resource:arn.',
+    errorName: 'CloudformationResourceUpdateInProgressError',
+    expectedDownstreamErrorMessage: undefined,
+  },
 ];
 
 void describe('invokeCDKCommand', { concurrency: 1 }, () => {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -490,6 +490,14 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex:
+        /ResourceConflictException: (.*) An update is in progress for resource: (?<resourceArn>.*)/,
+      humanReadableErrorMessage: `Deployment failed because an update is in progress for {resourceArn}.`,
+      resolutionMessage: `Wait for the update for {resourceArn} to be completed before attempting to deploy again.`,
+      errorName: 'CloudformationResourceUpdateInProgressError',
+      classification: 'ERROR',
+    },
+    {
       // We capture the parameter name to show relevant error message
       errorRegex:
         /destroy failed Error: Stack \[(?<stackArn>.*)\] cannot be deleted while in status /,
@@ -577,6 +585,7 @@ export type CDKDeploymentError =
   | 'CDKVersionMismatchError'
   | 'CFNUpdateNotSupportedError'
   | 'CloudformationResourceCircularDependencyError'
+  | 'CloudformationResourceUpdateInProgressError'
   | 'CloudformationStackCircularDependencyError'
   | 'CloudFormationDeletionError'
   | 'CloudFormationDeploymentError'


### PR DESCRIPTION
## Problem

During deployments, if a lambda is still in a pending state due to updating its configuration, we get the error:
`ResourceConflictException: The operation cannot be performed at this time. An update is in progress for resource: <arn>`

**Issue number, if available:**

## Changes

Wrap error with resolution message to try again once the resource is done updating.

**Corresponding docs PR, if applicable:**

## Validation

Unit test

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
