### PR TITLE
Upgrade data construct and CDK

### DIFF
--- a/.changeset/shaggy-students-knock.md
+++ b/.changeset/shaggy-students-knock.md
@@ -14,6 +14,7 @@
 '@aws-amplify/backend-ai': patch
 '@aws-amplify/backend': patch
 '@aws-amplify/sandbox': patch
+'create-amplify': patch
 ---
 
 Upgrade CDK version to 2.180.0

--- a/.changeset/shaggy-students-knock.md
+++ b/.changeset/shaggy-students-knock.md
@@ -1,0 +1,19 @@
+---
+'@aws-amplify/backend-platform-test-stubs': patch
+'@aws-amplify/backend-output-storage': patch
+'@aws-amplify/integration-tests': patch
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend-storage': patch
+'@aws-amplify/auth-construct': patch
+'@aws-amplify/ai-constructs': patch
+'@aws-amplify/platform-core': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/plugin-types': patch
+'@aws-amplify/backend-ai': patch
+'@aws-amplify/backend': patch
+'@aws-amplify/sandbox': patch
+---
+
+Upgrade CDK version to 2.180.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -35635,7 +35635,7 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.5.0",
@@ -35644,10 +35644,10 @@
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.4",
         "@aws-amplify/backend-secret": "^1.1.4",
-        "@aws-amplify/backend-storage": "^1.2.4",
+        "@aws-amplify/backend-storage": "^1.2.5",
         "@aws-amplify/client-config": "^1.5.7",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/platform-core": "^1.6.2",
+        "@aws-amplify/platform-core": "^1.6.4",
         "@aws-amplify/plugin-types": "^1.7.0",
         "@aws-sdk/client-amplify": "^3.624.0"
       },
@@ -35725,10 +35725,10 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "1.1.18",
+      "version": "1.1.19",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.6.2",
+        "@aws-amplify/platform-core": "^1.6.4",
         "@aws-amplify/plugin-types": "^1.8.0",
         "execa": "^9.5.1",
         "strip-ansi": "^6.0.1",
@@ -35826,7 +35826,7 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.1",
@@ -35835,7 +35835,7 @@
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.7",
-        "@aws-amplify/platform-core": "^1.3.0"
+        "@aws-amplify/platform-core": "^1.6.4"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.180.0",
@@ -35844,18 +35844,18 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.4.11",
+      "version": "1.4.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.1.17",
+        "@aws-amplify/backend-deployer": "^1.1.19",
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-secret": "^1.1.6",
-        "@aws-amplify/cli-core": "^1.2.4",
+        "@aws-amplify/cli-core": "^1.4.0",
         "@aws-amplify/client-config": "^1.5.7",
         "@aws-amplify/deployed-backend-client": "^1.5.0",
         "@aws-amplify/form-generator": "^1.0.4",
         "@aws-amplify/model-generator": "^1.0.12",
-        "@aws-amplify/platform-core": "^1.6.3",
+        "@aws-amplify/platform-core": "^1.6.4",
         "@aws-amplify/plugin-types": "^1.8.0",
         "@aws-amplify/sandbox": "^1.2.10",
         "@aws-amplify/schema-generator": "^1.2.7",
@@ -35891,10 +35891,10 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.6.2",
+        "@aws-amplify/platform-core": "^1.6.4",
         "@inquirer/prompts": "^7.3.2",
         "execa": "^9.5.1",
         "kleur": "^4.1.5",
@@ -36148,11 +36148,11 @@
       }
     },
     "packages/create-amplify": {
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^1.3.0",
-        "@aws-amplify/platform-core": "^1.6.0",
+        "@aws-amplify/cli-core": "^1.4.0",
+        "@aws-amplify/platform-core": "^1.6.4",
         "@aws-amplify/plugin-types": "^1.8.0",
         "execa": "^9.5.1",
         "kleur": "^4.1.5",
@@ -36311,19 +36311,19 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
         "@aws-amplify/ai-constructs": "^1.1.0",
         "@aws-amplify/auth-construct": "^1.6.0",
-        "@aws-amplify/backend": "^1.14.0",
+        "@aws-amplify/backend": "^1.14.2",
         "@aws-amplify/backend-ai": "^1.1.0",
         "@aws-amplify/backend-secret": "^1.1.4",
         "@aws-amplify/client-config": "^1.5.3",
         "@aws-amplify/data-schema": "^1.13.4",
         "@aws-amplify/deployed-backend-client": "^1.4.1",
-        "@aws-amplify/platform-core": "^1.3.0",
+        "@aws-amplify/platform-core": "^1.6.4",
         "@aws-amplify/plugin-types": "^1.6.0",
         "@aws-sdk/client-accessanalyzer": "^3.624.0",
         "@aws-sdk/client-amplify": "^3.624.0",
@@ -36395,7 +36395,7 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23494,16 +23494,16 @@
       "license": "0BSD"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1000.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1000.2.tgz",
-      "integrity": "sha512-QsXqJhGWjHNqP7etgE3sHOTiDBXItmSKdFKgsm1qPMBabCMyFfmWZnEeUxfZ4sMaIoxvLpr3sqoWSNeLuUk4sg==",
+      "version": "2.1003.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1003.0.tgz",
+      "integrity": "sha512-FORPDGW8oUg4tXFlhX+lv/j+152LO9wwi3/CwNr1WY3c3HwJUtc0fZGb2B3+Fzy6NhLWGHJclUsJPEhjEt8Nhg==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 14.15.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -35610,7 +35610,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -35629,7 +35629,7 @@
         "@aws-sdk/util-arn-parser": "^3.568.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -35657,7 +35657,7 @@
         "aws-lambda": "^1.0.7"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -35674,7 +35674,7 @@
         "@aws-amplify/plugin-types": "^1.7.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -35697,7 +35697,7 @@
         "aws-lambda": "^1.0.7"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -35719,7 +35719,7 @@
         "@aws-amplify/platform-core": "^1.5.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -35735,7 +35735,7 @@
         "tsx": "^4.6.1"
       },
       "peerDependencies": {
-        "aws-cdk": "^2.168.0",
+        "aws-cdk": "^2.1001.0",
         "typescript": "^5.0.0"
       }
     },
@@ -35759,7 +35759,7 @@
         "uuid": "^9.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -35798,7 +35798,7 @@
         "@aws-amplify/plugin-types": "^1.6.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0"
+        "aws-cdk-lib": "^2.180.0"
       }
     },
     "packages/backend-platform-test-stubs": {
@@ -35807,7 +35807,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.6.0",
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -35838,7 +35838,7 @@
         "@aws-amplify/platform-core": "^1.3.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36343,7 +36343,7 @@
         "@zip.js/zip.js": "^2.7.52",
         "aws-amplify": "^6.0.16",
         "aws-appsync-auth-link": "^3.0.7",
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0",
         "execa": "^9.5.1",
         "fs-extra": "^11.1.1",
@@ -36413,7 +36413,7 @@
         "@types/uuid": "9.0.7"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36436,7 +36436,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/types": "^3.609.0",
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36468,7 +36468,7 @@
         "@types/parse-gitignore": "^1.0.0"
       },
       "peerDependencies": {
-        "aws-cdk": "^2.168.0"
+        "aws-cdk": "^2.1001.0"
       }
     },
     "packages/schema-generator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -756,9 +756,9 @@
       }
     },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.14.6.tgz",
-      "integrity": "sha512-sMk1nFbJSOf3F581XSsK0YfdRK2E9Js3Zr2nvkP+R7maG9Oc7huaNkgKbEmE5W2zEHvjYw8S4C9BZYIxHV9TaA==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.15.1.tgz",
+      "integrity": "sha512-po8Q1yStA1Dx4vzx1SEMUgZq5VHlt6wxmh+GtROErnnYYpNdkJc+60Pc6l713J2xD+bST5Z1EpfNa8+kpzsHgQ==",
       "bundleDependencies": [
         "@aws-amplify/ai-constructs",
         "@aws-amplify/backend-output-schemas",
@@ -780,6 +780,7 @@
         "@aws-amplify/graphql-transformer",
         "@aws-amplify/graphql-transformer-core",
         "@aws-amplify/graphql-transformer-interfaces",
+        "@aws-amplify/graphql-validate-transformer",
         "@aws-amplify/platform-core",
         "@aws-amplify/plugin-types",
         "@aws-crypto/crc32",
@@ -872,6 +873,7 @@
         "libphonenumber-js",
         "lodash",
         "lodash.mergewith",
+        "lodash.snakecase",
         "md5",
         "object-hash",
         "pluralize",
@@ -885,27 +887,28 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.0.0",
+        "@aws-amplify/ai-constructs": "^1.2.4",
         "@aws-amplify/backend-output-schemas": "^1.0.0",
         "@aws-amplify/backend-output-storage": "^1.0.0",
-        "@aws-amplify/graphql-api-construct": "1.18.6",
-        "@aws-amplify/graphql-auth-transformer": "4.1.10",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.5",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.7",
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-function-transformer": "3.1.9",
-        "@aws-amplify/graphql-generation-transformer": "1.1.3",
-        "@aws-amplify/graphql-http-transformer": "3.0.12",
-        "@aws-amplify/graphql-index-transformer": "3.0.12",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.12",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.12",
-        "@aws-amplify/graphql-relational-transformer": "3.1.4",
-        "@aws-amplify/graphql-searchable-transformer": "3.0.12",
-        "@aws-amplify/graphql-sql-transformer": "0.4.12",
-        "@aws-amplify/graphql-transformer": "2.2.5",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-api-construct": "1.19.1",
+        "@aws-amplify/graphql-auth-transformer": "4.2.1",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.9",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.11",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-function-transformer": "3.1.13",
+        "@aws-amplify/graphql-generation-transformer": "1.2.1",
+        "@aws-amplify/graphql-http-transformer": "3.0.16",
+        "@aws-amplify/graphql-index-transformer": "3.0.16",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.16",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.16",
+        "@aws-amplify/graphql-relational-transformer": "3.1.8",
+        "@aws-amplify/graphql-searchable-transformer": "3.0.16",
+        "@aws-amplify/graphql-sql-transformer": "0.4.16",
+        "@aws-amplify/graphql-transformer": "2.3.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
+        "@aws-amplify/graphql-validate-transformer": "1.1.1",
         "@aws-amplify/platform-core": "^1.0.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "@aws-crypto/crc32": "5.2.0",
@@ -998,6 +1001,7 @@
         "libphonenumber-js": "1.9.47",
         "lodash": "^4.17.21",
         "lodash.mergewith": "^4.6.2",
+        "lodash.snakecase": "^4.1.1",
         "md5": "^2.2.1",
         "object-hash": "^3.0.0",
         "pluralize": "8.0.0",
@@ -1010,24 +1014,53 @@
         "zod": "^3.22.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs": {
-      "version": "1.0.0",
+      "version": "1.2.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
-        "@aws-amplify/platform-core": "^1.2.0",
-        "@aws-amplify/plugin-types": "^1.3.1",
+        "@aws-amplify/platform-core": "^1.6.2",
+        "@aws-amplify/plugin-types": "^1.6.0",
         "@aws-sdk/client-bedrock-runtime": "^3.622.0",
         "@smithy/types": "^3.3.0",
         "json-schema-to-ts": "^3.1.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/platform-core": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^1.8.0",
+        "@aws-sdk/client-sts": "^3.624.0",
+        "is-ci": "^3.0.1",
+        "lodash.mergewith": "^4.6.2",
+        "lodash.snakecase": "^4.1.1",
+        "semver": "^7.6.3",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.2"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.168.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/plugin-types": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/types": "^3.609.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -1053,15 +1086,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "4.1.10",
+      "version": "4.2.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-relational-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-relational-transformer": "3.1.8",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2",
@@ -1069,22 +1102,22 @@
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
-      "version": "1.1.5",
+      "version": "1.1.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.0.0",
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-index-transformer": "3.0.12",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-relational-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/ai-constructs": "^1.2.4",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-index-transformer": "3.0.16",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-relational-transformer": "3.1.8",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "@aws-amplify/plugin-types": "^1.0.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1093,18 +1126,18 @@
         "semver": "^7.6.3"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "3.1.7",
+      "version": "3.1.11",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2",
@@ -1112,220 +1145,221 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "2.6.1",
+      "version": "2.7.0",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "3.1.9",
+      "version": "3.1.13",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
-      "version": "1.1.3",
+      "version": "1.2.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "3.0.12",
+      "version": "3.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "3.0.12",
+      "version": "3.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "4.0.12",
+      "version": "4.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "3.1.4",
+      "version": "3.2.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "3.0.12",
+      "version": "3.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "3.1.4",
+      "version": "3.1.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-index-transformer": "3.0.12",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-index-transformer": "3.0.16",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "3.0.12",
+      "version": "3.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.4.12",
+      "version": "0.4.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "2.2.5",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "4.1.10",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.5",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.7",
-        "@aws-amplify/graphql-function-transformer": "3.1.9",
-        "@aws-amplify/graphql-generation-transformer": "1.1.3",
-        "@aws-amplify/graphql-http-transformer": "3.0.12",
-        "@aws-amplify/graphql-index-transformer": "3.0.12",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.12",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.12",
-        "@aws-amplify/graphql-relational-transformer": "3.1.4",
-        "@aws-amplify/graphql-searchable-transformer": "3.0.12",
-        "@aws-amplify/graphql-sql-transformer": "0.4.12",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-auth-transformer": "4.2.1",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.9",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.11",
+        "@aws-amplify/graphql-function-transformer": "3.1.13",
+        "@aws-amplify/graphql-generation-transformer": "1.2.1",
+        "@aws-amplify/graphql-http-transformer": "3.0.16",
+        "@aws-amplify/graphql-index-transformer": "3.0.16",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.16",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.16",
+        "@aws-amplify/graphql-relational-transformer": "3.1.8",
+        "@aws-amplify/graphql-searchable-transformer": "3.0.16",
+        "@aws-amplify/graphql-sql-transformer": "0.4.16",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
+        "@aws-amplify/graphql-validate-transformer": "1.1.1",
         "@aws-amplify/plugin-types": "^1.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "3.3.4",
+      "version": "3.4.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1337,20 +1371,33 @@
         "ts-dedent": "^2.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "4.2.1",
+      "version": "4.2.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "graphql": "^15.5.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-validate-transformer": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "5.0.2",
+        "graphql-transformer-common": "5.1.2"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core": {
@@ -3646,6 +3693,11 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/md5": {
       "version": "2.3.0",
       "inBundle": true,
@@ -3787,9 +3839,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.18.6.tgz",
-      "integrity": "sha512-YyUhxeAwwwmqTbMCQH0U9ATxgCPcnc9Ak6xAh9l9Y5xRSco+vcrzZSyMib1Q1bVtuEUj3EuKKi8ygvYUvgkz3Q==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.19.1.tgz",
+      "integrity": "sha512-AsM5qUYdMqlrA74qjCZs0lEEgUz42e0kAd10X7xc6ZQpxuq738FK9BVwzmhDjFEovaq7dj/AbEvwpuoaRoVeFQ==",
       "bundleDependencies": [
         "@aws-amplify/ai-constructs",
         "@aws-amplify/backend-output-schemas",
@@ -3811,6 +3863,7 @@
         "@aws-amplify/graphql-transformer",
         "@aws-amplify/graphql-transformer-core",
         "@aws-amplify/graphql-transformer-interfaces",
+        "@aws-amplify/graphql-validate-transformer",
         "@aws-amplify/platform-core",
         "@aws-amplify/plugin-types",
         "@aws-crypto/crc32",
@@ -3903,6 +3956,7 @@
         "libphonenumber-js",
         "lodash",
         "lodash.mergewith",
+        "lodash.snakecase",
         "md5",
         "object-hash",
         "pluralize",
@@ -3916,26 +3970,27 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.0.0",
+        "@aws-amplify/ai-constructs": "^1.2.4",
         "@aws-amplify/backend-output-schemas": "^1.0.0",
         "@aws-amplify/backend-output-storage": "^1.0.0",
-        "@aws-amplify/graphql-auth-transformer": "4.1.10",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.5",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.7",
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-function-transformer": "3.1.9",
-        "@aws-amplify/graphql-generation-transformer": "1.1.3",
-        "@aws-amplify/graphql-http-transformer": "3.0.12",
-        "@aws-amplify/graphql-index-transformer": "3.0.12",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.12",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.12",
-        "@aws-amplify/graphql-relational-transformer": "3.1.4",
-        "@aws-amplify/graphql-searchable-transformer": "3.0.12",
-        "@aws-amplify/graphql-sql-transformer": "0.4.12",
-        "@aws-amplify/graphql-transformer": "2.2.5",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-auth-transformer": "4.2.1",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.9",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.11",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-function-transformer": "3.1.13",
+        "@aws-amplify/graphql-generation-transformer": "1.2.1",
+        "@aws-amplify/graphql-http-transformer": "3.0.16",
+        "@aws-amplify/graphql-index-transformer": "3.0.16",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.16",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.16",
+        "@aws-amplify/graphql-relational-transformer": "3.1.8",
+        "@aws-amplify/graphql-searchable-transformer": "3.0.16",
+        "@aws-amplify/graphql-sql-transformer": "0.4.16",
+        "@aws-amplify/graphql-transformer": "2.3.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
+        "@aws-amplify/graphql-validate-transformer": "1.1.1",
         "@aws-amplify/platform-core": "^1.0.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "@aws-crypto/crc32": "5.2.0",
@@ -4028,6 +4083,7 @@
         "libphonenumber-js": "1.9.47",
         "lodash": "^4.17.21",
         "lodash.mergewith": "^4.6.2",
+        "lodash.snakecase": "^4.1.1",
         "md5": "^2.2.1",
         "object-hash": "^3.0.0",
         "pluralize": "8.0.0",
@@ -4040,24 +4096,53 @@
         "zod": "^3.22.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs": {
-      "version": "1.0.0",
+      "version": "1.2.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
-        "@aws-amplify/platform-core": "^1.2.0",
-        "@aws-amplify/plugin-types": "^1.3.1",
+        "@aws-amplify/platform-core": "^1.6.2",
+        "@aws-amplify/plugin-types": "^1.6.0",
         "@aws-sdk/client-bedrock-runtime": "^3.622.0",
         "@smithy/types": "^3.3.0",
         "json-schema-to-ts": "^3.1.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.158.0",
+        "aws-cdk-lib": "^2.168.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/platform-core": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^1.8.0",
+        "@aws-sdk/client-sts": "^3.624.0",
+        "is-ci": "^3.0.1",
+        "lodash.mergewith": "^4.6.2",
+        "lodash.snakecase": "^4.1.1",
+        "semver": "^7.6.3",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.2"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.168.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/plugin-types": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/types": "^3.609.0",
+        "aws-cdk-lib": "^2.168.0",
         "constructs": "^10.0.0"
       }
     },
@@ -4083,15 +4168,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "4.1.10",
+      "version": "4.2.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-relational-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-relational-transformer": "3.1.8",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2",
@@ -4099,22 +4184,22 @@
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
-      "version": "1.1.5",
+      "version": "1.1.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.0.0",
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-index-transformer": "3.0.12",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-relational-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/ai-constructs": "^1.2.4",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-index-transformer": "3.0.16",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-relational-transformer": "3.1.8",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "@aws-amplify/plugin-types": "^1.0.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -4123,18 +4208,18 @@
         "semver": "^7.6.3"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "3.1.7",
+      "version": "3.1.11",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2",
@@ -4142,220 +4227,221 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "2.6.1",
+      "version": "2.7.0",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "3.1.9",
+      "version": "3.1.13",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
-      "version": "1.1.3",
+      "version": "1.2.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "3.0.12",
+      "version": "3.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "3.0.12",
+      "version": "3.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "4.0.12",
+      "version": "4.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "3.1.4",
+      "version": "3.2.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "3.0.12",
+      "version": "3.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "3.1.4",
+      "version": "3.1.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-index-transformer": "3.0.12",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-index-transformer": "3.0.16",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "3.0.12",
+      "version": "3.0.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.4.12",
+      "version": "0.4.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "2.2.5",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "4.1.10",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.5",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.7",
-        "@aws-amplify/graphql-function-transformer": "3.1.9",
-        "@aws-amplify/graphql-generation-transformer": "1.1.3",
-        "@aws-amplify/graphql-http-transformer": "3.0.12",
-        "@aws-amplify/graphql-index-transformer": "3.0.12",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.12",
-        "@aws-amplify/graphql-model-transformer": "3.1.4",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.12",
-        "@aws-amplify/graphql-relational-transformer": "3.1.4",
-        "@aws-amplify/graphql-searchable-transformer": "3.0.12",
-        "@aws-amplify/graphql-sql-transformer": "0.4.12",
-        "@aws-amplify/graphql-transformer-core": "3.3.4",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-auth-transformer": "4.2.1",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.9",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.11",
+        "@aws-amplify/graphql-function-transformer": "3.1.13",
+        "@aws-amplify/graphql-generation-transformer": "1.2.1",
+        "@aws-amplify/graphql-http-transformer": "3.0.16",
+        "@aws-amplify/graphql-index-transformer": "3.0.16",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.16",
+        "@aws-amplify/graphql-model-transformer": "3.2.1",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.16",
+        "@aws-amplify/graphql-relational-transformer": "3.1.8",
+        "@aws-amplify/graphql-searchable-transformer": "3.0.16",
+        "@aws-amplify/graphql-sql-transformer": "0.4.16",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
+        "@aws-amplify/graphql-validate-transformer": "1.1.1",
         "@aws-amplify/plugin-types": "^1.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "3.3.4",
+      "version": "3.4.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.6.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.2.1",
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -4367,20 +4453,33 @@
         "ts-dedent": "^2.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "4.2.1",
+      "version": "4.2.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "graphql": "^15.5.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.168.0",
+        "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-validate-transformer": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-directives": "2.7.0",
+        "@aws-amplify/graphql-transformer-core": "3.4.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.2.4",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "5.0.2",
+        "graphql-transformer-common": "5.1.2"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core": {
@@ -6673,6 +6772,11 @@
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/lodash.mergewith": {
       "version": "4.6.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/lodash.snakecase": {
+      "version": "4.1.1",
       "inBundle": true,
       "license": "MIT"
     },
@@ -35604,7 +35708,7 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.4.0",
         "@aws-amplify/backend-output-storage": "^1.1.4",
-        "@aws-amplify/data-construct": "^1.14.5",
+        "@aws-amplify/data-construct": "^1.15.1",
         "@aws-amplify/data-schema-types": "^1.2.0",
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/plugin-types": "^1.7.0"

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -40,7 +40,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/auth-construct/package.json
+++ b/packages/auth-construct/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/util-arn-parser": "^3.568.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-ai/package.json
+++ b/packages/backend-ai/package.json
@@ -30,7 +30,7 @@
     "@aws-amplify/plugin-types": "^1.7.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-auth/package.json
+++ b/packages/backend-auth/package.json
@@ -33,7 +33,7 @@
     "aws-lambda": "^1.0.7"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "^1.1.4",
     "@aws-amplify/backend-output-schemas": "^1.4.0",
-    "@aws-amplify/data-construct": "^1.14.5",
+    "@aws-amplify/data-construct": "^1.15.1",
     "@aws-amplify/data-schema-types": "^1.2.0",
     "@aws-amplify/graphql-generator": "^0.5.1",
     "@aws-amplify/plugin-types": "^1.7.0"

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -24,7 +24,7 @@
     "@aws-amplify/platform-core": "^1.5.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   },
   "dependencies": {

--- a/packages/backend-deployer/package.json
+++ b/packages/backend-deployer/package.json
@@ -26,7 +26,7 @@
     "strip-ansi": "^6.0.1"
   },
   "peerDependencies": {
-    "aws-cdk": "^2.168.0",
+    "aws-cdk": "^2.1001.0",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/backend-function/package.json
+++ b/packages/backend-function/package.json
@@ -39,7 +39,7 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-output-storage/package.json
+++ b/packages/backend-output-storage/package.json
@@ -24,6 +24,6 @@
     "@aws-amplify/plugin-types": "^1.6.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0"
+    "aws-cdk-lib": "^2.180.0"
   }
 }

--- a/packages/backend-platform-test-stubs/package.json
+++ b/packages/backend-platform-test-stubs/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-amplify/plugin-types": "^1.6.0",
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-storage/package.json
+++ b/packages/backend-storage/package.json
@@ -28,7 +28,7 @@
     "@aws-amplify/platform-core": "^1.6.4"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/client-amplify": "^3.624.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/create-amplify/src/default_packages.json
+++ b/packages/create-amplify/src/default_packages.json
@@ -2,7 +2,7 @@
   "defaultDevPackages": [
     "@aws-amplify/backend",
     "@aws-amplify/backend-cli",
-    "aws-cdk@2.1000.2",
+    "aws-cdk@2.1003.0",
     "aws-cdk-lib@2.180.0",
     "constructs@^10.0.0",
     "typescript@^5.0.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -33,7 +33,7 @@
     "@zip.js/zip.js": "^2.7.52",
     "aws-amplify": "^6.0.16",
     "aws-appsync-auth-link": "^3.0.7",
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0",
     "execa": "^9.5.1",
     "fs-extra": "^11.1.1",

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -39,7 +39,7 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -11,7 +11,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.168.0",
+    "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.0.0",
     "@aws-sdk/types": "^3.609.0"
   },

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -42,6 +42,6 @@
     "@types/parse-gitignore": "^1.0.0"
   },
   "peerDependencies": {
-    "aws-cdk": "^2.168.0"
+    "aws-cdk": "^2.1001.0"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:** N/A

When attempting to upgrade the data construct for the migrations work (https://github.com/aws-amplify/amplify-backend/pull/1678) the [test_with_baseline_dependencies job failed](https://github.com/aws-amplify/amplify-backend/actions/runs/13724700722/job/38388428773). The [data construct was upgraded](https://github.com/aws-amplify/amplify-category-api/pull/3193) to CDK `aws-cdk-lib@2.180.0` and `aws-cdk@2.1001.0` and is no longer compatible with the lower versions of CDK. 

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:** N/A

* Upgrade the data construct to 1.15.1 (needed for migrations)
* Upgrade to `aws-cdk-lib@2.180.0`
* Upgrade to `aws-cdk@2.1001.0`

I've separated this PR from the data migrations PR to simplify the reviews.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Automated tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
