### PR TITLE
Fix amplifyApiEnvironmentName in non sandbox environments

### DIFF
--- a/.changeset/cool-olives-exist.md
+++ b/.changeset/cool-olives-exist.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': patch
+---
+
+Fix amplifyApiEnvironmentName in non sandbox environments

--- a/packages/backend-data/src/convert_js_resolvers.ts
+++ b/packages/backend-data/src/convert_js_resolvers.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'fs';
 import { Asset } from 'aws-cdk-lib/aws-s3-assets';
 import { resolveEntryPath } from './resolve_entry_path.js';
+import { CDKContextKey } from '@aws-amplify/platform-core';
 
 const APPSYNC_PIPELINE_RESOLVER = 'PIPELINE';
 const APPSYNC_JS_RUNTIME_NAME = 'APPSYNC_JS';
@@ -78,8 +79,11 @@ export const convertJsResolverDefinition = (
 
     const resolverName = `Resolver_${resolver.typeName}_${resolver.fieldName}`;
 
-    const amplifyApiEnvironmentName =
-      scope.node.tryGetContext('amplifyEnvironmentName') ?? 'NONE';
+    const isSandboxDeployment =
+      scope.node.tryGetContext(CDKContextKey.DEPLOYMENT_TYPE) === 'sandbox';
+    const amplifyApiEnvironmentName = isSandboxDeployment
+      ? 'NONE'
+      : scope.node.tryGetContext(CDKContextKey.BACKEND_NAME);
     new CfnResolver(scope, resolverName, {
       apiId: amplifyApi.apiId,
       fieldName: resolver.fieldName,


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

JS resolvers are supposed to have `amplifyApiEnvironmentName` in the `ctx.stash`. See expectations here https://docs.amplify.aws/react/build-a-backend/data/custom-business-logic/batch-ddb-operations/ .

`amplifyApiEnvironmentName` was never sourced correctly outside of Sandbox.
I.e. nothing ever wrote the `amplifyEnvironmentName` CDK context entry in entire Gen2 backend ecosystem (backend and data repos).
The `amplifyEnvironmentName` is used by old Gen1 code and shouldn't have been used to source `amplifyApiEnvironmentName` in a first place.

## Changes

PR changes the JS resolver logic to source `amplifyApiEnvironmentName` from gen2 cdk context keys.

## Validation

Modified/added unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
