### PR TITLE
Missing permissions in `release_switch` workflow

### DIFF
--- a/.github/workflows/release_switch.yml
+++ b/.github/workflows/release_switch.yml
@@ -7,10 +7,6 @@ on:
       - hotfix
   workflow_dispatch:
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   run_health_checks:
     if: ${{ github.ref_name == 'main' || github.ref_name == 'hotfix' }}


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
We are missing permissions that `health_checks` needs when it is run through `release_switch`: https://github.com/aws-amplify/amplify-backend/actions/runs/21688659105

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
Adds those permissions. Also simplifies the if statement to decide whether we should be running a snapshot release or a regular release. 
I also don't think we need to grant `id-token: write/contents: read` permissions to the `release_switch`.

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
