### PR TITLE
Use opt in list for dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,15 @@ updates:
     # Update package.json files if new version is outside of version range specified there. Otherwise lock file only.
     versioning-strategy: increase-if-necessary
     allow:
-      - dependency-type: 'production'
+      - dependency-name: '@aws-sdk/*'
+      - dependency-name: '@types/aws-*'
+      - dependency-name: '@smithy/*'
+      - dependency-name: '@inquirer/*'
+      - dependency-name: 'aws-cdk'
+      - dependency-name: 'aws-cdk-lib'
+      - dependency-name: '@aws-cdk/*'
+      - dependency-name: '@opentelemetry/*'
+      - dependency-name: 'yargs*'
     open-pull-requests-limit: 10
     # Groups dependencies into one PR, dependencies that don't match any group will be in their own individual PR
     # see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--.


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Dependabot version upgrades are random right now. Which tends to open PRs for deps we care less about.

And the `production` strategy seems to be not great either. For example here https://github.com/aws-amplify/amplify-backend/pull/2777 - it bumps some packages in prod closure but not dev. And we do use some packages or parts of package groups as both prod and dev dependencies.



## Changes

Change approach from "upgrade anything except some exceptions" to "here is list of dependencies we care most about, upgrade them". Or in other words - create allow list of depdendecies we care about most.

## Validation



## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
