### PR TITLE
reroute stderr through printer and ensure printing is done around spinners

### DIFF
--- a/.changeset/floppy-pianos-fold.md
+++ b/.changeset/floppy-pianos-fold.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/cli-core': patch
+'@aws-amplify/sandbox': patch
+---
+
+reroute stderr through printer and ensure printing is done around spinners

--- a/packages/cli-core/src/printer/printer.ts
+++ b/packages/cli-core/src/printer/printer.ts
@@ -33,13 +33,8 @@ export class Printer {
   print = (message: string) => {
     message = this.stringify(message);
     if (this.isSpinnerRunning()) {
-      if (this.currentSpinner.instance?.prefixText) {
-        const spinnerPrefixMessage = this.currentSpinner.instance?.prefixText;
-        this.currentSpinner.instance.prefixText =
-          message + EOL + spinnerPrefixMessage;
-        return;
-      }
-      this.printNewLine();
+      this.printWhileSpinnerRunning(message);
+      return;
     }
     if (!this.ttyEnabled) {
       message = stripANSI(message);
@@ -187,6 +182,21 @@ export class Printer {
     const lines = process.stdout.rows;
     this.stdout.write('\n'.repeat(process.stdout.rows));
     process.stdout.moveCursor(0, -lines);
+  };
+
+  private printWhileSpinnerRunning = (message: string) => {
+    if (this.isSpinnerRunning()) {
+      if (this.currentSpinner.instance?.prefixText) {
+        const spinnerPrefixMessage = this.currentSpinner.instance?.prefixText;
+        this.currentSpinner.instance.prefixText =
+          message + EOL + spinnerPrefixMessage;
+      } else {
+        const spinnerMessage = this.currentSpinner.instance?.text;
+        this.currentSpinner.instance?.clear();
+        this.stdout.write(message);
+        this.currentSpinner.instance?.start(spinnerMessage);
+      }
+    }
   };
 
   private stringify = (msg: unknown): string => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

customers or constructs can print to `stderr` e.g. using `console.error` and the output gets jumbled together with `stdout`.

**Issue number, if available:**

## Changes

1. reroute stderr through printer 
2. ensure printing is done around spinners

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
