### PR TITLE
Pin live canaries v2

### DIFF
--- a/.github/actions/build_with_cache/action.yml
+++ b/.github/actions/build_with_cache/action.yml
@@ -26,12 +26,21 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cdk-lib-version: ${{ inputs.cdk-lib-version }}
+    # Get the sha using local repository checkout instead of GitHub context.
+    # Some workflows might be trying to build repository using older commits.
+    - name: Get current commit sha
+      id: get-current-commit-sha
+      shell: bash
+      run: |
+        current_commit_sha=$(git rev-parse HEAD)
+        echo "current_commit_sha=$current_commit_sha"
+        echo "current_commit_sha=$current_commit_sha" >> "$GITHUB_OUTPUT";
     # cache build output based on commit sha
     - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # version 4.2.0
       id: build-cache
       with:
         path: '**/lib'
-        key: ${{ github.sha }}-node${{ inputs.node-version }}-cdklib${{ inputs.cdk-lib-version }}
+        key: ${{ steps.get-current-commit-sha.outputs.current_commit_sha }}-node${{ inputs.node-version }}-cdklib${{ inputs.cdk-lib-version }}
         enableCrossOsArchive: true
     # only build if cache miss
     - if: steps.build-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -46,7 +46,8 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
         with:
           # TODO temporarily pin to pre-pretty sandbox until we ship that
-          ref: 0cc2de3ae15f09a9eec5b9e0d54f0bae474c7aa9
+          # Branch contains repo at 0cc2de3ae15f09a9eec5b9e0d54f0bae474c7aa9 plus changes to build step caching
+          ref: pre-pretty-sandbox-branch
       - name: Run live dependency health checks
         uses: ./.github/actions/run_with_e2e_account
         with:

--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -55,6 +55,8 @@ jobs:
           # Use version from package lock. Tests projects are created outside of repository root
           # and are using latest CDK version.
           cdk-lib-version: FROM_PACKAGE_LOCK
+          # TODO temporarily bring back CDK CLI parameter since we bring back repo from before pretty sandbox work.
+          cdk-cli-version: FROM_PACKAGE_LOCK
           aws_region: ${{ matrix.region }}
           fresh_build: true
           shell: bash

--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -44,6 +44,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
+        with:
+          # TODO temporarily pin to pre-pretty sandbox until we ship that
+          ref: 0cc2de3ae15f09a9eec5b9e0d54f0bae474c7aa9
       - name: Run live dependency health checks
         uses: ./.github/actions/run_with_e2e_account
         with:


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Follow up on https://github.com/aws-amplify/amplify-backend/pull/2626 and https://github.com/aws-amplify/amplify-backend/pull/2630

1. Changes in main are not compatible with latest version that's live.
2. Using previous commit sha to build repo may corrupt HEAD's cache.

## Changes

1. Pin live checks to use commit from before toolkit integration.
2. Change build action to get SHA for caching from local repo instead of github context.

## Validation

Checks passing and caching as expected:

1. This PR checks.
    1. Sample hash key `6f78b4675e7cff4bb5d99d3e24c1520c5d95dd96-node18-cdklibFROM_PACKAGE_LOCK`
    2. `6f78b4675e7cff4bb5d99d3e24c1520c5d95dd96` is PR's merge commit (see https://github.com/aws-amplify/amplify-backend/commit/6f78b4675e7cff4bb5d99d3e24c1520c5d95dd96)
2. Manual health check run from head of branch https://github.com/aws-amplify/amplify-backend/actions/runs/14182200156
    1. Sample hash key `0d137fe68145de5b7422e1cafbac7fc6e18723b6-node18-cdklibFROM_PACKAGE_LOCK`
    2. `0d137fe68145de5b7422e1cafbac7fc6e18723b6` is HEAD of `pin-canaries-again` branch.
3. Manual canary run from head of branch https://github.com/aws-amplify/amplify-backend/actions/runs/14182195478
    1. Sample hash key `e250db527c675173c094f49729399aab37712225-node18-cdklibFROM_PACKAGE_LOCK`
    2. `e250db527c675173c094f49729399aab37712225` is HEAD of `pre-pretty-sandbox-branch` to which we pin live part of canary workflow. (note: I force pushed that branch again after this testing to account for cdkcli).

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
