### PR TITLE
update start spinner api to accept the id instead of generating a new

### DIFF
--- a/.changeset/hip-pens-walk.md
+++ b/.changeset/hip-pens-walk.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/cli-core': patch
+---
+
+update start spinner api to accept the id instead of generating a new

--- a/packages/cli-core/API.md
+++ b/packages/cli-core/API.md
@@ -94,7 +94,7 @@ export class Printer {
     log: (message: string, level?: LogLevel) => void;
     print: (message: string) => void;
     printNewLine: () => void;
-    startSpinner: (message: string, options?: {
+    startSpinner: (id: string, message: string, options?: {
         timeoutSeconds: number;
     }) => string;
     stopSpinner: (id: string) => void;

--- a/packages/cli-core/src/printer/printer.test.ts
+++ b/packages/cli-core/src/printer/printer.test.ts
@@ -2,11 +2,12 @@ import { after, before, beforeEach, describe, it, mock } from 'node:test';
 import assert from 'assert';
 import { LogLevel, Printer } from './printer.js';
 import tty from 'node:tty';
+import { randomUUID } from 'node:crypto';
 
 void describe('Printer', () => {
   const mockedWrite = mock.method(process.stdout, 'write');
   let originalWrite: typeof process.stdout.write;
-
+  let spinnerId = '';
   const mockedTTYWrite = mock.fn();
   const ttyStream: tty.WriteStream = {
     cursorTo: mock.fn(),
@@ -27,6 +28,7 @@ void describe('Printer', () => {
   });
 
   beforeEach(() => {
+    spinnerId = randomUUID();
     mockedTTYWrite.mock.resetCalls();
     mockedWrite.mock.resetCalls();
   });
@@ -146,7 +148,7 @@ void describe('Printer', () => {
       50,
       true
     );
-    const spinnerId = printer.startSpinner(message);
+    printer.startSpinner(spinnerId, message);
 
     // Wait for 190 ms
     await new Promise((resolve) => setTimeout(resolve, 190));
@@ -180,7 +182,7 @@ void describe('Printer', () => {
       50,
       false // simulate non-tty
     );
-    const spinnerId = printer.startSpinner(message);
+    printer.startSpinner(spinnerId, message);
 
     // Wait for 190 ms such that tty would have caused multiple prints
     await new Promise((resolve) => setTimeout(resolve, 190));
@@ -214,7 +216,9 @@ void describe('Printer', () => {
       50,
       true
     );
-    const spinnerId = printer.startSpinner(message, { timeoutSeconds: 0.1 });
+    printer.startSpinner(spinnerId, message, {
+      timeoutSeconds: 0.1,
+    });
     assert.ok(printer.isSpinnerRunning(spinnerId));
     // Wait for 110 ms for the spinner to timeout
     await new Promise((resolve) => setTimeout(resolve, 110));
@@ -232,7 +236,9 @@ void describe('Printer', () => {
       50,
       true
     );
-    const spinnerId = printer.startSpinner(message, { timeoutSeconds: 0.1 });
+    printer.startSpinner(spinnerId, message, {
+      timeoutSeconds: 0.1,
+    });
     assert.ok(printer.isSpinnerRunning(spinnerId));
     // Wait for 70 ms so the spinner doesn't timeout
     await new Promise((resolve) => setTimeout(resolve, 70));
@@ -271,7 +277,7 @@ void describe('Printer', () => {
       50,
       true
     );
-    const spinnerId = printer.startSpinner(message);
+    printer.startSpinner(spinnerId, message);
     printer.updateSpinner(spinnerId, {
       prefixText: 'this is some prefix text',
     });

--- a/packages/cli-core/src/printer/printer.ts
+++ b/packages/cli-core/src/printer/printer.ts
@@ -1,7 +1,6 @@
 import { WriteStream } from 'node:tty';
 import { EOL } from 'os';
 import ora, { Ora, oraPromise } from 'ora';
-import { randomUUID } from 'node:crypto';
 
 export type RecordValue = string | number | string[] | Date;
 
@@ -94,10 +93,10 @@ export class Printer {
    * @returns the id of the spinner
    */
   startSpinner = (
+    id: string,
     message: string,
     options: { timeoutSeconds: number } = { timeoutSeconds: 60 }
   ): string => {
-    const id = randomUUID();
     this.currentSpinners[id] = {
       instance: ora({
         text: message,


### PR DESCRIPTION
## Changes

update start spinner api to accept the id instead of generating a new one. Allow clients to generate the ids themselves for associating the spinners. This helps clients to easily access spinners across the threads.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
