### PR TITLE
Update permissions in release workflow

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -915,6 +915,7 @@ jobs:
     environment: release
     permissions:
       id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
@@ -936,8 +937,6 @@ jobs:
         uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # version 1.4.7
         with:
           publish: npm run publish
-        permissions:
-          contents: write
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TRUSTED_PUBLISHER: 'true'


### PR DESCRIPTION
To publish github tags related to a release, write permissions are needed in the release job.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
