### PR TITLE
update error path processing to include current working directory for anonymization

### DIFF
--- a/.changeset/four-tigers-divide.md
+++ b/.changeset/four-tigers-divide.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/platform-core': patch
+---
+
+Update error path processing to include current working directory for anonymization

--- a/packages/platform-core/src/telemetry/serializable_error.test.ts
+++ b/packages/platform-core/src/telemetry/serializable_error.test.ts
@@ -38,7 +38,7 @@ void describe('serializable error', () => {
   });
 
   void test('that error message does not contain user homedir', () => {
-    const error = new Error(`${process.cwd()} test error`);
+    const error = new Error(`${os.homedir()} test error`);
     const serializableError = new SerializableError(error);
     assert.ok(serializableError.message);
     const matches = [
@@ -50,9 +50,22 @@ void describe('serializable error', () => {
     );
   });
 
+  void test('that error message does not contain current working directory', () => {
+    const error = new Error(`${process.cwd()} test error`);
+    const serializableError = new SerializableError(error);
+    assert.ok(serializableError.message);
+    const matches = [
+      ...serializableError.message.matchAll(new RegExp(process.cwd(), 'g')),
+    ];
+    assert.ok(
+      matches.length === 0,
+      `${process.cwd()} is included in ${serializableError.message}`,
+    );
+  });
+
   void test('that error message does not contain file url path with user homedir', () => {
     const error = new Error(
-      `${pathToFileURL(process.cwd()).toString()} test error`,
+      `${pathToFileURL(os.homedir()).toString()} test error`,
     );
     const serializableError = new SerializableError(error);
     assert.ok(serializableError.message);
@@ -62,6 +75,21 @@ void describe('serializable error', () => {
     assert.ok(
       matches.length === 0,
       `${os.homedir()} is included in ${serializableError.message}`,
+    );
+  });
+
+  void test('that error message does not contain file url path with current working directory', () => {
+    const error = new Error(
+      `${pathToFileURL(process.cwd()).toString()} test error`,
+    );
+    const serializableError = new SerializableError(error);
+    assert.ok(serializableError.message);
+    const matches = [
+      ...serializableError.message.matchAll(new RegExp(process.cwd(), 'g')),
+    ];
+    assert.ok(
+      matches.length === 0,
+      `${process.cwd()} is included in ${serializableError.message}`,
     );
   });
 
@@ -89,8 +117,8 @@ void describe('serializable error', () => {
   });
 
   void test('that error stack does not contain user homedir', () => {
-    const error = new Error(`${process.cwd()} test error`);
-    error.stack = `${error.stack}  at methodName (${process.cwd()}:12:34)\n`;
+    const error = new Error(`${os.homedir()} test error`);
+    error.stack = `${error.stack}  at methodName (${os.homedir()}:12:34)\n`;
     const serializableError = new SerializableError(error);
     assert.ok(serializableError.stack);
     const matches = [
@@ -102,12 +130,26 @@ void describe('serializable error', () => {
     );
   });
 
+  void test('that error stack does not contain current working directory', () => {
+    const error = new Error(`${process.cwd()} test error`);
+    error.stack = `${error.stack}  at methodName (${process.cwd()}:12:34)\n`;
+    const serializableError = new SerializableError(error);
+    assert.ok(serializableError.stack);
+    const matches = [
+      ...serializableError.stack.matchAll(new RegExp(process.cwd(), 'g')),
+    ];
+    assert.ok(
+      matches.length === 0,
+      `${process.cwd()} is included in ${serializableError.stack}`,
+    );
+  });
+
   void test('that error stack does not contain file url path with user homedir', () => {
     const error = new Error(
-      `${pathToFileURL(process.cwd()).toString()} test error`,
+      `${pathToFileURL(os.homedir()).toString()} test error`,
     );
     error.stack = `${error.stack}  at methodName (${pathToFileURL(
-      process.cwd(),
+      os.homedir(),
     ).toString()}/node_modules/@aws-amplify/test-package/lib/test.js:12:34)\n`;
     const serializableError = new SerializableError(error);
     assert.ok(serializableError.stack);
@@ -117,6 +159,30 @@ void describe('serializable error', () => {
     assert.ok(
       matches.length === 0,
       `${os.homedir()} is included in ${serializableError.stack}`,
+    );
+    const expectedFilePath =
+      'node_modules/@aws-amplify/test-package/lib/test.js';
+    assert.ok(
+      serializableError.stack.includes(expectedFilePath),
+      `${expectedFilePath} is not found in ${serializableError.stack}`,
+    );
+  });
+
+  void test('that error stack does not contain file url path with current working directory', () => {
+    const error = new Error(
+      `${pathToFileURL(process.cwd()).toString()} test error`,
+    );
+    error.stack = `${error.stack}  at methodName (${pathToFileURL(
+      process.cwd(),
+    ).toString()}/node_modules/@aws-amplify/test-package/lib/test.js:12:34)\n`;
+    const serializableError = new SerializableError(error);
+    assert.ok(serializableError.stack);
+    const matches = [
+      ...serializableError.stack.matchAll(new RegExp(process.cwd(), 'g')),
+    ];
+    assert.ok(
+      matches.length === 0,
+      `${process.cwd()} is included in ${serializableError.stack}`,
     );
     const expectedFilePath =
       'node_modules/@aws-amplify/test-package/lib/test.js';

--- a/packages/platform-core/src/telemetry/serializable_error.ts
+++ b/packages/platform-core/src/telemetry/serializable_error.ts
@@ -12,10 +12,10 @@ export class SerializableError {
 
   // breakdown of filePathRegex:
   // (file:/+)? -> matches optional file url prefix
-  // homedir() -> users home directory, replacing \ with /
-  // [\\w.\\-_@\\\\/]+ -> matches nested directories and file name
+  // homedir()/process.cwd() -> users home directory or current working directory, replacing \ with /
+  // [\\w.\\-_@\\\\/]* -> matches nested directories and file name
   private filePathRegex = new RegExp(
-    `(file:/+)?${homedir().replaceAll('\\', '/')}[\\w.\\-_@\\\\/]+`,
+    `(file:/+)?(${homedir().replaceAll('\\', '/')}|${process.cwd().replaceAll('\\', '/')})[\\w.\\-_@\\\\/]*`,
     'g',
   );
   private arnRegex =

--- a/packages/platform-core/src/usage-data/serializable_error.test.ts
+++ b/packages/platform-core/src/usage-data/serializable_error.test.ts
@@ -27,7 +27,34 @@ void describe('serializable error', () => {
     });
   });
 
+  void test('that regular stack trace does not contain current working directory', () => {
+    const error = new Error('test error');
+    const serializableError = new SerializableError(error);
+    assert.ok(serializableError.trace);
+    serializableError.trace?.forEach((trace) => {
+      assert.ok(
+        trace.file.includes(process.cwd()) == false,
+        `${process.cwd()} is included in the ${trace.file}`,
+      );
+    });
+  });
+
   void test('that regular stack trace does not contain user homedir for file url paths', () => {
+    const error = new Error('test error');
+    error.stack = `at methodName (${pathToFileURL(
+      os.homedir(),
+    ).toString()}/node_modules/@aws-amplify/test-package/lib/test.js:12:34)\n`;
+    const serializableError = new SerializableError(error);
+    assert.ok(serializableError.trace);
+    serializableError.trace?.forEach((trace) => {
+      assert.ok(
+        trace.file.includes(os.homedir()) == false,
+        `${os.homedir()} is included in the ${trace.file}`,
+      );
+    });
+  });
+
+  void test('that regular stack trace does not contain current working directory for file url paths', () => {
     const error = new Error('test error');
     error.stack = `at methodName (${pathToFileURL(
       process.cwd(),
@@ -36,8 +63,8 @@ void describe('serializable error', () => {
     assert.ok(serializableError.trace);
     serializableError.trace?.forEach((trace) => {
       assert.ok(
-        trace.file.includes(os.homedir()) == false,
-        `${os.homedir()} is included in the ${trace.file}`,
+        trace.file.includes(process.cwd()) == false,
+        `${process.cwd()} is included in the ${trace.file}`,
       );
     });
   });
@@ -114,7 +141,7 @@ void describe('serializable error', () => {
   });
 
   void test('that error message does not contain user homedir', () => {
-    const error = new ErrorWithDetailsAndCode(`${process.cwd()} test error`);
+    const error = new ErrorWithDetailsAndCode(`${os.homedir()} test error`);
     const serializableError = new SerializableError(error);
     const matches = [
       ...serializableError.message.matchAll(new RegExp(os.homedir(), 'g')),
@@ -125,9 +152,21 @@ void describe('serializable error', () => {
     );
   });
 
+  void test('that error message does not contain current working directory', () => {
+    const error = new ErrorWithDetailsAndCode(`${process.cwd()} test error`);
+    const serializableError = new SerializableError(error);
+    const matches = [
+      ...serializableError.message.matchAll(new RegExp(process.cwd(), 'g')),
+    ];
+    assert.ok(
+      matches.length === 0,
+      `${process.cwd()} is included in ${serializableError.message}`,
+    );
+  });
+
   void test('that error message does not contain file url path with user homedir', () => {
     const error = new ErrorWithDetailsAndCode(
-      `${pathToFileURL(process.cwd()).toString()} test error`,
+      `${pathToFileURL(os.homedir()).toString()} test error`,
     );
     const serializableError = new SerializableError(error);
     const matches = [
@@ -136,13 +175,27 @@ void describe('serializable error', () => {
     assert.ok(
       matches.length === 0,
       `${os.homedir()} is included in ${serializableError.message}`,
+    );
+  });
+
+  void test('that error message does not contain file url path with current working directory', () => {
+    const error = new ErrorWithDetailsAndCode(
+      `${pathToFileURL(process.cwd()).toString()} test error`,
+    );
+    const serializableError = new SerializableError(error);
+    const matches = [
+      ...serializableError.message.matchAll(new RegExp(process.cwd(), 'g')),
+    ];
+    assert.ok(
+      matches.length === 0,
+      `${process.cwd()} is included in ${serializableError.message}`,
     );
   });
 
   void test('that error details do not contain user homedir', () => {
     const error = new ErrorWithDetailsAndCode(
       'test error',
-      `${process.cwd()} test details`,
+      `${os.homedir()} test details`,
     );
     const serializableError = new SerializableError(error);
     const matches = serializableError.details
@@ -154,10 +207,25 @@ void describe('serializable error', () => {
     );
   });
 
+  void test('that error details do not contain current working directory', () => {
+    const error = new ErrorWithDetailsAndCode(
+      'test error',
+      `${process.cwd()} test details`,
+    );
+    const serializableError = new SerializableError(error);
+    const matches = serializableError.details
+      ? [...serializableError.details.matchAll(new RegExp(process.cwd(), 'g'))]
+      : [];
+    assert.ok(
+      serializableError.details && matches.length === 0,
+      `${process.cwd()} is included in ${serializableError.details}`,
+    );
+  });
+
   void test('that error details do not contain file url path with user homedir', () => {
     const error = new ErrorWithDetailsAndCode(
       'test error',
-      `${pathToFileURL(process.cwd()).toString()} test details`,
+      `${pathToFileURL(os.homedir()).toString()} test details`,
     );
     const serializableError = new SerializableError(error);
     const matches = serializableError.details
@@ -166,6 +234,21 @@ void describe('serializable error', () => {
     assert.ok(
       serializableError.details && matches.length === 0,
       `${os.homedir()} is included in ${serializableError.details}`,
+    );
+  });
+
+  void test('that error details do not contain file url path with current working directory', () => {
+    const error = new ErrorWithDetailsAndCode(
+      'test error',
+      `${pathToFileURL(process.cwd()).toString()} test details`,
+    );
+    const serializableError = new SerializableError(error);
+    const matches = serializableError.details
+      ? [...serializableError.details.matchAll(new RegExp(process.cwd(), 'g'))]
+      : [];
+    assert.ok(
+      serializableError.details && matches.length === 0,
+      `${process.cwd()} is included in ${serializableError.details}`,
     );
   });
 

--- a/packages/platform-core/src/usage-data/serializable_error.ts
+++ b/packages/platform-core/src/usage-data/serializable_error.ts
@@ -13,10 +13,10 @@ export class SerializableError {
 
   // breakdown of filePathRegex:
   // (file:/+)? -> matches optional file url prefix
-  // homedir() -> users home directory, replacing \ with /
-  // [\\w.\\-_@\\\\/]+ -> matches nested directories and file name
+  // homedir()/process.cwd() -> users home directory or current working directory, replacing \ with /
+  // [\\w.\\-_@\\\\/]* -> matches nested directories and file name
   private filePathRegex = new RegExp(
-    `(file:/+)?${homedir().replaceAll('\\', '/')}[\\w.\\-_@\\\\/]+`,
+    `(file:/+)?(${homedir().replaceAll('\\', '/')}|${process.cwd().replaceAll('\\', '/')})[\\w.\\-_@\\\\/]*`,
     'g',
   );
   private stackTraceRegex =


### PR DESCRIPTION
## Problem

Some paths are not being processed for telemetry, best guess is this happens when the user's current working directory does not contain their home directory.

**Issue number, if available:**

## Changes

Update regex to capture current working directory as well for file paths to anonymize.

**Corresponding docs PR, if applicable:**

## Validation

Unit tests.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
