### PR TITLE
Cache dependencies for notices predicates evaluation

### DIFF
--- a/.changeset/lazy-words-invite.md
+++ b/.changeset/lazy-words-invite.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+Cache dependencies when assessing notices predicates

--- a/packages/cli/src/notices/notice_predicates_evaluator.test.ts
+++ b/packages/cli/src/notices/notice_predicates_evaluator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, mock } from 'node:test';
+import { beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { NoticePredicatesEvaluator } from './notice_predicates_evaluator.js';
 import { Notice } from '@aws-amplify/cli-core';
@@ -32,381 +32,417 @@ void describe('NoticePredicatesEvaluator', () => {
     details: 'test details',
   };
 
-  const testCases: Array<TestCase> = [
-    {
-      title: 'empty predicates happy case 1',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [],
-      },
-      opts: {
-        event: 'postCommand',
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'empty predicates happy case 2',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [],
-      },
-      opts: {
-        event: 'listNoticesCommand',
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'command happy case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'command',
-            command: 'sandbox',
-          },
-        ],
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'command negative case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'command',
-            command: 'sandbox',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        argv: ['node', 'ampx', 'pipeline-deploy'],
-      },
-      expectedOutput: false,
-    },
-    {
-      title: 'node version happy case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'nodeVersion',
-            versionRange: '>=18.3.1',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        version: '18.4.0',
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'node version negative case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'nodeVersion',
-            versionRange: '>=18.3.1',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        version: '18.2.0',
-      },
-      expectedOutput: false,
-    },
-    {
-      title: 'two predicates happy case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'command',
-            command: 'sandbox',
-          },
-          {
-            type: 'nodeVersion',
-            versionRange: '>=18.3.1',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        argv: ['node', 'ampx', 'sandbox'],
-        version: '18.4.0',
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'two predicates negative case 1',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'command',
-            command: 'sandbox',
-          },
-          {
-            type: 'nodeVersion',
-            versionRange: '>=18.3.1',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        argv: ['node', 'ampx', 'pipeline-deploy'],
-        version: '18.4.0',
-      },
-      expectedOutput: false,
-    },
-    {
-      title: 'two predicates negative case 2',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'command',
-            command: 'sandbox',
-          },
-          {
-            type: 'nodeVersion',
-            versionRange: '>=18.3.1',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        argv: ['node', 'ampx', 'sandbox'],
-        version: '18.2.0',
-      },
-      expectedOutput: false,
-    },
-    {
-      title: 'two predicates negative case 3',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'command',
-            command: 'sandbox',
-          },
-          {
-            type: 'nodeVersion',
-            versionRange: '>=18.3.1',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        argv: ['node', 'ampx', 'pipeline-deploy'],
-        version: '18.2.0',
-      },
-      expectedOutput: false,
-    },
-    {
-      title: 'osFamily happy case 1',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'osFamily',
-            osFamily: 'linux',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        platform: 'linux',
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'osFamily happy case 2',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'osFamily',
-            osFamily: 'windows',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        platform: 'win32',
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'osFamily happy case 3',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'osFamily',
-            osFamily: 'macos',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        platform: 'darwin',
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'osFamily negative case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'osFamily',
-            osFamily: 'macos',
-          },
-        ],
-      },
-      mockProcess: {
-        ...defaultMockProcess,
-        platform: 'win32',
-      },
-      expectedOutput: false,
-    },
-    {
-      title: 'error message happy case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'errorMessage',
-            errorMessage: 'expected error message',
-          },
-        ],
-      },
-      opts: {
-        event: 'postCommand',
-        error: new Error('some expected error message'),
-      },
-      expectedOutput: true,
-    },
-    {
-      title: 'error message negative case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'errorMessage',
-            errorMessage: 'unexpected error message',
-          },
-        ],
-      },
-      opts: {
-        event: 'postCommand',
-        error: new Error('some expected error message'),
-      },
-      expectedOutput: false,
-    },
+  beforeEach(() => {
+    mockPackageManagerController.tryGetDependencies.mock.resetCalls();
+  });
 
-    {
-      title: 'package version happy case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'packageVersion',
-            packageName: 'test-dependency',
-            versionRange: '>=2.0.0',
-          },
-        ],
-      },
-      dependencies: [
-        {
-          name: 'test-dependency',
-          version: '2.1.0',
+  void describe('evaluates', () => {
+    const testCases: Array<TestCase> = [
+      {
+        title: 'empty predicates happy case 1',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [],
         },
-      ],
-      expectedOutput: true,
-    },
-    {
-      title: 'package version negative case 1',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'packageVersion',
-            packageName: 'test-dependency',
-            versionRange: '>=2.0.0',
-          },
-        ],
-      },
-      dependencies: [
-        {
-          name: 'test-dependency',
-          version: '1.1.0',
+        opts: {
+          event: 'postCommand',
         },
-      ],
-      expectedOutput: false,
-    },
-    {
-      title: 'package version negative case 2',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'packageVersion',
-            packageName: 'test-dependency',
-            versionRange: '>=2.0.0',
-          },
-        ],
+        expectedOutput: true,
       },
-      dependencies: [
-        {
-          name: 'other-dependency',
-          version: '2.4.0',
+      {
+        title: 'empty predicates happy case 2',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [],
         },
-      ],
-      expectedOutput: false,
-    },
-    {
-      // This predicate is ignored for now until is implemented.
-      title: 'backend component happy case',
-      notice: {
-        ...commonNoticeProperties,
-        predicates: [
-          {
-            type: 'backendComponent',
-            backendComponent: 'function',
-          },
-        ],
+        opts: {
+          event: 'listNoticesCommand',
+        },
+        expectedOutput: true,
       },
-      expectedOutput: true,
-    },
-  ];
+      {
+        title: 'command happy case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'command',
+              command: 'sandbox',
+            },
+          ],
+        },
+        expectedOutput: true,
+      },
+      {
+        title: 'command negative case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'command',
+              command: 'sandbox',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          argv: ['node', 'ampx', 'pipeline-deploy'],
+        },
+        expectedOutput: false,
+      },
+      {
+        title: 'node version happy case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'nodeVersion',
+              versionRange: '>=18.3.1',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          version: '18.4.0',
+        },
+        expectedOutput: true,
+      },
+      {
+        title: 'node version negative case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'nodeVersion',
+              versionRange: '>=18.3.1',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          version: '18.2.0',
+        },
+        expectedOutput: false,
+      },
+      {
+        title: 'two predicates happy case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'command',
+              command: 'sandbox',
+            },
+            {
+              type: 'nodeVersion',
+              versionRange: '>=18.3.1',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          argv: ['node', 'ampx', 'sandbox'],
+          version: '18.4.0',
+        },
+        expectedOutput: true,
+      },
+      {
+        title: 'two predicates negative case 1',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'command',
+              command: 'sandbox',
+            },
+            {
+              type: 'nodeVersion',
+              versionRange: '>=18.3.1',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          argv: ['node', 'ampx', 'pipeline-deploy'],
+          version: '18.4.0',
+        },
+        expectedOutput: false,
+      },
+      {
+        title: 'two predicates negative case 2',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'command',
+              command: 'sandbox',
+            },
+            {
+              type: 'nodeVersion',
+              versionRange: '>=18.3.1',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          argv: ['node', 'ampx', 'sandbox'],
+          version: '18.2.0',
+        },
+        expectedOutput: false,
+      },
+      {
+        title: 'two predicates negative case 3',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'command',
+              command: 'sandbox',
+            },
+            {
+              type: 'nodeVersion',
+              versionRange: '>=18.3.1',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          argv: ['node', 'ampx', 'pipeline-deploy'],
+          version: '18.2.0',
+        },
+        expectedOutput: false,
+      },
+      {
+        title: 'osFamily happy case 1',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'osFamily',
+              osFamily: 'linux',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          platform: 'linux',
+        },
+        expectedOutput: true,
+      },
+      {
+        title: 'osFamily happy case 2',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'osFamily',
+              osFamily: 'windows',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          platform: 'win32',
+        },
+        expectedOutput: true,
+      },
+      {
+        title: 'osFamily happy case 3',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'osFamily',
+              osFamily: 'macos',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          platform: 'darwin',
+        },
+        expectedOutput: true,
+      },
+      {
+        title: 'osFamily negative case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'osFamily',
+              osFamily: 'macos',
+            },
+          ],
+        },
+        mockProcess: {
+          ...defaultMockProcess,
+          platform: 'win32',
+        },
+        expectedOutput: false,
+      },
+      {
+        title: 'error message happy case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'errorMessage',
+              errorMessage: 'expected error message',
+            },
+          ],
+        },
+        opts: {
+          event: 'postCommand',
+          error: new Error('some expected error message'),
+        },
+        expectedOutput: true,
+      },
+      {
+        title: 'error message negative case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'errorMessage',
+              errorMessage: 'unexpected error message',
+            },
+          ],
+        },
+        opts: {
+          event: 'postCommand',
+          error: new Error('some expected error message'),
+        },
+        expectedOutput: false,
+      },
 
-  testCases.forEach((testCase, index) => {
-    void it(`${index}: ${testCase.title}`, async () => {
-      const mockProcess = testCase.mockProcess ?? defaultMockProcess;
+      {
+        title: 'package version happy case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'packageVersion',
+              packageName: 'test-dependency',
+              versionRange: '>=2.0.0',
+            },
+          ],
+        },
+        dependencies: [
+          {
+            name: 'test-dependency',
+            version: '2.1.0',
+          },
+        ],
+        expectedOutput: true,
+      },
+      {
+        title: 'package version negative case 1',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'packageVersion',
+              packageName: 'test-dependency',
+              versionRange: '>=2.0.0',
+            },
+          ],
+        },
+        dependencies: [
+          {
+            name: 'test-dependency',
+            version: '1.1.0',
+          },
+        ],
+        expectedOutput: false,
+      },
+      {
+        title: 'package version negative case 2',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'packageVersion',
+              packageName: 'test-dependency',
+              versionRange: '>=2.0.0',
+            },
+          ],
+        },
+        dependencies: [
+          {
+            name: 'other-dependency',
+            version: '2.4.0',
+          },
+        ],
+        expectedOutput: false,
+      },
+      {
+        // This predicate is ignored for now until is implemented.
+        title: 'backend component happy case',
+        notice: {
+          ...commonNoticeProperties,
+          predicates: [
+            {
+              type: 'backendComponent',
+              backendComponent: 'function',
+            },
+          ],
+        },
+        expectedOutput: true,
+      },
+    ];
 
-      if (testCase.dependencies) {
-        const dependencies = testCase.dependencies;
-        mockPackageManagerController.tryGetDependencies.mock.mockImplementationOnce(
-          async () => dependencies,
+    testCases.forEach((testCase, index) => {
+      void it(`${index}: ${testCase.title}`, async () => {
+        const mockProcess = testCase.mockProcess ?? defaultMockProcess;
+
+        if (testCase.dependencies) {
+          const dependencies = testCase.dependencies;
+          mockPackageManagerController.tryGetDependencies.mock.mockImplementationOnce(
+            async () => dependencies,
+          );
+        }
+
+        const evaluator = new NoticePredicatesEvaluator(
+          mockPackageManagerController as unknown as PackageManagerController,
+          mockProcess as unknown as typeof process,
         );
-      }
 
-      const evaluator = new NoticePredicatesEvaluator(
-        mockPackageManagerController as unknown as PackageManagerController,
-        mockProcess as unknown as typeof process,
-      );
-
-      const opts = testCase.opts ?? {
-        event: 'postCommand',
-      };
-      const output = await evaluator.evaluate(testCase.notice, opts);
-      assert.strictEqual(output, testCase.expectedOutput);
+        const opts = testCase.opts ?? {
+          event: 'postCommand',
+        };
+        const output = await evaluator.evaluate(testCase.notice, opts);
+        assert.strictEqual(output, testCase.expectedOutput);
+      });
     });
+  });
+
+  void it('caches dependency list', async () => {
+    const notice: Notice = {
+      ...commonNoticeProperties,
+      predicates: [
+        {
+          type: 'packageVersion',
+          packageName: 'test-dependency1',
+          versionRange: '>=2.0.0',
+        },
+        {
+          type: 'packageVersion',
+          packageName: 'test-dependency2',
+          versionRange: '>=1.0.0',
+        },
+      ],
+    };
+
+    const evaluator = new NoticePredicatesEvaluator(
+      mockPackageManagerController as unknown as PackageManagerController,
+    );
+    await evaluator.evaluate(notice, {
+      event: 'postCommand',
+    });
+
+    assert.strictEqual(
+      mockPackageManagerController.tryGetDependencies.mock.callCount(),
+      1,
+    );
   });
 });

--- a/packages/cli/src/notices/notice_predicates_evaluator.ts
+++ b/packages/cli/src/notices/notice_predicates_evaluator.ts
@@ -1,6 +1,9 @@
 import { Notice } from '@aws-amplify/cli-core';
 import semver from 'semver';
-import { PackageManagerController } from '@aws-amplify/plugin-types';
+import {
+  Dependency,
+  PackageManagerController,
+} from '@aws-amplify/plugin-types';
 import { hideBin } from 'yargs/helpers';
 import { NoticesRendererParams } from './notices_renderer.js';
 
@@ -8,6 +11,8 @@ import { NoticesRendererParams } from './notices_renderer.js';
  * Evaluates notice predicates.
  */
 export class NoticePredicatesEvaluator {
+  private dependencies: Array<Dependency> | undefined;
+
   /**
    * Creates notice predicates evaluator.
    */
@@ -102,8 +107,7 @@ export class NoticePredicatesEvaluator {
     packageName: string,
     versionRange: string,
   ): Promise<boolean> => {
-    const dependencies =
-      await this.packageManagerController.tryGetDependencies();
+    const dependencies = await this.tryGetDependencies();
     if (dependencies) {
       const matchingPackage = dependencies.find(
         (dependency) =>
@@ -113,5 +117,13 @@ export class NoticePredicatesEvaluator {
       return matchingPackage !== undefined;
     }
     return false;
+  };
+
+  private tryGetDependencies = async () => {
+    if (!this.dependencies) {
+      this.dependencies =
+        await this.packageManagerController.tryGetDependencies();
+    }
+    return this.dependencies;
   };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Current logic would read from package lock files every time we evaluate single package version predicate.

## Changes

Cache result of `tryGetDependencies`.

## Validation

added test

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
