### PR TITLE
chore: move ulimit increase to per-step execution in CI workflows

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -150,10 +150,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - name: Increase ulimit
-        if: runner.os == 'macOS'
-        run: |
-          ulimit -n 10000
       - uses: ./.github/actions/setup_node
         with:
           node-version: ${{ matrix.node }}
@@ -482,10 +478,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - name: Increase ulimit
-        if: runner.os == 'macOS'
-        run: |
-          ulimit -n 10000
       - name: Run e2e deployment tests
         uses: ./.github/actions/run_with_e2e_account
         with:
@@ -494,6 +486,7 @@ jobs:
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
           link_cli: true
           run: |
+            [[ "$RUNNER_OS" == "macOS" ]] && ulimit -n 10000
             npm run test:dir ${{ matrix.testPaths }}
   e2e_generate_sandbox_tests_matrix:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
@@ -534,10 +527,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - name: Increase ulimit
-        if: runner.os == 'macOS'
-        run: |
-          ulimit -n 10000
       - name: Run e2e sandbox tests
         uses: ./.github/actions/run_with_e2e_account
         with:
@@ -545,7 +534,9 @@ jobs:
           node_version: ${{ matrix.node-version }}
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
           link_cli: true
-          run: npm run test:dir ${{ matrix.testPaths }}
+          run: |
+            [[ "$RUNNER_OS" == "macOS" ]] && ulimit -n 10000
+            npm run test:dir ${{ matrix.testPaths }}
   e2e_notices:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
     strategy:
@@ -566,10 +557,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - name: Increase ulimit
-        if: runner.os == 'macOS'
-        run: |
-          ulimit -n 10000
       - uses: ./.github/actions/setup_node
         with:
           node-version: 18
@@ -579,7 +566,9 @@ jobs:
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: cd packages/cli && npm link
       - name: Run e2e notices tests
-        run: npm run test:dir packages/integration-tests/lib/test-e2e/notices.test.js
+        run: |
+          [[ "$RUNNER_OS" == "macOS" ]] && ulimit -n 10000
+          npm run test:dir packages/integration-tests/lib/test-e2e/notices.test.js
   e2e_backend_output:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
@@ -628,10 +617,6 @@ jobs:
       - resolve_inputs
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
-      - name: Increase ulimit
-        if: runner.os == 'macOS'
-        run: |
-          ulimit -n 10000
       - uses: ./.github/actions/setup_node
         with:
           node-version: ${{ matrix.node-version }}
@@ -641,7 +626,9 @@ jobs:
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: cd packages/cli && npm link
       - name: Run e2e create-amplify tests
-        run: npm run test:dir packages/integration-tests/lib/test-e2e/create_amplify.test.js
+        run: |
+          [[ "$RUNNER_OS" == "macOS" ]] && ulimit -n 10000
+          npm run test:dir packages/integration-tests/lib/test-e2e/create_amplify.test.js
   e2e_package_manager:
     if: needs.do_include_e2e.outputs.run_e2e == 'true' && needs.do_include_e2e.outputs.include_package_manager_e2e == 'true'
     strategy:
@@ -664,10 +651,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Increase ulimit
-        if: runner.os == 'macOS'
-        run: |
-          ulimit -n 10000
       - name: Checkout aws-amplify/amplify-backend repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run E2E flow tests with ${{ matrix.pkg-manager }}
@@ -678,6 +661,7 @@ jobs:
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
           shell: bash
           run: |
+            [[ "$RUNNER_OS" == "macOS" ]] && ulimit -n 10000
             PACKAGE_MANAGER=${{matrix.pkg-manager}} npm run test:dir packages/integration-tests/src/package_manager_sanity_checks.test.ts
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The current CI workflow has separate ulimit increase steps, but ulimit changes don't persist across GitHub Actions steps. Each step runs in its own shell session, so the ulimit increase has no effect on subsequent test execution steps.

## Changes

- Remove ineffective dedicated "Increase ulimit" steps from GitHub Actions workflows
- Move ulimit increase inline with test execution commands so it applies to the same shell session
- Apply ulimit only when running on macOS runners where it's needed

## Validation

This change fixes the ulimit configuration that was previously ineffective. The ulimit increase now actually applies to the test execution since it runs in the same shell session.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._