### PR TITLE
Revert "pin live canaries (#2626)"

### DIFF
--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -44,9 +44,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-        with:
-          # TODO temporarily pin to pre-pretty sandbox until we ship that
-          ref: 0cc2de3ae15f09a9eec5b9e0d54f0bae474c7aa9
       - name: Run live dependency health checks
         uses: ./.github/actions/run_with_e2e_account
         with:


### PR DESCRIPTION
This reverts commit 15d186b836262539809f412e1b70ae9d5fe958e1.

<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Turns out that canary build can overwrite current `HEAD` cache with artifacts produced from previous commit hash (pinned). This is unwanted side-effect. 

## Changes

Undo the pinning.

## Validation

I inspected couple of failing canary runs to figure out why they're faling.

it turns out they're restoring build cache from `HEAD` and therefore ignoring the pin effectively.

The other way problem is possible. I.e. canary run MAY create build cache for `HEAD` commit with stale code.
The reason is that scheduled run run with `HEAD` sha, if cache doesn't exist it will try to populate it, but we check out repo with old commit to build artifacts.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
