### PR TITLE
wrap cdk's esbuild bundle error to remove clutter

### DIFF
--- a/.changeset/fair-crabs-laugh.md
+++ b/.changeset/fair-crabs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+wrap cdk's esbuild bundle error

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -347,6 +347,13 @@ npm error A complete log of this run can be found in: /home/some-path/.npm/_logs
   },
   {
     errorMessage:
+      'Failed to bundle asset assetName, bundle output is located at some rubbish',
+    expectedTopLevelErrorMessage: `CDK failed to bundle your function code`,
+    errorName: 'CDKAssetBundleError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
+    errorMessage:
       // eslint-disable-next-line spellcheck/spell-checker
       `Error: npm ERR! code ENOENT
 npm ERR! syscall lstat


### PR DESCRIPTION
## Problem

CDK's ESBuild execution happens in a [child process](https://github.com/aws/aws-cdk/blob/994e95289b589596179553a5b9d7201155bd9ed1/packages/aws-cdk-lib/aws-lambda-nodejs/lib/bundling.ts#L332-L350).

This means that the errors are printed to stderr and not included in the error thrown.

## Changes

wrap cdk's esbuild bundle error to remove clutter

### Pre
![Screenshot 2025-04-04 at 2 32 04 PM](https://github.com/user-attachments/assets/648da6ca-4fa0-45ae-8bd8-32b63dee803f)


### Post
![Screenshot 2025-04-04 at 2 30 45 PM](https://github.com/user-attachments/assets/68116bdd-5805-420e-be29-9f964b9eb47a)


**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
