### PR TITLE
Mapping for data schema errors

### DIFF
--- a/.changeset/rich-sheep-double.md
+++ b/.changeset/rich-sheep-double.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+updated mapping with schema errors from toolkit

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -427,6 +427,13 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: undefined,
   },
   {
+    errorMessage: `amplify-some-stack [22m failed: _ToolkitError: Found 2 problem(s) with the schema: The input value type 'string' is not present when resolving type 'TaskInput' [@78:1] The field type 'TaskInstanceStatus' is not present when resolving type 'Task' [@25:1]`,
+    expectedTopLevelErrorMessage:
+      '2 problem(s) have been found with your schema',
+    errorName: 'SchemaError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
     // eslint-disable-next-line spellcheck/spell-checker
     errorMessage: `Error: npm error code EJSONPARSE
 npm error path /home/some-path/package.json

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -304,8 +304,7 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex:
-        /_ToolkitError: Found (?<number>.*) problem\(s\) with the schema:/,
+      errorRegex: /Found (?<number>.*) problem\(s\) with the schema:/,
       humanReadableErrorMessage:
         '{number} problem(s) have been found with your schema',
       resolutionMessage:

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -304,6 +304,16 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
+      errorRegex:
+        /_ToolkitError: Found (?<number>.*) problem\(s\) with the schema:/,
+      humanReadableErrorMessage:
+        '{number} problem(s) have been found with your schema',
+      resolutionMessage:
+        'See the underlying error message for details about what the problems are and resolve them before attempting this action again',
+      errorName: 'SchemaError',
+      classification: 'ERROR',
+    },
+    {
       // Also extracts the first line in the stack where the error happened
       errorRegex: new RegExp(
         `\\[esbuild Error\\]: ((?:.|${this.multiLineEolRegex})*?at .*)`
@@ -593,6 +603,7 @@ export type CDKDeploymentError =
   | 'InsufficientMemorySpaceError'
   | 'InvalidOrCannotAssumeRoleError'
   | 'InvalidPackageJsonError'
+  | 'SchemaError'
   | 'SecretNotSetError'
   | 'SyntaxError'
   | 'GetLambdaLayerVersionError'


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Recently our data schema errors have been prefixed by `_Toolkit`, we do not have a mapping to capture those

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Added mapping to capture data schema errors prefixed with `_Toolkit`

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
