### PR TITLE
stagger FilterLogEvents API calls to prevent throttling exceptions

### DIFF
--- a/.changeset/eighty-items-repeat.md
+++ b/.changeset/eighty-items-repeat.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+stagger FilterLogEvents API calls to prevent throttling exceptions

--- a/packages/sandbox/src/cloudwatch_logs_monitor.test.ts
+++ b/packages/sandbox/src/cloudwatch_logs_monitor.test.ts
@@ -55,7 +55,7 @@ void describe('LambdaFunctionLogStreamer', () => {
     classUnderTest.addLogGroups('logFriendlyName2', 'logGroupName2');
     classUnderTest.activate();
     // wait just a bit to let the logs streamer run before deactivating it
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
     classUnderTest.pause();
 
     assert.strictEqual(mockedWrite.mock.callCount(), 4);
@@ -137,8 +137,9 @@ void describe('LambdaFunctionLogStreamer', () => {
 
     classUnderTest.addLogGroups('logFriendlyName1', 'logGroupName1');
     classUnderTest.activate();
-    // wait for just over two seconds to let the logs streamer get both the events before deactivating it
-    await new Promise((resolve) => setTimeout(resolve, 2100));
+    // wait for just 1 second to make the API calls and just over two seconds
+    // to let the logs streamer get both the events before deactivating it
+    await new Promise((resolve) => setTimeout(resolve, 3100));
     classUnderTest.pause();
 
     assert.strictEqual(mockedWrite.mock.callCount(), 2);
@@ -204,7 +205,7 @@ void describe('LambdaFunctionLogStreamer', () => {
     classUnderTest.addLogGroups('logFriendlyName1', 'logGroupName1');
     classUnderTest.activate();
     // wait just a bit to let the logs streamer run before deactivating it
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
     classUnderTest.pause();
 
     // 100 events + 1 informational for the user that 100 messages limit is hit
@@ -258,7 +259,7 @@ void describe('LambdaFunctionLogStreamer', () => {
     classUnderTest.addLogGroups('logFriendlyName1', 'logGroupName1');
     // activate it again and it should fetch the second event now
     classUnderTest.activate();
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 600));
     classUnderTest.pause();
 
     assert.strictEqual(mockedWrite.mock.callCount(), 2);

--- a/packages/sandbox/src/cloudwatch_logs_monitor.ts
+++ b/packages/sandbox/src/cloudwatch_logs_monitor.ts
@@ -192,11 +192,14 @@ export class CloudWatchLogEventMonitor {
    * Reads all new log events from a set of CloudWatch Log Groups in parallel
    */
   private readNewEvents = async (): Promise<Array<CloudWatchLogEvent>> => {
-    const promises: Array<Promise<Array<CloudWatchLogEvent>>> = [];
+    const results: Array<Array<CloudWatchLogEvent>> = [];
     for (const logGroup of this.allLogGroups) {
-      promises.push(this.readEventsFromLogGroup(logGroup));
+      results.push(await this.readEventsFromLogGroup(logGroup));
+      // There is a hard limit on TPS for `FilterLogEvents` API that is Account wide.
+      // We don't want to get throttled is customers are filtering for a lot of functions.
+      await new Promise((resolve) => setTimeout(resolve, 500));
     }
-    return (await Promise.all(promises)).flat();
+    return results.flat();
   };
 
   /**


### PR DESCRIPTION
## Problem

Fixes https://github.com/aws-amplify/amplify-backend/issues/2502

There is a hard limit on TPS for `FilterLogEvents` API that is Account wide. We don't want to get throttled if customers are streaming logs for a lot of functions.

**Issue number, if available:** #2502

## Changes

Instead of calling `FilterLogEvents` API for all the functions concurrently, stagger them with a 0.5s wait in between.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
