### PR TITLE
add default_packages.json

### DIFF
--- a/.changeset/itchy-geckos-end.md
+++ b/.changeset/itchy-geckos-end.md
@@ -1,0 +1,5 @@
+---
+'create-amplify': patch
+---
+
+add default_packages.json

--- a/packages/create-amplify/src/default_packages.json
+++ b/packages/create-amplify/src/default_packages.json
@@ -1,0 +1,13 @@
+{
+  "defaultDevPackages": [
+    "@aws-amplify/backend",
+    "@aws-amplify/backend-cli",
+    "aws-cdk@2.1000.2",
+    "aws-cdk-lib@2.180.0",
+    "constructs@^10.0.0",
+    "typescript@^5.0.0",
+    "tsx",
+    "esbuild"
+  ],
+  "defaultProdPackages": ["aws-amplify"]
+}

--- a/packages/create-amplify/tsconfig.json
+++ b/packages/create-amplify/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
+  "include": ["**/*", "src/**/*.json"],
   "exclude": ["templates", "lib"],
   "references": [
     { "path": "../cli-core" },


### PR DESCRIPTION
## Changes

From https://github.com/aws-amplify/amplify-backend/pull/2544, introduce `default_packages.json` for create amplify

**Corresponding docs PR, if applicable:**

## Validation

None for this PR, this only adds the json file which is currently not being used.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
