### PR TITLE
adjust spinner time to ensure it renders deterministic amount of time

### DIFF
--- a/.changeset/quick-pillows-type.md
+++ b/.changeset/quick-pillows-type.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/cli-core': patch
+---
+
+adjust spinner time to ensure it renders deterministic amount of time

--- a/packages/cli-core/src/printer/printer.test.ts
+++ b/packages/cli-core/src/printer/printer.test.ts
@@ -139,18 +139,18 @@ void describe('Printer', () => {
   void it('startSpinner start animating spinner with message until stopSpinner is called in TTY terminal', async () => {
     const message = 'Message 1';
 
-    // Refresh rate of 100 ms
+    // Refresh rate of 500 ms to avoid flakiness in tests
     const printer = new Printer(
       LogLevel.INFO,
       ttyStream,
       process.stderr,
-      100,
+      500,
       true,
     );
     printer.startSpinner(message);
 
-    // Wait for 400 ms
-    await new Promise((resolve) => setTimeout(resolve, 400));
+    // Wait for 1900 ms which should guarantee spinner outputting exactly 4 times at 0, 500, 1000, 1500
+    await new Promise((resolve) => setTimeout(resolve, 1900));
 
     // Stop spinner
     printer.stopSpinner();


### PR DESCRIPTION
## Changes

After this last change https://github.com/aws-amplify/amplify-backend/pull/2577 sometimes on a fast machine, the spinner ends up running one extra time just before the waiting period was over. See https://github.com/aws-amplify/amplify-backend/actions/runs/14346193591/job/40216502741

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
