### PR TITLE
chore: use node24 only in publish job

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -928,7 +928,7 @@ jobs:
         run: echo "is_version_packages_commit=$(npx tsx scripts/is_version_packages_commit.ts)" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 24        
+          node-version: 24
       - name: Publish packages
         # if this push is merging a version packages PR, then we publish the new versions
         if: ${{ steps.is_version_packages_commit.outputs.is_version_packages_commit == 'true' }}


### PR DESCRIPTION
Currently publish is failing with:

```console
Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: Linux-4c7d643f27f6e81e93c730d8c8f60cf1808038aee3c97303cbad98bbf8f4b29b-node24-cdklibFROM_PACKAGE_LOCK
```

We suspect the switch to node 24 in the restore cache step is messing it up. 