### PR TITLE
print stack traces in debug mode for sandbox deploy failures

### DIFF
--- a/.changeset/metal-foxes-argue.md
+++ b/.changeset/metal-foxes-argue.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/sandbox': patch
+---
+
+print stack traces in debug mode for sandbox deploy failures

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -721,7 +721,7 @@ void describe('Sandbox using local project name resolver', () => {
     );
 
     // assert print statements are called correctly
-    assert.strictEqual(printer.log.mock.callCount(), 17);
+    assert.strictEqual(printer.log.mock.callCount(), 15);
     assert.match(
       printer.log.mock.calls[5].arguments[0],
       /random BackendDeployer error/,

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -719,6 +719,24 @@ void describe('Sandbox using local project name resolver', () => {
       mockEmit.mock.calls[1].arguments[0],
       'successfulDeployment',
     );
+
+    // assert print statements are called correctly
+    assert.strictEqual(printer.log.mock.callCount(), 17);
+    assert.match(
+      printer.log.mock.calls[5].arguments[0],
+      /random BackendDeployer error/,
+    );
+    assert.strictEqual(printer.log.mock.calls[5].arguments[1], LogLevel.ERROR);
+    assert.strictEqual(
+      printer.log.mock.calls[6].arguments[0],
+      'Stack Trace for UnknownFault',
+    );
+    assert.strictEqual(printer.log.mock.calls[6].arguments[1], LogLevel.DEBUG);
+    assert.match(
+      printer.log.mock.calls[7].arguments[0],
+      /file_watching_sandbox.ts/,
+    );
+    assert.strictEqual(printer.log.mock.calls[7].arguments[1], LogLevel.DEBUG);
   });
 
   void it('handles UpdateNotSupported error while deploying and offers to reset sandbox and customer says yes', async (contextual) => {

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -348,11 +348,11 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
         // Print stack traces
         let errorToDisplayStackTrace: Error | undefined = amplifyError;
         while (errorToDisplayStackTrace) {
-          this.printer.log(
-            `Stack Trace for ${errorToDisplayStackTrace.name}`,
-            LogLevel.DEBUG,
-          );
           if (errorToDisplayStackTrace.stack) {
+            this.printer.log(
+              `Stack Trace for ${errorToDisplayStackTrace.name}`,
+              LogLevel.DEBUG,
+            );
             this.printer.log(
               format.dim(errorToDisplayStackTrace.stack),
               LogLevel.DEBUG,

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -363,15 +363,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
               ? errorToDisplayStackTrace.cause
               : undefined;
         }
-        if (amplifyError.stack) {
-          this.printer.log(format.dim(amplifyError.stack), LogLevel.DEBUG);
-        }
-        if (amplifyError.cause?.stack) {
-          this.printer.log(
-            format.dim(amplifyError.cause.stack),
-            LogLevel.DEBUG,
-          );
-        }
+
         this.emit('failedDeployment', error);
 
         // If the error is because of a non-allowed destructive change such as

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -343,7 +343,35 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
         setSpanAttributes(span, data);
         span.end();
         // Print a meaningful message
-        this.printer.log(format.error(error), LogLevel.ERROR);
+        this.printer.log(format.error(amplifyError), LogLevel.ERROR);
+
+        // Print stack traces
+        let errorToDisplayStackTrace: Error | undefined = amplifyError;
+        while (errorToDisplayStackTrace) {
+          this.printer.log(
+            `Stack Trace for ${errorToDisplayStackTrace.name}`,
+            LogLevel.DEBUG,
+          );
+          if (errorToDisplayStackTrace.stack) {
+            this.printer.log(
+              format.dim(errorToDisplayStackTrace.stack),
+              LogLevel.DEBUG,
+            );
+          }
+          errorToDisplayStackTrace =
+            errorToDisplayStackTrace.cause instanceof Error
+              ? errorToDisplayStackTrace.cause
+              : undefined;
+        }
+        if (amplifyError.stack) {
+          this.printer.log(format.dim(amplifyError.stack), LogLevel.DEBUG);
+        }
+        if (amplifyError.cause?.stack) {
+          this.printer.log(
+            format.dim(amplifyError.cause.stack),
+            LogLevel.DEBUG,
+          );
+        }
         this.emit('failedDeployment', error);
 
         // If the error is because of a non-allowed destructive change such as


### PR DESCRIPTION
## Problem

We don't display/print stack traces when sandbox deployments fail and customers are running in debug mode.

**Issue number, if available:**

## Changes

Display all stack traces in debug mode.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
