### PR TITLE
Updates to pretty sandbox display

### DIFF
--- a/.changeset/ten-ravens-rest.md
+++ b/.changeset/ten-ravens-rest.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/cli-core': patch
+---
+
+Move the spinner between timestamp and spinner text

--- a/.changeset/vast-dragons-yawn.md
+++ b/.changeset/vast-dragons-yawn.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/cli-core': patch
+'@aws-amplify/sandbox': patch
+---
+
+Updates to pretty sandbox display

--- a/packages/cli-core/src/format/format.test.ts
+++ b/packages/cli-core/src/format/format.test.ts
@@ -127,9 +127,8 @@ void describe('format.error', async () => {
     const expectedOutput =
       red(bold('[Error]')) +
       ' something went wrong' +
-      format.indent(
-        os.EOL + 'Caused by: ' + red(bold('[Error]')) + ' nested error',
-      );
+      os.EOL +
+      format.indent('∟ Caused by: ' + red(bold('[Error]')) + ' nested error');
     const actualOutput = format.error(input);
     assert.strictEqual(actualOutput, expectedOutput);
   });

--- a/packages/cli-core/src/format/format.ts
+++ b/packages/cli-core/src/format/format.ts
@@ -42,9 +42,7 @@ export class Format {
       }`;
 
       if (typeof error?.cause === 'object' && !!error.cause) {
-        message =
-          message +
-          this.indent(os.EOL + `Caused by: ${this.error(error.cause)}`);
+        message = `${message}${os.EOL}${format.indent(`∟ Caused by: ${this.error(error.cause)}`)}`;
       }
 
       if (AmplifyError.isAmplifyError(error) && error.resolution) {

--- a/packages/cli-core/src/loggers/amplify_event_logger_for_sandbox.test.ts
+++ b/packages/cli-core/src/loggers/amplify_event_logger_for_sandbox.test.ts
@@ -170,7 +170,7 @@ void describe('amplify sandbox event logging', () => {
         )} | CloudFormation:Stack      | ${format.color(
           format.bold('∟ data stack'),
           'Green',
-        )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+        )}${EOL}`,
       ],
     );
 
@@ -404,7 +404,7 @@ void describe('amplify sandbox event logging', () => {
               )} | S3BucketNotifications     | ${format.color(
                 format.bold('∟ Notifications'),
                 'Green',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           case 29:
@@ -470,7 +470,7 @@ void describe('amplify sandbox event logging', () => {
               )} | AmplifyDynamoDBTable      | ${format.color(
                 format.bold('  ∟ Default'),
                 'Green',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           case 41:
@@ -488,7 +488,7 @@ void describe('amplify sandbox event logging', () => {
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('data'),
                 'Green',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           default:
@@ -614,7 +614,7 @@ void describe('amplify sandbox event logging', () => {
               )} | IAM:Policy                | ${format.color(
                 format.bold('∟ DefaultPolicy'),
                 'Green',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           case 19:
@@ -646,7 +646,7 @@ void describe('amplify sandbox event logging', () => {
                   '∟ BucketNotificationsHandler050a0587b7544547bf325f094a3db834',
                 ),
                 'Green',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           case 23:
@@ -670,7 +670,7 @@ void describe('amplify sandbox event logging', () => {
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('storage'),
                 'Green',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           default:
@@ -748,7 +748,7 @@ void describe('amplify sandbox event logging', () => {
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('∟ data stack'),
                 'Green',
-              )}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           case 7:
@@ -816,7 +816,7 @@ void describe('amplify sandbox event logging', () => {
               )} | IAM:Role                  | ${format.color(
                 format.bold('sayhellolambdaServiceRole4BCAA6E2'),
                 'Yellow',
-              )}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
 
@@ -835,7 +835,7 @@ void describe('amplify sandbox event logging', () => {
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('function1351588B'),
                 'Yellow',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           default:
@@ -974,7 +974,7 @@ void describe('amplify sandbox event logging', () => {
                   '∟ BucketNotificationsHandler050a0587b7544547bf325f094a3db834',
                 ),
                 'Yellow',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           case 9:
@@ -1028,7 +1028,7 @@ void describe('amplify sandbox event logging', () => {
               )} | SNS:Topic                 | ${format.color(
                 format.bold('∟ CustomTopics'),
                 'Yellow',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           case 19:
@@ -1046,7 +1046,7 @@ void describe('amplify sandbox event logging', () => {
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('data'),
                 'Yellow',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           case 25:
@@ -1070,7 +1070,7 @@ void describe('amplify sandbox event logging', () => {
               )} | CloudFormation:Stack      | ${format.color(
                 format.bold('auth'),
                 'Yellow',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           default:
@@ -1207,7 +1207,7 @@ void describe('amplify sandbox event logging', () => {
               )}${EOL}${cll()}${format.color(
                 'Resource handler returned message: "Cognito received the following error from Amazon SES when attempting to send email: Email address is not verified. The following identities failed the check in region US-WEST-2: arn:aws:ses:us-west-2:123456789012:identity/blah@blah.com (Service: CognitoIdentityProvider, Status Code: 400, Request ID: 3bf35a6e-9667-4baf-8eab-19676643ac8d)" (RequestToken: 8c4cec48-3f40-7c73-a8b6-3afc0314b029, HandlerErrorCode: InvalidRequest)',
                 'Red',
-              )}${EOL}${cll()}${EOL}${cll()}${EOL}`,
+              )}${EOL}`,
             );
             break;
           default:

--- a/packages/cli-core/src/loggers/cfn-deployment-progress/rewritable_block.ts
+++ b/packages/cli-core/src/loggers/cfn-deployment-progress/rewritable_block.ts
@@ -7,7 +7,6 @@ import { EOL } from 'os';
  */
 export class RewritableBlock {
   private lastHeight = 0;
-  private trailingEmptyLines = 0;
 
   /**
    * Constructor for RewritableBlock
@@ -23,7 +22,7 @@ export class RewritableBlock {
 
   /**
    * Display the given lines in this rewritable block. It expands to make room for more lines
-   * and keep the size of the block constant until finished.
+   * and compress when not needed. It also takes care of not overflowing the block.
    */
   async displayLines(lines: string[]) {
     lines = this.terminalWrap(this.getBlockWidth(), this.expandNewlines(lines));
@@ -35,13 +34,6 @@ export class RewritableBlock {
     const progressUpdate: string[] = [];
     for (const line of lines) {
       progressUpdate.push(this.cll() + line + EOL);
-    }
-
-    this.trailingEmptyLines = Math.max(0, this.lastHeight - lines.length);
-
-    // Clear remainder of unwritten lines
-    for (let i = 0; i < this.trailingEmptyLines; i++) {
-      progressUpdate.push(this.cll() + EOL);
     }
 
     await this.ioHost.notify({

--- a/packages/cli-core/src/printer/printer.ts
+++ b/packages/cli-core/src/printer/printer.ts
@@ -100,7 +100,8 @@ export class Printer {
     }
     this.currentSpinner = {
       instance: ora({
-        text: this.prefixedMessage(message),
+        text: message,
+        prefixText: this.getLogPrefix(),
         color: 'white',
         stream: this.stdout,
         spinner: 'dots',
@@ -164,7 +165,8 @@ export class Printer {
       return;
     }
     if (options.prefixText) {
-      this.currentSpinner.instance.prefixText = options.prefixText;
+      this.currentSpinner.instance.prefixText =
+        options.prefixText + this.getLogPrefix();
     } else if (options.message) {
       this.currentSpinner.instance.text = options.message;
     }
@@ -185,18 +187,14 @@ export class Printer {
   };
 
   private printWhileSpinnerRunning = (message: string) => {
-    if (this.isSpinnerRunning()) {
-      if (this.currentSpinner.instance?.prefixText) {
-        const spinnerPrefixMessage = this.currentSpinner.instance?.prefixText;
-        this.currentSpinner.instance.prefixText =
-          message + EOL + spinnerPrefixMessage;
-      } else {
-        const spinnerMessage = this.currentSpinner.instance?.text;
-        this.currentSpinner.instance?.clear();
-        this.stdout.write(message);
-        this.currentSpinner.instance?.start(spinnerMessage);
-      }
+    if (!this.isSpinnerRunning()) {
+      return;
     }
+    const spinnerMessage = this.currentSpinner.instance?.text;
+    this.currentSpinner.instance?.clear();
+    this.stdout.write(message);
+    this.printNewLine();
+    this.currentSpinner.instance?.start(spinnerMessage);
   };
 
   private stringify = (msg: unknown): string => {

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -90,6 +90,7 @@ const printer = {
   log: mock.fn(),
   print: mock.fn(),
   clearConsole: mock.fn(),
+  printNewLine: mock.fn(),
 };
 
 const sandboxExecutor = new AmplifySandboxExecutor(


### PR DESCRIPTION
## Problem

Some updates to pretty sandbox display based on QA

**Issue number, if available:**

## Changes

1. Move the spinner between the timestamp and info message
2. Make the hierarchical error cause more obvious
3. Make the CFN progress display block collapsible instead of just expandable.
4. Keep the sandbox splash screen consistent
5. Start the sandbox with a clear screen

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
