### PR TITLE
update naming of storage access policies to also use stack

### DIFF
--- a/.changeset/eight-steaks-greet.md
+++ b/.changeset/eight-steaks-greet.md
@@ -1,6 +1,7 @@
 ---
 '@aws-amplify/integration-tests': patch
 '@aws-amplify/backend-storage': patch
+'@aws-amplify/backend': patch
 ---
 
 update naming of storage access policies to also use stack

--- a/.changeset/eight-steaks-greet.md
+++ b/.changeset/eight-steaks-greet.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/backend-storage': patch
+---
+
+update naming of storage access policies to also use stack

--- a/packages/backend-storage/src/storage_access_policy_factory.ts
+++ b/packages/backend-storage/src/storage_access_policy_factory.ts
@@ -62,7 +62,7 @@ export class StorageAccessPolicyFactory {
 
     return new Policy(
       this.stack,
-      `storageAccess${this.stack.node.children.length}`,
+      `${this.stack.toString()}Access${this.stack.node.children.length}`,
       {
         statements,
       }

--- a/packages/backend-storage/src/storage_access_policy_factory.ts
+++ b/packages/backend-storage/src/storage_access_policy_factory.ts
@@ -62,7 +62,7 @@ export class StorageAccessPolicyFactory {
 
     return new Policy(
       this.stack,
-      `${this.stack.toString()}Access${this.stack.node.children.length}`,
+      `${this.stack.node.path}Access${this.stack.node.children.length}`,
       {
         statements,
       }

--- a/packages/integration-tests/src/test-project-setup/cdk/auth_cdk_project.ts
+++ b/packages/integration-tests/src/test-project-setup/cdk/auth_cdk_project.ts
@@ -60,7 +60,7 @@ class AuthTestCdkProject extends TestCdkProjectBase {
   }
   assertPostDeployment = async (): Promise<void> => {
     // assert has some of expected resources
-    const userPools = await this.resourceFinder.findPhysicalNamesByStackName(
+    const userPools = await this.resourceFinder.findNamesByStackName(
       this.stackName,
       'AWS::Cognito::UserPool'
     );

--- a/packages/integration-tests/src/test-project-setup/cdk/auth_cdk_project.ts
+++ b/packages/integration-tests/src/test-project-setup/cdk/auth_cdk_project.ts
@@ -60,7 +60,7 @@ class AuthTestCdkProject extends TestCdkProjectBase {
   }
   assertPostDeployment = async (): Promise<void> => {
     // assert has some of expected resources
-    const userPools = await this.resourceFinder.findByStackName(
+    const userPools = await this.resourceFinder.findPhysicalNamesByStackName(
       this.stackName,
       'AWS::Cognito::UserPool'
     );

--- a/packages/integration-tests/src/test-project-setup/reference_auth_project.ts
+++ b/packages/integration-tests/src/test-project-setup/reference_auth_project.ts
@@ -354,21 +354,11 @@ class ReferenceAuthTestProject extends TestProjectBase {
       await this.resourceFinder.findByBackendIdentifier(
         backendId,
         'AWS::IAM::Policy',
+        undefined,
         (name) => name.startsWith(`${sanitizedStackName}storageAccess`)
       );
-    const allStorageAccessPolicies =
-      await this.resourceFinder.findByBackendIdentifier(
-        backendId,
-        'AWS::IAM::Policy',
-        (name) => name.includes('storageAccess')
-      );
 
-    assert.ok(
-      storageAccessPolicy.length,
-      `Could not find storage access policies that start with stack from ${JSON.stringify(
-        allStorageAccessPolicies
-      )}`
-    );
+    assert.ok(storageAccessPolicy.length);
   }
 
   /**

--- a/packages/integration-tests/src/test-project-setup/reference_auth_project.ts
+++ b/packages/integration-tests/src/test-project-setup/reference_auth_project.ts
@@ -356,8 +356,19 @@ class ReferenceAuthTestProject extends TestProjectBase {
         'AWS::IAM::Policy',
         (name) => name.startsWith(`${sanitizedStackName}storageAccess`)
       );
+    const allStorageAccessPolicies =
+      await this.resourceFinder.findByBackendIdentifier(
+        backendId,
+        'AWS::IAM::Policy',
+        (name) => name.includes('storageAccess')
+      );
 
-    assert.ok(storageAccessPolicy.length);
+    assert.ok(
+      storageAccessPolicy.length,
+      `Could not find storage access policies that start with stack from ${JSON.stringify(
+        allStorageAccessPolicies
+      )}`
+    );
   }
 
   /**

--- a/packages/integration-tests/src/test-project-setup/reference_auth_project.ts
+++ b/packages/integration-tests/src/test-project-setup/reference_auth_project.ts
@@ -10,6 +10,9 @@ import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
 import { IAMClient } from '@aws-sdk/client-iam';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { e2eToolingClientConfig } from '../e2e_tooling_client_config.js';
+import { DeployedResourcesFinder } from '../find_deployed_resource.js';
+import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import assert from 'node:assert';
 
 /**
  * Creates a reference auth project
@@ -35,7 +38,8 @@ export class ReferenceAuthTestProjectCreator implements TestProjectCreator {
     ),
     private readonly iamClient: IAMClient = new IAMClient(
       e2eToolingClientConfig
-    )
+    ),
+    private readonly resourceFinder: DeployedResourcesFinder = new DeployedResourcesFinder()
   ) {}
 
   createProject = async (e2eProjectDir: string): Promise<TestProjectBase> => {
@@ -50,7 +54,8 @@ export class ReferenceAuthTestProjectCreator implements TestProjectCreator {
       this.amplifyClient,
       this.cognitoIdentityProviderClient,
       this.cognitoIdentityClient,
-      this.iamClient
+      this.iamClient,
+      this.resourceFinder
     );
 
     await fsp.cp(
@@ -121,7 +126,8 @@ class ReferenceAuthTestProject extends TestProjectBase {
     amplifyClient: AmplifyClient,
     cognitoIdentityProviderClient: CognitoIdentityProviderClient,
     private cognitoIdentityClient: CognitoIdentityClient,
-    iamClient: IAMClient
+    iamClient: IAMClient,
+    private readonly resourceFinder: DeployedResourcesFinder
   ) {
     super(
       name,
@@ -334,6 +340,25 @@ class ReferenceAuthTestProject extends TestProjectBase {
       throw e;
     }
   };
+
+  override async assertPostDeployment(
+    backendId: BackendIdentifier
+  ): Promise<void> {
+    await super.assertPostDeployment(backendId);
+
+    // find storage access policy by stack name
+    const sanitizedStackName = BackendIdentifierConversions.toStackName(
+      backendId
+    ).replaceAll('-', '');
+    const storageAccessPolicy =
+      await this.resourceFinder.findByBackendIdentifier(
+        backendId,
+        'AWS::IAM::Policy',
+        (name) => name.startsWith(`${sanitizedStackName}storageAccess`)
+      );
+
+    assert.ok(storageAccessPolicy.length);
+  }
 
   /**
    * @inheritdoc


### PR DESCRIPTION
## Problem

When we create policies for storage access, the id for each new policy is `storageAccess<stack node children length>`. This works to keep policies unique within a stack, but there is overlap when it comes to reference auth since each role will have a newly created policy overwriting the existing policy.

**Issue number, if available:**

## Changes

Prepend storage access policy id with stack to stop ids from clashing when using reference auth. This way auth and unauth roles get a new storage access policy when being referenced in another app.

**Corresponding docs PR, if applicable:**

## Validation

Updated E2E test to ensure storage access policies start with storage stack.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
