### PR TITLE
Use Node 20 as default runtime in functions.

### DIFF
--- a/.changeset/hungry-games-cover.md
+++ b/.changeset/hungry-games-cover.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-function': minor
+---
+
+Use Node 20 as default runtime

--- a/packages/backend-function/src/factory.test.ts
+++ b/packages/backend-function/src/factory.test.ts
@@ -430,7 +430,7 @@ void describe('AmplifyFunctionFactory', () => {
       const template = Template.fromStack(lambda.stack);
 
       template.hasResourceProperties('AWS::Lambda::Function', {
-        Runtime: Runtime.NODEJS_18_X.name,
+        Runtime: Runtime.NODEJS_20_X.name,
       });
     });
 
@@ -452,7 +452,7 @@ void describe('AmplifyFunctionFactory', () => {
       // A month before the date when the oldest Node LTS maintenance ends according to https://github.com/nodejs/release#release-schedule.
       // Once this test fails, update endDate to a month before the end date of the next Node LTS version.
       // After updating the date, next would be updating the default function runtime in factory.ts.
-      const endDate = new Date('2025-03-30');
+      const endDate = new Date('2026-03-30');
       const currentDate = new Date();
 
       assert.ok(endDate > currentDate);

--- a/packages/backend-function/src/factory.ts
+++ b/packages/backend-function/src/factory.ts
@@ -418,7 +418,7 @@ class FunctionFactory implements ConstructFactory<AmplifyFunction> {
   };
 
   private resolveRuntime = () => {
-    const runtimeDefault = 18;
+    const runtimeDefault = 20;
 
     // if runtime is not set, default to the oldest LTS
     if (!this.props.runtime) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Node 18 is EOL in a month,

## Changes

Move default version to Node 20 and bump date in test.

## Validation

PR checks.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
