### PR TITLE
Emit notices metrics

### DIFF
--- a/.changeset/bitter-news-tickle.md
+++ b/.changeset/bitter-news-tickle.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/platform-core': minor
+'@aws-amplify/backend-cli': patch
+---
+
+Add ability to collect notices metrics

--- a/packages/cli/src/ampx.ts
+++ b/packages/cli/src/ampx.ts
@@ -41,7 +41,10 @@ attachUnhandledExceptionListeners(usageDataEmitter);
 
 verifyCommandName();
 
-const noticesRenderer = new NoticesRenderer(packageManagerController);
+const noticesRenderer = new NoticesRenderer(
+  packageManagerController,
+  usageDataEmitter.collector,
+);
 const parser = createMainParser(
   libraryVersion,
   noticesRenderer,

--- a/packages/cli/src/ampx.ts
+++ b/packages/cli/src/ampx.ts
@@ -42,7 +42,11 @@ attachUnhandledExceptionListeners(usageDataEmitter);
 verifyCommandName();
 
 const noticesRenderer = new NoticesRenderer(packageManagerController);
-const parser = createMainParser(libraryVersion, noticesRenderer);
+const parser = createMainParser(
+  libraryVersion,
+  noticesRenderer,
+  usageDataEmitter,
+);
 const errorHandler = generateCommandFailureHandler(parser, usageDataEmitter);
 
 try {

--- a/packages/cli/src/commands/configure/configure_profile_command.test.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.test.ts
@@ -32,6 +32,10 @@ void describe('configure command', () => {
   const configureCommand = new ConfigureProfileCommand(profileController);
   const parser = yargs().command(configureCommand as unknown as CommandModule);
   const commandRunner = new TestCommandRunner(parser, {
+    collector: {
+      collectMetric: () => {},
+      collectDimension: () => {},
+    },
     emitSuccess: emitSuccessMock,
     emitFailure: emitFailureMock,
   });

--- a/packages/cli/src/commands/configure/configure_profile_command.test.ts
+++ b/packages/cli/src/commands/configure/configure_profile_command.test.ts
@@ -35,6 +35,7 @@ void describe('configure command', () => {
     collector: {
       collectMetric: () => {},
       collectDimension: () => {},
+      collectError: () => {},
     },
     emitSuccess: emitSuccessMock,
     emitFailure: emitFailureMock,

--- a/packages/cli/src/commands/configure/telemetry/configure_telemetry_command.test.ts
+++ b/packages/cli/src/commands/configure/telemetry/configure_telemetry_command.test.ts
@@ -31,6 +31,7 @@ void describe('configure command', () => {
     collector: {
       collectMetric: () => {},
       collectDimension: () => {},
+      collectError: () => {},
     },
     emitSuccess: emitSuccessMock,
     emitFailure: emitFailureMock,

--- a/packages/cli/src/commands/configure/telemetry/configure_telemetry_command.test.ts
+++ b/packages/cli/src/commands/configure/telemetry/configure_telemetry_command.test.ts
@@ -28,6 +28,10 @@ void describe('configure command', () => {
   );
   const parser = yargs().command(telemetryCommand);
   const commandRunner = new TestCommandRunner(parser, {
+    collector: {
+      collectMetric: () => {},
+      collectDimension: () => {},
+    },
     emitSuccess: emitSuccessMock,
     emitFailure: emitFailureMock,
   });

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -20,7 +20,7 @@ import {
 import { createSandboxSecretCommand } from './sandbox-secret/sandbox_secret_command_factory.js';
 import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
 import { CommandMiddleware } from '../../command_middleware.js';
-import { AmplifyError } from '@aws-amplify/platform-core';
+import { AmplifyError, UsageDataEmitter } from '@aws-amplify/platform-core';
 import { NoticesRenderer } from '../../notices/notices_renderer.js';
 import { EOL } from 'node:os';
 
@@ -33,10 +33,14 @@ const tryFindAndPrintApplicableNoticesMock = mock.fn();
 const noticesRenderer = {
   tryFindAndPrintApplicableNotices: tryFindAndPrintApplicableNoticesMock,
 } as unknown as NoticesRenderer;
+const usageDataEmitter = {} as unknown as UsageDataEmitter;
 
 void describe('sandbox command factory', () => {
   void it('instantiate a sandbox command correctly', () => {
-    assert.ok(createSandboxCommand(noticesRenderer) instanceof SandboxCommand);
+    assert.ok(
+      createSandboxCommand(noticesRenderer, usageDataEmitter) instanceof
+        SandboxCommand,
+    );
   });
 });
 

--- a/packages/cli/src/main_parser_factory.test.ts
+++ b/packages/cli/src/main_parser_factory.test.ts
@@ -8,6 +8,7 @@ import {
 import { createMainParser } from './main_parser_factory.js';
 import { NoticesRenderer } from './notices/notices_renderer.js';
 import { fileURLToPath } from 'node:url';
+import { UsageDataEmitter } from '@aws-amplify/platform-core';
 
 void describe('main parser', { concurrency: false }, async () => {
   const packageJson = JSON.parse(
@@ -21,8 +22,9 @@ void describe('main parser', { concurrency: false }, async () => {
   const noticesRenderer = {
     tryFindAndPrintApplicableNotices: tryFindAndPrintApplicableNoticesMock,
   } as unknown as NoticesRenderer;
+  const usageDataEmitter = {} as unknown as UsageDataEmitter;
 
-  const parser = createMainParser(version, noticesRenderer);
+  const parser = createMainParser(version, noticesRenderer, usageDataEmitter);
   const commandRunner = new TestCommandRunner(parser);
 
   void it('includes generate command in help output', async () => {

--- a/packages/cli/src/main_parser_factory.ts
+++ b/packages/cli/src/main_parser_factory.ts
@@ -7,6 +7,7 @@ import { createInfoCommand } from './commands/info/info_command_factory.js';
 import { createNoticesCommand } from './commands/notices/notices_command_factory.js';
 import * as path from 'path';
 import { NoticesRenderer } from './notices/notices_renderer.js';
+import { UsageDataEmitter } from '@aws-amplify/platform-core';
 
 /**
  * Creates main parser.
@@ -14,6 +15,7 @@ import { NoticesRenderer } from './notices/notices_renderer.js';
 export const createMainParser = (
   libraryVersion: string,
   noticesRenderer: NoticesRenderer,
+  usageDataEmitter: UsageDataEmitter,
 ): Argv => {
   const parser = yargs()
     .version(libraryVersion)
@@ -29,7 +31,7 @@ export const createMainParser = (
     // This tells yargs that the command name is `ampx`.
     .scriptName(path.parse(process.argv[1]).name)
     .command(createGenerateCommand())
-    .command(createSandboxCommand(noticesRenderer))
+    .command(createSandboxCommand(noticesRenderer, usageDataEmitter))
     .command(createPipelineDeployCommand())
     .command(createConfigureCommand())
     .command(createInfoCommand())

--- a/packages/cli/src/notices/notices_renderer.test.ts
+++ b/packages/cli/src/notices/notices_renderer.test.ts
@@ -27,9 +27,12 @@ void describe('NoticesRenderer', () => {
     mock.fn<UsageDataCollector['collectMetric']>();
   const mockUsageDataCollectorCollectDimension =
     mock.fn<UsageDataCollector['collectDimension']>();
+  const mockUsageDataCollectorCollectError =
+    mock.fn<UsageDataCollector['collectError']>();
   const mockUsageDataCollector = {
     collectMetric: mockUsageDataCollectorCollectMetric,
     collectDimension: mockUsageDataCollectorCollectDimension,
+    collectError: mockUsageDataCollectorCollectError,
   } as unknown as UsageDataCollector;
 
   const mockNoticesControllerGetApplicableNotices =
@@ -55,6 +58,7 @@ void describe('NoticesRenderer', () => {
     mockNoticesPrinterPrint.mock.resetCalls();
     mockUsageDataCollectorCollectMetric.mock.resetCalls();
     mockUsageDataCollectorCollectDimension.mock.resetCalls();
+    mockUsageDataCollectorCollectError.mock.resetCalls();
   });
 
   void it('should skip notices for notices command', async () => {
@@ -78,6 +82,7 @@ void describe('NoticesRenderer', () => {
     assert.equal(mockNoticesPrinterPrint.mock.calls.length, 0);
     assert.equal(mockUsageDataCollectorCollectMetric.mock.calls.length, 0);
     assert.equal(mockUsageDataCollectorCollectDimension.mock.calls.length, 0);
+    assert.equal(mockUsageDataCollectorCollectError.mock.calls.length, 0);
   });
 
   void it('should fetch and print notices for non-notices commands', async () => {
@@ -199,9 +204,10 @@ void describe('NoticesRenderer', () => {
   });
 
   void it('should handle errors gracefully', async () => {
+    const testError = new Error('Test error');
     mockNoticesControllerGetApplicableNotices.mock.mockImplementation(
       async () => {
-        throw new Error('Test error');
+        throw testError;
       },
     );
 
@@ -242,6 +248,10 @@ void describe('NoticesRenderer', () => {
     assert.deepStrictEqual(
       mockUsageDataCollectorCollectDimension.mock.calls[0].arguments,
       ['noticesRenderingStatus', 'FAILURE'],
+    );
+    assert.deepStrictEqual(
+      mockUsageDataCollectorCollectError.mock.calls[0].arguments,
+      ['noticesError', testError],
     );
   });
 });

--- a/packages/cli/src/notices/notices_renderer.ts
+++ b/packages/cli/src/notices/notices_renderer.ts
@@ -55,6 +55,9 @@ export class NoticesRenderer {
         'noticesRenderingStatus',
         'FAILURE',
       );
+      if (e instanceof Error) {
+        this.usageDataCollector.collectError('noticesError', e);
+      }
       this._printer.log(
         `Unable to render notices on event=${params.event}`,
         LogLevel.DEBUG,

--- a/packages/cli/src/test-utils/command_runner.ts
+++ b/packages/cli/src/test-utils/command_runner.ts
@@ -63,6 +63,7 @@ export class TestCommandRunner {
       collector: {
         collectMetric: () => {},
         collectDimension: () => {},
+        collectError: () => {},
       },
       emitFailure: () => Promise.resolve(),
       emitSuccess: () => Promise.resolve(),

--- a/packages/cli/src/test-utils/command_runner.ts
+++ b/packages/cli/src/test-utils/command_runner.ts
@@ -60,6 +60,10 @@ export class TestCommandRunner {
   constructor(
     private parser: Argv,
     private usageDataEmitter: UsageDataEmitter = {
+      collector: {
+        collectMetric: () => {},
+        collectDimension: () => {},
+      },
       emitFailure: () => Promise.resolve(),
       emitSuccess: () => Promise.resolve(),
     },

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -487,7 +487,14 @@ export type TypedConfigurationFileName = 'notices_metadata.json' | 'notices_ackn
 export const USAGE_DATA_TRACKING_ENABLED = "telemetry.enabled";
 
 // @public (undocumented)
+export type UsageDataCollector = {
+    collectMetric: (key: string, value: number) => void;
+    collectDimension: (key: string, value: string) => void;
+};
+
+// @public (undocumented)
 export type UsageDataEmitter = {
+    readonly collector: UsageDataCollector;
     emitSuccess: (metrics?: Record<string, number>, dimensions?: Record<string, string>) => Promise<void>;
     emitFailure: (error: AmplifyError, dimensions?: Record<string, string>) => Promise<void>;
 };

--- a/packages/platform-core/API.md
+++ b/packages/platform-core/API.md
@@ -490,6 +490,7 @@ export const USAGE_DATA_TRACKING_ENABLED = "telemetry.enabled";
 export type UsageDataCollector = {
     collectMetric: (key: string, value: number) => void;
     collectDimension: (key: string, value: string) => void;
+    collectError: (key: string, error: Error) => void;
 };
 
 // @public (undocumented)

--- a/packages/platform-core/src/usage-data/noop_usage_data_emitter.ts
+++ b/packages/platform-core/src/usage-data/noop_usage_data_emitter.ts
@@ -7,6 +7,7 @@ export class NoOpUsageDataEmitter implements UsageDataEmitter {
   readonly collector = {
     collectMetric: () => {},
     collectDimension: () => {},
+    collectError: () => {},
   };
 
   /**

--- a/packages/platform-core/src/usage-data/noop_usage_data_emitter.ts
+++ b/packages/platform-core/src/usage-data/noop_usage_data_emitter.ts
@@ -4,6 +4,11 @@ import { UsageDataEmitter } from './usage_data_emitter_factory';
  * no-op class that implements UsageDataEmitter.
  */
 export class NoOpUsageDataEmitter implements UsageDataEmitter {
+  readonly collector = {
+    collectMetric: () => {},
+    collectDimension: () => {},
+  };
+
   /**
    * no-op emitSuccess
    */

--- a/packages/platform-core/src/usage-data/usage_data_emitter.ts
+++ b/packages/platform-core/src/usage-data/usage_data_emitter.ts
@@ -26,10 +26,14 @@ export class DefaultUsageDataEmitter implements UsageDataEmitter {
     collectDimension: (key: string, value: string) => {
       this.dimensions[key] = value;
     },
+    collectError: (key: string, error: Error) => {
+      this.errors[key] = error;
+    },
   };
   private readonly dependenciesToReport?: Array<Dependency>;
   private readonly metrics: Record<string, number> = {};
   private readonly dimensions: Record<string, string> = {};
+  private readonly errors: Record<string, Error> = {};
   /**
    * Constructor for UsageDataEmitter
    */

--- a/packages/platform-core/src/usage-data/usage_data_emitter_factory.ts
+++ b/packages/platform-core/src/usage-data/usage_data_emitter_factory.ts
@@ -8,6 +8,7 @@ import { Dependency } from '@aws-amplify/plugin-types';
 export type UsageDataCollector = {
   collectMetric: (key: string, value: number) => void;
   collectDimension: (key: string, value: string) => void;
+  collectError: (key: string, error: Error) => void;
 };
 
 export type UsageDataEmitter = {

--- a/packages/platform-core/src/usage-data/usage_data_emitter_factory.ts
+++ b/packages/platform-core/src/usage-data/usage_data_emitter_factory.ts
@@ -5,7 +5,13 @@ import { USAGE_DATA_TRACKING_ENABLED } from './constants.js';
 import { AmplifyError } from '../index.js';
 import { Dependency } from '@aws-amplify/plugin-types';
 
+export type UsageDataCollector = {
+  collectMetric: (key: string, value: number) => void;
+  collectDimension: (key: string, value: string) => void;
+};
+
 export type UsageDataEmitter = {
+  readonly collector: UsageDataCollector;
   emitSuccess: (
     metrics?: Record<string, number>,
     dimensions?: Record<string, string>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

**Specific problem**
We don't know if notice rendering system is heathy (the part that renders notices after command/deployment as best effort).

**Generic problem**
We don't have any way to collect data from pieces of logic that are not happening at the end of process lifespan or end of sandbox deployment.
This is especially affecting activities that are optional/best effort like notices. I.e. they don't disrupt main control flow even if they fail. 

## Changes

1. Added a concept of `UsageDataCollector` - a long living instance that can be injected into logical component and gather data. Some notes here:
   1. I was wondering if this new functionality should be in `UsageDataEmitter` type or not. But decided this should be a new type, so that we inject narrow interface into components. In other words components should not have access to `emitX` interfaces, just to data collection.
   2. I was wondering if `UsageDataCollector` instance should be injected into `UsageDataEmitter` and other components. But decided to make `UsageDataCollector` a property on `UsageDataEmitter` since they are supposed to share lifetime scope (process long). So effectively at implementation layer the "collector" is kind of a view of "emitter" but for the rest of the world they are separate entities and we leave room to refactor implementation if needed.
   3. The implementation assumes Gen1 telemetry event, so mapping collected data into payload is gross. This should be changed in telemetry V2, i.e. telemetry event should be expanded to cover this new functionality (not sure what should go first to main tbh).
2. Added data collection into notices renderer.

## Validation

Added unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
