### PR TITLE
Poke package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52685,8 +52685,8 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "2.1.2",
       "license": "Apache-2.0",
+      "version": "2.1.2",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^2.1.1",
         "@aws-amplify/backend-secret": "^1.4.0",


### PR DESCRIPTION
This is to resolve 
<img width="1982" height="831" alt="image" src="https://github.com/user-attachments/assets/0deb4a68-b80b-467c-a3e5-0ff66133df9f" />

It seems that github started using different drive letter (C instead of D) overnight. We need to invalidate caches.