### PR TITLE
Re-gate release with package manager tests

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -688,7 +688,7 @@ jobs:
         with:
           node-version: 18
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
-      # - run: npm run check:dependencies
+      - run: npm run check:dependencies
   check_tsconfig_refs:
     runs-on: ubuntu-latest
     needs:
@@ -857,7 +857,7 @@ jobs:
     if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'hotfix') }}
     needs:
       - test_with_coverage
-      # - e2e_package_manager
+      - e2e_package_manager
       - e2e_deployment
       - e2e_sandbox
       - e2e_notices

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -688,7 +688,7 @@ jobs:
         with:
           node-version: 18
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
-      - run: npm run check:dependencies
+      # - run: npm run check:dependencies
   check_tsconfig_refs:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Undoes the hack where we removed package manager tests as release gate.