### PR TITLE
fix `update_package_versions` workflow

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -875,6 +875,7 @@ jobs:
       - run: npm run check:package-versions
 
   update_package_versions:
+    # only runs when merging a PR into main
     if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'hotfix') }}
     needs:
       - install


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
`update_package_versions` is still broken (https://github.com/aws-amplify/amplify-backend/actions/runs/20929350066/job/60136119770), which means we cannot generate Version Packages PRs that are used to release. 
This PR attempted to fix `update_package_versions` and `docs_build_and_publish`: #3080 
It was successful in fixing `docs_build_and_publish` but not `update_package_versions`. 

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Switches permissions for `update_package_versions` from `pull-requests: write` to `contents: write`

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
