### PR TITLE
Minor fixes for seed

### DIFF
--- a/.changeset/rare-buckets-show.md
+++ b/.changeset/rare-buckets-show.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/seed': patch
+'@aws-amplify/backend-cli': patch
+---
+
+removed spinners, adjusted mfaConfig detection with email

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.ts
@@ -36,20 +36,16 @@ export class SandboxSeedCommand implements CommandModule<object> {
    * @inheritDoc
    */
   handler = async (): Promise<void> => {
-    printer.startSpinner('Running seed...');
+    printer.print(`${format.color('seed is running...', 'Blue')}`);
     const backendID = await this.backendIDResolver.resolve();
     const seedPath = path.join('amplify', 'seed', 'seed.ts');
-    try {
-      await execa('tsx', [seedPath], {
-        cwd: process.cwd(),
-        stdio: 'inherit',
-        env: {
-          AMPLIFY_BACKEND_IDENTIFIER: JSON.stringify(backendID),
-        },
-      });
-    } finally {
-      printer.stopSpinner();
-    }
+    await execa('tsx', [seedPath], {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+      env: {
+        AMPLIFY_BACKEND_IDENTIFIER: JSON.stringify(backendID),
+      },
+    });
     printer.printNewLine();
     printer.print(`${format.success('✔')} seed has successfully completed`);
   };

--- a/packages/seed/src/auth-seed/auth_client.ts
+++ b/packages/seed/src/auth-seed/auth_client.ts
@@ -87,7 +87,6 @@ export class AuthClient {
         }
         case 'MFA': {
           if (
-            newUser.mfaPreference &&
             newUser.mfaPreference !== 'EMAIL' &&
             (!authConfig.mfaConfig ||
               (authConfig.mfaConfig && authConfig.mfaConfig === 'NONE'))

--- a/packages/seed/src/auth-seed/auth_client.ts
+++ b/packages/seed/src/auth-seed/auth_client.ts
@@ -87,15 +87,16 @@ export class AuthClient {
         }
         case 'MFA': {
           if (
-            !authConfig.mfaConfig ||
-            (authConfig.mfaConfig && authConfig.mfaConfig === 'NONE')
+            newUser.mfaPreference &&
+            newUser.mfaPreference !== 'EMAIL' &&
+            (!authConfig.mfaConfig ||
+              (authConfig.mfaConfig && authConfig.mfaConfig === 'NONE'))
           ) {
             throw new AmplifyUserError('MFANotConfiguredError', {
               message: `MFA is not configured for this userpool, you cannot create ${newUser.username} with MFA.`,
               resolution: `Enable MFA for this userpool or create ${newUser.username} with a different sign up flow.`,
             });
           }
-
           await this.mfaFlow.mfaSignUp(newUser, tempPassword);
           break;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Found 2 issues with seed:
1. spinners provide spinner text to the MFA command line prompts (so you do not get the opportunity to provide your own input) and if you stop the spinners before entering the MFA flow, they will eat the output of the command line prompt
2. when using the email MFA flow, you may not have an `mfaConfig` because we do not support email in our MFA config, so you would get thrown an error even if you have email MFA set up in cognito

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

1. replaced spinners with a line of text when seed starts running that informs the customer seed is running (this line of text is not removed upon completion of seed since customers might be logging output to the console so we do not want to clear it)
2. re-configured the way `mfaConfig` detection works so if a customer is using email MFA as their only form of MFA, they must specify through `mfaPreference` so they can bypass the `mfaConfig` check and are not given an error
EX: 
```
// this will give an error if you have no mfaConfig
const user1 = await createAndSignUpUser({
    username: username1,
    password: password1,
    signInAfterCreation: false,
    signInFlow: 'MFA',
});

//this will not (since it assumes you have configured email MFA in cognito)
const user1 = await createAndSignUpUser({
    username: username1,
    password: password1,
    signInAfterCreation: false,
    signInFlow: 'MFA',
    mfaPreference: 'EMAIL'
});
```

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
tests still work properly and did manual testing to ensure expected results

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
