### PR TITLE
Use deployment started as a marker for assets published

### DIFF
--- a/.changeset/ripe-lemons-turn.md
+++ b/.changeset/ripe-lemons-turn.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/cli-core': patch
+---
+
+Use deployment started as a marker for assets published

--- a/packages/cli-core/src/loggers/amplify_io_events_bridge_singleton_factory.ts
+++ b/packages/cli-core/src/loggers/amplify_io_events_bridge_singleton_factory.ts
@@ -22,7 +22,7 @@ export class AmplifyIOEventsBridgeSingletonFactory {
    */
   getInstance = (): AmplifyIOHost => {
     if (!AmplifyIOEventsBridgeSingletonFactory.instance) {
-      const cdkEventLogger = new AmplifyEventLogger(this.printer);
+      const cdkEventLogger = new AmplifyEventLogger(this.printer, this);
       AmplifyIOEventsBridgeSingletonFactory.instance =
         new AmplifyIOEventsBridge(
           cdkEventLogger.getEventLoggers(),


### PR DESCRIPTION
## Problem

There can be a slight delay between messages "Built and published assets" and `Deployment in progress..." causing customers to believe that the process has hanged.

**Issue number, if available:**

## Changes

Change the CDK event marker to use `Deployment started` as a way to mark assets were published.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
