### PR TITLE
Add option to skip package

### DIFF
--- a/.github/workflows/deprecate_release.yml
+++ b/.github/workflows/deprecate_release.yml
@@ -21,6 +21,12 @@ on:
         description: |
           By default, the most recent release from HEAD (inclusive) of the target branch will be deprecated.
           To deprecate a different release, specify the release commit to deprecate here.
+      packagesToSkip:
+        required: false
+        type: string
+        default: []
+        description: |
+          JSON array with packages to skip. Empty by default.
 
 jobs:
   install:
@@ -47,6 +53,7 @@ jobs:
       INPUT_DEPRECATIONMESSAGE: ${{ inputs.deprecationMessage }}
       INPUT_USENPMREGISTRY: ${{ inputs.useNpmRegistry }}
       INPUT_SEARCHFORRELEASESTARTINGFROM: ${{ inputs.searchForReleaseStartingFrom }}
+      INPUT_PACKAGESTOSKIP: ${{ inputs.packagesToSkip }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
         with:

--- a/.github/workflows/deprecate_release.yml
+++ b/.github/workflows/deprecate_release.yml
@@ -24,7 +24,7 @@ on:
       packagesToSkip:
         required: false
         type: string
-        default: []
+        default: '[]'
         description: |
           JSON array with packages to skip. Empty by default.
 

--- a/.github/workflows/restore_release.yml
+++ b/.github/workflows/restore_release.yml
@@ -17,6 +17,12 @@ on:
         description: |
           By default, the most recent release from HEAD (inclusive) of the target branch will be restored.
           To restore a different release, specify the release commit to restore here.
+      packagesToSkip:
+        required: false
+        type: string
+        default: []
+        description: |
+          JSON array with packages to skip. Empty by default.
 
 jobs:
   install:
@@ -42,6 +48,7 @@ jobs:
       # mapping the inputs to these environment variables allows the @actions/core toolkit to pick up the inputs
       INPUT_USENPMREGISTRY: ${{ inputs.useNpmRegistry }}
       INPUT_SEARCHFORRELEASESTARTINGFROM: ${{ inputs.searchForReleaseStartingFrom }}
+      INPUT_PACKAGESTOSKIP: ${{ inputs.packagesToSkip }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
         with:

--- a/.github/workflows/restore_release.yml
+++ b/.github/workflows/restore_release.yml
@@ -20,7 +20,7 @@ on:
       packagesToSkip:
         required: false
         type: string
-        default: []
+        default: '[]'
         description: |
           JSON array with packages to skip. Empty by default.
 

--- a/scripts/components/git_client.ts
+++ b/scripts/components/git_client.ts
@@ -129,7 +129,7 @@ export class GitClient {
     let tags = tagsString.split(EOL).filter((line) => line.trim().length > 0);
     if (packagesToSkip) {
       tags = tags.filter(
-        (tag) => !packagesToSkip.has(tag.substring(0, tag.indexOf('@'))),
+        (tag) => !packagesToSkip.has(tag.substring(0, tag.lastIndexOf('@'))),
       );
     }
     return tags;

--- a/scripts/components/release_deprecator.ts
+++ b/scripts/components/release_deprecator.ts
@@ -14,6 +14,7 @@ export class ReleaseDeprecator {
   constructor(
     private readonly gitRefToStartReleaseSearchFrom: string,
     private readonly deprecationMessage: string,
+    private readonly packagesToSkip: Set<string>,
     private readonly githubClient: GithubClient,
     private readonly gitClient: GitClient,
     private readonly npmClient: NpmClient,
@@ -41,10 +42,12 @@ export class ReleaseDeprecator {
 
     const releaseTagsToDeprecate = await this.gitClient.getTagsAtCommit(
       releaseCommitHashToDeprecate,
+      this.packagesToSkip,
     );
 
     const previousReleaseTags = await this.gitClient.getPreviousReleaseTags(
       releaseCommitHashToDeprecate,
+      this.packagesToSkip,
     );
 
     // Create the changeset revert PR

--- a/scripts/components/release_restorer.ts
+++ b/scripts/components/release_restorer.ts
@@ -14,6 +14,7 @@ export class ReleaseRestorer {
    */
   constructor(
     private readonly gitRefToStartReleaseSearchFrom: string,
+    private readonly packagesToSkip: Set<string>,
     private readonly githubClient: GithubClient,
     private readonly gitClient: GitClient,
     private readonly npmClient: NpmClient,
@@ -39,10 +40,12 @@ export class ReleaseRestorer {
 
     const releaseTagsToRestore = await this.gitClient.getTagsAtCommit(
       releaseCommitHashToRestore,
+      this.packagesToSkip,
     );
 
     const previousReleaseTags = await this.gitClient.getPreviousReleaseTags(
       releaseCommitHashToRestore,
+      this.packagesToSkip,
     );
 
     // first create the changeset restore PR

--- a/scripts/deprecate_release.ts
+++ b/scripts/deprecate_release.ts
@@ -31,9 +31,16 @@ const npmClient = new NpmClient(
 
 await npmClient.configureNpmRc();
 
+const packagesToSkipJSON = getInput('packagesToSkip', {
+  required: true,
+});
+
+const packagesToSkip = new Set(JSON.parse(packagesToSkipJSON) as Array<string>);
+
 const releaseDeprecator = new ReleaseDeprecator(
   searchForReleaseStartingFrom,
   deprecationMessage,
+  packagesToSkip,
   new GithubClient(),
   new GitClient(),
   npmClient,

--- a/scripts/publish_runner.ts
+++ b/scripts/publish_runner.ts
@@ -56,12 +56,12 @@ export const runPublish = async (props?: PublishOptions, cwd?: string) => {
   if (options.snapshotRelease) {
     if (fs.existsSync(path.join('.changeset', 'pre.json'))) {
       // Snapshot releases are not allowed in pre mode.
-      await execa('changeset', ['pre', 'exit'], execaOptions);
+      await execa('npx', ['changeset', 'pre', 'exit'], execaOptions);
     }
     await runVersion(['--snapshot', snapshotTag], cwd);
   }
 
-  const changesetArgs = ['publish'];
+  const changesetArgs = ['changeset', 'publish'];
   if (!options.includeGitTags) {
     changesetArgs.push('--no-git-tag');
   }
@@ -75,5 +75,5 @@ export const runPublish = async (props?: PublishOptions, cwd?: string) => {
       ? { env: { npm_config_registry: 'http://localhost:4873/' } }
       : {}),
   };
-  await execa('changeset', changesetArgs, execaPublishOptions);
+  await execa('npx', changesetArgs, execaPublishOptions);
 };

--- a/scripts/restore_release.ts
+++ b/scripts/restore_release.ts
@@ -28,8 +28,15 @@ const npmClient = new NpmClient(
 
 await npmClient.configureNpmRc();
 
+const packagesToSkipJSON = getInput('packagesToSkip', {
+  required: true,
+});
+
+const packagesToSkip = new Set(JSON.parse(packagesToSkipJSON) as Array<string>);
+
 const releaseRestorer = new ReleaseRestorer(
   searchForReleaseStartingFrom,
+  packagesToSkip,
   new GithubClient(),
   new GitClient(),
   npmClient,

--- a/scripts/version_runner.ts
+++ b/scripts/version_runner.ts
@@ -23,8 +23,8 @@ export const runVersion = async (
     );
   }
 
-  const args = ['version', ...additionalArgs];
-  await execa('changeset', args, {
+  const args = ['changeset', 'version', ...additionalArgs];
+  await execa('npx', args, {
     stdio: 'inherit',
     cwd,
   });


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

While trying to deprecate recent release we encountered a problem:
One of packages was brand new. First time released. Therefore the algorithm was unable to find previous release to roll back to.

## Changes

1. Add option to skip packages to rollback and restore workflow.
2. Print packages that failed to resolve previous release.

## Validation

### Unhappy case.

Tested with `@aws-amplify/seed` included here https://github.com/aws-amplify/amplify-backend/actions/runs/14094450735/job/39478789483 .

It failed but printed
```
Set npm registry to http://localhost:4873
Unable to resolve previous release tags for @aws-amplify/seed
Error: 
        Expected release commit commit to be authored by github-actions[bot].
        Instead found "Edward Foyle".
        Make sure commit 42302df04380d044e8b7391c872628592ce9f9cf points to a release commit.
```

### Happy case.

Tested with `@aws-amplify/seed` excluded here
https://github.com/aws-amplify/amplify-backend/actions/runs/14094702982

workflow succeeded and skipped seed.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
