### PR TITLE
fix small 'pretty sandbox' qa bugs

### DIFF
--- a/.changeset/easy-points-shop.md
+++ b/.changeset/easy-points-shop.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-function': patch
+'@aws-amplify/cli-core': patch
+'@aws-amplify/sandbox': patch
+---
+
+fix pretty sandbox qa bugs

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -33,7 +33,11 @@ import {
   LayerVersion,
   Runtime,
 } from 'aws-cdk-lib/aws-lambda';
-import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
+import {
+  LogLevel as EsBuildLogLevel,
+  NodejsFunction,
+  OutputFormat,
+} from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Construct } from 'constructs';
 import { readFileSync } from 'fs';
 import { createRequire } from 'module';
@@ -592,6 +596,7 @@ class AmplifyFunction
           banner: bannerCode,
           inject: shims,
           externalModules: Object.keys(props.layers),
+          logLevel: EsBuildLogLevel.ERROR,
         },
         logRetention: cdkLoggingOptions.retention,
         applicationLogLevelV2: cdkLoggingOptions.level,

--- a/packages/cli-core/src/loggers/amplify_event_logger_for_sandbox.test.ts
+++ b/packages/cli-core/src/loggers/amplify_event_logger_for_sandbox.test.ts
@@ -70,101 +70,101 @@ void describe('amplify sandbox event logging', () => {
       ),
       [
         '',
-        `${cll()}3:26:02 AM | ${format.color(
+        `${cll()}${format.dim('3:26:02 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('root stack'),
           'Green',
         )}${EOL}`,
-        `${cll()}3:26:02 AM | ${format.color(
+        `${cll()}${format.dim('3:26:02 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('root stack'),
           'Green',
-        )}${EOL}${cll()}3:26:07 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:07 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('∟ data stack'),
           'Green',
-        )}${EOL}${cll()}3:26:06 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:06 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('data'),
           'Green',
         )}${EOL}`,
-        `${cll()}3:26:02 AM | ${format.color(
+        `${cll()}${format.dim('3:26:02 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('root stack'),
           'Green',
-        )}${EOL}${cll()}3:26:07 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:07 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('∟ data stack'),
           'Green',
-        )}${EOL}${cll()}3:26:06 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:06 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('data'),
           'Green',
-        )}${EOL}${cll()}3:26:12 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:12 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('∟ Person'),
           'Green',
-        )}${EOL}${cll()}3:26:13 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:13 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('∟ Post'),
           'Green',
         )}${EOL}`,
-        `${cll()}3:26:02 AM | ${format.color(
+        `${cll()}${format.dim('3:26:02 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('root stack'),
           'Green',
-        )}${EOL}${cll()}3:26:07 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:07 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('∟ data stack'),
           'Green',
-        )}${EOL}${cll()}3:26:06 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:06 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('data'),
           'Green',
-        )}${EOL}${cll()}3:26:12 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:12 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('∟ Person'),
           'Green',
-        )}${EOL}${cll()}3:26:13 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:13 AM')} | ${format.color(
           'UPDATE_IN_PROGRESS  ',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('∟ Post'),
           'Green',
         )}${EOL}`,
-        `${cll()}3:26:18 AM | ${format.color(
+        `${cll()}${format.dim('3:26:18 AM')} | ${format.color(
           'UPDATE_COMPLETE_CLEA',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('root stack'),
           'Green',
-        )}${EOL}${cll()}3:26:16 AM | ${format.color(
+        )}${EOL}${cll()}${format.dim('3:26:16 AM')} | ${format.color(
           'UPDATE_COMPLETE_CLEA',
           'Green',
         )} | CloudFormation:Stack      | ${format.color(
@@ -260,19 +260,19 @@ void describe('amplify sandbox event logging', () => {
           case 1:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:09:42 AM | ${format.color(
+              `${cll()}${format.dim('3:09:42 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:09:44 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:09:44 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('function'),
                 'Green',
-              )}${EOL}${cll()}3:09:44 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:09:44 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
@@ -284,79 +284,79 @@ void describe('amplify sandbox event logging', () => {
           case 9:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:09:42 AM | ${format.color(
+              `${cll()}${format.dim('3:09:42 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:10:20 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:20 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('data'),
                 'Green',
-              )}${EOL}${cll()}3:10:24 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:24 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | S3:Bucket                 | ${format.color(
                 format.bold('∟ AmplifyCodegenAssetsBucket'),
                 'Green',
-              )}${EOL}${cll()}3:10:23 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:23 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | Lambda:LayerVersion       | ${format.color(
                 format.bold('  ∟ AwsCliLayer'),
                 'Green',
-              )}${EOL}${cll()}3:10:26 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:26 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ AmplifyTableManager'),
                 'Green',
-              )}${EOL}${cll()}3:10:28 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:28 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | IAM:Role                  | ${format.color(
                 format.bold('  ∟ AmplifyManagedTableIsCompleteRole'),
                 'Green',
-              )}${EOL}${cll()}3:10:24 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:24 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | IAM:Role                  | ${format.color(
                 format.bold('  ∟ ServiceRole'),
                 'Green',
-              )}${EOL}${cll()}3:10:24 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:24 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | IAM:Role                  | ${format.color(
                 format.bold('  ∟ Role'),
                 'Green',
-              )}${EOL}${cll()}3:10:26 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:26 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | AppSync:GraphQLSchema     | ${format.color(
                 format.bold('  ∟ TransformerSchema'),
                 'Green',
-              )}${EOL}${cll()}3:10:24 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:24 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | S3:Bucket                 | ${format.color(
                 format.bold('∟ modelIntrospectionSchemaBucket'),
                 'Green',
-              )}${EOL}${cll()}3:10:23 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:23 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | Lambda:LayerVersion       | ${format.color(
                 format.bold('  ∟ AwsCliLayer'),
                 'Green',
-              )}${EOL}${cll()}3:09:45 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:09:45 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('function'),
                 'Green',
-              )}${EOL}${cll()}3:09:45 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:09:45 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
@@ -368,37 +368,37 @@ void describe('amplify sandbox event logging', () => {
           case 19:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:09:42 AM | ${format.color(
+              `${cll()}${format.dim('3:09:42 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:10:20 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:20 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('data'),
                 'Green',
-              )}${EOL}${cll()}3:10:26 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:26 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ AmplifyTableManager'),
                 'Green',
-              )}${EOL}${cll()}3:11:15 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:11:15 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | IAM:Policy                | ${format.color(
                 format.bold('  ∟ DefaultPolicy'),
                 'Green',
-              )}${EOL}${cll()}3:10:33 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:33 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('storage'),
                 'Green',
-              )}${EOL}${cll()}3:11:19 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:11:19 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | S3BucketNotifications     | ${format.color(
@@ -410,61 +410,61 @@ void describe('amplify sandbox event logging', () => {
           case 29:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:09:42 AM | ${format.color(
+              `${cll()}${format.dim('3:09:42 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:10:20 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:20 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('data'),
                 'Green',
-              )}${EOL}${cll()}3:11:44 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:11:44 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ Person'),
                 'Green',
-              )}${EOL}${cll()}3:12:13 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:12:13 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | AppSync:Resolver          | ${format.color(
                 format.bold('  ∟ mutationCreatePersonResolver'),
                 'Green',
-              )}${EOL}${cll()}3:12:13 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:12:13 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | AppSync:Resolver          | ${format.color(
                 format.bold('  ∟ mutationDeletePersonResolver'),
                 'Green',
-              )}${EOL}${cll()}3:12:13 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:12:13 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | AppSync:Resolver          | ${format.color(
                 format.bold('  ∟ mutationUpdatePersonResolver'),
                 'Green',
-              )}${EOL}${cll()}3:12:13 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:12:13 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | AppSync:Resolver          | ${format.color(
                 format.bold('  ∟ queryGetPersonResolver'),
                 'Green',
-              )}${EOL}${cll()}3:12:13 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:12:13 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | AppSync:Resolver          | ${format.color(
                 format.bold('  ∟ queryListPeopleResolver'),
                 'Green',
-              )}${EOL}${cll()}3:11:44 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:11:44 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ Post'),
                 'Green',
-              )}${EOL}${cll()}3:11:48 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:11:48 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | AmplifyDynamoDBTable      | ${format.color(
@@ -476,13 +476,13 @@ void describe('amplify sandbox event logging', () => {
           case 41:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:09:42 AM | ${format.color(
+              `${cll()}${format.dim('3:09:42 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:10:20 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:10:20 AM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
@@ -542,7 +542,7 @@ void describe('amplify sandbox event logging', () => {
           case 1:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}4:01:02 PM | ${format.color(
+              `${cll()}${format.dim('4:01:02 PM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
@@ -554,31 +554,31 @@ void describe('amplify sandbox event logging', () => {
           case 4:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}4:01:02 PM | ${format.color(
+              `${cll()}${format.dim('4:01:02 PM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}4:01:08 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:08 PM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ data stack'),
                 'Green',
-              )}${EOL}${cll()}4:01:07 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:07 PM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('data'),
                 'Green',
-              )}${EOL}${cll()}4:01:06 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:06 PM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('function'),
                 'Green',
-              )}${EOL}${cll()}4:01:09 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:09 PM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | IAM:Role                  | ${format.color(
@@ -590,25 +590,25 @@ void describe('amplify sandbox event logging', () => {
           case 9:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}4:01:02 PM | ${format.color(
+              `${cll()}${format.dim('4:01:02 PM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}4:01:18 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:18 PM')} | ${format.color(
                 'UPDATE_COMPLETE_CLEA',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ data stack'),
                 'Green',
-              )}${EOL}${cll()}4:01:06 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:06 PM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('function'),
                 'Green',
-              )}${EOL}${cll()}4:01:27 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:27 PM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | IAM:Policy                | ${format.color(
@@ -620,25 +620,25 @@ void describe('amplify sandbox event logging', () => {
           case 19:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}4:01:02 PM | ${format.color(
+              `${cll()}${format.dim('4:01:02 PM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}4:01:18 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:18 PM')} | ${format.color(
                 'UPDATE_COMPLETE_CLEA',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ data stack'),
                 'Green',
-              )}${EOL}${cll()}4:01:54 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:54 PM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('storage'),
                 'Green',
-              )}${EOL}${cll()}4:02:33 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:02:33 PM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | Lambda:Function           | ${format.color(
@@ -652,19 +652,19 @@ void describe('amplify sandbox event logging', () => {
           case 23:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}4:01:02 PM | ${format.color(
+              `${cll()}${format.dim('4:01:02 PM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}4:01:18 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:18 PM')} | ${format.color(
                 'UPDATE_COMPLETE_CLEA',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ data stack'),
                 'Green',
-              )}${EOL}${cll()}4:01:54 PM | ${format.color(
+              )}${EOL}${cll()}${format.dim('4:01:54 PM')} | ${format.color(
                 'CREATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
@@ -724,7 +724,7 @@ void describe('amplify sandbox event logging', () => {
           case 1:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:20:31 AM | ${format.color(
+              `${cll()}${format.dim('3:20:31 AM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
@@ -736,13 +736,13 @@ void describe('amplify sandbox event logging', () => {
           case 4:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:20:31 AM | ${format.color(
+              `${cll()}${format.dim('3:20:31 AM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:20:45 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:20:45 AM')} | ${format.color(
                 'UPDATE_COMPLETE_CLEA',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
@@ -754,31 +754,31 @@ void describe('amplify sandbox event logging', () => {
           case 7:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:20:47 AM | ${format.color(
+              `${cll()}${format.dim('3:20:47 AM')} | ${format.color(
                 'UPDATE_COMPLETE_CLEA',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:20:48 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:20:48 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('storage0EC3F24A'),
                 'Yellow',
-              )}${EOL}${cll()}3:20:48 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:20:48 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ storage stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:20:59 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:20:59 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | IAM:Role                  | ${format.color(
                 format.bold('  ∟ Role'),
                 'Yellow',
-              )}${EOL}${cll()}3:20:59 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:20:59 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | IAM:Role                  | ${format.color(
@@ -792,25 +792,25 @@ void describe('amplify sandbox event logging', () => {
           case 9:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:20:47 AM | ${format.color(
+              `${cll()}${format.dim('3:20:47 AM')} | ${format.color(
                 'UPDATE_COMPLETE_CLEA',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:21:10 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:21:10 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('function1351588B'),
                 'Yellow',
-              )}${EOL}${cll()}3:21:10 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:21:10 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ function stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:21:16 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:21:16 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | IAM:Role                  | ${format.color(
@@ -823,13 +823,13 @@ void describe('amplify sandbox event logging', () => {
           case 11:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:20:47 AM | ${format.color(
+              `${cll()}${format.dim('3:20:47 AM')} | ${format.color(
                 'UPDATE_COMPLETE_CLEA',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:21:10 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:21:10 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
@@ -876,7 +876,7 @@ void describe('amplify sandbox event logging', () => {
           case 1:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:05:29 AM | ${format.color(
+              `${cll()}${format.dim('3:05:29 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
@@ -888,85 +888,85 @@ void describe('amplify sandbox event logging', () => {
           case 4:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:05:29 AM | ${format.color(
+              `${cll()}${format.dim('3:05:29 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:32 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:32 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ data stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:32 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:32 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ MyCustomResources stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:32 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:32 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ storage stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:31 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:31 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('data'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:41 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:41 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | Lambda:LayerVersion       | ${format.color(
                 format.bold('∟ AwsCliLayer'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:34 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:34 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ ConnectionStack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:41 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:41 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | IAM:Policy                | ${format.color(
                 format.bold('  ∟ DefaultPolicy'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:39 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:39 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | Lambda:Function           | ${format.color(
                 format.bold('  ∟ Handler'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:31 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:31 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('MyCustomResources'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:33 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:33 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | SQS:Queue                 | ${format.color(
                 format.bold('∟ CustomQueue'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:33 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:33 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | SNS:Topic                 | ${format.color(
                 format.bold('∟ CustomTopics'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:31 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:31 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('storage'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:37 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:37 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | Lambda:Function           | ${format.color(
@@ -980,49 +980,49 @@ void describe('amplify sandbox event logging', () => {
           case 9:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:05:29 AM | ${format.color(
+              `${cll()}${format.dim('3:05:29 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:32 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:32 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ data stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:32 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:32 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ MyCustomResources stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:31 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:31 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('data'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:45 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:45 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ Person'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:53 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:53 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('function'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:31 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:31 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('MyCustomResources'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:33 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:33 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | SNS:Topic                 | ${format.color(
@@ -1034,13 +1034,13 @@ void describe('amplify sandbox event logging', () => {
           case 19:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:05:29 AM | ${format.color(
+              `${cll()}${format.dim('3:05:29 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:05:31 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:05:31 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
@@ -1052,19 +1052,19 @@ void describe('amplify sandbox event logging', () => {
           case 25:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:05:29 AM | ${format.color(
+              `${cll()}${format.dim('3:05:29 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:07:25 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:07:25 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ auth stack'),
                 'Yellow',
-              )}${EOL}${cll()}3:07:25 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:07:25 AM')} | ${format.color(
                 'DELETE_IN_PROGRESS  ',
                 'Yellow',
               )} | CloudFormation:Stack      | ${format.color(
@@ -1114,7 +1114,7 @@ void describe('amplify sandbox event logging', () => {
           case 1:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:31:09 AM | ${format.color(
+              `${cll()}${format.dim('3:31:09 AM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
@@ -1126,25 +1126,25 @@ void describe('amplify sandbox event logging', () => {
           case 3:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:31:09 AM | ${format.color(
+              `${cll()}${format.dim('3:31:09 AM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:31:17 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:31:17 AM')} | ${format.color(
                 'UPDATE_ROLLBACK_IN_P',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ auth stack'),
                 'Green',
-              )}${EOL}${cll()}3:31:12 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:31:12 AM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('auth'),
                 'Green',
-              )}${EOL}${cll()}3:31:17 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:31:17 AM')} | ${format.color(
                 'UPDATE_FAILED       ',
                 'Red',
               )} | Cognito:UserPool          | ${format.color(
@@ -1159,25 +1159,25 @@ void describe('amplify sandbox event logging', () => {
           case 5:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:31:23 AM | ${format.color(
+              `${cll()}${format.dim('3:31:23 AM')} | ${format.color(
                 'UPDATE_ROLLBACK_IN_P',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:31:33 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:31:33 AM')} | ${format.color(
                 'UPDATE_ROLLBACK_COMP',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ auth stack'),
                 'Green',
-              )}${EOL}${cll()}3:31:25 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:31:25 AM')} | ${format.color(
                 'UPDATE_IN_PROGRESS  ',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('auth'),
                 'Green',
-              )}${EOL}${cll()}3:31:17 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:31:17 AM')} | ${format.color(
                 'UPDATE_FAILED       ',
                 'Red',
               )} | Cognito:UserPool          | ${format.color(
@@ -1192,13 +1192,13 @@ void describe('amplify sandbox event logging', () => {
           case 7:
             assert.deepStrictEqual(
               prefixTextActual,
-              `${cll()}3:31:36 AM | ${format.color(
+              `${cll()}${format.dim('3:31:36 AM')} | ${format.color(
                 'UPDATE_ROLLBACK_COMP',
                 'Green',
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('root stack'),
                 'Green',
-              )}${EOL}${cll()}3:31:17 AM | ${format.color(
+              )}${EOL}${cll()}${format.dim('3:31:17 AM')} | ${format.color(
                 'UPDATE_FAILED       ',
                 'Red',
               )} | Cognito:UserPool          | ${format.color(

--- a/packages/cli-core/src/loggers/amplify_event_loggers.ts
+++ b/packages/cli-core/src/loggers/amplify_event_loggers.ts
@@ -124,17 +124,22 @@ export class AmplifyEventLogger {
   cdkDeploymentProgress = async <T>(
     msg: AmplifyIoHostEventMessage<T>,
   ): Promise<void> => {
-    // Asset publishing if any. CDK_TOOLKIT_I5210 is when CDK starts building an asset
-    if (msg.code === 'CDK_TOOLKIT_I5210') {
-      this.printer.startSpinner('Building and publishing assets...');
+    // Asset publishing if any.
+    if (msg.message.includes('Checking for previously published assets')) {
+      if (!this.printer.isSpinnerRunning()) {
+        this.printer.startSpinner('Building and publishing assets...');
+      }
       return Promise.resolve();
     } else if (
       // CDK_TOOLKIT_I5221 when assets are published or when no publishing is required
       msg.code === 'CDK_TOOLKIT_I5221' ||
       msg.message.includes('0 still need to be published')
     ) {
-      this.printer.stopSpinner();
-      this.printer.log(`${format.success('✔')} Built and published assets`);
+      // We only want to display the success message once or if tty is not available
+      if (this.printer.isSpinnerRunning() || !this.printer.ttyEnabled) {
+        this.printer.stopSpinner();
+        this.printer.log(`${format.success('✔')} Built and published assets`);
+      }
       return Promise.resolve();
     }
 

--- a/packages/cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.ts
+++ b/packages/cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.ts
@@ -364,7 +364,7 @@ export class CfnDeploymentProgressLogger {
           color,
         )
       : format.bold(this.shorten(100, formattedResourceName));
-    return `${timeStamp} | ${status} | ${resourceType} | ${resourceNameToDisplay}${this.failureReasonOnNextLine(
+    return `${format.dim(timeStamp)} | ${status} | ${resourceType} | ${resourceNameToDisplay}${this.failureReasonOnNextLine(
       event,
     )}`;
   };


### PR DESCRIPTION
## Problem

Few display related bugs in pretty sandbox

**Issue number, if available:**

## Changes

1. Suppress ESBuild bundling output.
2. Suppress some specific `stderr` messages that come from `aws-cdk-lib` that currently does not use IoHost to delivery logs
3. Dim the timestamp for CFN progress
4. Print `"Built and published assets"` only once.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
