### PR TITLE
update error handling for js resolvers input path validations

### DIFF
--- a/.changeset/five-dancers-brush.md
+++ b/.changeset/five-dancers-brush.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': patch
+---
+
+Update error handling for js resolvers input path validations

--- a/packages/backend-data/src/resolve_entry_path.test.ts
+++ b/packages/backend-data/src/resolve_entry_path.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import { resolveEntryPath } from './resolve_entry_path.js';
+import fs from 'fs';
+void describe('resolveEntryPath', () => {
+  const testExistentPath = '/existent/path';
+  const fsMock = mock.method(fs, 'existsSync', (path: string) => {
+    if (path === testExistentPath) return true;
+    return false;
+  });
+  void beforeEach(() => {
+    fsMock.mock.resetCalls();
+  });
+  void it('should return the same path if it is a string and it exists', () => {
+    const result = resolveEntryPath(testExistentPath);
+    assert.strictEqual(result, testExistentPath);
+  });
+
+  void it('should throw error if the path is a string and it does not exist', () => {
+    assert.throws(() => resolveEntryPath('testNonExistentPath'), {
+      message: 'Cannot find file at testNonExistentPath',
+    });
+  });
+});

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -159,6 +159,7 @@ export type DataProps = {
 
 export type AmplifyDataError =
   | 'DefineDataConfigurationError'
+  | 'InvalidPathError'
   | 'InvalidSchemaAuthError'
   | 'InvalidSchemaError'
   | 'MultipleSingletonResourcesError'


### PR DESCRIPTION
## Problem

If the user provided path for JS resolvers doesn't exist, it fails [here](https://github.com/aws-amplify/amplify-backend/blob/ea28e834c2202916986046108003a5c74a19e7a8/packages/backend-data/src/convert_js_resolvers.ts#L62) creating a new asset in CDK

**Issue number, if available:**

## Changes

Add validation to ensure that the path exists before moving on.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
