### PR TITLE
Seed Command using Identifier

### DIFF
--- a/.changeset/silver-lies-jam.md
+++ b/.changeset/silver-lies-jam.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+update seed commands to take identifier

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.test.ts
@@ -121,6 +121,24 @@ void describe('sandbox seed command', () => {
       );
       assert.strictEqual(mockHandleProfile.mock.callCount(), 1);
     });
+
+    void it('run seed with identifier if provided', async () => {
+      const output = await commandRunner.runCommand(
+        'sandbox seed --identifier app-name',
+      );
+
+      const outputArr = output.trimEnd().split('\n');
+      const seedMessage = outputArr[1];
+      const successMessage = outputArr[3].trimStart();
+
+      assert.ok(output !== undefined);
+      assert.deepStrictEqual(seedMessage, 'seed has been run');
+      assert.deepStrictEqual(
+        successMessage,
+        '✔ seed has successfully completed',
+      );
+      assert.strictEqual(mockHandleProfile.mock.callCount(), 1);
+    });
   });
 
   void describe('seed script does not exist', () => {

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.test.ts
@@ -137,7 +137,6 @@ void describe('sandbox seed command', () => {
         successMessage,
         '✔ seed has successfully completed',
       );
-      assert.strictEqual(mockHandleProfile.mock.callCount(), 1);
     });
   });
 

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_command.ts
@@ -1,4 +1,4 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import path from 'path';
 import { existsSync } from 'fs';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
@@ -36,9 +36,11 @@ export class SandboxSeedCommand implements CommandModule<object> {
   /**
    * @inheritDoc
    */
-  handler = async (): Promise<void> => {
+  handler = async (
+    args: ArgumentsCamelCase<SandboxCommandGlobalOptions>,
+  ): Promise<void> => {
     printer.print(`${format.color('seed is running...', 'Blue')}`);
-    const backendID = await this.backendIDResolver.resolve();
+    const backendID = await this.backendIDResolver.resolve(args.identifier);
     const seedPath = path.join('amplify', 'seed', 'seed.ts');
     process.env.AMPLIFY_BACKEND_IDENTIFIER = JSON.stringify(backendID);
     try {

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_policy_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_policy_command.test.ts
@@ -1,0 +1,98 @@
+import { before, describe, it, mock } from 'node:test';
+import { SandboxSeedCommand } from './sandbox_seed_command.js';
+import yargs, { CommandModule } from 'yargs';
+import { TestCommandRunner } from '../../../test-utils/command_runner.js';
+import { createSandboxSecretCommand } from '../sandbox-secret/sandbox_secret_command_factory.js';
+import { EventHandler, SandboxCommand } from '../sandbox_command.js';
+import { SandboxSingletonFactory } from '@aws-amplify/sandbox';
+import { SandboxDeleteCommand } from '../sandbox-delete/sandbox_delete_command.js';
+import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
+import { format, printer } from '@aws-amplify/cli-core';
+import { CommandMiddleware } from '../../../command_middleware.js';
+import { SandboxSeedGeneratePolicyCommand } from './sandbox_seed_policy_command.js';
+import assert from 'node:assert';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+
+const testBackendNameSpace = 'testSandboxId';
+const testSandboxName = 'testSandboxName';
+
+const testBackendId: BackendIdentifier = {
+  namespace: testBackendNameSpace,
+  name: testSandboxName,
+  type: 'sandbox',
+};
+
+void describe('sandbox seed command', () => {
+  let commandRunner: TestCommandRunner;
+
+  const clientConfigGenerationMock = mock.fn<EventHandler>();
+  const clientConfigDeletionMock = mock.fn<EventHandler>();
+
+  const clientConfigGeneratorAdapterMock = {
+    generateClientConfigToFile: clientConfigGenerationMock,
+  } as unknown as ClientConfigGeneratorAdapter;
+
+  const commandMiddleware = new CommandMiddleware(printer);
+  const mockHandleProfile = mock.method(
+    commandMiddleware,
+    'ensureAwsCredentialAndRegion',
+    () => null,
+  );
+
+  const mockProfileResolver = mock.fn();
+
+  const sandboxIdResolver: SandboxBackendIdResolver = {
+    resolve: () => Promise.resolve(testBackendId),
+  } as SandboxBackendIdResolver;
+
+  before(async () => {
+    const sandboxFactory = new SandboxSingletonFactory(
+      () => Promise.resolve(testBackendId),
+      mockProfileResolver,
+      printer,
+      format,
+    );
+
+    const sandboxSeedCommand = new SandboxSeedCommand(sandboxIdResolver, [
+      new SandboxSeedGeneratePolicyCommand(sandboxIdResolver),
+    ]);
+
+    const sandboxCommand = new SandboxCommand(
+      sandboxFactory,
+      [
+        new SandboxDeleteCommand(sandboxFactory),
+        createSandboxSecretCommand(),
+        sandboxSeedCommand,
+      ],
+      clientConfigGeneratorAdapterMock,
+      commandMiddleware,
+      () => ({
+        successfulDeployment: [clientConfigGenerationMock],
+        successfulDeletion: [clientConfigDeletionMock],
+        failedDeployment: [],
+      }),
+    );
+    const parser = yargs().command(sandboxCommand as unknown as CommandModule);
+    commandRunner = new TestCommandRunner(parser);
+    mockHandleProfile.mock.resetCalls();
+  });
+
+  void it('runs seed policy command without identifier', async () => {
+    const output = await commandRunner.runCommand(
+      'sandbox seed generate-policy',
+    );
+
+    assert.ok(output !== undefined);
+    assert.strictEqual(mockHandleProfile.mock.callCount(), 1);
+  });
+
+  void it('runs seed policy command with identifier', async () => {
+    const output = await commandRunner.runCommand(
+      'sandbox seed generate-policy --identifier app-name',
+    );
+
+    assert.ok(output !== undefined);
+    assert.strictEqual(mockHandleProfile.mock.callCount(), 1);
+  });
+});

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_policy_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_policy_command.test.ts
@@ -1,18 +1,18 @@
-import { before, describe, it, mock } from 'node:test';
-import { SandboxSeedCommand } from './sandbox_seed_command.js';
+import { after, before, describe, it, mock } from 'node:test';
+import fsp from 'fs/promises';
+import * as path from 'path';
 import yargs, { CommandModule } from 'yargs';
 import { TestCommandRunner } from '../../../test-utils/command_runner.js';
-import { createSandboxSecretCommand } from '../sandbox-secret/sandbox_secret_command_factory.js';
-import { EventHandler, SandboxCommand } from '../sandbox_command.js';
-import { SandboxSingletonFactory } from '@aws-amplify/sandbox';
-import { SandboxDeleteCommand } from '../sandbox-delete/sandbox_delete_command.js';
-import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
-import { format, printer } from '@aws-amplify/cli-core';
+import { printer } from '@aws-amplify/cli-core';
 import { CommandMiddleware } from '../../../command_middleware.js';
 import { SandboxSeedGeneratePolicyCommand } from './sandbox_seed_policy_command.js';
 import assert from 'node:assert';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
+import { Effect, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { generateSeedPolicyTemplate } from '../../../seed-policy-generation/generate_seed_policy_template.js';
+
+const seedFileContents = 'console.log(`seed has been run`);';
 
 const testBackendNameSpace = 'testSandboxId';
 const testSandboxName = 'testSandboxName';
@@ -23,15 +23,8 @@ const testBackendId: BackendIdentifier = {
   type: 'sandbox',
 };
 
-void describe('sandbox seed command', () => {
+void describe('sandbox policy seed command', () => {
   let commandRunner: TestCommandRunner;
-
-  const clientConfigGenerationMock = mock.fn<EventHandler>();
-  const clientConfigDeletionMock = mock.fn<EventHandler>();
-
-  const clientConfigGeneratorAdapterMock = {
-    generateClientConfigToFile: clientConfigGenerationMock,
-  } as unknown as ClientConfigGeneratorAdapter;
 
   const commandMiddleware = new CommandMiddleware(printer);
   const mockHandleProfile = mock.method(
@@ -40,42 +33,56 @@ void describe('sandbox seed command', () => {
     () => null,
   );
 
-  const mockProfileResolver = mock.fn();
+  let amplifySeedDir: string;
+  let fullPath: string;
 
   const sandboxIdResolver: SandboxBackendIdResolver = {
     resolve: () => Promise.resolve(testBackendId),
   } as SandboxBackendIdResolver;
 
+  const seedPolicyMock = mock.fn(
+    generateSeedPolicyTemplate,
+    (): Promise<PolicyDocument> =>
+      Promise.resolve(
+        new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: [
+                'cognito-idp:AdminCreateUser',
+                'cognito-idp:AdminAddUserToGroup',
+              ],
+              resources: ['test-arn'],
+            }),
+          ],
+        }),
+      ),
+  );
+
   before(async () => {
-    const sandboxFactory = new SandboxSingletonFactory(
-      () => Promise.resolve(testBackendId),
-      mockProfileResolver,
-      printer,
-      format,
-    );
+    const sandboxSeedGeneratePolicyCommand =
+      new SandboxSeedGeneratePolicyCommand(sandboxIdResolver, seedPolicyMock);
 
-    const sandboxSeedCommand = new SandboxSeedCommand(sandboxIdResolver, [
-      new SandboxSeedGeneratePolicyCommand(sandboxIdResolver),
-    ]);
-
-    const sandboxCommand = new SandboxCommand(
-      sandboxFactory,
-      [
-        new SandboxDeleteCommand(sandboxFactory),
-        createSandboxSecretCommand(),
-        sandboxSeedCommand,
-      ],
-      clientConfigGeneratorAdapterMock,
-      commandMiddleware,
-      () => ({
-        successfulDeployment: [clientConfigGenerationMock],
-        successfulDeletion: [clientConfigDeletionMock],
-        failedDeployment: [],
-      }),
+    const parser = yargs().command(
+      sandboxSeedGeneratePolicyCommand as unknown as CommandModule,
     );
-    const parser = yargs().command(sandboxCommand as unknown as CommandModule);
     commandRunner = new TestCommandRunner(parser);
     mockHandleProfile.mock.resetCalls();
+
+    await fsp.mkdir(path.join(process.cwd(), 'amplify', 'seed'), {
+      recursive: true,
+    });
+
+    amplifySeedDir = path.join(process.cwd(), 'amplify');
+    fullPath = path.join(process.cwd(), 'amplify', 'seed', 'seed.ts');
+    await fsp.writeFile(fullPath, seedFileContents, 'utf8');
+  });
+
+  after(async () => {
+    await fsp.rm(amplifySeedDir, { recursive: true, force: true });
+    if (process.env.AMPLIFY_BACKEND_IDENTIFIER) {
+      delete process.env.AMPLIFY_BACKEND_IDENTIFIER;
+    }
   });
 
   void it('runs seed policy command without identifier', async () => {
@@ -84,7 +91,6 @@ void describe('sandbox seed command', () => {
     );
 
     assert.ok(output !== undefined);
-    assert.strictEqual(mockHandleProfile.mock.callCount(), 1);
   });
 
   void it('runs seed policy command with identifier', async () => {
@@ -93,6 +99,5 @@ void describe('sandbox seed command', () => {
     );
 
     assert.ok(output !== undefined);
-    assert.strictEqual(mockHandleProfile.mock.callCount(), 1);
   });
 });

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_policy_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_policy_command.ts
@@ -21,7 +21,10 @@ export class SandboxSeedGeneratePolicyCommand implements CommandModule<object> {
   /**
    * Generates policy to run seed, is a subcommand of seed
    */
-  constructor(private readonly backendIdResolver: SandboxBackendIdResolver) {
+  constructor(
+    private readonly backendIdResolver: SandboxBackendIdResolver,
+    private readonly seedPolicyTemplate = generateSeedPolicyTemplate,
+  ) {
     this.command = 'generate-policy';
     this.describe = 'Generates policy for seeding';
   }
@@ -33,7 +36,7 @@ export class SandboxSeedGeneratePolicyCommand implements CommandModule<object> {
     args: ArgumentsCamelCase<SandboxCommandGlobalOptions>,
   ): Promise<void> => {
     const backendId = await this.backendIdResolver.resolve(args.identifier);
-    const policyDocument = await generateSeedPolicyTemplate(backendId);
+    const policyDocument = await this.seedPolicyTemplate(backendId);
     printer.print(JSON.stringify(policyDocument.toJSON(), null, 2));
   };
 

--- a/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_policy_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox-seed/sandbox_seed_policy_command.ts
@@ -1,7 +1,8 @@
-import { Argv, CommandModule } from 'yargs';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { printer } from '@aws-amplify/cli-core';
 import { SandboxBackendIdResolver } from '../sandbox_id_resolver.js';
 import { generateSeedPolicyTemplate } from '../../../seed-policy-generation/generate_seed_policy_template.js';
+import { SandboxCommandGlobalOptions } from '../option_types.js';
 
 /**
  * Command that generates policy template with permissions to be able to run seed in sandbox environment
@@ -28,8 +29,10 @@ export class SandboxSeedGeneratePolicyCommand implements CommandModule<object> {
   /**
    * @inheritDoc
    */
-  handler = async (): Promise<void> => {
-    const backendId = await this.backendIdResolver.resolve();
+  handler = async (
+    args: ArgumentsCamelCase<SandboxCommandGlobalOptions>,
+  ): Promise<void> => {
+    const backendId = await this.backendIdResolver.resolve(args.identifier);
     const policyDocument = await generateSeedPolicyTemplate(backendId);
     printer.print(JSON.stringify(policyDocument.toJSON(), null, 2));
   };


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Seed commands previously did properly resolve backends that were created using the `--identifier` flag and would throw errors instead of running the commands.

**Issue number, if available:** #2802 

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Updates the way seed resolves sandbox backend Ids so it can properly resolve backendIds for sandboxes that were created with `--identifier`. 

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
Added new unit tests for this behavior and manually ensured that the seed commands work with and without the use of `--identifier`. 

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
