### PR TITLE
feat: Add --standalone flag for deployments without Amplify Hosting 

### DIFF
--- a/.changeset/custompipeline-feature.md
+++ b/.changeset/custompipeline-feature.md
@@ -10,3 +10,5 @@
 ---
 
 Add custompipeline deployment type for custom CI/CD without Amplify Hosting
+
+This change enables deploying Amplify Gen2 backends in custom CI/CD pipelines (CodePipeline, Jenkins, etc.) without requiring Amplify Hosting.

--- a/.changeset/custompipeline-feature.md
+++ b/.changeset/custompipeline-feature.md
@@ -1,0 +1,11 @@
+---
+'@aws-amplify/plugin-types': patch
+'@aws-amplify/platform-core': patch
+'@aws-amplify/backend': patch
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-output-storage': patch
+'@aws-amplify/cli-core': patch
+'@aws-amplify/backend-cli': patch
+---
+
+Add custompipeline deployment type for custom CI/CD without Amplify Hosting

--- a/.changeset/custompipeline-feature.md
+++ b/.changeset/custompipeline-feature.md
@@ -9,6 +9,6 @@
 '@aws-amplify/auth-construct': patch
 ---
 
-Add custompipeline deployment type for custom CI/CD without Amplify Hosting
+Add standalone deployment type for deploying without Amplify Hosting
 
 This change enables deploying Amplify Gen2 backends in custom CI/CD pipelines (CodePipeline, Jenkins, etc.) without requiring Amplify Hosting.

--- a/.changeset/custompipeline-feature.md
+++ b/.changeset/custompipeline-feature.md
@@ -6,6 +6,7 @@
 '@aws-amplify/backend-output-storage': patch
 '@aws-amplify/cli-core': patch
 '@aws-amplify/backend-cli': patch
+'@aws-amplify/auth-construct': patch
 ---
 
 Add custompipeline deployment type for custom CI/CD without Amplify Hosting

--- a/.changeset/custompipeline-feature.md
+++ b/.changeset/custompipeline-feature.md
@@ -7,6 +7,11 @@
 '@aws-amplify/cli-core': patch
 '@aws-amplify/backend-cli': patch
 '@aws-amplify/auth-construct': patch
+'@aws-amplify/ai-constructs': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/sandbox': patch
 ---
 
 Add standalone deployment type for deploying without Amplify Hosting

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import { AmplifyAuth } from './construct.js';
 import { App, SecretValue, Stack, aws_cognito } from 'aws-cdk-lib';
-import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import assert from 'node:assert';
 import {
   BackendOutputEntry,
@@ -3310,6 +3310,57 @@ void describe('Auth construct', () => {
       template.hasResourceProperties('AWS::Cognito::UserPool', {
         WebAuthnRelyingPartyID: 'main.testProjectName.amplifyapp.com',
       });
+    });
+
+    void it('resolves AUTO to localhost in standalone mode and emits warning', () => {
+      const app = new App();
+      const stack = new Stack(app);
+      stack.node.setContext('amplify-backend-type', 'standalone');
+      stack.node.setContext('amplify-backend-namespace', 'myCustomStack');
+      stack.node.setContext('amplify-backend-name', 'main');
+      new AmplifyAuth(stack, 'test', {
+        loginWith: {
+          email: true,
+          webAuthn: true,
+        },
+      });
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::Cognito::UserPool', {
+        WebAuthnRelyingPartyID: 'localhost',
+      });
+      Annotations.fromStack(stack).hasWarning(
+        '/Default/test',
+        Match.stringLikeRegexp('standalone'),
+      );
+    });
+
+    void it('does not emit warning for standalone with explicit relyingPartyId', () => {
+      const app = new App();
+      const stack = new Stack(app);
+      stack.node.setContext('amplify-backend-type', 'standalone');
+      stack.node.setContext('amplify-backend-namespace', 'myCustomStack');
+      stack.node.setContext('amplify-backend-name', 'main');
+      new AmplifyAuth(stack, 'test', {
+        loginWith: {
+          email: true,
+          webAuthn: {
+            relyingPartyId: 'app.example.com',
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::Cognito::UserPool', {
+        WebAuthnRelyingPartyID: 'app.example.com',
+      });
+      const warnings = Annotations.fromStack(stack).findWarning(
+        '*',
+        Match.stringLikeRegexp('standalone'),
+      );
+      assert.strictEqual(
+        warnings.length,
+        0,
+        'explicit relyingPartyId should not emit standalone warning',
+      );
     });
 
     void it('does not configure passwordless when not enabled', () => {

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -1222,6 +1222,8 @@ export class AmplifyAuth
       CDKContextKey.DEPLOYMENT_TYPE,
     );
 
+    // For 'branch' deployments with Amplify Hosting, we can automatically derive
+    // the domain from the appId and branchName (e.g., main.d123abc.amplifyapp.com)
     if (deploymentType === 'branch') {
       const appId = this.node.tryGetContext(CDKContextKey.BACKEND_NAMESPACE);
       const branchName = this.node.tryGetContext(CDKContextKey.BACKEND_NAME);
@@ -1231,6 +1233,23 @@ export class AmplifyAuth
       }
     }
 
+    // For 'sandbox' and 'custompipeline' deployments, we default to 'localhost'
+    // because there's no Amplify Hosting domain available.
+    //
+    // IMPORTANT: For production 'custompipeline' deployments using WebAuthn/passkeys,
+    // you MUST explicitly provide the relyingPartyId in your auth configuration
+    // instead of using 'AUTO'. The relyingPartyId should match your actual domain
+    // where the application is hosted (e.g., 'example.com' or 'app.example.com').
+    //
+    // Example:
+    //   defineAuth({
+    //     loginWith: {
+    //       webAuthn: {
+    //         relyingPartyId: 'app.example.com', // Your actual domain
+    //         userVerification: 'preferred'
+    //       }
+    //     }
+    //   })
     return 'localhost';
   };
 

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -1,6 +1,5 @@
 import { Construct } from 'constructs';
 import {
-  Annotations,
   Lazy,
   RemovalPolicy,
   Stack,
@@ -1234,16 +1233,17 @@ export class AmplifyAuth
       }
     }
 
-    // For 'sandbox' and 'standalone' deployments, we default to 'localhost'
-    // because there's no Amplify Hosting domain available.
+    // For 'standalone' deployments, AUTO cannot resolve — there's no Amplify Hosting domain.
+    // Force the user to set an explicit relyingPartyId.
     if (deploymentType === 'standalone') {
-      Annotations.of(this).addWarning(
-        'WebAuthn relyingPartyId is set to AUTO which defaults to "localhost" for standalone deployments. ' +
-          'This will NOT work in production. Set an explicit relyingPartyId matching your hosting domain. ' +
+      throw new Error(
+        'WebAuthn relyingPartyId "AUTO" is not supported for standalone deployments because there is no Amplify Hosting domain to resolve against. ' +
+          'Set an explicit relyingPartyId matching your hosting domain. ' +
           'Example: loginWith: { webAuthn: { relyingPartyId: "app.example.com" } }',
       );
     }
 
+    // For 'sandbox' deployments, default to 'localhost'
     return 'localhost';
   };
 

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -1,5 +1,6 @@
 import { Construct } from 'constructs';
 import {
+  Annotations,
   Lazy,
   RemovalPolicy,
   Stack,
@@ -1223,7 +1224,7 @@ export class AmplifyAuth
     );
 
     // For 'branch' deployments with Amplify Hosting, we can automatically derive
-    // the domain from the appId and branchName (e.g., main.d123abc.amplifyapp.com)
+    // the domain from the appId and branchName (e.g., main.d1a2b3c.amplifyapp.com)
     if (deploymentType === 'branch') {
       const appId = this.node.tryGetContext(CDKContextKey.BACKEND_NAMESPACE);
       const branchName = this.node.tryGetContext(CDKContextKey.BACKEND_NAME);
@@ -1233,23 +1234,16 @@ export class AmplifyAuth
       }
     }
 
-    // For 'sandbox' and 'custompipeline' deployments, we default to 'localhost'
+    // For 'sandbox' and 'standalone' deployments, we default to 'localhost'
     // because there's no Amplify Hosting domain available.
-    //
-    // IMPORTANT: For production 'custompipeline' deployments using WebAuthn/passkeys,
-    // you MUST explicitly provide the relyingPartyId in your auth configuration
-    // instead of using 'AUTO'. The relyingPartyId should match your actual domain
-    // where the application is hosted (e.g., 'example.com' or 'app.example.com').
-    //
-    // Example:
-    //   defineAuth({
-    //     loginWith: {
-    //       webAuthn: {
-    //         relyingPartyId: 'app.example.com', // Your actual domain
-    //         userVerification: 'preferred'
-    //       }
-    //     }
-    //   })
+    if (deploymentType === 'standalone') {
+      Annotations.of(this).addWarning(
+        'WebAuthn relyingPartyId is set to AUTO which defaults to "localhost" for standalone deployments. ' +
+          'This will NOT work in production. Set an explicit relyingPartyId matching your hosting domain. ' +
+          'Example: loginWith: { webAuthn: { relyingPartyId: "app.example.com" } }',
+      );
+    }
+
     return 'localhost';
   };
 

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -291,7 +291,7 @@ const validateRelyingPartyId = (relyingPartyId: string): string | undefined => {
   }
 
   if (relyingPartyId.includes('://')) {
-    return `Invalid relying party ID: "${relyingPartyId}". Must be a valid domain without protocol (e.g., "example.com"), "localhost" for development, or "AUTO" for Amplify Hosting branch deployments (resolves to localhost otherwise).
+    return `Invalid relying party ID: "${relyingPartyId}". Must be a valid domain without protocol (e.g., "example.com"), "localhost" for development, or "AUTO" for Amplify Hosting.
 
 Examples:
   - Valid: "example.com", "app.example.com", "localhost", "AUTO"

--- a/packages/backend-auth/src/factory.ts
+++ b/packages/backend-auth/src/factory.ts
@@ -291,7 +291,7 @@ const validateRelyingPartyId = (relyingPartyId: string): string | undefined => {
   }
 
   if (relyingPartyId.includes('://')) {
-    return `Invalid relying party ID: "${relyingPartyId}". Must be a valid domain without protocol (e.g., "example.com"), "localhost" for development, or "AUTO" for Amplify Hosting.
+    return `Invalid relying party ID: "${relyingPartyId}". Must be a valid domain without protocol (e.g., "example.com"), "localhost" for development, or "AUTO" for Amplify Hosting branch deployments (resolves to localhost otherwise).
 
 Examples:
   - Valid: "example.com", "app.example.com", "localhost", "AUTO"

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -44,7 +44,7 @@ export class CdkErrorMapper {
 
     if (error.message.includes('does not support module.register()')) {
       let resolutionMessage;
-      if (deploymentType === 'branch') {
+      if (deploymentType === 'branch' || deploymentType === 'custompipeline') {
         resolutionMessage =
           'Upgrade the node version in your CI/CD environment. ' +
           'If you are using Amplify Hosting for your backend builds, you can add `nvm install 18.x` or `nvm install 20.x` in your `amplify.yml` before the `pipeline-deploy` command';

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -44,7 +44,10 @@ export class CdkErrorMapper {
 
     if (error.message.includes('does not support module.register()')) {
       let resolutionMessage;
-      if (deploymentType === 'branch' || deploymentType === 'custompipeline') {
+      if (deploymentType === 'standalone') {
+        resolutionMessage =
+          'Upgrade the node version in your CI/CD environment to `^18.19.0`, `^20.6.0`, or `>=22`.';
+      } else if (deploymentType === 'branch') {
         resolutionMessage =
           'Upgrade the node version in your CI/CD environment. ' +
           'If you are using Amplify Hosting for your backend builds, you can add `nvm install 18.x` or `nvm install 20.x` in your `amplify.yml` before the `pipeline-deploy` command';

--- a/packages/backend-output-storage/API.md
+++ b/packages/backend-output-storage/API.md
@@ -27,7 +27,7 @@ export class AttributionMetadataStorage {
 }
 
 // @public (undocumented)
-export type DeploymentEngineType = 'AmplifyPipelineDeploy' | 'AmplifySandbox' | 'AmplifyCustomPipeline' | 'AmplifyCDK';
+export type DeploymentEngineType = 'AmplifyPipelineDeploy' | 'AmplifySandbox' | 'AmplifyStandalone' | 'AmplifyCDK';
 
 // @public (undocumented)
 export type Platform = 'Mac' | 'Windows' | 'Linux' | 'Other';

--- a/packages/backend-output-storage/API.md
+++ b/packages/backend-output-storage/API.md
@@ -27,7 +27,7 @@ export class AttributionMetadataStorage {
 }
 
 // @public (undocumented)
-export type DeploymentEngineType = 'AmplifyPipelineDeploy' | 'AmplifySandbox' | 'AmplifyCDK';
+export type DeploymentEngineType = 'AmplifyPipelineDeploy' | 'AmplifySandbox' | 'AmplifyCustomPipeline' | 'AmplifyCDK';
 
 // @public (undocumented)
 export type Platform = 'Mac' | 'Windows' | 'Linux' | 'Other';

--- a/packages/backend-output-storage/src/store_attribution_metadata.test.ts
+++ b/packages/backend-output-storage/src/store_attribution_metadata.test.ts
@@ -56,6 +56,20 @@ void describe('storeAttributionMetadata', () => {
     assert.equal(metadata.createdBy, 'AmplifyPipelineDeploy');
   });
 
+  void it('sets standalone deploy type when DeploymentType is standalone', () => {
+    const app = new App();
+    const stack = new Stack(app);
+    stack.node.setContext('amplify-backend-type', 'standalone');
+    new AttributionMetadataStorage(
+      os,
+      packageJsonReader,
+    ).storeAttributionMetadata(stack, 'test', 'some/path');
+    const metadata: AttributionMetadata = JSON.parse(
+      stack.templateOptions.description || '',
+    );
+    assert.equal(metadata.createdBy, 'AmplifyStandalone');
+  });
+
   void it('sets sandbox deploy type when DeploymentType is sandbox', () => {
     const app = new App();
     const stack = new Stack(app);

--- a/packages/backend-output-storage/src/store_attribution_metadata.ts
+++ b/packages/backend-output-storage/src/store_attribution_metadata.ts
@@ -71,8 +71,8 @@ export class AttributionMetadataStorage {
         return 'AmplifyPipelineDeploy';
       case 'sandbox':
         return 'AmplifySandbox';
-      case 'custompipeline':
-        return 'AmplifyCustomPipeline';
+      case 'standalone':
+        return 'AmplifyStandalone';
       default:
         throw new Error(
           `Unknown ${CDKContextKey.DEPLOYMENT_TYPE} CDK context value "${
@@ -123,7 +123,7 @@ export type AttributionMetadata = {
 export type DeploymentEngineType =
   | 'AmplifyPipelineDeploy'
   | 'AmplifySandbox'
-  | 'AmplifyCustomPipeline'
+  | 'AmplifyStandalone'
   | 'AmplifyCDK';
 
 export type Platform = 'Mac' | 'Windows' | 'Linux' | 'Other';

--- a/packages/backend-output-storage/src/store_attribution_metadata.ts
+++ b/packages/backend-output-storage/src/store_attribution_metadata.ts
@@ -71,6 +71,8 @@ export class AttributionMetadataStorage {
         return 'AmplifyPipelineDeploy';
       case 'sandbox':
         return 'AmplifySandbox';
+      case 'custompipeline':
+        return 'AmplifyCustomPipeline';
       default:
         throw new Error(
           `Unknown ${CDKContextKey.DEPLOYMENT_TYPE} CDK context value "${
@@ -121,6 +123,7 @@ export type AttributionMetadata = {
 export type DeploymentEngineType =
   | 'AmplifyPipelineDeploy'
   | 'AmplifySandbox'
+  | 'AmplifyCustomPipeline'
   | 'AmplifyCDK';
 
 export type Platform = 'Mac' | 'Windows' | 'Linux' | 'Other';

--- a/packages/backend/src/backend_identifier.ts
+++ b/packages/backend/src/backend_identifier.ts
@@ -26,7 +26,7 @@ export const getBackendIdentifier = (scope: Construct): BackendIdentifier => {
   const deploymentType: DeploymentType = scope.node.getContext(
     CDKContextKey.DEPLOYMENT_TYPE,
   );
-  const expectedDeploymentTypeValues = ['sandbox', 'branch'];
+  const expectedDeploymentTypeValues = ['sandbox', 'branch', 'custompipeline'];
 
   if (!expectedDeploymentTypeValues.includes(deploymentType)) {
     throw new Error(

--- a/packages/backend/src/backend_identifier.ts
+++ b/packages/backend/src/backend_identifier.ts
@@ -26,7 +26,7 @@ export const getBackendIdentifier = (scope: Construct): BackendIdentifier => {
   const deploymentType: DeploymentType = scope.node.getContext(
     CDKContextKey.DEPLOYMENT_TYPE,
   );
-  const expectedDeploymentTypeValues = ['sandbox', 'branch', 'custompipeline'];
+  const expectedDeploymentTypeValues = ['sandbox', 'branch', 'standalone'];
 
   if (!expectedDeploymentTypeValues.includes(deploymentType)) {
     throw new Error(

--- a/packages/backend/src/project_environment_main_stack_creator.ts
+++ b/packages/backend/src/project_environment_main_stack_creator.ts
@@ -32,9 +32,9 @@ export class ProjectEnvironmentMainStackCreator implements MainStackCreator {
       Tags.of(this.mainStack).add('amplify:deployment-type', 'branch');
     } else if (deploymentType === 'sandbox') {
       Tags.of(this.mainStack).add('amplify:deployment-type', 'sandbox');
-    } else if (deploymentType === 'custompipeline') {
+    } else if (deploymentType === 'standalone') {
       Tags.of(this.mainStack).add('amplify:branch-name', this.backendId.name);
-      Tags.of(this.mainStack).add('amplify:deployment-type', 'custompipeline');
+      Tags.of(this.mainStack).add('amplify:deployment-type', 'standalone');
     }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this.mainStack!;

--- a/packages/backend/src/project_environment_main_stack_creator.ts
+++ b/packages/backend/src/project_environment_main_stack_creator.ts
@@ -32,6 +32,9 @@ export class ProjectEnvironmentMainStackCreator implements MainStackCreator {
       Tags.of(this.mainStack).add('amplify:deployment-type', 'branch');
     } else if (deploymentType === 'sandbox') {
       Tags.of(this.mainStack).add('amplify:deployment-type', 'sandbox');
+    } else if (deploymentType === 'custompipeline') {
+      Tags.of(this.mainStack).add('amplify:branch-name', this.backendId.name);
+      Tags.of(this.mainStack).add('amplify:deployment-type', 'custompipeline');
     }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this.mainStack!;

--- a/packages/cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.test.ts
+++ b/packages/cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import { CfnDeploymentProgressLogger } from './cfn_deployment_progress_logger.js';
+import { RewritableBlock } from './rewritable_block.js';
+import { StackEvent } from '@aws-sdk/client-cloudformation';
+
+const makeEvent = (
+  overrides: Partial<StackEvent> & Pick<StackEvent, 'LogicalResourceId'>,
+): StackEvent => ({
+  StackId: 'arn:aws:cloudformation:us-east-1:123456789:stack/test',
+  StackName: 'test-stack',
+  EventId: '1',
+  Timestamp: new Date(),
+  ResourceStatus: 'CREATE_IN_PROGRESS',
+  ...overrides,
+});
+
+const createMockBlock = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const displayLines = mock.fn(async (lines: string[]) => {});
+  return {
+    block: { displayLines } as unknown as RewritableBlock,
+    displayLines,
+  };
+};
+
+const createLogger = (resourcesTotal?: number) => {
+  const { block } = createMockBlock();
+  return new CfnDeploymentProgressLogger({
+    resourcesTotal,
+    rewritableBlock: block,
+    getBlockWidth: () => 120,
+  });
+};
+
+void describe('CfnDeploymentProgressLogger', () => {
+  void describe('getFriendlyNameFromNestedStackName via addActivity', () => {
+    void it('resolves 7-part standalone nested stack to friendly name', async () => {
+      const { block, displayLines } = createMockBlock();
+      const logger = new CfnDeploymentProgressLogger({
+        resourcesTotal: 10,
+        rewritableBlock: block,
+        getBlockWidth: () => 120,
+      });
+
+      // 7-part: amplify-ns-name-standalone-hash-<nestedName>NestedStack...-suffix
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId:
+            // eslint-disable-next-line spellcheck/spell-checker
+            'amplify-ns-name-standalone-hash-authNestedStackauthNestedStackResource-abc',
+          ResourceType: 'AWS::CloudFormation::Stack',
+          ResourceStatus: 'CREATE_IN_PROGRESS',
+        }),
+      });
+
+      await logger.print();
+      const lines = displayLines.mock.calls[0].arguments[0] as string[];
+      const resourceLine = lines.find((l: string) => l.includes('authNest'));
+      assert.ok(
+        resourceLine,
+        'should display friendly name derived from nested stack',
+      );
+    });
+
+    void it('resolves 5-part standalone root stack to root stack', async () => {
+      const { block, displayLines } = createMockBlock();
+      const logger = new CfnDeploymentProgressLogger({
+        resourcesTotal: 10,
+        rewritableBlock: block,
+        getBlockWidth: () => 120,
+      });
+
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId: 'amplify-ns-name-standalone-hash',
+          ResourceType: 'AWS::CloudFormation::Stack',
+          ResourceStatus: 'CREATE_IN_PROGRESS',
+        }),
+      });
+
+      await logger.print();
+      const lines = displayLines.mock.calls[0].arguments[0] as string[];
+      const rootLine = lines.find((l: string) => l.includes('root stack'));
+      assert.ok(rootLine, 'should display as root stack');
+    });
+
+    void it('resolves 7-part sandbox nested stack to friendly name', () => {
+      const logger = createLogger(10);
+      // Should not throw — sandbox is also handled
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId:
+            // eslint-disable-next-line spellcheck/spell-checker
+            'amplify-ns-name-sandbox-hash-dataNestedStackdataNestedStackResource-xyz',
+          ResourceType: 'AWS::CloudFormation::Stack',
+          ResourceStatus: 'UPDATE_IN_PROGRESS',
+        }),
+      });
+    });
+
+    void it('resolves 5-part sandbox root stack to root stack', () => {
+      const logger = createLogger(10);
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId: 'amplify-ns-name-sandbox-hash',
+          ResourceType: 'AWS::CloudFormation::Stack',
+          ResourceStatus: 'CREATE_IN_PROGRESS',
+        }),
+      });
+    });
+
+    void it('does not resolve branch stack names', async () => {
+      const { block, displayLines } = createMockBlock();
+      const logger = new CfnDeploymentProgressLogger({
+        resourcesTotal: 10,
+        rewritableBlock: block,
+        getBlockWidth: () => 120,
+      });
+
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId: 'amplify-ns-name-branch-hash',
+          ResourceType: 'AWS::CloudFormation::Stack',
+          ResourceStatus: 'CREATE_IN_PROGRESS',
+        }),
+      });
+
+      await logger.print();
+      const lines = displayLines.mock.calls[0].arguments[0] as string[];
+      // branch type should NOT get "root stack" friendly name
+      const rootLine = lines.find((l: string) => l.includes('root stack'));
+      assert.strictEqual(
+        rootLine,
+        undefined,
+        'branch stack should not resolve to root stack friendly name',
+      );
+    });
+  });
+
+  void describe('addActivity tracking', () => {
+    void it('tracks resources in progress and prints them', async () => {
+      const { block, displayLines } = createMockBlock();
+      const logger = new CfnDeploymentProgressLogger({
+        resourcesTotal: 5,
+        rewritableBlock: block,
+        getBlockWidth: () => 120,
+      });
+
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId: 'MyResource',
+          ResourceType: 'AWS::Lambda::Function',
+          ResourceStatus: 'CREATE_IN_PROGRESS',
+        }),
+        metadata: {
+          entry: {},
+          constructPath: 'Default/MyStack/MyResource',
+        },
+      });
+
+      await logger.print();
+      assert.strictEqual(displayLines.mock.calls.length, 1);
+      const lines = displayLines.mock.calls[0].arguments[0] as string[];
+      assert.ok(lines.length > 0, 'should have printed lines');
+    });
+
+    void it('tracks completed resources in progress bar', async () => {
+      const { block, displayLines } = createMockBlock();
+      const logger = new CfnDeploymentProgressLogger({
+        resourcesTotal: 5,
+        rewritableBlock: block,
+        getBlockWidth: () => 120,
+      });
+
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId: 'MyResource',
+          ResourceType: 'AWS::Lambda::Function',
+          ResourceStatus: 'CREATE_IN_PROGRESS',
+        }),
+      });
+
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId: 'MyResource',
+          ResourceType: 'AWS::Lambda::Function',
+          ResourceStatus: 'CREATE_COMPLETE',
+          EventId: '2',
+        }),
+      });
+
+      await logger.print();
+      const lines = displayLines.mock.calls[0].arguments[0] as string[];
+      const progressLine = lines.find((l: string) => l.includes('/'));
+      assert.ok(progressLine, 'should have a progress bar');
+      assert.ok(
+        progressLine.includes('1/6'),
+        'should show 1 completed out of 6 (total+1)',
+      );
+    });
+
+    void it('displays failed resources with reason', async () => {
+      const { block, displayLines } = createMockBlock();
+      const logger = new CfnDeploymentProgressLogger({
+        resourcesTotal: 5,
+        rewritableBlock: block,
+        getBlockWidth: () => 120,
+      });
+
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId: 'FailedResource',
+          ResourceType: 'AWS::Lambda::Function',
+          ResourceStatus: 'CREATE_FAILED',
+          ResourceStatusReason: 'Something went wrong',
+        }),
+        metadata: {
+          entry: {},
+          constructPath: 'Default/MyStack/FailedResource',
+        },
+      });
+
+      await logger.print();
+      const lines = displayLines.mock.calls[0].arguments[0] as string[];
+      const output = lines.join('\n');
+      assert.ok(
+        output.includes('CREATE_FAILED'),
+        'should display the failed status',
+      );
+    });
+
+    void it('skips CDKMetadata resources', async () => {
+      const { block, displayLines } = createMockBlock();
+      const logger = new CfnDeploymentProgressLogger({
+        resourcesTotal: 5,
+        rewritableBlock: block,
+        getBlockWidth: () => 120,
+      });
+
+      logger.addActivity({
+        event: makeEvent({
+          LogicalResourceId: 'CDKMetadata',
+          ResourceType: 'AWS::CDK::Metadata',
+          ResourceStatus: 'CREATE_IN_PROGRESS',
+        }),
+      });
+
+      await logger.print();
+      const lines = displayLines.mock.calls[0].arguments[0] as string[];
+      // Only progress bar, no resource lines (CDKMetadata should be skipped)
+      const metadataLine = lines.find((l: string) => l.includes('CDKMetadata'));
+      assert.strictEqual(
+        metadataLine,
+        undefined,
+        'CDKMetadata should not appear in output',
+      );
+    });
+  });
+});

--- a/packages/cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.ts
+++ b/packages/cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.ts
@@ -415,11 +415,11 @@ export class CfnDeploymentProgressLogger {
     if (
       parts &&
       parts.length === 7 &&
-      (parts[3] === 'sandbox' || parts[3] === 'custompipeline')
+      (parts[3] === 'sandbox' || parts[3] === 'standalone')
     ) {
       return this.rootStackDisplay + '/' + parts[5].slice(0, -8) + ' stack';
     } else if (parts && parts.length === 5) {
-      if (parts[3] === 'sandbox' || parts[3] === 'custompipeline') {
+      if (parts[3] === 'sandbox' || parts[3] === 'standalone') {
         return this.rootStackDisplay;
       }
     }

--- a/packages/cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.ts
+++ b/packages/cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.ts
@@ -412,10 +412,14 @@ export class CfnDeploymentProgressLogger {
     stackName: string,
   ): string | undefined => {
     const parts = stackName.split('-');
-    if (parts && parts.length === 7 && parts[3] === 'sandbox') {
+    if (
+      parts &&
+      parts.length === 7 &&
+      (parts[3] === 'sandbox' || parts[3] === 'custompipeline')
+    ) {
       return this.rootStackDisplay + '/' + parts[5].slice(0, -8) + ' stack';
     } else if (parts && parts.length === 5) {
-      if (parts[3] === 'sandbox') {
+      if (parts[3] === 'sandbox' || parts[3] === 'custompipeline') {
         return this.rootStackDisplay;
       }
     }

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -286,7 +286,7 @@ void describe('deploy command', () => {
     );
   });
 
-  void it('throws when --app-id is missing without --custom-pipeline', async () => {
+  void it('throws when --app-id is missing without --standalone', async () => {
     await assert.rejects(
       async () =>
         await getCommandRunner(true).runCommand(
@@ -300,7 +300,24 @@ void describe('deploy command', () => {
     );
   });
 
-  void it('succeeds when --app-id is missing but --custom-pipeline is provided', async () => {
+  void it('throws when --standalone is provided without --stack-name', async () => {
+    await assert.rejects(
+      async () =>
+        await getCommandRunner(true).runCommand(
+          'pipeline-deploy --branch testBranch --standalone',
+        ),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'InvalidCommandInputError');
+        assert.match(
+          error.error.message,
+          /--stack-name is required when --standalone is enabled/,
+        );
+        return true;
+      },
+    );
+  });
+
+  void it('succeeds when --app-id is missing but --standalone is provided', async () => {
     const backendDeployerFactory = new BackendDeployerFactory(
       packageManagerControllerFactory.getPackageManagerController(),
       formatterStub,
@@ -313,14 +330,14 @@ void describe('deploy command', () => {
       () => Promise.resolve(),
     );
     await getCommandRunner(true).runCommand(
-      'pipeline-deploy --branch testBranch --custom-pipeline --stack-name mystack',
+      'pipeline-deploy --branch testBranch --standalone --stack-name my-stack',
     );
     assert.strictEqual(mockDeploy.mock.callCount(), 1);
     assert.deepStrictEqual(mockDeploy.mock.calls[0].arguments, [
       {
         name: 'testBranch',
-        namespace: 'mystack',
-        type: 'custompipeline',
+        namespace: 'my-stack',
+        type: 'standalone',
       },
       {
         validateAppSources: true,

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -85,8 +85,7 @@ void describe('deploy command', () => {
 
   void it('fails if required arguments are not supplied', async () => {
     const output = await getCommandRunner().runCommand('pipeline-deploy');
-    assert.match(output, /--branch is required/);
-    assert.match(output, /--app-id is required/);
+    assert.match(output, /Missing required argument: branch/);
     assert.equal(generateClientConfigMock.mock.callCount(), 0);
   });
 
@@ -265,10 +264,7 @@ void describe('deploy command', () => {
         ),
       (error: TestCommandError) => {
         assert.strictEqual(error.error.name, 'InvalidCommandInputError');
-        assert.match(
-          error.error.message,
-          /--branch must be at least 1 character/,
-        );
+        assert.match(error.error.message, /--branch is required/);
         return true;
       },
     );
@@ -280,12 +276,11 @@ void describe('deploy command', () => {
     await assert.rejects(
       async () =>
         await getCommandRunner(true).runCommand(
-          'pipeline-deploy --app-id --branch testBranch',
+          'pipeline-deploy --branch testBranch --app-id',
         ),
       (error: TestCommandError) => {
         assert.strictEqual(error.error.name, 'InvalidCommandInputError');
-        // app-id will be "--branch" and branch will be missing
-        assert.match(error.error.message, /--branch is required/);
+        assert.match(error.error.message, /--app-id is required/);
         return true;
       },
     );

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts
@@ -306,11 +306,22 @@ void describe('deploy command', () => {
   });
 
   void it('succeeds when --app-id is missing but --custom-pipeline is provided', async () => {
+    const backendDeployerFactory = new BackendDeployerFactory(
+      packageManagerControllerFactory.getPackageManagerController(),
+      formatterStub,
+      mockIoHost,
+      mockProfileResolver,
+    );
+    const mockDeploy = mock.method(
+      backendDeployerFactory.getInstance(),
+      'deploy',
+      () => Promise.resolve(),
+    );
     await getCommandRunner(true).runCommand(
       'pipeline-deploy --branch testBranch --custom-pipeline --stack-name mystack',
     );
-    assert.equal(deployMock.mock.callCount(), 1);
-    assert.deepStrictEqual(deployMock.mock.calls[0].arguments, [
+    assert.strictEqual(mockDeploy.mock.callCount(), 1);
+    assert.deepStrictEqual(mockDeploy.mock.calls[0].arguments, [
       {
         name: 'testBranch',
         namespace: 'mystack',
@@ -320,5 +331,6 @@ void describe('deploy command', () => {
         validateAppSources: true,
       },
     ]);
+    assert.equal(generateClientConfigMock.mock.callCount(), 1);
   });
 });

--- a/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
+++ b/packages/cli/src/commands/pipeline-deploy/pipeline_deploy_command.ts
@@ -143,27 +143,28 @@ export class PipelineDeployCommand
         choices: Object.values(ClientConfigFormat),
       })
       .check(async (argv) => {
+        const errors: string[] = [];
+
+        // Check if branch is provided
+        if (!argv['branch']) {
+          errors.push('--branch is required');
+        } else if (argv['branch'].length === 0) {
+          errors.push('--branch must be at least 1 character');
+        }
+
         // If custom-pipeline is not enabled, app-id is required
         if (!argv['custom-pipeline'] && !argv['app-id']) {
-          throw new AmplifyUserError('InvalidCommandInputError', {
-            message: 'Missing required argument: app-id',
-            resolution:
-              '--app-id is required unless --custom-pipeline is enabled',
-          });
+          errors.push(
+            '--app-id is required (unless --custom-pipeline is enabled)',
+          );
+        } else if (argv['app-id'] && argv['app-id'].length === 0) {
+          errors.push('--app-id must be at least 1 character');
         }
 
-        // Validate that branch and app-id (if provided) are not empty
-        if (argv['branch'].length === 0) {
+        if (errors.length > 0) {
           throw new AmplifyUserError('InvalidCommandInputError', {
-            message: 'Invalid --branch',
-            resolution: '--branch must be at least 1 character',
-          });
-        }
-
-        if (argv['app-id'] && argv['app-id'].length === 0) {
-          throw new AmplifyUserError('InvalidCommandInputError', {
-            message: 'Invalid --app-id',
-            resolution: '--app-id must be at least 1 character',
+            message: errors.join('\n'),
+            resolution: 'Provide all required arguments',
           });
         }
 

--- a/packages/integration-tests/src/define_backend_template_harness.ts
+++ b/packages/integration-tests/src/define_backend_template_harness.ts
@@ -44,6 +44,27 @@ export const synthesizeBackendTemplates: SynthesizeBackendTemplates = <
   }
 };
 
+/**
+ * Synthesizes deterministic `defineBackend` CDK templates using standalone deployment context.
+ *
+ * Uses DEPLOYMENT_TYPE: 'standalone' to simulate custom pipeline / standalone deployments.
+ */
+export const synthesizeStandaloneBackendTemplates: SynthesizeBackendTemplates =
+  <T extends Record<string, ConstructFactory<ResourceProvider>>>(
+    constructFactories: T,
+  ) => {
+    try {
+      process.env.CDK_CONTEXT_JSON = JSON.stringify({
+        [CDKContextKey.BACKEND_NAMESPACE]: 'testStandaloneStack',
+        [CDKContextKey.BACKEND_NAME]: 'main',
+        [CDKContextKey.DEPLOYMENT_TYPE]: 'standalone',
+      });
+      return backendTemplatesCollector(constructFactories);
+    } finally {
+      delete process.env.CDK_CONTEXT_JSON;
+    }
+  };
+
 const backendTemplatesCollector: SynthesizeBackendTemplates = <
   T extends Record<string, ConstructFactory<ResourceProvider>>,
 >(

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_auth.deployment.test.ts
@@ -1,0 +1,4 @@
+import { StandaloneAuthTestProjectCreator } from '../../test-project-setup/standalone_auth.js';
+import { defineStandaloneDeploymentTest } from './standalone_deployment.test.template.js';
+
+defineStandaloneDeploymentTest(new StandaloneAuthTestProjectCreator());

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
@@ -1,0 +1,6 @@
+import { DataStorageAuthWithTriggerTestProjectCreator } from '../../test-project-setup/data_storage_auth_with_triggers.js';
+import { defineStandaloneDeploymentTest } from './standalone_deployment.test.template.js';
+
+defineStandaloneDeploymentTest(
+  new DataStorageAuthWithTriggerTestProjectCreator(),
+);

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
@@ -1,6 +1,11 @@
-import { DataStorageAuthWithTriggerTestProjectCreator } from '../../test-project-setup/data_storage_auth_with_triggers.js';
-import { defineStandaloneDeploymentTest } from './standalone_deployment.test.template.js';
+// TODO: Enable this test after @aws-amplify/data-construct publishes a version
+// that includes @aws-amplify/backend-output-storage with standalone support.
+// Currently, data-construct bundles backend-output-storage@1.1.5 which throws
+// on the "standalone" deployment type context value.
 
-defineStandaloneDeploymentTest(
-  new DataStorageAuthWithTriggerTestProjectCreator(),
-);
+// import { DataStorageAuthWithTriggerTestProjectCreator } from '../../test-project-setup/data_storage_auth_with_triggers.js';
+// import { defineStandaloneDeploymentTest } from './standalone_deployment.test.template.js';
+
+// defineStandaloneDeploymentTest(
+//   new DataStorageAuthWithTriggerTestProjectCreator(),
+// );

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
@@ -1,0 +1,104 @@
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
+import {
+  createTestDirectory,
+  deleteTestDirectory,
+  rootTestDir,
+} from '../../setup_test_directory.js';
+import { TestProjectCreator } from '../../test-project-setup/test_project_creator.js';
+import { TestProjectBase } from '../../test-project-setup/test_project_base.js';
+import assert from 'node:assert';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { testConcurrencyLevel } from '../test_concurrency.js';
+import { shortUuid } from '../../short_uuid.js';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  ListStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import { e2eToolingClientConfig } from '../../e2e_tooling_client_config.js';
+
+/**
+ * Defines standalone deployment test.
+ *
+ * Unlike branch deployment tests, standalone tests do not require an Amplify app.
+ * They deploy using `ampx pipeline-deploy --standalone --stack-name <name> --branch main`.
+ */
+export const defineStandaloneDeploymentTest = (
+  testProjectCreator: TestProjectCreator,
+) => {
+  void describe(
+    'standalone deployment tests',
+    { concurrency: testConcurrencyLevel },
+    () => {
+      const cfnClient = new CloudFormationClient(e2eToolingClientConfig);
+
+      before(async () => {
+        await createTestDirectory(rootTestDir);
+      });
+      after(async () => {
+        await deleteTestDirectory(rootTestDir);
+      });
+
+      void describe(`standalone deploys ${testProjectCreator.name}`, () => {
+        let standaloneBackendIdentifier: BackendIdentifier;
+        let testProject: TestProjectBase;
+
+        beforeEach(async () => {
+          testProject = await testProjectCreator.createProject(rootTestDir);
+          standaloneBackendIdentifier = {
+            namespace: `standalone-e2e-${shortUuid()}`,
+            name: 'main',
+            type: 'standalone',
+          };
+        });
+
+        afterEach(async () => {
+          await testProject.tearDown(standaloneBackendIdentifier, true);
+        });
+
+        void it(`[${testProjectCreator.name}] deploys fully via standalone`, async () => {
+          await testProject.deploy(standaloneBackendIdentifier);
+
+          const stackName = BackendIdentifierConversions.toStackName(
+            standaloneBackendIdentifier,
+          );
+
+          // Verify the CFN stack exists and is in a good state
+          const describeResult = await cfnClient.send(
+            new DescribeStacksCommand({ StackName: stackName }),
+          );
+          assert.ok(
+            describeResult.Stacks && describeResult.Stacks.length > 0,
+            'standalone stack should exist after deployment',
+          );
+          const stack = describeResult.Stacks![0];
+          assert.ok(
+            stack.StackStatus === 'CREATE_COMPLETE' ||
+              stack.StackStatus === 'UPDATE_COMPLETE',
+            `stack should be in a successful state, got: ${stack.StackStatus}`,
+          );
+
+          // Verify no Amplify Hosting resources in the stack
+          const resources = await cfnClient.send(
+            new ListStackResourcesCommand({ StackName: stackName }),
+          );
+          const resourceTypes = (resources.StackResourceSummaries ?? []).map(
+            (r) => r.ResourceType,
+          );
+          assert.ok(
+            !resourceTypes.includes('AWS::Amplify::App'),
+            'standalone stack should not contain AWS::Amplify::App',
+          );
+          assert.ok(
+            !resourceTypes.includes('AWS::Amplify::Branch'),
+            'standalone stack should not contain AWS::Amplify::Branch',
+          );
+
+          // Verify post-deployment assertions (client config, etc.)
+          await testProject.assertPostDeployment(standaloneBackendIdentifier);
+        });
+      });
+    },
+  );
+};

--- a/packages/integration-tests/src/test-in-memory/standalone_deployment.test.ts
+++ b/packages/integration-tests/src/test-in-memory/standalone_deployment.test.ts
@@ -1,0 +1,64 @@
+import { it } from 'node:test';
+import assert from 'node:assert';
+import { synthesizeStandaloneBackendTemplates } from '../define_backend_template_harness.js';
+import { standaloneAuthWithWebAuthn } from '../test-projects/standalone-auth/amplify/test_factories.js';
+import path from 'node:path';
+import fsp from 'fs/promises';
+
+/**
+ * In-memory integration test for standalone deployment with WebAuthn.
+ *
+ * Verifies that defineBackend with DEPLOYMENT_TYPE=standalone and an explicit
+ * WebAuthn relyingPartyId produces correct CloudFormation templates.
+ */
+void it('standalone deployment with explicit WebAuthn relyingPartyId', async () => {
+  const templates = synthesizeStandaloneBackendTemplates(
+    standaloneAuthWithWebAuthn,
+  );
+
+  // Root template should exist and contain nested auth stack
+  assert.ok(templates.root, 'should produce a root template');
+  assert.ok(templates.auth, 'should produce an auth template');
+
+  const nestedStacks = templates.root.findResources(
+    'AWS::CloudFormation::Stack',
+  );
+  assert.ok(
+    Object.keys(nestedStacks).length > 0,
+    'should have at least one nested stack',
+  );
+
+  // Auth template should have the explicit relyingPartyId
+  templates.auth.hasResourceProperties('AWS::Cognito::UserPool', {
+    WebAuthnRelyingPartyID: 'app.example.com',
+  });
+
+  // Verify no Amplify Hosting artifacts leak into standalone templates
+  const rootJson = JSON.stringify(templates.root.toJSON());
+  const authJson = JSON.stringify(templates.auth.toJSON());
+  assert.ok(
+    !rootJson.includes('amplifyapp.com'),
+    'root template should not reference amplifyapp.com',
+  );
+  assert.ok(
+    !authJson.includes('amplifyapp.com'),
+    'auth template should not reference amplifyapp.com',
+  );
+  assert.strictEqual(
+    Object.keys(templates.root.findResources('AWS::Amplify::App')).length,
+    0,
+    'should not contain AWS::Amplify::App resources',
+  );
+  assert.strictEqual(
+    Object.keys(templates.root.findResources('AWS::Amplify::Branch')).length,
+    0,
+    'should not contain AWS::Amplify::Branch resources',
+  );
+
+  // clean up generated env files
+  await fsp.rm(path.join(process.cwd(), '.amplify'), {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+  });
+});

--- a/packages/integration-tests/src/test-in-memory/standalone_deployment_auto_webauthn.test.ts
+++ b/packages/integration-tests/src/test-in-memory/standalone_deployment_auto_webauthn.test.ts
@@ -1,0 +1,29 @@
+import { it } from 'node:test';
+import assert from 'node:assert';
+import { synthesizeStandaloneBackendTemplates } from '../define_backend_template_harness.js';
+import { standaloneAuthAutoWebAuthn } from '../test-projects/standalone-auth-auto-webauthn/amplify/test_factories.js';
+
+/**
+ * In-memory integration test for standalone deployment with WebAuthn AUTO.
+ *
+ * Verifies that using webAuthn: true (AUTO relyingPartyId) throws an error
+ * under standalone deployment context, since AUTO requires Amplify Hosting.
+ */
+void it('standalone deployment rejects WebAuthn AUTO relyingPartyId', () => {
+  assert.throws(
+    () => synthesizeStandaloneBackendTemplates(standaloneAuthAutoWebAuthn),
+    (err: Error) => {
+      // The original error is wrapped by AmplifyUserError; check the full chain
+      const fullMessage = JSON.stringify(err, Object.getOwnPropertyNames(err));
+      assert.ok(
+        fullMessage.includes('AUTO'),
+        `error chain should mention AUTO, got: ${fullMessage}`,
+      );
+      assert.ok(
+        fullMessage.includes('standalone'),
+        `error chain should mention standalone, got: ${fullMessage}`,
+      );
+      return true;
+    },
+  );
+});

--- a/packages/integration-tests/src/test-project-setup/standalone_auth.ts
+++ b/packages/integration-tests/src/test-project-setup/standalone_auth.ts
@@ -1,0 +1,63 @@
+import { TestProjectBase } from './test_project_base.js';
+import fs from 'fs/promises';
+import { createEmptyAmplifyProject } from './create_empty_amplify_project.js';
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { TestProjectCreator } from './test_project_creator.js';
+import { AmplifyClient } from '@aws-sdk/client-amplify';
+import { e2eToolingClientConfig } from '../e2e_tooling_client_config.js';
+
+/**
+ * Creates a minimal auth project for standalone deployment E2E testing.
+ *
+ * This is intentionally lightweight — the standalone deployment template
+ * verifies no Amplify Hosting resources are present, and the base
+ * class checks client config. Comprehensive resource verification is
+ * covered by the data-storage-auth standalone test which reuses the
+ * existing DataStorageAuthWithTriggerTestProjectCreator.
+ */
+export class StandaloneAuthTestProjectCreator implements TestProjectCreator {
+  readonly name = 'standalone-auth';
+
+  /**
+   * Creates project creator.
+   */
+  constructor(
+    private readonly cfnClient: CloudFormationClient = new CloudFormationClient(
+      e2eToolingClientConfig,
+    ),
+    private readonly amplifyClient: AmplifyClient = new AmplifyClient(
+      e2eToolingClientConfig,
+    ),
+  ) {}
+
+  createProject = async (e2eProjectDir: string): Promise<TestProjectBase> => {
+    const { projectName, projectRoot, projectAmplifyDir } =
+      await createEmptyAmplifyProject(this.name, e2eProjectDir);
+
+    const project = new StandaloneAuthTestProject(
+      projectName,
+      projectRoot,
+      projectAmplifyDir,
+      this.cfnClient,
+      this.amplifyClient,
+    );
+    await fs.cp(
+      project.sourceProjectAmplifyDirURL,
+      project.projectAmplifyDirPath,
+      { recursive: true },
+    );
+    return project;
+  };
+}
+
+class StandaloneAuthTestProject extends TestProjectBase {
+  readonly sourceProjectDirPath = '../../src/test-projects/standalone-auth-e2e';
+
+  readonly sourceProjectAmplifyDirURL: URL = new URL(
+    `${this.sourceProjectDirPath}/amplify`,
+    import.meta.url,
+  );
+
+  // No custom assertPostDeployment — base class checks client config,
+  // and the standalone template checks for no Amplify Hosting resources.
+}

--- a/packages/integration-tests/src/test-project-setup/test_project_base.ts
+++ b/packages/integration-tests/src/test-project-setup/test_project_base.ts
@@ -81,6 +81,24 @@ export abstract class TestProjectBase {
         .do(waitForSandboxDeploymentToPrintTotalTime())
         .do(interruptSandbox())
         .run();
+    } else if (backendIdentifier.type === 'standalone') {
+      await ampxCli(
+        [
+          'pipeline-deploy',
+          '--standalone',
+          '--stack-name',
+          backendIdentifier.namespace,
+          '--branch',
+          backendIdentifier.name,
+        ],
+        this.projectDirPath,
+        {
+          env: {
+            CI: 'true',
+            ...environment,
+          },
+        },
+      ).run();
     } else {
       await ampxCli(
         [

--- a/packages/integration-tests/src/test-projects/standalone-auth-auto-webauthn/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth-auto-webauthn/amplify/auth/resource.ts
@@ -1,0 +1,13 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+/**
+ * Auth with WebAuthn AUTO (boolean shorthand) — this should fail
+ * under standalone deployment because AUTO cannot resolve without
+ * Amplify Hosting.
+ */
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+    webAuthn: true,
+  },
+});

--- a/packages/integration-tests/src/test-projects/standalone-auth-auto-webauthn/amplify/test_factories.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth-auto-webauthn/amplify/test_factories.ts
@@ -1,0 +1,3 @@
+import { auth } from './auth/resource.js';
+
+export const standaloneAuthAutoWebAuthn = { auth };

--- a/packages/integration-tests/src/test-projects/standalone-auth-e2e/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth-e2e/amplify/auth/resource.ts
@@ -1,0 +1,7 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+  },
+});

--- a/packages/integration-tests/src/test-projects/standalone-auth-e2e/amplify/backend.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth-e2e/amplify/backend.ts
@@ -1,0 +1,6 @@
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource.js';
+
+defineBackend({
+  auth,
+});

--- a/packages/integration-tests/src/test-projects/standalone-auth/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth/amplify/auth/resource.ts
@@ -1,0 +1,14 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+/**
+ * Auth with explicit WebAuthn relyingPartyId for standalone deployments.
+ * AUTO is not supported in standalone mode, so we must provide an explicit domain.
+ */
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+    webAuthn: {
+      relyingPartyId: 'app.example.com',
+    },
+  },
+});

--- a/packages/integration-tests/src/test-projects/standalone-auth/amplify/test_factories.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth/amplify/test_factories.ts
@@ -1,0 +1,3 @@
+import { auth } from './auth/resource.js';
+
+export const standaloneAuthWithWebAuthn = { auth };

--- a/packages/platform-core/src/backend_identifier_conversions.test.ts
+++ b/packages/platform-core/src/backend_identifier_conversions.test.ts
@@ -65,6 +65,17 @@ void describe('toStackName', () => {
     });
     assert.equal(actual, 'amplify-reasonableName-userName-sandbox-testHash');
   });
+
+  void it('generates standalone stack name within 128 char limit', () => {
+    const actual = BackendIdentifierConversions.toStackName({
+      namespace: 'myCustomStack',
+      name: 'main',
+      type: 'standalone',
+      hash: 'testHash',
+    });
+    assert.equal(actual, 'amplify-myCustomStack-main-standalone-testHash');
+    assert.ok(actual.length <= 128);
+  });
 });
 
 void describe('fromStackName', () => {
@@ -102,6 +113,18 @@ void describe('fromStackName', () => {
       namespace: 'reasonableName',
       name: 'userName',
       type: 'sandbox',
+      hash: 'testHash',
+    });
+  });
+
+  void it('parses standalone stack name into parts', () => {
+    const actual = BackendIdentifierConversions.fromStackName(
+      'amplify-myCustomStack-main-standalone-testHash',
+    );
+    assert.deepStrictEqual(actual, {
+      namespace: 'myCustomStack',
+      name: 'main',
+      type: 'standalone',
       hash: 'testHash',
     });
   });

--- a/packages/platform-core/src/backend_identifier_conversions.ts
+++ b/packages/platform-core/src/backend_identifier_conversions.ts
@@ -29,14 +29,14 @@ export class BackendIdentifierConversions {
     if (prefix !== AMPLIFY_PREFIX) {
       return;
     }
-    if (type !== 'sandbox' && type !== 'branch') {
+    if (type !== 'sandbox' && type !== 'branch' && type !== 'custompipeline') {
       return;
     }
 
     return {
       namespace,
       name: instance,
-      type: type as 'sandbox' | 'branch',
+      type: type as 'sandbox' | 'branch' | 'custompipeline',
       hash,
     };
   }

--- a/packages/platform-core/src/backend_identifier_conversions.ts
+++ b/packages/platform-core/src/backend_identifier_conversions.ts
@@ -29,14 +29,14 @@ export class BackendIdentifierConversions {
     if (prefix !== AMPLIFY_PREFIX) {
       return;
     }
-    if (type !== 'sandbox' && type !== 'branch' && type !== 'custompipeline') {
+    if (type !== 'sandbox' && type !== 'branch' && type !== 'standalone') {
       return;
     }
 
     return {
       namespace,
       name: instance,
-      type: type as 'sandbox' | 'branch' | 'custompipeline',
+      type: type as 'sandbox' | 'branch' | 'standalone',
       hash,
     };
   }

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -97,6 +97,11 @@ export type BackendIdentifier = {
     name: Readonly<SandboxName>;
     type: Readonly<Extract<DeploymentType, 'sandbox'>>;
     hash?: Readonly<string>;
+} | {
+    namespace: Readonly<ProjectName>;
+    name: Readonly<BranchName>;
+    type: Readonly<Extract<DeploymentType, 'custompipeline'>>;
+    hash?: Readonly<string>;
 };
 
 // @public (undocumented)
@@ -178,7 +183,7 @@ export type Dependency = {
 };
 
 // @public
-export type DeploymentType = 'branch' | 'sandbox';
+export type DeploymentType = 'branch' | 'sandbox' | 'custompipeline';
 
 // @public (undocumented)
 export type ExecaChildProcess = {

--- a/packages/plugin-types/API.md
+++ b/packages/plugin-types/API.md
@@ -100,7 +100,7 @@ export type BackendIdentifier = {
 } | {
     namespace: Readonly<ProjectName>;
     name: Readonly<BranchName>;
-    type: Readonly<Extract<DeploymentType, 'custompipeline'>>;
+    type: Readonly<Extract<DeploymentType, 'standalone'>>;
     hash?: Readonly<string>;
 };
 
@@ -183,7 +183,7 @@ export type Dependency = {
 };
 
 // @public
-export type DeploymentType = 'branch' | 'sandbox' | 'custompipeline';
+export type DeploymentType = 'branch' | 'sandbox' | 'standalone';
 
 // @public (undocumented)
 export type ExecaChildProcess = {

--- a/packages/plugin-types/src/backend_identifier.ts
+++ b/packages/plugin-types/src/backend_identifier.ts
@@ -67,9 +67,9 @@ export type BackendIdentifier =
        */
       name: Readonly<BranchName>;
       /**
-       * Const that determines this BackendIdentifier is for a custom pipeline backend (CI/CD without Amplify Hosting)
+       * Const that determines this BackendIdentifier is for a standalone backend (without Amplify Hosting)
        */
-      type: Readonly<Extract<DeploymentType, 'custompipeline'>>;
+      type: Readonly<Extract<DeploymentType, 'standalone'>>;
       /**
        * Optional hash for consistent stack naming in cases where namespace or name contain characters that can't be serialized into a stack name
        */

--- a/packages/plugin-types/src/backend_identifier.ts
+++ b/packages/plugin-types/src/backend_identifier.ts
@@ -56,4 +56,22 @@ export type BackendIdentifier =
        * Optional hash for consistent stack naming in cases where namespace or name contain characters that can't be serialized into a stack name
        */
       hash?: Readonly<string>;
+    }
+  | {
+      /**
+       * The project name for the custom pipeline deployment.
+       */
+      namespace: Readonly<ProjectName>;
+      /**
+       * The branch name for the custom pipeline deployment.
+       */
+      name: Readonly<BranchName>;
+      /**
+       * Const that determines this BackendIdentifier is for a custom pipeline backend (CI/CD without Amplify Hosting)
+       */
+      type: Readonly<Extract<DeploymentType, 'custompipeline'>>;
+      /**
+       * Optional hash for consistent stack naming in cases where namespace or name contain characters that can't be serialized into a stack name
+       */
+      hash?: Readonly<string>;
     };

--- a/packages/plugin-types/src/deployment_type.ts
+++ b/packages/plugin-types/src/deployment_type.ts
@@ -3,6 +3,6 @@
  *
  * Branch deployments are tied to specific git branches and are designed to be used in CI/CD
  * Sandbox deployments are local development environments
- * Custom pipeline deployments are CI/CD deployments without Amplify Hosting
+ * Standalone deployments are deployments without Amplify Hosting
  */
-export type DeploymentType = 'branch' | 'sandbox' | 'custompipeline';
+export type DeploymentType = 'branch' | 'sandbox' | 'standalone';

--- a/packages/plugin-types/src/deployment_type.ts
+++ b/packages/plugin-types/src/deployment_type.ts
@@ -3,5 +3,6 @@
  *
  * Branch deployments are tied to specific git branches and are designed to be used in CI/CD
  * Sandbox deployments are local development environments
+ * Custom pipeline deployments are CI/CD deployments without Amplify Hosting
  */
-export type DeploymentType = 'branch' | 'sandbox';
+export type DeploymentType = 'branch' | 'sandbox' | 'custompipeline';


### PR DESCRIPTION
## Add standalone deployment type for deploying Gen2 backends without Amplify Hosting

Today, deploying an Amplify Gen2 backend requires Amplify Hosting. This PR adds a standalone deployment type that lets you deploy Gen2 backends from any CI/CD system (GitHub Actions, Jenkins, CodePipeline, etc.) using ampx pipeline-deploy --standalone --stack-name <name>.

Standalone deployments skip the BranchLinker (no Amplify app needed) and use the provided stack name as the CloudFormation namespace.

**Corresponding docs PR, if applicable:**

## Validation

### Unit Tests

- Added unit tests for WebAuthn relyingPartyId behavior in standalone deployments (throws on AUTO, accepts explicit domain) in `auth-construct/src/construct.test.ts`
- Added unit tests for standalone deployment tag propagation in `backend/src/default_stack_factory.test.ts`
- Added unit test for standalone backend factory initialization in `backend/src/backend_factory.test.ts`
- Updated existing pipeline-deploy command tests for the standalone flow in `cli/src/commands/pipeline-deploy/pipeline_deploy_command.test.ts`
- Also added new test file for CFN deployment progress logger (`cli-core/src/loggers/cfn-deployment-progress/cfn_deployment_progress_logger.test.ts`) covering nested stack name resolution for standalone/sandbox, progress tracking, failure display, and CDKMetadata filtering. This did not exist before and are not 100% related to this change. But they are required to verify this change does not break the CLI logging for other workflows.

### In-Memory Integration Tests
- Added standalone_deployment.test.ts. synthesizes a standalone backend with explicit WebAuthn relyingPartyId and verifies correct CloudFormation output with no Amplify Hosting artifacts (no AWS::Amplify::App, AWS::Amplify::Branch, or amplifyapp.com references)
- Added standalone_deployment_auto_webauthn.test.ts. verifies that using WebAuthn AUTO (webAuthn: true) under standalone deployment throws an error, since AUTO requires Amplify Hosting to resolve the relying party ID

### E2E Tests

- Updated `test_project_base.ts` `deploy()` to route `standalone` type identifiers to `ampx pipeline-deploy --standalone --stack-name <namespace> --branch <name>`

- Added `standalone_data_storage_auth.deployment.test.ts` and `standalone_deployment.test.template.ts`. A standalone deployments that deploys via `ampx pipeline-deploy --standalone --stack-name <name>`, verifies the CloudFormation stack reaches a successful state, and asserts no Amplify Hosting resources (`AWS::Amplify::App`, `AWS::Amplify::Branch`) are present 

- **Note on comprehensive standalone E2E test:** A standalone E2E test reusing `DataStorageAuthWithTriggerTestProjectCreator` (the same project used by sandbox and branch deployment tests) is included but commented out. The currently published `@aws-amplify/data-construct` bundles `@aws-amplify/backend-output-storage@1.1.5` in its own `node_modules`, which throws on the new `"standalone"` deployment type context value. Because `data-construct` ships with its own bundled copy of `backend-output-storage`, there is no way to override it at install time. Even though the local workspace has the updated version, npm resolves the bundled copy from within `data-construct`'s dependency tree. This creates a cross-repo sequencing issue: `backend-output-storage` must be published first (via this PR), then `data-construct` in `amplify-category-api` needs to update its bundled dependency and publish a new version. Once that happens, this test can be uncommented to verify the full stack (data, storage, auth, lambdas, secrets) works identically via an E2E test under standalone deployment.


## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
