### PR TITLE
fix: Add `amplifyconfig` alias in gen1 Dart output for backwards compatibility

### DIFF
--- a/.changeset/fix-dart-amplifyconfig-alias.md
+++ b/.changeset/fix-dart-amplifyconfig-alias.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/client-config': patch
+---
+
+Add `amplifyconfig` alias in gen1 Dart output for backwards compatibility

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -7,6 +7,7 @@
   "amazonaws",
   "amazoncognito",
   "amplifyapp",
+  "amplifyconfig",
   "amplifyconfiguration",
   "ampx",
   "anonymize",

--- a/packages/client-config/src/client-config-writer/client_config_formatter_legacy.ts
+++ b/packages/client-config/src/client-config-writer/client_config_formatter_legacy.ts
@@ -35,7 +35,7 @@ export class ClientConfigFormatterLegacy implements ClientConfigFormatter {
           this.configConverter.convertToMobileConfig(legacyConfig),
           null,
           2,
-        )}''';`;
+        )}''';\n\nconst amplifyconfig = amplifyConfig;`;
       }
       case ClientConfigFormat.JSON_MOBILE:
         return JSON.stringify(


### PR DESCRIPTION
## Problem

Calls like
```Dart
Process.runSync('npx', [
    'ampx',
    'generate',
    'outputs',
    '--format',
    'dart',
    '--outputs-version',
    '0',
    '--out-dir',
    outputPath,
    '--profile=${Platform.environment['AWS_PROFILE'] ?? 'default'}',
    '--stack',
    stack,
    '--debug',
    'true',
  ]
```

Produce a Gen1 config with the var wrong name. To make this usable, we need workarounds like
```Dart
    final content = outputFile.readAsStringSync();
    if (!content.contains('const amplifyconfig =') &&
        content.contains('const amplifyConfig =')) {
      // Workaround because ampx writes the wrong const name
      outputFile.writeAsStringSync(
        '\n\nconst amplifyconfig = amplifyConfig;\n',
        mode: FileMode.append,
      );
    }
```
(https://github.com/aws-amplify/amplify-flutter/pull/6587/changes#diff-531a45f010f5643830df799f91008ef7834b8f6feff7584c8b4b980d447e832cR603-R611)

## Changes

Adds an alias instead of renaming it so that this is not a breaking change.

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
