### PR TITLE
After clearing console, move the cursor to the top of terminal

### DIFF
--- a/.changeset/orange-rats-jog.md
+++ b/.changeset/orange-rats-jog.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/cli-core': patch
+---
+
+After clearing console, move the cursor to the top of terminal

--- a/packages/cli-core/src/printer/printer.ts
+++ b/packages/cli-core/src/printer/printer.ts
@@ -181,9 +181,12 @@ export class Printer {
    * Clears the console
    */
   clearConsole = () => {
-    if (this.ttyEnabled) {
-      this.stdout.write('\n'.repeat(process.stdout.rows));
+    if (!this.ttyEnabled) {
+      return;
     }
+    const lines = process.stdout.rows;
+    this.stdout.write('\n'.repeat(process.stdout.rows));
+    process.stdout.moveCursor(0, -lines);
   };
 
   private stringify = (msg: unknown): string => {


### PR DESCRIPTION
## Problem

On a sandbox deployment trigger, we "clear" the screen by adding terminal size of new lines. But we leave the cursor at the bottom which creates a gap between different sandbox sessions.

**Issue number, if available:**

## Changes

After "clearing" the screen, move the cursor to the top of terminal.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
