### PR TITLE
fix(auth): handle custom Cognito domains without appending regional suffix

### DIFF
--- a/packages/backend-auth/src/lambda/reference_auth_initializer.ts
+++ b/packages/backend-auth/src/lambda/reference_auth_initializer.ts
@@ -459,7 +459,9 @@ export class ReferenceAuthInitializer {
 
     // domain
     const oauthDomain = userPool.CustomDomain ?? userPool.Domain ?? '';
-    const fullDomainPath = `${oauthDomain}.auth.${region}.amazoncognito.com`;
+    const fullDomainPath = userPool.CustomDomain
+      ? userPool.CustomDomain
+      : `${oauthDomain}.auth.${region}.amazoncognito.com`;
     const data = {
       signupAttributes: JSON.stringify(
         userPool.SchemaAttributes?.filter(


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem
When using imported Cognito resources in Amplify Gen2 with SSO enabled, login redirects were broken because the initializer Lambda unconditionally appended `.auth.{region}.amazoncognito.com` to the OAuth domain.
This caused malformed redirect URLs when a custom domain was already set in the Cognito User Pool (e.g., `auth.dev.example.com` → `auth.dev.example.com.auth.us-east-1.amazoncognito.com`).
<!--
Describe the issue this PR is solving
-->

**Issue number, if available:** #2991 

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

- Updated getUserPoolOutputs logic so that:
  - If a custom domain is provided, it is used as-is.
  - Otherwise, fallback to Cognito-managed domain ({domain}.auth.{region}.amazoncognito.com).
- Ensures fullDomainPath is properly constructed in both scenarios.
This fixes the malformed OAuth redirect URLs when signing in via SSO providers (e.g., Google).

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

- Manually tested with imported Cognito resources and a custom domain (auth.dev.example.com) → redirect now works correctly.
- Verified fallback behavior with Cognito-managed domains continues to work.
- Confirmed <Authenticator> still detects Google as an IdP and completes the sign-in flow.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
