### PR TITLE
fix: check_api_changes times out when steps are retried

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -245,7 +245,7 @@ jobs:
       - build
       - resolve_inputs
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Checkout pull request ref
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
<img width="1494" height="258" alt="Screenshot 2025-10-07 at 11 55 40" src="https://github.com/user-attachments/assets/4e6945ba-d891-455f-bffe-268333c270c3" />

The **check_api_changes** job is sometimes cancelled when the job exceeds the timeout of 20 minutes. This can happen when steps are retried (introduced in https://github.com/aws-amplify/amplify-backend/pull/3010).

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Increased the timeout from 20 minutes to 60 minutes. Being generous here, as a successful run of step `Check API changes with retry` should take around *14 minutes*. If we try that step three times, a 60 min timeout should be able to cover the time needed for 3 tries and other steps in the run.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Run workflows on this PR.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [X] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [X] If this PR requires a docs update, I have linked to that docs PR above.
- [X] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
