### PR TITLE
chore: increase `health_checks` workflow frequency to reduce alarm sensitivity

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -11,12 +11,12 @@ on:
       - hotfix
       - feature/**
   schedule:
-    # Every day at minute 0 past hour 0, 6, 12, and 18 UTC.
-    # This is to make sure that there is at least one workflow run every 24 hours
+    # Run every two hours. A single run takes about 40min so we should
+    # get about 10 runs per day. If at least one of them succeeds, we are happy.
     # taking into account that
     # 1) scheduled runs may not fire at exact prescribed time;
     # 2) transient failures may happen and auto recover;
-    - cron: '0 0,6,12,18 * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
     inputs:
       desired-cdk-lib-version:


### PR DESCRIPTION

<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

The `health_checks` [workflow](https://github.com/aws-amplify/amplify-backend/actions/workflows/health_checks.yml?query=branch%3Amain) on `main` is nutritiously sporadic (likely due to race conditions). Our alarm is set to fire if all workflow executions in a 24 hour period fail; currently - we run this workflow every 6 hours which in practice means just 3 consecutive failures will trigger an alarm. 

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

Increase the frequency of executions to one every 2 hours so that we get at least 10 executions per day, giving the workflow more chances to succeed and not trigger the alarm.

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

None. No code changes.

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [x] If this PR requires a docs update, I have linked to that docs PR above.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
