### PR TITLE
map errors from CDK destroy

### DIFF
--- a/.changeset/blue-dots-count.md
+++ b/.changeset/blue-dots-count.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Map errors from CDK destroy

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -273,13 +273,32 @@ void describe('invokeCDKCommand', () => {
     assert.deepStrictEqual(tsCompilerMock.mock.calls[0].arguments, ['amplify']);
   });
 
-  void it('returns human readable errors', async () => {
+  void it('returns human readable errors on deploy', async () => {
     synthMock.mock.mockImplementationOnce(() => {
       throw new Error('Access Denied');
     });
 
     await assert.rejects(
       () => invoker.deploy(branchBackendId, sandboxDeployProps),
+      (err: AmplifyError<CDKDeploymentError>) => {
+        assert.equal(
+          err.message,
+          'The deployment role does not have sufficient permissions to perform this deployment.',
+        );
+        assert.equal(err.name, 'AccessDeniedError');
+        assert.equal(err.cause?.message, 'Access Denied');
+        return true;
+      },
+    );
+  });
+
+  void it('returns human readable errors on destroy', async () => {
+    destroyMock.mock.mockImplementationOnce(() => {
+      throw new Error('Access Denied');
+    });
+
+    await assert.rejects(
+      () => invoker.destroy(branchBackendId),
       (err: AmplifyError<CDKDeploymentError>) => {
         assert.equal(
           err.message,

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -182,16 +182,20 @@ export class CDKDeployer implements BackendDeployer {
    */
   destroy = async (backendId: BackendIdentifier) => {
     const deploymentStartTime = Date.now();
-    await this.cdkToolkit.destroy(await this.getCdkCloudAssembly(backendId), {
-      stacks: {
-        strategy: StackSelectionStrategy.ALL_STACKS,
-      },
-    });
-    return {
-      deploymentTimes: {
-        totalTime: Math.floor((Date.now() - deploymentStartTime) / 10) / 100,
-      },
-    };
+    try {
+      await this.cdkToolkit.destroy(await this.getCdkCloudAssembly(backendId), {
+        stacks: {
+          strategy: StackSelectionStrategy.ALL_STACKS,
+        },
+      });
+      return {
+        deploymentTimes: {
+          totalTime: Math.floor((Date.now() - deploymentStartTime) / 10) / 100,
+        },
+      };
+    } catch (error) {
+      throw this.cdkErrorMapper.getAmplifyError(error as Error, backendId.type);
+    }
   };
 
   compileProject = (projectDirectory: string): Promise<void> => {


### PR DESCRIPTION
## Problem

We are missing mapping CDK errors thrown on `cdk.destory`

**Issue number, if available:**

## Changes

Add the same error mapper that is used for `deploy`

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
