### PR TITLE
Switched Windows runner to 2025

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -114,8 +114,8 @@ jobs:
             os_for_e2e+=', "macos-14-xlarge"'
           fi
           if [ "${{ inputs.include-windows }}" != "false" ]; then
-            os+=', "windows-latest"'
-            os_for_e2e+=', "windows-latest"'
+            os+=', "windows-2025"'
+            os_for_e2e+=', "windows-2025"'
           fi
           os+=']'
           os_for_e2e+=']'
@@ -463,7 +463,7 @@ jobs:
       matrix: ${{ fromJson(needs.e2e_generate_deployment_tests_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: e2e_deployment ${{ matrix.displayNames }} ${{ matrix.node-version }} ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && 35 || 25 }}
+    timeout-minutes: ${{ matrix.os == 'windows-2025' && 35 || 25 }}
     needs:
       - do_include_e2e
       - build
@@ -511,7 +511,7 @@ jobs:
       matrix: ${{ fromJson(needs.e2e_generate_sandbox_tests_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: e2e_sandbox ${{ matrix.displayNames }} ${{ matrix.node-version }} ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && 35 || 25 }}
+    timeout-minutes: ${{ matrix.os == 'windows-2025' && 35 || 25 }}
     needs:
       - do_include_e2e
       - build
@@ -595,14 +595,14 @@ jobs:
         exclude:
           - os: macos-14
             node-version: 20
-          - os: windows-latest
+          - os: windows-2025
             node-version: 18
           - os: macos-14
             node-version: 22
-          - os: windows-latest
+          - os: windows-2025
             node-version: 22
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && 35 || 25 }}
+    timeout-minutes: ${{ matrix.os == 'windows-2025' && 35 || 25 }}
     needs:
       - do_include_e2e
       - build

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -245,7 +245,7 @@ jobs:
       - build
       - resolve_inputs
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout pull request ref
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
@@ -540,7 +540,7 @@ jobs:
         os: ${{ fromJSON(needs.resolve_inputs.outputs.os) }}
     runs-on: ${{ matrix.os }}
     name: e2e_notices ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: ${{ matrix.os == 'windows-2025' && 8 || 5 }}
     needs:
       - do_include_e2e
       - build


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

Currently health checks are using `windows-latest` which maps to `windows-2022`. This runner is currently exhibiting degrading performance. 
`e2e_notices` test for windows and `check_api_changes` are often unable to complete within their current timeout windows, extended timeout windows for these tests.

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

A newer runner for windows, `windows-2025`, is available has better performance than previous runner when running health checks.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
e2es are mostly successful. 
Health checks were eventually successful against this branch: https://github.com/aws-amplify/amplify-backend/actions/runs/15541874326

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
