### PR TITLE
Fix api check - array properties under namespaces

### DIFF
--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/API.md
@@ -14,6 +14,7 @@ type SomeTypeUnderSubNamespace = {
 
 type SomeOtherTypeUnderSubNamespace = {
   someProperty: SomeTypeUnderSubNamespace;
+  someArrayProperty: SomeTypeUnderSubNamespace[];
 };
 
 class SomeClassUnderNamespace {

--- a/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_sub_namespace.ts
+++ b/scripts/components/api-changes-validator/test-resources/test-projects/without-breaks/project-with-namespace/src/some_sub_namespace.ts
@@ -4,4 +4,5 @@ export type SomeTypeUnderSubNamespace = {
 
 export type SomeOtherTypeUnderSubNamespace = {
   someProperty: SomeTypeUnderSubNamespace;
+  someArrayProperty: SomeTypeUnderSubNamespace[];
 };

--- a/scripts/components/api-changes-validator/usage_statemets_renderer.ts
+++ b/scripts/components/api-changes-validator/usage_statemets_renderer.ts
@@ -70,7 +70,7 @@ export class UsageStatementsRenderer {
       // characters that can be found before or after symbol
       // this is to prevent partial matches in case one symbol's characters are subset of longer one
       const possibleSymbolPrefix = '[\\s\\,\\(<;]';
-      const possibleSymbolSuffix = '[\\s\\,\\(\\)<>;\\.]';
+      const possibleSymbolSuffix = '[\\s\\,\\(\\)<>;\\.[]';
       const regex = new RegExp(
         `(${possibleSymbolPrefix})(${symbolName})(${possibleSymbolSuffix})`,
         'g',


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Fixes

```
/Users/sobkamil/git/amplify-backend/scripts/check_api_changes.ts:100
  throw new AggregateError(
        ^


AggregateError: Breaking API changes detected. See below for details.
    If these changes are intentional, this is okay.
    Otherwise, update the PR to remove the unintentional breaks
    at <anonymous> (/Users/sobkamil/git/amplify-backend/scripts/check_api_changes.ts:100:9) {
  [errors]: [
    Error: Validation of @aws-amplify/client-config failed, compiler output:
    index.ts(100,13): error TS2552: Cannot find name 'AmplifyStorageAccessActions'. Did you mean 'AmplifyStorageAccessActionsBaseline'?
    index.ts(101,21): error TS2552: Cannot find name 'AmplifyStorageAccessActions'. Did you mean 'AmplifyStorageAccessActionsBaseline'?
    index.ts(102,33): error TS2552: Cannot find name 'AmplifyStorageAccessActions'. Did you mean 'AmplifyStorageAccessActionsBaseline'?
    index.ts(103,34): error TS2552: Cannot find name 'AmplifyStorageAccessActions'. Did you mean 'AmplifyStorageAccessActionsBaseline'?
    index.ts(104,16): error TS2552: Cannot find name 'AmplifyStorageAccessActions'. Did you mean 'AmplifyStorageAccessActionsBaseline'?
        at ApiChangesValidator.validate (/Users/sobkamil/git/amplify-backend/scripts/components/api-changes-validator/api_changes_validator.ts:62:13)
        at async <anonymous> (/Users/sobkamil/git/amplify-backend/scripts/check_api_changes.ts:82:5)
        at async Promise.allSettled (index 11)
        at async <anonymous> (/Users/sobkamil/git/amplify-backend/scripts/check_api_changes.ts:62:27)
  ]
}

```

## Changes

Handle case when namespaced type is used for array property.

## Validation

Added test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
