### PR TITLE
Adds and updates mapping for some validation errors

### DIFF
--- a/.changeset/great-swans-collect.md
+++ b/.changeset/great-swans-collect.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+added/updated ValidationError mappings

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -407,15 +407,19 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: undefined,
   },
   {
+    // eslint-disable-next-line spellcheck/spell-checker
     errorMessage: `[31mamplifysomestack [34m failed: ValidationError: Stack:<stack-arn> is in UPDATE_ROLLBACK_FAILED state and can not be updated.`,
     expectedTopLevelErrorMessage:
+      // eslint-disable-next-line spellcheck/spell-checker
       'The CloudFormation deployment failed due to amplifysomestack being in UPDATE_ROLLBACK_FAILED state.',
     errorName: 'CloudFormationDeploymentError',
     expectedDownstreamErrorMessage: undefined,
   },
   {
+    // eslint-disable-next-line spellcheck/spell-checker
     errorMessage: `[1mamplifysomebranch [22m failed: ValidationError: Stack [amplifysomebranch] cannot be deleted while TerminationProtection is enabled`,
     expectedTopLevelErrorMessage:
+      // eslint-disable-next-line spellcheck/spell-checker
       'amplifysomebranch cannot be deleted because it has termination deployment enabled.',
     errorName: 'CloudFormationDeletionError',
     expectedDownstreamErrorMessage: undefined,

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -400,10 +400,24 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: `error Command cdk not found. Did you mean cdl?`,
   },
   {
-    errorMessage: `[31m  amplify-some-stack failed: ValidationError: Stack:stack-arn is in UPDATE_ROLLBACK_FAILED state and can not be updated.`,
+    errorMessage: `[31mamplify-some-stack [34m failed: ValidationError: Stack:<stack-arn> is in UPDATE_ROLLBACK_FAILED state and can not be updated.`,
     expectedTopLevelErrorMessage:
       'The CloudFormation deployment failed due to amplify-some-stack being in UPDATE_ROLLBACK_FAILED state.',
     errorName: 'CloudFormationDeploymentError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage: `[31mamplifysomestack [34m failed: ValidationError: Stack:<stack-arn> is in UPDATE_ROLLBACK_FAILED state and can not be updated.`,
+    expectedTopLevelErrorMessage:
+      'The CloudFormation deployment failed due to amplifysomestack being in UPDATE_ROLLBACK_FAILED state.',
+    errorName: 'CloudFormationDeploymentError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage: `[1mamplifysomebranch [22m failed: ValidationError: Stack [amplifysomebranch] cannot be deleted while TerminationProtection is enabled`,
+    expectedTopLevelErrorMessage:
+      'amplifysomebranch cannot be deleted because it has termination deployment enabled.',
+    errorName: 'CloudFormationDeletionError',
     expectedDownstreamErrorMessage: undefined,
   },
   {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -560,12 +560,22 @@ If your circular dependency issue is not resolved with this workaround, please c
     },
     {
       errorRegex:
-        /(?<stackName>amplify-[a-z0-9-]+)(.*) failed: ValidationError: Stack:(.*) is in (?<state>.*) state and can not be updated/,
+        /(?<stackName>amplify[a-z0-9-]+)(.*) failed: ValidationError: Stack:(.*) is in (?<state>.*) state and can not be updated/,
       humanReadableErrorMessage:
         'The CloudFormation deployment failed due to {stackName} being in {state} state.',
       resolutionMessage:
         'Find more information in the CloudFormation AWS Console for this stack.',
       errorName: 'CloudFormationDeploymentError',
+      classification: 'ERROR',
+    },
+    {
+      errorRegex:
+        /failed: ValidationError: Stack \[(?<stackName>amplify[a-z0-9-]+)(.*)\] cannot be deleted while TerminationProtection is enabled/,
+      humanReadableErrorMessage:
+        '{stackName} cannot be deleted because it has termination deployment enabled.',
+      resolutionMessage:
+        'If you are sure you want to delete {stackName}, you will need to disable TerminationProtection.',
+      errorName: 'CloudFormationDeletionError',
       classification: 'ERROR',
     },
     {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

- we were previously not mapping validation errors like `failed: ValidationError: Stack <some stack> cannot be deleted while TerminationProtection is enabled`
- the current mapping for `failed: ValidationError: Stack:<stack arn> is in STATE state and can not be updated` did not capture stacks that do not have hyphens (EX: some stacks come in looking like this - `amplifysomestack`)

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

- created a mapping for errors like `failed: ValidationError: Stack <some stack> cannot be deleted while TerminationProtection is enabled`
- updated the mapping for `failed: ValidationError: Stack:<stack arn> is in STATE state and can not be updated` to capture stacks without hyphens in their names

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
