### PR TITLE
poke package lock again 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52684,8 +52684,8 @@
       }
     },
     "packages/sandbox": {
-      "name": "@aws-amplify/sandbox",
       "license": "Apache-2.0",
+      "name": "@aws-amplify/sandbox",
       "version": "2.1.2",
       "dependencies": {
         "@aws-amplify/backend-deployer": "^2.1.1",


### PR DESCRIPTION
Follow up on https://github.com/aws-amplify/amplify-backend/pull/2895 .

looks like github reverted the change ... so invalidating cache again.