### PR TITLE
increase spinner time to more accurately capture spinner refreshes in unit tests

### DIFF
--- a/.changeset/smart-beds-exercise.md
+++ b/.changeset/smart-beds-exercise.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/cli-core': patch
+---
+
+increase spinner time to more accurately capture spinner refreshes in unit tests

--- a/packages/cli-core/src/printer/printer.test.ts
+++ b/packages/cli-core/src/printer/printer.test.ts
@@ -140,18 +140,18 @@ void describe('Printer', () => {
   void it('startSpinner start animating spinner with message until stopSpinner is called in TTY terminal', async () => {
     const message = 'Message 1';
 
-    // Refresh rate of 50 ms
+    // Refresh rate of 100 ms
     const printer = new Printer(
       LogLevel.INFO,
       ttyStream,
       process.stderr,
-      50,
+      100,
       true
     );
     printer.startSpinner(spinnerId, message);
 
-    // Wait for 190 ms
-    await new Promise((resolve) => setTimeout(resolve, 190));
+    // Wait for 400 ms
+    await new Promise((resolve) => setTimeout(resolve, 400));
 
     // Stop spinner
     printer.stopSpinner(spinnerId);


### PR DESCRIPTION
## Problem

For some slower machines, the spinner (with 50ms refresh) only spins 3 times instead of 4 in 190 ms. 

See failing run https://github.com/aws-amplify/amplify-backend/actions/runs/13794734502/job/38583723506

**Issue number, if available:**

## Changes

This PR updates the refresh rate to 100ms to bridge the gap between slower and powerful machines.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
