### PR TITLE
add cloud assembly schema version mismatch error to error mapping

### DIFF
--- a/.changeset/fast-wasps-bathe.md
+++ b/.changeset/fast-wasps-bathe.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+add cloud assembly schema version mismatch error to error mapping

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -230,6 +230,13 @@ const testErrorMappings = [
       (Cloud assembly schema version mismatch: Maximum schema version supported is 36.0.0, but found 36.1.1)`,
   },
   {
+    errorMessage: `Error: Cannot read asset manifest '.amplify/artifacts/cdk.out<escaped stack>.assets.json': Cloud assembly schema version mismatch: Maximum schema version supported is 43.x.x, but found 44.0.0`,
+    expectedTopLevelErrorMessage:
+      "Installed 'aws-cdk' is not compatible with installed 'aws-cdk-lib'.",
+    errorName: 'CDKVersionMismatchError',
+    expectedDownstreamErrorMessage: `Error: Cannot read asset manifest '.amplify/artifacts/cdk.out<escaped stack>.assets.json': Cloud assembly schema version mismatch: Maximum schema version supported is 43.x.x, but found 44.0.0`,
+  },
+  {
     errorMessage: `error Command cdk not found. Did you mean cdl?`,
     expectedTopLevelErrorMessage: 'Unable to detect cdk installation',
     errorName: 'CDKNotFoundError',

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -260,6 +260,17 @@ export class CdkErrorMapper {
       errorName: 'CDKVersionMismatchError',
       classification: 'ERROR',
     },
+    // Similar to previous error but there are instances of the error that do not mention upgrading CDK CLI or compatible CDK CLI version
+    {
+      errorRegex:
+        /Cannot read asset manifest .*: Cloud assembly schema version mismatch: Maximum schema version supported is .*, but found .*/,
+      humanReadableErrorMessage:
+        "Installed 'aws-cdk' is not compatible with installed 'aws-cdk-lib'.",
+      resolutionMessage:
+        "Make sure that version of 'aws-cdk' is greater or equal to version of 'aws-cdk-lib'",
+      errorName: 'CDKVersionMismatchError',
+      classification: 'ERROR',
+    },
     {
       errorRegex: /Command cdk not found/,
       humanReadableErrorMessage: 'Unable to detect cdk installation',


### PR DESCRIPTION
## Problem

Variation of cloud assembly schema version mismatch error is not being captured in our error handling.

**Issue number, if available:**

## Changes

Add the variation to error mapping to provide better messaging to resolve the error.

**Corresponding docs PR, if applicable:**

## Validation

Unit test.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
