### PR TITLE
correctly handle non backend outputs from stack metadata

### DIFF
--- a/.changeset/real-pants-smash.md
+++ b/.changeset/real-pants-smash.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/deployed-backend-client': patch
+---
+
+correctly handle non backend outputs from stack metadata


### PR DESCRIPTION
## Problem

Using CDK nag or doing `backend.stack.addMetadata()` causes Zod error when generating the `amplify_outputs.json` file. The Zod error is occurring when we are parsing the stack metadata in order to fetch backend outputs and the parsing is not expecting non backend output entries.

**Issue number, if available:**
https://github.com/aws-amplify/amplify-backend/issues/2428

## Changes

Filter out non backend output entries in stack metadata before parsing.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
