### PR TITLE
chore: add permissions to validate cdk release workflow

### DIFF
--- a/.github/workflows/validate_cdk_release.yml
+++ b/.github/workflows/validate_cdk_release.yml
@@ -16,6 +16,12 @@ jobs:
   health_checks_with_cdk_version:
     uses: ./.github/workflows/health_checks.yml
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      security-events: write
+      id-token: write
     with:
       # This runs all deployment and sandbox tests.
       desired-cdk-lib-version: ${{ inputs.desired-cdk-lib-version || 'latest' }}


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

Runs of `validate_cdk_release` have been failing since 2025-12-12. E.g., [this run](https://github.com/aws-amplify/amplify-backend/actions/runs/20468038258).


> The workflow is not valid. .github/workflows/validate_cdk_release.yml (Line: 16, Col: 3): Error calling workflow 'aws-amplify/amplify-backend/.github/workflows/health_checks.yml@ffdc9dc5deea61bef70848c5efdf67ef3ee13ad0'. The nested job 'handle_dependabot_version_update' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'. .github/workflows/validate_cdk_release.yml (Line: 16, Col: 3): Error calling workflow 'aws-amplify/amplify-backend/.github/workflows/health_checks.yml@ffdc9dc5deea61bef70848c5efdf67ef3ee13ad0'. The nested job 'do_include_e2e' is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.

https://github.com/actions/runner/issues/4151 suggests that this may have started failing spontaneously due to new, stricter validations.

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

Adds permissions used by child workflow to the parent workflow.

**Corresponding docs PR, if applicable:**

## Validation

Kicked off a run of the validation flow in this branch. It did not immediately fail with the aforementioned error. ✅ 

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
