### PR TITLE
Seed uses tsImport instead of execa

### DIFF
--- a/.changeset/ten-rings-crash.md
+++ b/.changeset/ten-rings-crash.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+switched seed runner from execa to tsImport

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.ts
@@ -2,7 +2,7 @@ import { Argv, CommandModule } from 'yargs';
 import path from 'path';
 import { existsSync } from 'fs';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
-import { AmplifyUserError } from '@aws-amplify/platform-core';
+import { AmplifyError, AmplifyUserError } from '@aws-amplify/platform-core';
 import { SandboxCommandGlobalOptions } from '../option_types.js';
 import { format, printer } from '@aws-amplify/cli-core';
 import { tsImport } from 'tsx/esm/api';
@@ -58,7 +58,18 @@ export class SandboxSeedCommand implements CommandModule<object> {
           error,
         );
       } else {
-        throw e;
+        if (AmplifyError.isAmplifyError(e)) {
+          throw e;
+        }
+        throw new AmplifyUserError(
+          'SeedingFailedError',
+          {
+            message: 'Seed failed to complete',
+            resolution:
+              'Check the Caused by error and fix any issues in your seed script',
+          },
+          e instanceof Error ? error : undefined,
+        );
       }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
When seed used `execa`, we would not see the actual error message that were thrown to the customer while seed was running. instead all we would see is something like: `"message": "ExecaError: Command failed with exit code 1: tsx amplify/seed/seed.ts"`.
This appears as an unknown fault in our telemetry and is unhelpful for debugging the actual issue the customer may have run into.

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Switches seed from using `execa` to run the seed script to using `tsImport`. `tsImport` allows us to run the seed script in the same process as the seed command so any error messages that appear will go through `stderr`.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Tested manually to ensure error messages still appear when running seed. Ensured seed command tests still operate correctly.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
