### PR TITLE
fix: check_api_changes often fails on network error

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -267,10 +267,15 @@ jobs:
         with:
           path: base-branch-content
           ref: ${{ github.event.pull_request.base.sha }}
-      - name: Check API changes
-        run: |
-          mkdir api-validation-projects
-          npx tsx scripts/check_api_changes.ts base-branch-content api-validation-projects
+      - name: Check API changes with retry
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            mkdir -p api-validation-projects
+            npx tsx scripts/check_api_changes.ts base-branch-content api-validation-projects
   handle_dependabot_version_update:
     if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

<img width="1075" height="542" alt="Screenshot 2025-09-30 at 15 01 05" src="https://github.com/user-attachments/assets/5625a64a-c63f-48ed-a0cc-ecb4a61c95c0" />

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Added a 3x retry to `check_api_changes` on a commonly failing step.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Running the workflow in this PR.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [X] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [X] If this PR requires a docs update, I have linked to that docs PR above.
- [X] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
