### PR TITLE
fix: `Failed to instantiate data construct` in new projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   },
   "overrides": {
     "minimatch": "10.0.1",
-    "@graphql-tools/merge": "9.0.22"
+    "@graphql-tools/merge": "9.0.22",
+    "@graphql-tools/utils": "10.8.4"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Canaries that check for latest versions of our dependencies are failing:

```console
Error [AmplifyDataConstructInitializationError]: Failed to instantiate data construct
      at DataGenerator.generateContainerEntry (/home/runner/work/amplify-backend/amplify-backend/packages/backend-data/src/factory.ts:310:13)
      at ConstructContainerStub.getOrCompute (/home/runner/work/amplify-backend/amplify-backend/packages/backend-platform-test-stubs/src/construct_container_stub.ts:51:19)
      at DataFactory.getInstance (/home/runner/work/amplify-backend/amplify-backend/packages/backend-data/src/factory.ts:118:31)
      at TestContext.<anonymous> (/home/runner/work/amplify-backend/amplify-backend/packages/backend-data/src/factory.test.ts:172:35)
      at Test.runInAsyncScope (node:async_hooks:214:14)
      at Test.run (node:internal/test_runner/test:1106:25)
      at async Promise.all (index 0)
      at async Suite.run (node:internal/test_runner/test:1516:7)
      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {
    cause: TypeError: Cannot read properties of undefined (reading 'schemaExtensions')
        at applyExtensions (/home/runner/work/amplify-backend/amplify-backend/node_modules/@graphql-tools/merge/cjs/extensions.js:23:45)
        at makeExecutableSchema (/home/runner/work/amplify-backend/amplify-backend/node_modules/@graphql-tools/schema/cjs/makeExecutableSchema.js:88:37)
        at mergeSchemas (/home/runner/work/amplify-backend/amplify-backend/node_modules/@graphql-tools/schema/cjs/merge-schemas.js:32:63)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/node_modules/@aws-amplify/graphql-generator/src/vendor/@graphql-codegen/core/codegen.ts:58:21)
        at Object.run (/home/runner/work/amplify-backend/amplify-backend/node_modules/@aws-amplify/graphql-generator/src/profiler.ts:10:20)
        at codegen (/home/runner/work/amplify-backend/amplify-backend/node_modules/@aws-amplify/graphql-generator/src/vendor/@graphql-codegen/core/codegen.ts:56:35)
        at <anonymous> (/home/runner/work/amplify-backend/amplify-backend/node_modules/@aws-amplify/graphql-generator/src/models.ts:97:34)
        at Array.map (<anonymous>)
        at generateModelsSync (/home/runner/work/amplify-backend/amplify-backend/node_modules/@aws-amplify/graphql-generator/src/models.ts:96:29)
        at DataGenerator.generateContainerEntry (/home/runner/work/amplify-backend/amplify-backend/packages/backend-data/src/factory.ts:287:34)
```

Likely caused by the latest release of `@graphql-tools/utils`: https://github.com/ardatan/graphql-tools/pull/7012. 

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Pin the version of `@graphql-tools/utils` to the minimum one allowed by our (already pinned) dependency of `@graphql-tools/merge`. See https://www.npmjs.com/package/@graphql-tools/merge/v/9.0.22?activeTab=code.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
