### PR TITLE
fix: cognito users in a group cannot access their own files in s3

### DIFF
--- a/.changeset/wicked-experts-shake.md
+++ b/.changeset/wicked-experts-shake.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-storage': patch
+---
+
+fix: users in Cognito groups could not access their own files

--- a/packages/backend-storage/src/access_builder.test.ts
+++ b/packages/backend-storage/src/access_builder.test.ts
@@ -4,9 +4,13 @@ import { roleAccessBuilder } from './access_builder.js';
 import {
   ConstructContainer,
   ConstructFactoryGetInstanceProps,
+  ResourceAccessAcceptor,
   ResourceAccessAcceptorFactory,
   ResourceProvider,
+  SsmEnvironmentEntry,
 } from '@aws-amplify/plugin-types';
+import { App, Stack } from 'aws-cdk-lib';
+import { Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 
 void describe('storageAccessBuilder', () => {
   const resourceAccessAcceptorMock = mock.fn();
@@ -115,13 +119,21 @@ void describe('storageAccessBuilder', () => {
       accessDefinition.idSubstitution,
       '${cognito-identity.amazonaws.com:sub}',
     );
-    assert.deepStrictEqual(
-      accessDefinition.getResourceAccessAcceptors.map(
-        (getResourceAccessAcceptor) =>
-          getResourceAccessAcceptor(stubGetInstanceProps),
-      ),
-      [resourceAccessAcceptorMock],
-    );
+
+    // Should have 2 resource access acceptors now: authenticated role + compound group acceptor
+    assert.equal(accessDefinition.getResourceAccessAcceptors.length, 2);
+
+    // First acceptor should be the authenticated role
+    const authAcceptor =
+      accessDefinition.getResourceAccessAcceptors[0](stubGetInstanceProps);
+    assert.equal(authAcceptor, resourceAccessAcceptorMock);
+
+    // Second acceptor should be the compound group acceptor
+    const groupAcceptor =
+      accessDefinition.getResourceAccessAcceptors[1](stubGetInstanceProps);
+    assert.equal(typeof groupAcceptor.identifier, 'string');
+    assert.equal(typeof groupAcceptor.acceptResourceAccess, 'function');
+
     assert.equal(
       getConstructFactoryMock.mock.calls[0].arguments[0],
       'AuthResources',
@@ -171,5 +183,131 @@ void describe('storageAccessBuilder', () => {
       ),
       [group1AccessAcceptorMock, group2AccessAcceptorMock],
     );
+  });
+
+  void it('entity permissions apply to all group roles when groups are defined', () => {
+    // Mock acceptResourceAccess calls to verify they're made
+    const adminAcceptResourceAccessMock = mock.fn();
+    const usersAcceptResourceAccessMock = mock.fn();
+    const adminAcceptorMock: ResourceAccessAcceptor = {
+      identifier: 'adminAcceptor',
+      acceptResourceAccess: adminAcceptResourceAccessMock,
+    };
+    const usersAcceptorMock: ResourceAccessAcceptor = {
+      identifier: 'usersAcceptor',
+      acceptResourceAccess: usersAcceptResourceAccessMock,
+    };
+
+    // Create a group-specific mock that returns the correct types
+    const groupSpecificMock = mock.fn((roleName: string) => {
+      if (roleName === 'Admins') return adminAcceptorMock;
+      if (roleName === 'Users') return usersAcceptorMock;
+      return resourceAccessAcceptorMock;
+    });
+
+    // Mock auth resources with groups
+    const mockAuthResources = {
+      resources: {
+        groups: {
+          Admins: { role: {} },
+          Users: { role: {} },
+        },
+      },
+      getResourceAccessAcceptor: groupSpecificMock,
+    };
+
+    const mockConstructFactory = mock.fn(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      <T extends ResourceProvider>(_: string) => ({
+        getInstance: () => mockAuthResources as unknown as T,
+      }),
+    );
+
+    const mockGetInstanceProps: ConstructFactoryGetInstanceProps = {
+      constructContainer: {
+        getConstructFactory: mockConstructFactory,
+      } as unknown as ConstructContainer,
+    } as unknown as ConstructFactoryGetInstanceProps;
+
+    const accessDefinition = roleAccessBuilder
+      .entity('identity')
+      .to(['read', 'write', 'delete']);
+
+    // Should have 2 resource access acceptors: authenticated role + compound group acceptor
+    assert.equal(accessDefinition.getResourceAccessAcceptors.length, 2);
+
+    // Get the compound group acceptor
+    const groupAcceptor =
+      accessDefinition.getResourceAccessAcceptors[1](mockGetInstanceProps);
+
+    // Verify it has the expected structure
+    assert.ok(groupAcceptor.identifier.includes('entityAccessForAllGroups'));
+    assert.ok(groupAcceptor.identifier.includes('Admins'));
+    assert.ok(groupAcceptor.identifier.includes('Users'));
+    assert.equal(typeof groupAcceptor.acceptResourceAccess, 'function');
+
+    // Call acceptResourceAccess on the compound acceptor
+    const stack = new Stack(new App(), 'TestStack');
+    const mockPolicy = new Policy(stack, 'TestPolicy', {
+      statements: [new PolicyStatement()],
+    });
+    const mockSsmEntries: SsmEnvironmentEntry[] = [];
+    groupAcceptor.acceptResourceAccess(mockPolicy, mockSsmEntries);
+
+    // Verify both group roles had the policy applied
+    assert.equal(adminAcceptResourceAccessMock.mock.callCount(), 1);
+    assert.equal(usersAcceptResourceAccessMock.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      adminAcceptResourceAccessMock.mock.calls[0].arguments,
+      [mockPolicy, mockSsmEntries],
+    );
+    assert.deepStrictEqual(
+      usersAcceptResourceAccessMock.mock.calls[0].arguments,
+      [mockPolicy, mockSsmEntries],
+    );
+  });
+
+  void it('entity permissions handle case when no groups are defined', () => {
+    // Mock auth resources without groups
+    const mockAuthResources = {
+      resources: {
+        groups: undefined,
+      },
+      getResourceAccessAcceptor: getResourceAccessAcceptorMock,
+    };
+
+    const mockConstructFactory = mock.fn(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      <T extends ResourceProvider>(_: string) => ({
+        getInstance: () => mockAuthResources as unknown as T,
+      }),
+    );
+
+    const mockGetInstanceProps: ConstructFactoryGetInstanceProps = {
+      constructContainer: {
+        getConstructFactory: mockConstructFactory,
+      } as unknown as ConstructContainer,
+    } as unknown as ConstructFactoryGetInstanceProps;
+
+    const accessDefinition = roleAccessBuilder
+      .entity('identity')
+      .to(['read', 'write', 'delete']);
+
+    // Should still have 2 resource access acceptors
+    assert.equal(accessDefinition.getResourceAccessAcceptors.length, 2);
+
+    // Get the compound group acceptor (should be empty/no-op)
+    const groupAcceptor =
+      accessDefinition.getResourceAccessAcceptors[1](mockGetInstanceProps);
+    assert.equal(groupAcceptor.identifier, 'entityAccessForAllGroups-empty');
+
+    // Should not throw when called (no-op behavior)
+    const stack = new Stack(new App(), 'TestStack');
+    const emptyPolicy = new Policy(stack, 'EmptyPolicy', {
+      statements: [new PolicyStatement()],
+    });
+    assert.doesNotThrow(() => {
+      groupAcceptor.acceptResourceAccess(emptyPolicy, []);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

If an authenticated user is in a group, it is impossible to set up owner-based access rules for storage without specifying the same-level group permission. This means app owners have to sacrifice either confidentiality (by adding permissions to files by group) or availability (by disallowing users from reading/modifying their own files, when those files are accessible to a group).

**Issue number, if available:** #1771

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Coalesced permissions for individual identities and groups, to allow identities that belong to a group to access their own files.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

Added unit tests. Pending validation by hand.

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [X] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
