### PR TITLE
group eslint upgrades together into single PR.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,11 @@ updates:
       smithy:
         patterns:
           - '@smithy/*'
+      eslint:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'eslint'
+          - 'eslint-*'
     # Ignore updates to certain dependencies.
     # See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
           - '@smithy/*'
       eslint:
         patterns:
+          - '@shopify/eslint-plugin'
           - '@typescript-eslint/*'
           - 'eslint'
           - 'eslint-*'


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Dependabot is opening plenty of eslint PRs separately.

These packages are connected by peer-deps.

## Changes

This changes dependabot config to bundle all eslint packages together into single pr.

Note. This doesn't solve the peer dependencies problems in all cases.
However, there are the following benefits:
1. These dependencies usually have to be solved in single PR anyway, often manually. We can take over dependabot initial draft and iterate on that.
2. It should prevent dependabot of claiming most of the weekly PR quota for eslint packages.

## Validation

Validation needs a merge to main.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
