### PR TITLE
throw more actionable error message for unsupported versions of node

### DIFF
--- a/.changeset/slimy-mangos-draw.md
+++ b/.changeset/slimy-mangos-draw.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+throw more actionable error message when unsupported version of node is used

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -426,4 +426,51 @@ void describe('invokeCDKCommand', () => {
       },
     );
   });
+
+  void it('displays actionable error when older version of node is used during branch deployments', async () => {
+    const olderNodeVersionError = new Error(
+      'This version of Node.js (v18.18.2) does not support module.register(). Please upgrade to Node v18.19 or v20.6 and above.',
+    );
+    synthMock.mock.mockImplementationOnce(() => {
+      throw olderNodeVersionError;
+    });
+
+    await assert.rejects(
+      () => invoker.deploy(branchBackendId, sandboxDeployProps),
+      (err: AmplifyError<CDKDeploymentError>) => {
+        assert.equal(
+          err.message,
+          'Unable to deploy due to unsupported node version',
+        );
+        assert.equal(err.name, 'NodeVersionNotSupportedError');
+        assert.equal(
+          err.resolution,
+          'Upgrade the node version in your CI/CD environment. If you are using Amplify Hosting for your backend builds, you can add `nvm install 18.x` or `nvm install 20.x` in your `amplify.yml` before the `pipeline-deploy` command',
+        );
+        assert.deepStrictEqual(err.cause, olderNodeVersionError);
+        return true;
+      },
+    );
+
+    synthMock.mock.mockImplementationOnce(() => {
+      throw olderNodeVersionError;
+    });
+
+    await assert.rejects(
+      () => invoker.deploy(sandboxBackendId, sandboxDeployProps),
+      (err: AmplifyUserError) => {
+        assert.equal(
+          err.message,
+          'Unable to deploy due to unsupported node version',
+        );
+        assert.equal(err.name, 'NodeVersionNotSupportedError');
+        assert.equal(
+          err.resolution,
+          'Upgrade to node `^18.19.0`, `^20.6.0,` or `>=22`',
+        );
+        assert.deepStrictEqual(err.cause, olderNodeVersionError);
+        return true;
+      },
+    );
+  });
 });

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -123,7 +123,7 @@ export class CDKDeployer implements BackendDeployer {
         // synth has failed and we don't have auto generated function environment definition files. This
         // resulted in the exception caught here, which is not very useful for the customers.
         // We instead throw the synth error for customers to fix what caused the synth to fail.
-        throw this.cdkErrorMapper.getAmplifyError(synthError);
+        throw this.cdkErrorMapper.getAmplifyError(synthError, backendId.type);
       }
       throw typeError;
     } finally {
@@ -141,7 +141,7 @@ export class CDKDeployer implements BackendDeployer {
 
     // If typescript compilation was successful but synth had failed, we throw synth error
     if (synthError) {
-      throw this.cdkErrorMapper.getAmplifyError(synthError);
+      throw this.cdkErrorMapper.getAmplifyError(synthError, backendId.type);
     }
 
     // Perform actual deployment. CFN or hotswap
@@ -160,7 +160,7 @@ export class CDKDeployer implements BackendDeployer {
           backendId.type !== 'sandbox' ? RequireApproval.NEVER : undefined,
       });
     } catch (error) {
-      throw this.cdkErrorMapper.getAmplifyError(error as Error);
+      throw this.cdkErrorMapper.getAmplifyError(error as Error, backendId.type);
     }
 
     return {


### PR DESCRIPTION
## Problem

Minimum node version requirement for using amplify has been increased due to using tsx's dynamic import APIs.

**Issue number, if available:**

## Changes

throw more actionable error message for unsupported versions of node

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
