### PR TITLE
wrap inotify errors in AmplifyUserError

### DIFF
--- a/.changeset/mighty-kids-thank.md
+++ b/.changeset/mighty-kids-thank.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+wrap inotify errors in AmplifyUserError

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -88,6 +88,7 @@
   "idps",
   "implementors",
   "inheritdoc",
+  "inotify",
   "instanceof",
   "interop",
   "invokable",

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -316,4 +316,15 @@ void describe('AmplifyError.fromError', async () => {
       `Failed the test for error ${error.message}`
     );
   });
+  void it('wraps InsufficientInotifyWatchersError in AmplifyUserError when system has reached the limit of inotify watchers', () => {
+    const error = new Error(
+      `Error: inotify_add_watch on '/some/path' failed: No space left on device`
+    );
+    const actual = AmplifyError.fromError(error);
+    assert.ok(
+      AmplifyError.isAmplifyError(actual) &&
+        actual.name === 'InsufficientInotifyWatchersError',
+      `Failed the test for error ${error.message}`
+    );
+  });
 });

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -194,6 +194,17 @@ export abstract class AmplifyError<T extends string = string> extends Error {
         error
       );
     }
+    if (error instanceof Error && isInotifyError(error)) {
+      return new AmplifyUserError(
+        'InsufficientInotifyWatchersError',
+        {
+          message: error.message,
+          resolution:
+            'There appears to be an insufficient number of inotify watchers. To increase the amount of inotify watchers, change the `fs.inotify.max_user_watches` setting in your system config files to a higher value.',
+        },
+        error
+      );
+    }
     return new AmplifyFault(
       'UnknownFault',
       {
@@ -328,6 +339,10 @@ const isOutOfMemoryError = (err?: Error): boolean => {
     (err.message.includes('process out of memory') ||
       err.message.includes('connect ENOMEM'))
   );
+};
+
+const isInotifyError = (err?: Error): boolean => {
+  return !!err && err.message.includes('inotify_add_watch');
 };
 
 /**


### PR DESCRIPTION
## Problem

When watching for file changes for the sandbox command, the system may run out of watchers and throw the following error as a fault:
```
Error: inotify_add_watch on '/some/path' failed: No space left on device
```

**Issue number, if available:**

## Changes

Add logic to classify as user error with directions to increase the amount of watchers (system config file varies based on Linux distro so being vague here instead of pointing to the exact config file path).

**Corresponding docs PR, if applicable:**

## Validation

Unit test

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
