### PR TITLE
anonymize account id and error details for telemetry

### DIFF
--- a/.changeset/good-falcons-attend.md
+++ b/.changeset/good-falcons-attend.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+anonymize account id and file paths/stacks in error details for telemetry

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -6,6 +6,7 @@
   "amazoncognito",
   "amplifyconfiguration",
   "ampx",
+  "anonymize",
   "anthropic",
   "apns",
   "apollo",

--- a/packages/platform-core/src/usage-data/account_id_fetcher.test.ts
+++ b/packages/platform-core/src/usage-data/account_id_fetcher.test.ts
@@ -2,9 +2,10 @@ import { AccountIdFetcher } from './account_id_fetcher';
 import { GetCallerIdentityCommandOutput, STSClient } from '@aws-sdk/client-sts';
 import { describe, mock, test } from 'node:test';
 import assert from 'node:assert';
+import { validate } from 'uuid';
 
 void describe('AccountIdFetcher', async () => {
-  void test('fetches account ID successfully', async () => {
+  void test('fetches a valid account UUID successfully', async () => {
     const mockSend = mock.method(STSClient.prototype, 'send', () =>
       Promise.resolve({
         Account: '123456789012',
@@ -14,11 +15,11 @@ void describe('AccountIdFetcher', async () => {
     const accountIdFetcher = new AccountIdFetcher(new STSClient({}));
     const accountId = await accountIdFetcher.fetch();
 
-    assert.strictEqual(accountId, '123456789012');
+    assert.ok(validate(accountId), `${accountId} is not a valid UUID string`);
     mockSend.mock.resetCalls();
   });
 
-  void test('returns default account ID when STS fails', async () => {
+  void test('returns no account ID when STS fails', async () => {
     const mockSend = mock.method(STSClient.prototype, 'send', () =>
       Promise.reject(new Error('STS error'))
     );
@@ -30,7 +31,7 @@ void describe('AccountIdFetcher', async () => {
     mockSend.mock.resetCalls();
   });
 
-  void test('returns cached account ID on subsequent calls', async () => {
+  void test('returns cached account UUID on subsequent calls', async () => {
     const mockSend = mock.method(STSClient.prototype, 'send', () =>
       Promise.resolve({
         Account: '123456789012',
@@ -41,8 +42,7 @@ void describe('AccountIdFetcher', async () => {
     const accountId1 = await accountIdFetcher.fetch();
     const accountId2 = await accountIdFetcher.fetch();
 
-    assert.strictEqual(accountId1, '123456789012');
-    assert.strictEqual(accountId2, '123456789012');
+    assert.strictEqual(accountId1, accountId2);
 
     // we only call the service once.
     assert.strictEqual(mockSend.mock.callCount(), 1);

--- a/packages/platform-core/src/usage-data/account_id_fetcher.ts
+++ b/packages/platform-core/src/usage-data/account_id_fetcher.ts
@@ -1,6 +1,11 @@
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+import { v5 as uuidV5 } from 'uuid';
 
 const NO_ACCOUNT_ID = 'NO_ACCOUNT_ID';
+
+// eslint-disable-next-line spellcheck/spell-checker
+const AMPLIFY_CLI_UUID_NAMESPACE = '283cae3e-c611-4659-9044-6796e5d696ec'; // A random v4 UUID
+
 /**
  * Retrieves the account ID of the user
  */
@@ -19,7 +24,11 @@ export class AccountIdFetcher {
         new GetCallerIdentityCommand({})
       );
       if (stsResponse && stsResponse.Account) {
-        this.accountId = stsResponse.Account;
+        const accountIdBucket = Number(stsResponse.Account) / 100;
+        this.accountId = uuidV5(
+          accountIdBucket.toString(),
+          AMPLIFY_CLI_UUID_NAMESPACE
+        );
         return this.accountId;
       }
       // We failed to get the account Id. Most likely the user doesn't have credentials

--- a/packages/platform-core/src/usage-data/serializable_error.test.ts
+++ b/packages/platform-core/src/usage-data/serializable_error.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import os from 'os';
 import { SerializableError } from './serializable_error';
+import { pathToFileURL } from 'node:url';
 
 void describe('serializable error', () => {
   class ErrorWithDetailsAndCode extends Error {
@@ -16,6 +17,21 @@ void describe('serializable error', () => {
 
   void test('that regular stack trace does not contain user homedir', () => {
     const error = new Error('test error');
+    const serializableError = new SerializableError(error);
+    assert.ok(serializableError.trace);
+    serializableError.trace?.forEach((trace) => {
+      assert.ok(
+        trace.file.includes(os.homedir()) == false,
+        `${os.homedir()} is included in the ${trace.file}`
+      );
+    });
+  });
+
+  void test('that regular stack trace does not contain user homedir for file url paths', () => {
+    const error = new Error('test error');
+    error.stack = `at methodName (${pathToFileURL(
+      process.cwd()
+    ).toString()}/node_modules/@aws-amplify/test-package/lib/test.js:12:34)\n`;
     const serializableError = new SerializableError(error);
     assert.ok(serializableError.trace);
     serializableError.trace?.forEach((trace) => {
@@ -42,15 +58,15 @@ void describe('serializable error', () => {
     assert.deepStrictEqual(serializableError.name, 'Error');
   });
 
-  void test('that no change in error details that does not have AWS ARNs', () => {
+  void test('that no change in error details that does not have AWS ARNs or stacks', () => {
     const error = new ErrorWithDetailsAndCode(
       'some error message',
-      'some error details that do not have ARNs'
+      'some error details that do not have ARNs or stacks'
     );
     const serializableError = new SerializableError(error);
     assert.deepStrictEqual(
       serializableError.details,
-      'some error details that do not have ARNs'
+      'some error details that do not have ARNs or stacks'
     );
   });
 
@@ -66,9 +82,58 @@ void describe('serializable error', () => {
     );
   });
 
+  void test('that stacks are escaped when error details has two AWS stacks', () => {
+    const error = new ErrorWithDetailsAndCode(
+      'some error message',
+      'some error details with stack: amplify-testapp-test-sandbox-1234abcd and stack: amplify-testapp-test-branch-1234abcd and something else'
+    );
+    const serializableError = new SerializableError(error);
+    assert.deepStrictEqual(
+      serializableError.details,
+      'some error details with stack: <escaped stack> and stack: <escaped stack> and something else'
+    );
+  });
+
   void test('that error message is sanitized by removing invalid characters', () => {
     const error = new ErrorWithDetailsAndCode('some" er❌ror ""m"es❌sage❌');
     const serializableError = new SerializableError(error);
     assert.deepStrictEqual(serializableError.message, 'some error message');
+  });
+
+  void test('that error message does not contain AWS ARNs or stacks', () => {
+    const error = new ErrorWithDetailsAndCode(
+      'test error with stack: amplify-testapp-test-branch-1234abcd and arn: arn:aws-iso:service:region::res'
+    );
+    const serializableError = new SerializableError(error);
+    assert.deepStrictEqual(
+      serializableError.message,
+      'test error with stack: <escaped stack> and arn: <escaped ARN>'
+    );
+  });
+
+  void test('that error message does not contain user homedir', () => {
+    const error = new ErrorWithDetailsAndCode(`${process.cwd()} test error`);
+    const serializableError = new SerializableError(error);
+    const matches = [
+      ...serializableError.message.matchAll(new RegExp(os.homedir(), 'g')),
+    ];
+    assert.ok(
+      matches.length === 0,
+      `${os.homedir()} is included in ${serializableError.message}`
+    );
+  });
+
+  void test('that error message does not contain file url path with user homedir', () => {
+    const error = new ErrorWithDetailsAndCode(
+      `${pathToFileURL(process.cwd()).toString()} test error`
+    );
+    const serializableError = new SerializableError(error);
+    const matches = [
+      ...serializableError.message.matchAll(new RegExp(os.homedir(), 'g')),
+    ];
+    assert.ok(
+      matches.length === 0,
+      `${os.homedir()} is included in ${serializableError.message}`
+    );
   });
 });

--- a/packages/platform-core/src/usage-data/serializable_error.test.ts
+++ b/packages/platform-core/src/usage-data/serializable_error.test.ts
@@ -85,6 +85,7 @@ void describe('serializable error', () => {
   void test('that stacks are escaped when error details has two AWS stacks', () => {
     const error = new ErrorWithDetailsAndCode(
       'some error message',
+      // eslint-disable-next-line spellcheck/spell-checker
       'some error details with stack: amplify-testapp-test-sandbox-1234abcd and stack: amplify-testapp-test-branch-1234abcd and something else'
     );
     const serializableError = new SerializableError(error);
@@ -102,6 +103,7 @@ void describe('serializable error', () => {
 
   void test('that error message does not contain AWS ARNs or stacks', () => {
     const error = new ErrorWithDetailsAndCode(
+      // eslint-disable-next-line spellcheck/spell-checker
       'test error with stack: amplify-testapp-test-branch-1234abcd and arn: arn:aws-iso:service:region::res'
     );
     const serializableError = new SerializableError(error);

--- a/packages/platform-core/src/usage-data/serializable_error.ts
+++ b/packages/platform-core/src/usage-data/serializable_error.ts
@@ -34,7 +34,9 @@ export class SerializableError {
         : error.name;
     this.message = this.anonymizePaths(this.sanitize(error.message));
     this.details =
-      'details' in error ? this.sanitize(error.details as string) : undefined;
+      'details' in error
+        ? this.anonymizePaths(this.sanitize(error.details as string))
+        : undefined;
     this.trace = this.extractStackTrace(error);
   }
 

--- a/packages/platform-core/src/usage-data/serializable_error.ts
+++ b/packages/platform-core/src/usage-data/serializable_error.ts
@@ -92,14 +92,14 @@ export class SerializableError {
     return str?.replace(this.arnRegex, '<escaped ARN>') ?? '';
   };
 
-  private removeStack = (str?: string): string => {
+  private removeStackIdentifier = (str?: string): string => {
     return str?.replace(this.stackRegex, '<escaped stack>') ?? '';
   };
 
   private sanitize = (str: string) => {
     let result = str;
     result = this.removeARN(result);
-    result = this.removeStack(result);
+    result = this.removeStackIdentifier(result);
     return result.replaceAll(/["❌]/g, '');
   };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

We include account id and error details can contain stack name and file paths with user info when being sent to our telemetry.

**Issue number, if available:**

## Changes

- "Bucketize" account ids and hash them
- Remove stacks from errors like we do with ARNs
- Make file paths in errors relative to remove user info

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
