### PR TITLE
feat(ci): add on_retry_command input to run_with_e2e_account action

### DIFF
--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -4,6 +4,9 @@ inputs:
   run:
     description: Script to run
     required: true
+  on_retry_command:
+    description: Script to run before a retry (e.g. a cleanup script).
+    required: false
   shell:
     description: Shell
     required: false
@@ -177,6 +180,13 @@ runs:
           if [ $ATTEMPT -lt $RETRY_ATTEMPTS ]; then
             echo "Retrying in $RETRY_DELAY seconds..."
             sleep $RETRY_DELAY
+            # Run on retry command if provided
+            if [ -n "${{ inputs.on_retry_command }}" ]; then
+              echo "Running on retry command..."
+              if ! run_with_timeout '${{ inputs.on_retry_command }}' "$SHELL_CMD"; then
+                echo "On retry command failed, but continuing with retry attempt"
+              fi
+            fi
           else
             echo "Script failed after $RETRY_ATTEMPTS attempts"
             exit 1

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -700,6 +700,7 @@ jobs:
           node_version: ${{ matrix.node-version }}
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
           shell: bash
+          on_retry_command: git clean -f -d
           attempt_timeout_minutes: ${{ matrix.os == 'windows-2025' && 40 || 25 }}
           run: PACKAGE_MANAGER=${{matrix.pkg-manager}} npm run test:dir packages/integration-tests/src/package_manager_sanity_checks.test.ts
   lint:


### PR DESCRIPTION
## Problem

The package manager sanity checks fail immediately on retry attempts with the error `Error: Dirty working tree detected. Commit or stash changes to continue.` This happens because the previous test run leaves behind untracked files that aren't cleaned up before the retry.

## Changes

This PR adds an `on_retry_command` input to the `run_with_e2e_account` action. This optional parameter allows specifying a cleanup script that runs before each retry attempt. The command runs with a timeout and failures are logged but don't prevent the retry from proceeding.

The package manager sanity checks now use `git clean -f -d` as the on retry command to remove untracked files and directories before each retry.

## Validation

The changes are to CI infrastructure. The action input is optional and backward compatible. The cleanup command failure is handled gracefully to avoid breaking existing retry behavior.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
