### PR TITLE
Decouple ai constructs from platform core

### DIFF
--- a/.changeset/witty-towns-live.md
+++ b/.changeset/witty-towns-live.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+Remove dependency on platform-core

--- a/package-lock.json
+++ b/package-lock.json
@@ -48502,11 +48502,10 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.6.0",
-        "@aws-amplify/platform-core": "^1.9.0",
         "@aws-amplify/plugin-types": "^1.10.1",
         "@aws-sdk/client-bedrock-runtime": "3.622.0",
         "@smithy/types": "^4.1.0",
@@ -50597,7 +50596,7 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^2.1.1",
@@ -50610,7 +50609,7 @@
         "@aws-amplify/model-generator": "^1.2.0",
         "@aws-amplify/platform-core": "^1.9.0",
         "@aws-amplify/plugin-types": "^1.10.1",
-        "@aws-amplify/sandbox": "^2.1.1",
+        "@aws-amplify/sandbox": "^2.1.2",
         "@aws-amplify/schema-generator": "^1.4.0",
         "@aws-sdk/client-amplify": "^3.750.0",
         "@aws-sdk/client-cloudformation": "^3.750.0",
@@ -53126,7 +53125,7 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^2.1.1",

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -29,7 +29,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-amplify/backend-output-schemas": "^1.6.0",
-    "@aws-amplify/platform-core": "^1.9.0",
     "@aws-amplify/plugin-types": "^1.10.1",
     "@aws-sdk/client-bedrock-runtime": "3.622.0",
     "@smithy/types": "^4.1.0",

--- a/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
+++ b/packages/ai-constructs/src/conversation/conversation_handler_construct.ts
@@ -23,7 +23,6 @@ import {
 } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import path from 'path';
-import { TagName } from '@aws-amplify/platform-core';
 import {
   AIConversationOutput,
   aiConversationOutputKey,
@@ -102,7 +101,9 @@ export class ConversationHandlerFunction
       throw new Error('Entry must be absolute path');
     }
 
-    Tags.of(this).add(TagName.FRIENDLY_NAME, id);
+    // Intentionally not using import from 'platform-core'
+    // To not drag excessive amount of dependencies into construct layer.
+    Tags.of(this).add('amplify:friendly-name', id);
 
     const commonHandlerProperties = {
       runtime: LambdaRuntime.NODEJS_20_X,

--- a/packages/ai-constructs/tsconfig.json
+++ b/packages/ai-constructs/tsconfig.json
@@ -11,7 +11,6 @@
   },
   "references": [
     { "path": "../backend-output-schemas" },
-    { "path": "../platform-core" },
     { "path": "../plugin-types" },
     { "path": "../backend-output-storage" }
   ]


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

An attempt to upgrade `ai-constructs` on data side ends up with:

<img width="992" alt="image" src="https://github.com/user-attachments/assets/6f2fe4dd-9511-4ee2-b2b5-55a8e6326b0a" />

I.e. it's trying to load `platform-core` with its dependencies eagerly, even though they're unused.

Which causes problems on data side since data construct is bundling dependencies.

## Changes

The only thing `ai-constructs` wants from `platform-core` is tag name.

Therefore. I just replaced it with a copy, which is lesser evil than dragging heavy dependency closure.

Btw. our other construct layer package - auth-construct is deliberately not using platform-core.
The tagging there happens at `backend-auth`.
However for ai construct we need tag name at construct layer to make log streaming possible for default handler scenario, so I couldn't move tagging up in this case.

## Validation

tests

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
