### PR TITLE
Add support for 'bun' package manager

### DIFF
--- a/packages/cli-core/src/package-manager-controller/get_package_manager_name.ts
+++ b/packages/cli-core/src/package-manager-controller/get_package_manager_name.ts
@@ -34,6 +34,7 @@ const runnerMap: Record<string, string> = {
   'yarn-modern': 'yarn',
   'yarn-classic': 'yarn',
   pnpm: 'pnpm',
+  bun: 'bunx',
 };
 
 /**


### PR DESCRIPTION
Added a mapping for the `bun` package manager to use the `bunx` runner in the `runnerMap` object in `get_package_manager_name.ts`.