### PR TITLE
Update error matching and parsing based on toolkit integration

### DIFF
--- a/.changeset/moody-friends-invent.md
+++ b/.changeset/moody-friends-invent.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/cli-core': patch
+---
+
+Update error matching and parsing based on toolkit integration

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -818,7 +818,7 @@ jobs:
   check_package_versions:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs:
       - install
       - resolve_inputs

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -207,7 +207,8 @@ void describe('invokeCDKCommand', () => {
 
   void it('throws the original synth error if the synth failed but tsc succeeded', async () => {
     // simulate first execa call for synth as throwing error
-    const synthError = new Error('Error: some cdk synth error\n at some/file');
+    const synthError = new Error('some cdk esbuild transform error');
+    synthError.name = 'TransformError';
     synthMock.mock.mockImplementationOnce(() => {
       throw synthError;
     });
@@ -217,11 +218,11 @@ void describe('invokeCDKCommand', () => {
           validateAppSources: true,
         }),
       new AmplifyUserError(
-        'BackendSynthError',
+        'SyntaxError',
         {
           message: 'Unable to build the Amplify backend definition.',
           resolution:
-            'Check your backend definition in the `amplify` folder for syntax and type errors.',
+            'Check the Caused by error and fix any issues in your backend code',
         },
         synthError,
       ),

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -49,43 +49,6 @@ const testErrorMappings = [
     expectedDownstreamErrorMessage: 'Access Denied',
   },
   {
-    errorMessage:
-      `ReferenceError: var is not defined` +
-      EOL +
-      `    at lookup(/some_random/path.js: 1: 3005)`,
-    expectedTopLevelErrorMessage:
-      'Unable to build the Amplify backend definition.',
-    errorName: 'SyntaxError',
-    expectedDownstreamErrorMessage:
-      `ReferenceError: var is not defined` +
-      EOL +
-      `    at lookup(/some_random/path.js: 1: 3005)`,
-  },
-  {
-    errorMessage:
-      `TypeError: Cannot read properties of undefined (reading 'post')` +
-      EOL +
-      `    at lookup(/some_random/path.js: 1: 3005)`,
-    expectedTopLevelErrorMessage:
-      'Unable to build the Amplify backend definition.',
-    errorName: 'SyntaxError',
-    expectedDownstreamErrorMessage:
-      `TypeError: Cannot read properties of undefined (reading 'post')` +
-      EOL +
-      `    at lookup(/some_random/path.js: 1: 3005)`,
-  },
-  {
-    errorMessage: `TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module ..../function/foo/resource.ts is not a valid package name imported from 
-/Users/foo/Desktop/amplify-app/amplify/storage/foo/resource.ts
-    at new NodeError (node:internal/errors:405:5)`,
-    expectedTopLevelErrorMessage:
-      'Unable to build the Amplify backend definition.',
-    errorName: 'SyntaxError',
-    expectedDownstreamErrorMessage: `TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module ..../function/foo/resource.ts is not a valid package name imported from 
-/Users/foo/Desktop/amplify-app/amplify/storage/foo/resource.ts
-    at new NodeError (node:internal/errors:405:5)`,
-  },
-  {
     errorMessage: 'Has the environment been bootstrapped',
     expectedTopLevelErrorMessage:
       'This AWS account and region has not been bootstrapped.',
@@ -220,133 +183,6 @@ const testErrorMappings = [
   },
   {
     errorMessage:
-      `[esbuild Error]: Expected identifier but found ")"` +
-      EOL +
-      `      at /Users/user/work-space/amplify-app/amplify/data/resource.ts:16:0`,
-    expectedTopLevelErrorMessage:
-      'Unable to build the Amplify backend definition.',
-    errorName: 'ESBuildError',
-    expectedDownstreamErrorMessage:
-      `[esbuild Error]: Expected identifier but found ")"` +
-      EOL +
-      `      at /Users/user/work-space/amplify-app/amplify/data/resource.ts:16:0`,
-  },
-  {
-    errorMessage:
-      `✘ [ERROR] Could not resolve "$amplify/env/defaultNodeFunctions"` +
-      EOL +
-      EOL +
-      `    amplify/func-src/handler.ts:1:20:` +
-      EOL +
-      `      1 │ ...t { env } from '$amplify/env/defaultNodeFunctions';` +
-      EOL +
-      `1 error`,
-    expectedTopLevelErrorMessage:
-      'Unable to build the Amplify backend definition.',
-    errorName: 'ESBuildError',
-    expectedDownstreamErrorMessage:
-      `✘ [ERROR] Could not resolve "$amplify/env/defaultNodeFunctions"` +
-      EOL +
-      EOL +
-      `    amplify/func-src/handler.ts:1:20:` +
-      EOL +
-      `      1 │ ...t { env } from '$amplify/env/defaultNodeFunctions';` +
-      EOL +
-      `1 error`,
-  },
-  {
-    errorMessage:
-      `Error [TransformError]: Transform failed with 1 error:` +
-      EOL +
-      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Expected "}" but found "email"` +
-      EOL +
-      `    at failureErrorWithLog (/Users/user/work-space/amplify-app/node_modules/tsx/node_modules/esbuild/lib/main.js:1472:15)`,
-    expectedTopLevelErrorMessage:
-      '/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Expected "}" but found "email"',
-    errorName: 'ESBuildError',
-    expectedDownstreamErrorMessage: undefined,
-  },
-  {
-    errorMessage:
-      `Error [TransformError]: Transform failed with 2 errors:` +
-      EOL +
-      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Multiple exports with the same name auth` +
-      EOL +
-      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: The symbol auth has already been declared` +
-      EOL +
-      `    at failureErrorWithLog (/Users/user/work-space/amplify-app/node_modules/tsx/node_modules/esbuild/lib/main.js:1472:15)`,
-    expectedTopLevelErrorMessage:
-      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: Multiple exports with the same name auth` +
-      EOL +
-      `/Users/user/work-space/amplify-app/amplify/auth/resource.ts:48:4: ERROR: The symbol auth has already been declared`,
-    errorName: 'ESBuildError',
-    expectedDownstreamErrorMessage: undefined,
-  },
-  {
-    errorMessage:
-      `some rubbish before` +
-      EOL +
-      `Error: some cdk synth error` +
-      EOL +
-      `    at lookup (/some_random/path.js:1:3005)` +
-      EOL +
-      `    at lookup2 (/some_random/path2.js:2:3005)`,
-    expectedTopLevelErrorMessage:
-      'Unable to build the Amplify backend definition.',
-    errorName: 'BackendSynthError',
-    expectedDownstreamErrorMessage:
-      'Error: some cdk synth error' +
-      EOL +
-      '    at lookup (/some_random/path.js:1:3005)',
-  },
-  {
-    errorMessage:
-      `Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/user/work-space/shared_secret.js' imported from /Users/user/work-space/amplify-app/amplify/function.ts` +
-      EOL +
-      `      at __node_internal_captureLargerStackTrace (node:internal/errors:496:5)` +
-      EOL +
-      `      at new NodeError (node:internal/errors:405:5) {` +
-      EOL +
-      `    url: 'file:///Users/user/work-space/shared_secret.js',` +
-      EOL +
-      `    code: 'ERR_MODULE_NOT_FOUND'` +
-      EOL +
-      `  }` +
-      EOL +
-      `  ` +
-      EOL +
-      `  Node.js v18.19.0`,
-    expectedTopLevelErrorMessage: 'Cannot find module',
-    errorName: 'ModuleNotFoundError',
-    expectedDownstreamErrorMessage: `[ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/user/work-space/shared_secret.js' imported from /Users/user/work-space/amplify-app/amplify/function.ts${EOL}`,
-  },
-  {
-    errorMessage:
-      `Error: node:internal/modules/cjs/loader:1098` +
-      EOL +
-      `    const err = new Error('Cannot find module ');` +
-      EOL +
-      `                ^` +
-      EOL +
-      `  ` +
-      EOL +
-      `  Error: Cannot find module '/Users/user/work-space/amplify/resources/module.ts'` +
-      EOL +
-      `      at createEsmNotFoundErr (node:internal/modules/cjs/loader:1098:15)` +
-      EOL +
-      `    code: 'MODULE_NOT_FOUND',` +
-      EOL +
-      `  }` +
-      EOL +
-      `  ` +
-      EOL +
-      `  Node.js v18.17.1`,
-    expectedTopLevelErrorMessage: 'Cannot find module',
-    errorName: 'ModuleNotFoundError',
-    expectedDownstreamErrorMessage: `Error: Cannot find module '/Users/user/work-space/amplify/resources/module.ts'`,
-  },
-  {
-    errorMessage:
       'Unable to resolve AWS account to use. It must be either configured when you define your CDK Stack, or through the environment',
     expectedTopLevelErrorMessage:
       'Unable to resolve AWS account to use. It must be either configured when you define your CDK Stack, or through the environment',
@@ -398,6 +234,12 @@ const testErrorMappings = [
     expectedTopLevelErrorMessage: 'Unable to detect cdk installation',
     errorName: 'CDKNotFoundError',
     expectedDownstreamErrorMessage: `error Command cdk not found. Did you mean cdl?`,
+  },
+  {
+    errorMessage: `Cannot find module './myModule'`,
+    expectedTopLevelErrorMessage: 'Cannot find module',
+    errorName: 'ModuleNotFoundError',
+    expectedDownstreamErrorMessage: `Cannot find module './myModule'`,
   },
   {
     errorMessage: `[31mamplify-some-stack [34m failed: ValidationError: Stack:<stack-arn> is in UPDATE_ROLLBACK_FAILED state and can not be updated.`,
@@ -496,120 +338,11 @@ npm error A complete log of this run can be found in: /home/some-path/.npm/_logs
   },
   {
     // eslint-disable-next-line spellcheck/spell-checker
-    errorMessage: `[31m[1mamplify-stack-sandbox-11[22m: fail: Bucket named 'cdk-abc-assets-11-us-west-2' exists, but we do not have access to it.[39m
-[31m[1mamplify-stack-sandbox-11[22m: fail: Bucket named 'cdk-abc-assets-11-us-west-2' exists, but we do not have access to it.[39m
-[31mFailed to publish asset abc:current_account-current_region[39m`,
-    expectedTopLevelErrorMessage: `CDK failed to publish assets due to 'Bucket named 'cdk-abc-assets-11-us-west-2' exists, but we do not have access to it.'`,
-    errorName: 'CDKAssetPublishError',
-    expectedDownstreamErrorMessage: undefined,
-  },
-  {
-    // eslint-disable-next-line spellcheck/spell-checker
     errorMessage: `[31m[1mamplify-user-sandbox-c71414864a[22m: fail: socket hang up[39m
 
 [31mFailed to publish asset abc:current_account-current_region[39m`,
-    expectedTopLevelErrorMessage: `CDK failed to publish assets due to 'socket hang up'`,
+    expectedTopLevelErrorMessage: `CDK failed to publish assets`,
     errorName: 'CDKAssetPublishError',
-    expectedDownstreamErrorMessage: undefined,
-  },
-  {
-    errorMessage:
-      `Error: Transform failed with 1 error:` +
-      EOL +
-      `/Users/some-path/amplify/storage/resource.ts:1:2: ERROR: Expected identifier but found }` +
-      EOL +
-      `at failureErrorWithLog (/Users/some-path/esbuild/lib/main.js:123:45)` +
-      EOL +
-      `at /Users/some-path/esbuild/lib/main.js:678:90`,
-    expectedTopLevelErrorMessage:
-      '/Users/some-path/amplify/storage/resource.ts:1:2: ERROR: Expected identifier but found }',
-    errorName: 'ESBuildError',
-    expectedDownstreamErrorMessage: undefined,
-  },
-  {
-    errorMessage:
-      `Error [TransformError]:` +
-      EOL +
-      `You installed esbuild for another platform than the one you're currently using.
-    This won't work because esbuild is written with native code and needs to
-    install a platform-specific binary executable.` +
-      EOL +
-      `Specifically the @esbuild/linux-arm64 package is present but this platform
-    needs the @esbuild/darwin-arm64 package instead. People often get into this
-    situation by installing esbuild on Windows or macOS and copying node_modules
-    into a Docker image that runs Linux, or by copying node_modules between
-    Windows and WSL environments.` +
-      EOL +
-      `If you are installing with npm, you can try not copying the node_modules
-    directory when you copy the files over, and running npm ci or npm install
-    on the destination platform after the copy. Or you could consider using yarn
-    instead of npm which has built-in support for installing a package on multiple
-    platforms simultaneously.` +
-      EOL +
-      `If you are installing with yarn, you can try listing both this platform and the
-    other platform in your .yarnrc.yml file using the supportedArchitectures
-    feature: https://yarnpkg.com/configuration/yarnrc/#supportedArchitectures
-    Keep in mind that this means multiple copies of esbuild will be present.` +
-      EOL +
-      // eslint-disable-next-line spellcheck/spell-checker
-      `Another alternative is to use the esbuild-wasm package instead, which works
-    the same way on all platforms. But it comes with a heavy performance cost and
-    can sometimes be 10x slower than the esbuild package, so you may also not want to do that.`,
-    expectedTopLevelErrorMessage:
-      `You installed esbuild for another platform than the one you're currently using.
-    This won't work because esbuild is written with native code and needs to
-    install a platform-specific binary executable.` +
-      EOL +
-      `Specifically the @esbuild/linux-arm64 package is present but this platform
-    needs the @esbuild/darwin-arm64 package instead. People often get into this
-    situation by installing esbuild on Windows or macOS and copying node_modules
-    into a Docker image that runs Linux, or by copying node_modules between
-    Windows and WSL environments.` +
-      EOL +
-      `If you are installing with npm, you can try not copying the node_modules
-    directory when you copy the files over, and running npm ci or npm install
-    on the destination platform after the copy. Or you could consider using yarn
-    instead of npm which has built-in support for installing a package on multiple
-    platforms simultaneously.` +
-      EOL +
-      `If you are installing with yarn, you can try listing both this platform and the
-    other platform in your .yarnrc.yml file using the supportedArchitectures
-    feature: https://yarnpkg.com/configuration/yarnrc/#supportedArchitectures
-    Keep in mind that this means multiple copies of esbuild will be present.` +
-      EOL +
-      // eslint-disable-next-line spellcheck/spell-checker
-      `Another alternative is to use the esbuild-wasm package instead, which works
-    the same way on all platforms. But it comes with a heavy performance cost and
-    can sometimes be 10x slower than the esbuild package, so you may also not want to do that.`,
-    errorName: 'ESBuildError',
-    expectedDownstreamErrorMessage: undefined,
-  },
-  {
-    errorMessage:
-      `Error [TransformError]: The package esbuild-package could not be found, and is needed by esbuild.` +
-      EOL +
-      `If you are installing esbuild with npm, make sure that you don't specify the
---no-optional or --omit=optional flags. The optionalDependencies feature
-of package.json is used by esbuild to install the correct binary executable
-for your current platform.
-` +
-      EOL +
-      `at generateBinPath (/Users/some-path/esbuild/lib/main.js:123:45)` +
-      EOL +
-      `at /Users/some-path/esbuild/lib/main.js:678:90`,
-    expectedTopLevelErrorMessage:
-      `The package esbuild-package could not be found, and is needed by esbuild.` +
-      EOL +
-      `If you are installing esbuild with npm, make sure that you don't specify the
---no-optional or --omit=optional flags. The optionalDependencies feature
-of package.json is used by esbuild to install the correct binary executable
-for your current platform.
-` +
-      EOL +
-      `at generateBinPath (/Users/some-path/esbuild/lib/main.js:123:45)` +
-      EOL +
-      `at /Users/some-path/esbuild/lib/main.js:678:90`,
-    errorName: 'ESBuildError',
     expectedDownstreamErrorMessage: undefined,
   },
   {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -13,7 +13,7 @@ import { DeploymentType } from '@aws-amplify/plugin-types';
  * Transforms CDK error messages to human readable ones
  */
 export class CdkErrorMapper {
-  private multiLineEolRegex = '[\r\n]+';
+  private multiLineEolRegex = '[\r\n]*';
   /**
    * Instantiate with a formatter that will be used for formatting CLI commands in error messages
    */
@@ -153,6 +153,20 @@ export class CdkErrorMapper {
         },
         error,
       );
+    } else if (
+      ['TypeError', 'TransformError', 'ReferenceError', 'SyntaxError'].some(
+        (errorName) => errorName === error.name,
+      )
+    ) {
+      throw new AmplifyUserError(
+        'SyntaxError',
+        {
+          message: 'Unable to build the Amplify backend definition.',
+          resolution:
+            'Check the Caused by error and fix any issues in your backend code',
+        },
+        error,
+      );
     } else if (ToolkitError.isToolkitError(error)) {
       // Handle all other Toolkit errors, we fallback to our own mapping for this one.
     }
@@ -244,24 +258,12 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex:
-        /ValidationError: Role (?<roleArn>.*) is invalid or cannot be assumed/,
+      errorRegex: /Role (?<roleArn>.*) is invalid or cannot be assumed/,
       humanReadableErrorMessage:
         'Role {roleArn} is invalid or cannot be assumed',
       resolutionMessage:
         'Ensure the role exists and AWS credentials have an IAM policy that grants sts:AssumeRole for the role',
       errorName: 'InvalidOrCannotAssumeRoleError',
-      classification: 'ERROR',
-    },
-    {
-      errorRegex: new RegExp(
-        `(SyntaxError|ReferenceError|TypeError)( \\[[A-Z_]+])?:((?:.|${this.multiLineEolRegex})*?at .*)`,
-      ),
-      humanReadableErrorMessage:
-        'Unable to build the Amplify backend definition.',
-      resolutionMessage:
-        'Check your backend definition in the `amplify` folder for syntax and type errors.',
-      errorName: 'SyntaxError',
       classification: 'ERROR',
     },
     {
@@ -283,7 +285,7 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
-        /EPERM: operation not permitted, rename (?<fileName>(.*)\/synth\.lock\.\S+) → '(.*)\/synth\.lock'/,
+        /operation not permitted, rename (?<fileName>(.*)\/synth\.lock\.\S+) → '(.*)\/synth\.lock'/,
       humanReadableErrorMessage: 'Not permitted to rename file: {fileName}',
       resolutionMessage: `Try running the command again and ensure that only one instance of sandbox is running. If it still doesn't work check the permissions of '.amplify' folder`,
       errorName: 'FilePermissionsError',
@@ -291,7 +293,7 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
-        /EPERM: operation not permitted, mkdir '(.*).amplify\/artifacts\/cdk.out'/,
+        /operation not permitted, mkdir '(.*).amplify\/artifacts\/cdk.out'/,
       humanReadableErrorMessage: `Not permitted to create the directory '.amplify/artifacts/cdk.out'`,
       resolutionMessage: `Check the permissions of '.amplify' folder and try running the command again`,
       errorName: 'FilePermissionsError',
@@ -299,16 +301,14 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
-        /EPERM: operation not permitted, (unlink|open) (?<fileName>(.*)\.lock\S+)/,
+        /operation not permitted, (unlink|open) (?<fileName>(.*)\.lock\S+)/,
       humanReadableErrorMessage: 'Operation not permitted on file: {fileName}',
       resolutionMessage: `Check the permissions of '.amplify' folder and try running the command again`,
       errorName: 'FilePermissionsError',
       classification: 'ERROR',
     },
     {
-      errorRegex: new RegExp(
-        `\\[ERR_MODULE_NOT_FOUND\\]:(.*)${this.multiLineEolRegex}|Error: Cannot find module (.*)`,
-      ),
+      errorRegex: new RegExp(`Cannot find module (.*)`),
       humanReadableErrorMessage: 'Cannot find module',
       resolutionMessage:
         'Check your backend definition in the `amplify` folder for missing file or package imports. Try installing them with your package manager.',
@@ -327,7 +327,7 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
-        /InvalidParameterValueException:(.*) (size must be smaller than|exceeds the maximum allowed size of) (?<maxSize>\d+) bytes/,
+        /(.*) (size must be smaller than|exceeds the maximum allowed size of) (?<maxSize>\d+) bytes/,
       humanReadableErrorMessage: 'Maximum Lambda size exceeded',
       resolutionMessage:
         'Make sure your Lambda bundled packages with layers and dependencies is smaller than {maxSize} bytes unzipped.',
@@ -335,8 +335,7 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex:
-        /InvalidParameterValueException: Uploaded file must be a non-empty zip/,
+      errorRegex: /Uploaded file must be a non-empty zip/,
       humanReadableErrorMessage: 'Lambda bundled into an empty zip',
       resolutionMessage: `Try removing '.amplify/artifacts' then running the command again. If it still doesn't work, see https://github.com/aws/aws-cdk/issues/18459 for more methods.`,
       errorName: 'LambdaEmptyZipFault',
@@ -392,48 +391,13 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      // Also extracts the first line in the stack where the error happened
-      errorRegex: new RegExp(
-        `\\[esbuild Error\\]: ((?:.|${this.multiLineEolRegex})*?at .*)`,
-      ),
-      humanReadableErrorMessage:
-        'Unable to build the Amplify backend definition.',
-      resolutionMessage:
-        'Check your backend definition in the `amplify` folder for syntax and type errors.',
-      errorName: 'ESBuildError',
-      classification: 'ERROR',
-    },
-    {
-      // Also extracts the first line in the stack where the error happened
-      errorRegex: new RegExp(
-        `[✘X] \\[ERROR\\] ((?:.|${this.multiLineEolRegex})*error.*)`,
-      ),
-      humanReadableErrorMessage:
-        'Unable to build the Amplify backend definition.',
-      resolutionMessage:
-        'Check your backend definition in the `amplify` folder for syntax and type errors.',
-      errorName: 'ESBuildError',
-      classification: 'ERROR',
-    },
-    {
       // If there are multiple errors, capture all lines containing the errors
       errorRegex: new RegExp(
-        `(\\[TransformError\\]|Error): Transform failed with .* error(s?):${this.multiLineEolRegex}(?<esBuildErrorMessage>(.*ERROR:.*${this.multiLineEolRegex})+)`,
+        `Transform failed with .* error(s?):${this.multiLineEolRegex}(?<esBuildErrorMessage>(.*${this.multiLineEolRegex})+)`,
       ),
       humanReadableErrorMessage: '{esBuildErrorMessage}',
       resolutionMessage:
         'Fix the above mentioned type or syntax error in your backend definition.',
-      errorName: 'ESBuildError',
-      classification: 'ERROR',
-    },
-    {
-      // Captures other forms of transform error
-      errorRegex: new RegExp(
-        `Error \\[TransformError\\]:(${this.multiLineEolRegex}|\\s)?(?<esBuildErrorMessage>(.*(${this.multiLineEolRegex})?)+)`,
-      ),
-      humanReadableErrorMessage: '{esBuildErrorMessage}',
-      resolutionMessage:
-        'Make sure esbuild is installed and is compatible with the platform you are currently using.',
       errorName: 'ESBuildError',
       classification: 'ERROR',
     },
@@ -503,26 +467,12 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      // Error: .* is printed to stderr during cdk synth
-      // Also extracts the first line in the stack where the error happened
-      errorRegex: new RegExp(
-        `^Error: (.*${this.multiLineEolRegex}.*at.*)`,
-        'm',
-      ),
-      humanReadableErrorMessage:
-        'Unable to build the Amplify backend definition.',
-      resolutionMessage:
-        'Check your backend definition in the `amplify` folder for syntax and type errors.',
-      errorName: 'BackendSynthError',
-      classification: 'ERROR',
-    },
-    {
       // This happens when 'defineBackend' call is missing in customer's app.
       // 'defineBackend' creates CDK app in memory. If it's missing then no cdk.App exists in memory and nothing is rendered.
       // During 'cdk synth' CDK CLI attempts to read CDK assembly after calling customer's app.
       // But no files are rendered causing it to fail.
       errorRegex:
-        /ENOENT: no such file or directory, open '.*\.amplify.artifacts.cdk\.out.manifest\.json'/,
+        /no such file or directory, open '.*\.amplify.artifacts.cdk\.out.manifest\.json'/,
       humanReadableErrorMessage:
         'The Amplify backend definition is missing `defineBackend` call.',
       resolutionMessage:
@@ -531,8 +481,7 @@ export class CdkErrorMapper {
       classification: 'ERROR',
     },
     {
-      errorRegex:
-        /^ENOENT: no such file or directory, (?<action_and_filepath>.*)$/,
+      errorRegex: /no such file or directory, (?<action_and_filepath>.*)$/,
       humanReadableErrorMessage: 'Failed to {action_and_filepath}',
       resolutionMessage:
         'File or directory not found. Failed to {action_and_filepath}',
@@ -561,18 +510,15 @@ export class CdkErrorMapper {
     },
     {
       errorRegex:
-        /BadRequestException: The code contains one or more errors|The code contains one or more errors.*AppSync/,
+        /The code contains one or more errors|The code contains one or more errors.*AppSync/,
       humanReadableErrorMessage: `A custom resolver used in your defineData contains one or more errors`,
       resolutionMessage: `Check for any syntax errors in your custom resolvers code.`,
       errorName: 'AppSyncResolverSyntaxError',
       classification: 'ERROR',
     },
     {
-      errorRegex: new RegExp(
-        `amplify-.*-(branch|sandbox)-.*fail: (?<publishFailure>.*)${this.multiLineEolRegex}.*Failed to publish asset`,
-        'm',
-      ),
-      humanReadableErrorMessage: `CDK failed to publish assets due to '{publishFailure}'`,
+      errorRegex: new RegExp(`Failed to publish asset`, 'm'),
+      humanReadableErrorMessage: `CDK failed to publish assets`,
       resolutionMessage: `Check the error message for more details.`,
       errorName: 'CDKAssetPublishError',
       classification: 'ERROR',
@@ -584,21 +530,6 @@ export class CdkErrorMapper {
       humanReadableErrorMessage: `Backend failed to be deleted since the previous deployment is still in progress.`,
       resolutionMessage: `Wait for the previous deployment for stack {stackArn} to be completed before attempting to delete again.`,
       errorName: 'DeleteFailedWhileDeploymentInProgressError',
-      classification: 'ERROR',
-    },
-    // Generic error printed by CDK. Order matters so keep this towards the bottom of this list
-    {
-      // Error: .* is printed to stderr during cdk synth
-      // Also extracts the first line in the stack where the error happened
-      errorRegex: new RegExp(
-        `^Error: (.*${this.multiLineEolRegex}.*at.*)`,
-        'm',
-      ),
-      humanReadableErrorMessage:
-        'Unable to build the Amplify backend definition.',
-      resolutionMessage:
-        'Check your backend definition in the `amplify` folder for syntax and type errors.',
-      errorName: 'BackendSynthError',
       classification: 'ERROR',
     },
     {

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -597,7 +597,6 @@ export type CDKDeploymentError =
   | 'AuthenticationError'
   | 'AppSyncResolverSyntaxError'
   | 'BackendBuildError'
-  | 'BackendSynthError'
   | 'BootstrapNotDetectedError'
   | 'BootstrapDetectionError'
   | 'BootstrapOutdatedError'


### PR DESCRIPTION
## Problem

with the new cdk toolkit integration, the errors fed to the cdk_error_mapper have changed from being scraped from `stdout` to now fully structured errors. This causes the error mapper to not match some of the known common errors.

**Issue number, if available:**

## Changes

This is beginning of updating the error mapper to now start consuming structured errors to minimize falling back to unknown faults category

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
