### PR TITLE
add permissions related error mapping

### DIFF
--- a/.changeset/flat-spoons-enjoy.md
+++ b/.changeset/flat-spoons-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/platform-core': patch
+---
+
+Add permissions related error mapping

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -337,6 +337,13 @@ npm error A complete log of this run can be found in: /home/some-path/.npm/_logs
     expectedDownstreamErrorMessage: undefined,
   },
   {
+    errorMessage: `StackName failed: AccessDenied: User: <escaped ARN> is not authorized to perform: cloudformation:ListExports because no identity-based policy allows the cloudformation:ListExports action`,
+    expectedTopLevelErrorMessage:
+      'Unable to deploy due to insufficient permissions',
+    errorName: 'AccessDeniedError',
+    expectedDownstreamErrorMessage: undefined,
+  },
+  {
     // eslint-disable-next-line spellcheck/spell-checker
     errorMessage: `[31m[1mamplify-user-sandbox-c71414864a[22m: fail: socket hang up[39m
 

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -372,7 +372,6 @@ export class CdkErrorMapper {
       errorName: 'CloudFormationDeletionError',
       classification: 'ERROR',
     },
-    //User: <escaped ARN> is not authorized to perform: cloudformation:ListExports because no identity-based policy allows the cloudformation:ListExports action
     {
       errorRegex:
         /User:(.*) is not authorized to perform:(.*) on resource:(?<resource>.*) because no identity-based policy allows the (?<action>.*) action/,

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -372,6 +372,7 @@ export class CdkErrorMapper {
       errorName: 'CloudFormationDeletionError',
       classification: 'ERROR',
     },
+    //User: <escaped ARN> is not authorized to perform: cloudformation:ListExports because no identity-based policy allows the cloudformation:ListExports action
     {
       errorRegex:
         /User:(.*) is not authorized to perform:(.*) on resource:(?<resource>.*) because no identity-based policy allows the (?<action>.*) action/,
@@ -379,6 +380,16 @@ export class CdkErrorMapper {
         'Unable to deploy due to insufficient permissions',
       resolutionMessage:
         'Ensure you have permissions to call {action} for {resource}',
+      errorName: 'AccessDeniedError',
+      classification: 'ERROR',
+    },
+    // Same as above but matches Service errors where resource name is not included in the message
+    {
+      errorRegex:
+        /User:(.*) is not authorized to perform:(.*) because no identity-based policy allows the (?<action>.*) action/,
+      humanReadableErrorMessage:
+        'Unable to deploy due to insufficient permissions',
+      resolutionMessage: 'Ensure you have permissions to call {action}',
       errorName: 'AccessDeniedError',
       classification: 'ERROR',
     },

--- a/packages/platform-core/src/errors/amplify_error.test.ts
+++ b/packages/platform-core/src/errors/amplify_error.test.ts
@@ -255,6 +255,18 @@ void describe('AmplifyError.fromError', async () => {
       );
     });
   });
+  void it('wraps permissions related errors in AmplifyUserError', () => {
+    const error = new Error('You do not have permissions.');
+    ['AccessDenied', 'AccessDeniedException'].forEach((name) => {
+      error.name = name;
+      const actual = AmplifyError.fromError(error);
+      assert.ok(
+        AmplifyError.isAmplifyError(actual) &&
+          actual.name === 'AccessDeniedError',
+        `Failed the test while wrapping error ${name}`,
+      );
+    });
+  });
   void it('wraps request signature related errors in AmplifyUserError', () => {
     const error = new Error(
       'The request signature we calculated does not match the signature you provided.',

--- a/packages/platform-core/src/errors/amplify_error.ts
+++ b/packages/platform-core/src/errors/amplify_error.ts
@@ -125,6 +125,17 @@ export abstract class AmplifyError<T extends string = string> extends Error {
         error,
       );
     }
+    if (error instanceof Error && isPermissionsError(error)) {
+      return new AmplifyUserError(
+        'AccessDeniedError',
+        {
+          message: errorMessage,
+          resolution:
+            'Ensure your IAM role has the AmplifyBackendDeployFullAccess policy along with any additional permissions required for this operation.',
+        },
+        error,
+      );
+    }
     if (error instanceof Error && isRequestSignatureError(error)) {
       return new AmplifyUserError(
         'RequestSignatureError',
@@ -288,6 +299,10 @@ const isCredentialsError = (err?: Error): boolean => {
       'CredentialsError',
     ].includes(err.name)
   );
+};
+
+const isPermissionsError = (err?: Error): boolean => {
+  return !!err && ['AccessDeniedException', 'AccessDenied'].includes(err.name);
 };
 
 const isRequestSignatureError = (err?: Error): boolean => {


### PR DESCRIPTION
## Problem

Some permissions related mappings are still missing, specially outside of cdk calls (e.g. generate commands)

**Issue number, if available:**

## Changes
add permissions related error mapping

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
