### PR TITLE
feat: ampx deploy

### DIFF
--- a/.changeset/feat-ampx-deploy.md
+++ b/.changeset/feat-ampx-deploy.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': minor
+---
+
+Add `ampx deploy` command for deploying Gen2 backends without Amplify Hosting

--- a/package-lock.json
+++ b/package-lock.json
@@ -779,6 +779,7 @@
         "@aws-sdk/credential-provider-node",
         "@aws-sdk/credential-provider-process",
         "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-login",
         "@aws-sdk/credential-provider-web-identity",
         "@aws-sdk/middleware-host-header",
         "@aws-sdk/middleware-logger",
@@ -792,6 +793,13 @@
         "@aws-sdk/util-locate-window",
         "@aws-sdk/util-user-agent-browser",
         "@aws-sdk/util-user-agent-node",
+        "@aws-sdk/xml-builder",
+        "@aws/lambda-invoke-store",
+        "@opentelemetry/api",
+        "@opentelemetry/core",
+        "@opentelemetry/resources",
+        "@opentelemetry/sdk-trace-base",
+        "@opentelemetry/semantic-conventions",
         "@smithy/abort-controller",
         "@smithy/config-resolver",
         "@smithy/core",
@@ -836,11 +844,13 @@
         "@smithy/util-stream",
         "@smithy/util-uri-escape",
         "@smithy/util-utf8",
+        "@smithy/uuid",
         "@types/uuid",
         "bowser",
         "charenc",
         "ci-info",
         "crypt",
+        "fast-xml-builder",
         "fast-xml-parser",
         "fs-extra",
         "graceful-fs",
@@ -858,6 +868,7 @@
         "lodash.snakecase",
         "md5",
         "object-hash",
+        "path-expression-matcher",
         "pluralize",
         "semver",
         "strnum",
@@ -867,30 +878,29 @@
         "uuid",
         "zod"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.5.3",
+        "@aws-amplify/ai-constructs": "^1.6.1",
         "@aws-amplify/backend-output-schemas": "^1.0.0",
         "@aws-amplify/backend-output-storage": "^1.0.0",
-        "@aws-amplify/graphql-api-construct": "1.21.0",
-        "@aws-amplify/graphql-auth-transformer": "4.2.5",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.13",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.15",
+        "@aws-amplify/graphql-api-construct": "1.21.1",
+        "@aws-amplify/graphql-auth-transformer": "4.2.6",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.14",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.16",
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-function-transformer": "3.1.17",
-        "@aws-amplify/graphql-generation-transformer": "1.2.5",
-        "@aws-amplify/graphql-http-transformer": "3.0.20",
-        "@aws-amplify/graphql-index-transformer": "3.1.0",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.20",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.20",
-        "@aws-amplify/graphql-relational-transformer": "3.1.12",
-        "@aws-amplify/graphql-searchable-transformer": "3.1.0",
-        "@aws-amplify/graphql-sql-transformer": "0.4.20",
-        "@aws-amplify/graphql-transformer": "2.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-function-transformer": "3.1.18",
+        "@aws-amplify/graphql-generation-transformer": "1.2.6",
+        "@aws-amplify/graphql-http-transformer": "3.0.21",
+        "@aws-amplify/graphql-index-transformer": "3.1.1",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.21",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.21",
+        "@aws-amplify/graphql-relational-transformer": "3.1.13",
+        "@aws-amplify/graphql-searchable-transformer": "3.1.1",
+        "@aws-amplify/graphql-sql-transformer": "0.4.21",
+        "@aws-amplify/graphql-transformer": "2.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
-        "@aws-amplify/graphql-validate-transformer": "1.1.5",
+        "@aws-amplify/graphql-validate-transformer": "1.1.6",
         "@aws-amplify/platform-core": "^1.0.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "@aws-crypto/crc32": "5.2.0",
@@ -906,6 +916,7 @@
         "@aws-sdk/credential-provider-env": "3.620.1",
         "@aws-sdk/credential-provider-http": "3.635.0",
         "@aws-sdk/credential-provider-ini": "3.637.0",
+        "@aws-sdk/credential-provider-login": "3.955.0",
         "@aws-sdk/credential-provider-node": "3.637.0",
         "@aws-sdk/credential-provider-process": "3.620.1",
         "@aws-sdk/credential-provider-sso": "3.637.0",
@@ -922,6 +933,13 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@aws-sdk/xml-builder": "3.804.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
         "@smithy/abort-controller": "^3.1.1",
         "@smithy/config-resolver": "^3.0.5",
         "@smithy/core": "^2.4.0",
@@ -966,12 +984,14 @@
         "@smithy/util-stream": "^3.1.3",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
+        "@smithy/uuid": "^1.1.0",
         "@types/uuid": "^9.0.8",
         "bowser": "^2.11.0",
         "charenc": "^0.0.2",
         "ci-info": "^3.2.0",
         "crypt": "^0.0.2",
-        "fast-xml-parser": "4.4.1",
+        "fast-xml-builder": "1.1.1",
+        "fast-xml-parser": "5.5.2",
         "fs-extra": "^8.1.0",
         "graceful-fs": "^4.2.0",
         "graphql": "^15.5.0",
@@ -983,11 +1003,12 @@
         "is-ci": "^3.0.1",
         "jsonfile": "^4.0.0",
         "libphonenumber-js": "1.9.47",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "lodash.mergewith": "^4.6.2",
         "lodash.snakecase": "^4.1.1",
         "md5": "^2.2.1",
         "object-hash": "^3.0.0",
+        "path-expression-matcher": "1.1.3",
         "pluralize": "8.0.0",
         "semver": "^7.6.3",
         "strnum": "^1.0.5",
@@ -1003,53 +1024,19 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs": {
-      "version": "1.5.3",
+      "version": "1.6.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.6.0",
-        "@aws-amplify/plugin-types": "^1.10.1",
+        "@aws-amplify/backend-output-schemas": "^1.8.0",
+        "@aws-amplify/plugin-types": "^1.11.2",
         "@aws-sdk/client-bedrock-runtime": "3.622.0",
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "json-schema-to-ts": "^3.1.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.189.1",
+        "aws-cdk-lib": "^2.234.1",
         "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "1.6.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "zod": "^3.22.2"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/plugin-types": {
-      "version": "1.10.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-cdk/toolkit-lib": "0.3.2"
-      },
-      "peerDependencies": {
-        "@aws-sdk/types": "^3.734.0",
-        "aws-cdk-lib": "^2.189.1",
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/plugin-types/node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-bedrock-runtime": {
@@ -1532,7 +1519,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@smithy/types": {
-      "version": "4.3.1",
+      "version": "4.13.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1543,40 +1530,49 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "1.4.1",
+      "version": "1.8.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "zod": "^3.22.2"
+        "zod": "3.25.17"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-schemas/node_modules/zod": {
+      "version": "3.25.17",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-storage": {
-      "version": "1.1.5",
+      "version": "1.3.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.4.1",
-        "@aws-amplify/platform-core": "^1.6.5",
-        "@aws-amplify/plugin-types": "^1.8.1"
+        "@aws-amplify/backend-output-schemas": "^1.8.0",
+        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/plugin-types": "^1.12.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.180.0"
+        "aws-cdk-lib": "^2.234.1"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "4.2.5",
+      "version": "4.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-relational-transformer": "3.1.12",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-relational-transformer": "3.1.13",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "md5": "^2.3.0"
       },
       "peerDependencies": {
@@ -1585,16 +1581,16 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
-      "version": "1.1.13",
+      "version": "1.1.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.5.3",
+        "@aws-amplify/ai-constructs": "^1.6.1",
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-index-transformer": "3.1.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-relational-transformer": "3.1.12",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-index-transformer": "3.1.1",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-relational-transformer": "3.1.13",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "graphql": "^15.5.0",
@@ -1609,12 +1605,12 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "3.1.15",
+      "version": "3.1.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1628,12 +1624,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "3.1.17",
+      "version": "3.1.18",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1645,12 +1641,12 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1663,12 +1659,12 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "3.0.20",
+      "version": "3.0.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1680,13 +1676,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1698,12 +1694,12 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "4.0.20",
+      "version": "4.0.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1714,12 +1710,12 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "3.4.0",
+      "version": "3.4.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1731,12 +1727,12 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "3.0.20",
+      "version": "3.0.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1748,14 +1744,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "3.1.12",
+      "version": "3.1.13",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-index-transformer": "3.1.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-index-transformer": "3.1.1",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1768,13 +1764,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1786,13 +1782,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.4.20",
+      "version": "0.4.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1804,26 +1800,26 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "2.4.0",
+      "version": "2.4.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "4.2.5",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.13",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.15",
-        "@aws-amplify/graphql-function-transformer": "3.1.17",
-        "@aws-amplify/graphql-generation-transformer": "1.2.5",
-        "@aws-amplify/graphql-http-transformer": "3.0.20",
-        "@aws-amplify/graphql-index-transformer": "3.1.0",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.20",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.20",
-        "@aws-amplify/graphql-relational-transformer": "3.1.12",
-        "@aws-amplify/graphql-searchable-transformer": "3.1.0",
-        "@aws-amplify/graphql-sql-transformer": "0.4.20",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-auth-transformer": "4.2.6",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.14",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.16",
+        "@aws-amplify/graphql-function-transformer": "3.1.18",
+        "@aws-amplify/graphql-generation-transformer": "1.2.6",
+        "@aws-amplify/graphql-http-transformer": "3.0.21",
+        "@aws-amplify/graphql-index-transformer": "3.1.1",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.21",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.21",
+        "@aws-amplify/graphql-relational-transformer": "3.1.13",
+        "@aws-amplify/graphql-searchable-transformer": "3.1.1",
+        "@aws-amplify/graphql-sql-transformer": "0.4.21",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
-        "@aws-amplify/graphql-validate-transformer": "1.1.5",
+        "@aws-amplify/graphql-validate-transformer": "1.1.6",
         "@aws-amplify/plugin-types": "^1.0.0"
       },
       "peerDependencies": {
@@ -1832,7 +1828,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "3.5.0",
+      "version": "3.5.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1843,7 +1839,7 @@
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
         "hjson": "^3.2.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "md5": "^2.3.0",
         "object-hash": "^3.0.0",
         "ts-dedent": "^2.0.0"
@@ -1866,12 +1862,12 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-validate-transformer": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1879,22 +1875,1003 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core": {
-      "version": "1.6.5",
+      "version": "1.11.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.8.1",
-        "@aws-sdk/client-sts": "^3.624.0",
+        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-sdk/client-sts": "^3.936.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
         "is-ci": "^4.1.0",
         "lodash.mergewith": "^4.6.2",
         "lodash.snakecase": "^4.1.1",
         "semver": "^7.6.3",
-        "uuid": "^9.0.1",
-        "zod": "^3.22.2"
+        "uuid": "^11.1.0",
+        "zod": "3.25.17"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.180.0",
+        "aws-cdk-lib": "^2.234.1",
         "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/client-sts": {
+      "version": "3.1011.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-node": "^3.972.21",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/core": {
+      "version": "3.973.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.18",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.19",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-env": "^3.972.18",
+        "@aws-sdk/credential-provider-http": "^3.972.20",
+        "@aws-sdk/credential-provider-login": "^3.972.20",
+        "@aws-sdk/credential-provider-process": "^3.972.18",
+        "@aws-sdk/credential-provider-sso": "^3.972.20",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.21",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.18",
+        "@aws-sdk/credential-provider-http": "^3.972.20",
+        "@aws-sdk/credential-provider-ini": "^3.972.20",
+        "@aws-sdk/credential-provider-process": "^3.972.18",
+        "@aws-sdk/credential-provider-sso": "^3.972.20",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.18",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/token-providers": "3.1009.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.21",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.11",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.10",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1009.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.11",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/abort-controller": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/config-resolver": {
+      "version": "4.4.11",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/core": {
+      "version": "3.23.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.15",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/hash-node": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.26",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-retry": {
+      "version": "4.4.43",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-serde": {
+      "version": "4.2.15",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-stack": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/node-config-provider": {
+      "version": "4.3.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/node-http-handler": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/property-provider": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/querystring-builder": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/querystring-parser": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/service-error-classification": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/signature-v4": {
+      "version": "5.3.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/smithy-client": {
+      "version": "4.12.6",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/url-parser": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.42",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.45",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-endpoints": {
+      "version": "3.3.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-middleware": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-retry": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-stream": {
+      "version": "4.5.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/ci-info": {
@@ -1928,13 +2905,36 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/uuid": {
+      "version": "11.1.0",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/zod": {
+      "version": "3.25.17",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/plugin-types": {
-      "version": "1.8.1",
+      "version": "1.12.0",
       "inBundle": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/toolkit-lib": "1.16.0"
+      },
       "peerDependencies": {
-        "@aws-sdk/types": "^3.609.0",
-        "aws-cdk-lib": "^2.180.0",
+        "@aws-sdk/types": "^3.734.0",
+        "aws-cdk-lib": "^2.234.1",
         "constructs": "^10.0.0"
       }
     },
@@ -2511,6 +3511,18 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/abort-controller": {
@@ -4386,6 +5398,100 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.821.0.tgz",
+      "integrity": "sha512-JqmzOCAnd9pUnmbrqXIbyBUxjw/UAfXAu8KAsE/4SveUIvyYRbYSTfCoPq6nnNJQpBtdEFLkjvBnHKBcInDwkg==",
+      "inBundle": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/eventstream-codec": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/eventstream-handler-node/node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+      "inBundle": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/eventstream-handler-node/node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "inBundle": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/eventstream-handler-node/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "inBundle": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.821.0.tgz",
+      "integrity": "sha512-L+qud1uX1hX7MpRy564dFj4/5sDRKVLToiydvgRy6Rc3pwsVhRpm6/2djMVgDsFI3sYd+JoeTFjEypkoV3LE5Q==",
+      "inBundle": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-eventstream/node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "inBundle": true,
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-eventstream/node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "inBundle": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.620.0",
       "inBundle": true,
@@ -5394,27 +6500,73 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.821.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
-      "version": "4.3.1",
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.33.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/abort-controller": {
@@ -6045,26 +7197,49 @@
         "node": "*"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/fast-xml-parser": {
-      "version": "4.4.1",
+    "node_modules/@aws-amplify/data-construct/node_modules/fast-xml-builder": {
+      "version": "1.1.1",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/fast-xml-parser": {
+      "version": "5.5.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.1",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/fast-xml-parser/node_modules/strnum": {
+      "version": "2.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -6155,7 +7330,7 @@
       "license": "MIT"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.17.23",
       "inBundle": true,
       "license": "MIT"
     },
@@ -6185,6 +7360,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/pluralize": {
@@ -6390,9 +7579,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.21.0.tgz",
-      "integrity": "sha512-jYUzcDCy1GmXwIEtjStKhC3N428WpfDPvMl1x8m2mnMPBoWOmATYwR6DsT9DSZU7MHQUXvJiNGmITuwmPmld9g==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.21.1.tgz",
+      "integrity": "sha512-W1hwVUFodaDOIX4yOHCJ4CWa/2Wb5vW9OUQXbwXadrsKdVvGsaVi5shT2F+ZVuHLbgbfNG6hM02n9DxqZzKS0g==",
       "bundleDependencies": [
         "@aws-amplify/ai-constructs",
         "@aws-amplify/backend-output-schemas",
@@ -6433,6 +7622,7 @@
         "@aws-sdk/credential-provider-node",
         "@aws-sdk/credential-provider-process",
         "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-login",
         "@aws-sdk/credential-provider-web-identity",
         "@aws-sdk/middleware-host-header",
         "@aws-sdk/middleware-logger",
@@ -6446,6 +7636,13 @@
         "@aws-sdk/util-locate-window",
         "@aws-sdk/util-user-agent-browser",
         "@aws-sdk/util-user-agent-node",
+        "@aws-sdk/xml-builder",
+        "@aws/lambda-invoke-store",
+        "@opentelemetry/api",
+        "@opentelemetry/core",
+        "@opentelemetry/resources",
+        "@opentelemetry/sdk-trace-base",
+        "@opentelemetry/semantic-conventions",
         "@smithy/abort-controller",
         "@smithy/config-resolver",
         "@smithy/core",
@@ -6490,11 +7687,13 @@
         "@smithy/util-stream",
         "@smithy/util-uri-escape",
         "@smithy/util-utf8",
+        "@smithy/uuid",
         "@types/uuid",
         "bowser",
         "charenc",
         "ci-info",
         "crypt",
+        "fast-xml-builder",
         "fast-xml-parser",
         "fs-extra",
         "graceful-fs",
@@ -6512,6 +7711,7 @@
         "lodash.snakecase",
         "md5",
         "object-hash",
+        "path-expression-matcher",
         "pluralize",
         "semver",
         "strnum",
@@ -6521,29 +7721,28 @@
         "uuid",
         "zod"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.5.3",
+        "@aws-amplify/ai-constructs": "^1.6.1",
         "@aws-amplify/backend-output-schemas": "^1.0.0",
         "@aws-amplify/backend-output-storage": "^1.0.0",
-        "@aws-amplify/graphql-auth-transformer": "4.2.5",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.13",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.15",
+        "@aws-amplify/graphql-auth-transformer": "4.2.6",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.14",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.16",
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-function-transformer": "3.1.17",
-        "@aws-amplify/graphql-generation-transformer": "1.2.5",
-        "@aws-amplify/graphql-http-transformer": "3.0.20",
-        "@aws-amplify/graphql-index-transformer": "3.1.0",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.20",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.20",
-        "@aws-amplify/graphql-relational-transformer": "3.1.12",
-        "@aws-amplify/graphql-searchable-transformer": "3.1.0",
-        "@aws-amplify/graphql-sql-transformer": "0.4.20",
-        "@aws-amplify/graphql-transformer": "2.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-function-transformer": "3.1.18",
+        "@aws-amplify/graphql-generation-transformer": "1.2.6",
+        "@aws-amplify/graphql-http-transformer": "3.0.21",
+        "@aws-amplify/graphql-index-transformer": "3.1.1",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.21",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.21",
+        "@aws-amplify/graphql-relational-transformer": "3.1.13",
+        "@aws-amplify/graphql-searchable-transformer": "3.1.1",
+        "@aws-amplify/graphql-sql-transformer": "0.4.21",
+        "@aws-amplify/graphql-transformer": "2.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
-        "@aws-amplify/graphql-validate-transformer": "1.1.5",
+        "@aws-amplify/graphql-validate-transformer": "1.1.6",
         "@aws-amplify/platform-core": "^1.0.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "@aws-crypto/crc32": "5.2.0",
@@ -6559,6 +7758,7 @@
         "@aws-sdk/credential-provider-env": "3.620.1",
         "@aws-sdk/credential-provider-http": "3.635.0",
         "@aws-sdk/credential-provider-ini": "3.637.0",
+        "@aws-sdk/credential-provider-login": "3.955.0",
         "@aws-sdk/credential-provider-node": "3.637.0",
         "@aws-sdk/credential-provider-process": "3.620.1",
         "@aws-sdk/credential-provider-sso": "3.637.0",
@@ -6575,6 +7775,13 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@aws-sdk/xml-builder": "3.804.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
         "@smithy/abort-controller": "^3.1.1",
         "@smithy/config-resolver": "^3.0.5",
         "@smithy/core": "^2.4.0",
@@ -6619,12 +7826,14 @@
         "@smithy/util-stream": "^3.1.3",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
+        "@smithy/uuid": "^1.1.0",
         "@types/uuid": "^9.0.8",
         "bowser": "^2.11.0",
         "charenc": "^0.0.2",
         "ci-info": "^3.2.0",
         "crypt": "^0.0.2",
-        "fast-xml-parser": "4.4.1",
+        "fast-xml-builder": "1.1.1",
+        "fast-xml-parser": "5.5.2",
         "fs-extra": "^8.1.0",
         "graceful-fs": "^4.2.0",
         "graphql": "^15.5.0",
@@ -6636,11 +7845,12 @@
         "is-ci": "^3.0.1",
         "jsonfile": "^4.0.0",
         "libphonenumber-js": "1.9.47",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "lodash.mergewith": "^4.6.2",
         "lodash.snakecase": "^4.1.1",
         "md5": "^2.2.1",
         "object-hash": "^3.0.0",
+        "path-expression-matcher": "1.1.3",
         "pluralize": "8.0.0",
         "semver": "^7.6.3",
         "strnum": "^1.0.5",
@@ -6656,53 +7866,19 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs": {
-      "version": "1.5.3",
+      "version": "1.6.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.6.0",
-        "@aws-amplify/plugin-types": "^1.10.1",
+        "@aws-amplify/backend-output-schemas": "^1.8.0",
+        "@aws-amplify/plugin-types": "^1.11.2",
         "@aws-sdk/client-bedrock-runtime": "3.622.0",
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "json-schema-to-ts": "^3.1.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.189.1",
+        "aws-cdk-lib": "^2.234.1",
         "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "1.6.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "zod": "^3.22.2"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/plugin-types": {
-      "version": "1.10.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-cdk/toolkit-lib": "0.3.2"
-      },
-      "peerDependencies": {
-        "@aws-sdk/types": "^3.734.0",
-        "aws-cdk-lib": "^2.189.1",
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-amplify/plugin-types/node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-bedrock-runtime": {
@@ -7185,7 +8361,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@smithy/types": {
-      "version": "4.3.1",
+      "version": "4.13.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7196,40 +8372,49 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "1.4.1",
+      "version": "1.8.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "zod": "^3.22.2"
+        "zod": "3.25.17"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-schemas/node_modules/zod": {
+      "version": "3.25.17",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-storage": {
-      "version": "1.1.5",
+      "version": "1.3.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.4.1",
-        "@aws-amplify/platform-core": "^1.6.5",
-        "@aws-amplify/plugin-types": "^1.8.1"
+        "@aws-amplify/backend-output-schemas": "^1.8.0",
+        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/plugin-types": "^1.12.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.180.0"
+        "aws-cdk-lib": "^2.234.1"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "4.2.5",
+      "version": "4.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-relational-transformer": "3.1.12",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-relational-transformer": "3.1.13",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "md5": "^2.3.0"
       },
       "peerDependencies": {
@@ -7238,16 +8423,16 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
-      "version": "1.1.13",
+      "version": "1.1.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.5.3",
+        "@aws-amplify/ai-constructs": "^1.6.1",
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-index-transformer": "3.1.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-relational-transformer": "3.1.12",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-index-transformer": "3.1.1",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-relational-transformer": "3.1.13",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "graphql": "^15.5.0",
@@ -7262,12 +8447,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "3.1.15",
+      "version": "3.1.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7281,12 +8466,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "3.1.17",
+      "version": "3.1.18",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7298,12 +8483,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7316,12 +8501,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "3.0.20",
+      "version": "3.0.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7333,13 +8518,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7351,12 +8536,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "4.0.20",
+      "version": "4.0.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -7367,12 +8552,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "3.4.0",
+      "version": "3.4.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7384,12 +8569,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "3.0.20",
+      "version": "3.0.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7401,14 +8586,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "3.1.12",
+      "version": "3.1.13",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-index-transformer": "3.1.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-index-transformer": "3.1.1",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7421,13 +8606,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7439,13 +8624,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.4.20",
+      "version": "0.4.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7457,26 +8642,26 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "2.4.0",
+      "version": "2.4.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "4.2.5",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.13",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.15",
-        "@aws-amplify/graphql-function-transformer": "3.1.17",
-        "@aws-amplify/graphql-generation-transformer": "1.2.5",
-        "@aws-amplify/graphql-http-transformer": "3.0.20",
-        "@aws-amplify/graphql-index-transformer": "3.1.0",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.20",
-        "@aws-amplify/graphql-model-transformer": "3.4.0",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.20",
-        "@aws-amplify/graphql-relational-transformer": "3.1.12",
-        "@aws-amplify/graphql-searchable-transformer": "3.1.0",
-        "@aws-amplify/graphql-sql-transformer": "0.4.20",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-auth-transformer": "4.2.6",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.14",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.16",
+        "@aws-amplify/graphql-function-transformer": "3.1.18",
+        "@aws-amplify/graphql-generation-transformer": "1.2.6",
+        "@aws-amplify/graphql-http-transformer": "3.0.21",
+        "@aws-amplify/graphql-index-transformer": "3.1.1",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.21",
+        "@aws-amplify/graphql-model-transformer": "3.4.1",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.21",
+        "@aws-amplify/graphql-relational-transformer": "3.1.13",
+        "@aws-amplify/graphql-searchable-transformer": "3.1.1",
+        "@aws-amplify/graphql-sql-transformer": "0.4.21",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
-        "@aws-amplify/graphql-validate-transformer": "1.1.5",
+        "@aws-amplify/graphql-validate-transformer": "1.1.6",
         "@aws-amplify/plugin-types": "^1.0.0"
       },
       "peerDependencies": {
@@ -7485,7 +8670,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "3.5.0",
+      "version": "3.5.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7496,7 +8681,7 @@
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
         "hjson": "^3.2.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "md5": "^2.3.0",
         "object-hash": "^3.0.0",
         "ts-dedent": "^2.0.0"
@@ -7519,12 +8704,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-validate-transformer": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.5.1",
         "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -7532,22 +8717,1003 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core": {
-      "version": "1.6.5",
+      "version": "1.11.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.8.1",
-        "@aws-sdk/client-sts": "^3.624.0",
+        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-sdk/client-sts": "^3.936.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
         "is-ci": "^4.1.0",
         "lodash.mergewith": "^4.6.2",
         "lodash.snakecase": "^4.1.1",
         "semver": "^7.6.3",
-        "uuid": "^9.0.1",
-        "zod": "^3.22.2"
+        "uuid": "^11.1.0",
+        "zod": "3.25.17"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.180.0",
+        "aws-cdk-lib": "^2.234.1",
         "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/client-sts": {
+      "version": "3.1011.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-node": "^3.972.21",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/core": {
+      "version": "3.973.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.18",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.19",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-env": "^3.972.18",
+        "@aws-sdk/credential-provider-http": "^3.972.20",
+        "@aws-sdk/credential-provider-login": "^3.972.20",
+        "@aws-sdk/credential-provider-process": "^3.972.18",
+        "@aws-sdk/credential-provider-sso": "^3.972.20",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.21",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.18",
+        "@aws-sdk/credential-provider-http": "^3.972.20",
+        "@aws-sdk/credential-provider-ini": "^3.972.20",
+        "@aws-sdk/credential-provider-process": "^3.972.18",
+        "@aws-sdk/credential-provider-sso": "^3.972.20",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.18",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/token-providers": "3.1009.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.21",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.11",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.10",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1009.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.11",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/abort-controller": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/config-resolver": {
+      "version": "4.4.11",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/core": {
+      "version": "3.23.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.15",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/hash-node": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.26",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-retry": {
+      "version": "4.4.43",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-serde": {
+      "version": "4.2.15",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-stack": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/node-config-provider": {
+      "version": "4.3.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/node-http-handler": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/property-provider": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/querystring-builder": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/querystring-parser": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/service-error-classification": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/signature-v4": {
+      "version": "5.3.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/smithy-client": {
+      "version": "4.12.6",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/url-parser": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.42",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.45",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-endpoints": {
+      "version": "3.3.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-middleware": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-retry": {
+      "version": "4.2.12",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-stream": {
+      "version": "4.5.20",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/ci-info": {
@@ -7581,13 +9747,36 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/uuid": {
+      "version": "11.1.0",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/zod": {
+      "version": "3.25.17",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/plugin-types": {
-      "version": "1.8.1",
+      "version": "1.12.0",
       "inBundle": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/toolkit-lib": "1.16.0"
+      },
       "peerDependencies": {
-        "@aws-sdk/types": "^3.609.0",
-        "aws-cdk-lib": "^2.180.0",
+        "@aws-sdk/types": "^3.734.0",
+        "aws-cdk-lib": "^2.234.1",
         "constructs": "^10.0.0"
       }
     },
@@ -8164,6 +10353,18 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/abort-controller": {
@@ -9948,6 +12149,772 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.955.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.954.0",
+        "@aws-sdk/nested-clients": "3.955.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/shared-ini-file-loader": "^4.4.1",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
+      "version": "3.954.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/xml-builder": "3.953.0",
+        "@smithy/core": "^3.19.0",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/property-provider": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/signature-v4": "^5.3.6",
+        "@smithy/smithy-client": "^4.10.1",
+        "@smithy/types": "^4.10.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.953.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.953.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.953.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.954.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.954.0",
+        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/util-endpoints": "3.953.0",
+        "@smithy/core": "^3.19.0",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.955.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.954.0",
+        "@aws-sdk/middleware-host-header": "3.953.0",
+        "@aws-sdk/middleware-logger": "3.953.0",
+        "@aws-sdk/middleware-recursion-detection": "3.953.0",
+        "@aws-sdk/middleware-user-agent": "3.954.0",
+        "@aws-sdk/region-config-resolver": "3.953.0",
+        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/util-endpoints": "3.953.0",
+        "@aws-sdk/util-user-agent-browser": "3.953.0",
+        "@aws-sdk/util-user-agent-node": "3.954.0",
+        "@smithy/config-resolver": "^4.4.4",
+        "@smithy/core": "^3.19.0",
+        "@smithy/fetch-http-handler": "^5.3.7",
+        "@smithy/hash-node": "^4.2.6",
+        "@smithy/invalid-dependency": "^4.2.6",
+        "@smithy/middleware-content-length": "^4.2.6",
+        "@smithy/middleware-endpoint": "^4.4.0",
+        "@smithy/middleware-retry": "^4.4.16",
+        "@smithy/middleware-serde": "^4.2.7",
+        "@smithy/middleware-stack": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/node-http-handler": "^4.4.6",
+        "@smithy/protocol-http": "^5.3.6",
+        "@smithy/smithy-client": "^4.10.1",
+        "@smithy/types": "^4.10.0",
+        "@smithy/url-parser": "^4.2.6",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.15",
+        "@smithy/util-defaults-mode-node": "^4.2.18",
+        "@smithy/util-endpoints": "^3.2.6",
+        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/util-retry": "^4.2.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.953.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/config-resolver": "^4.4.4",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
+      "version": "3.953.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.953.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/types": "^4.10.0",
+        "@smithy/url-parser": "^4.2.6",
+        "@smithy/util-endpoints": "^3.2.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.953.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/types": "^4.10.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.954.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.954.0",
+        "@aws-sdk/types": "3.953.0",
+        "@smithy/node-config-provider": "^4.3.6",
+        "@smithy/types": "^4.10.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.953.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.10.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/abort-controller": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/config-resolver": {
+      "version": "4.4.5",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/core": {
+      "version": "3.20.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-stream": "^4.5.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/hash-node": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.20.0",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-retry": {
+      "version": "4.4.17",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-serde": {
+      "version": "4.2.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-stack": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/node-config-provider": {
+      "version": "4.3.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/node-http-handler": {
+      "version": "4.4.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/property-provider": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/protocol-http": {
+      "version": "5.3.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/querystring-builder": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/querystring-parser": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/service-error-classification": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/signature-v4": {
+      "version": "5.3.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/smithy-client": {
+      "version": "4.10.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.20.0",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/types": {
+      "version": "4.11.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/url-parser": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.16",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.19",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-endpoints": {
+      "version": "3.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-middleware": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-retry": {
+      "version": "4.2.7",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-stream": {
+      "version": "4.5.8",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.637.0",
       "inBundle": true,
@@ -11152,11 +14119,11 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.821.0",
+      "version": "3.804.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11172,6 +14139,75 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.33.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/abort-controller": {
@@ -11762,6 +14798,17 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@types/uuid": {
       "version": "9.0.8",
       "inBundle": true,
@@ -11802,26 +14849,49 @@
         "node": "*"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-parser": {
-      "version": "4.4.1",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-builder": {
+      "version": "1.1.1",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-parser": {
+      "version": "5.5.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.1",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-parser/node_modules/strnum": {
+      "version": "2.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -11912,7 +14982,7 @@
       "license": "MIT"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.17.23",
       "inBundle": true,
       "license": "MIT"
     },
@@ -11942,6 +15012,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/pluralize": {
@@ -14513,16 +17597,17 @@
       }
     },
     "node_modules/@aws-cdk/toolkit-lib": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.6.1.tgz",
-      "integrity": "sha512-EJlek1OwIsPZ0JJXNnXnQlFqJcbBVrxEPU1mDpgh3EPJmwRX0vAButju1BptRb1q3tHDCShnzfhGFTvDLqA9UQ==",
-      "license": "Apache-2.0",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.16.0.tgz",
+      "integrity": "sha512-zytduPrbKjb3lyM6+xcgRrZ+YcXXbeiYst76W1jg9fMWP3yP0i1/plD81LuO6VpDhj++fedpAADGXIqDbIlMlg==",
       "dependencies": {
         "@aws-cdk/cdk-assets-lib": "^1",
-        "@aws-cdk/cloud-assembly-schema": ">=48.6.0",
+        "@aws-cdk/cloud-assembly-api": "2.1.1",
+        "@aws-cdk/cloud-assembly-schema": ">=52.2.0",
         "@aws-cdk/cloudformation-diff": "^2",
         "@aws-cdk/cx-api": "^2",
         "@aws-sdk/client-appsync": "^3",
+        "@aws-sdk/client-bedrock-agentcore-control": "^3",
         "@aws-sdk/client-cloudcontrol": "^3",
         "@aws-sdk/client-cloudformation": "^3",
         "@aws-sdk/client-cloudwatch-logs": "^3",
@@ -14549,14 +17634,15 @@
         "@smithy/util-retry": "^4",
         "@smithy/util-waiter": "^4",
         "archiver": "^7.0.1",
-        "cdk-from-cfn": "^0.236.0",
+        "cdk-from-cfn": "^0.263.0",
         "chalk": "^4",
-        "chokidar": "^3",
+        "chokidar": "^4",
+        "fast-deep-equal": "^3.1.3",
+        "fast-glob": "^3.3.3",
         "fs-extra": "^9",
-        "glob": "^11.0.3",
-        "minimatch": "10.0.3",
         "p-limit": "^3",
-        "semver": "^7.7.2",
+        "picomatch": "^4",
+        "semver": "^7.7.3",
         "split2": "^4.2.0",
         "uuid": "^11.1.0",
         "wrap-ansi": "^7",
@@ -14567,6 +17653,79 @@
       },
       "peerDependencies": {
         "@aws-cdk/cli-plugin-contract": "^2"
+      }
+    },
+    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.1.1.tgz",
+      "integrity": "sha512-lIFgatwM/jmeKU629aaPv+VR+wYYIBXHmId+UBxR65JxhZ+TQD6QWDzkpjPRPKlGw7Rz8gNXs4eEYv98voxvAw==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
+      }
+    },
+    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.7.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "53.7.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.7.0.tgz",
+      "integrity": "sha512-zzPA859b8+rn1yLs+vscgqU5f/7KvFKhLTVqbwkgEJz1MLvYPEHTpmGNEcE2LtxT2mabYzja+p6zQoggwDdxbw==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@aws-cdk/toolkit-lib/node_modules/fs-extra": {
@@ -14584,21 +17743,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@aws-cdk/toolkit-lib/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -14612,6 +17756,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-cdk/toolkit-lib/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -36704,27 +39859,6 @@
         }
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -41246,19 +44380,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/apache-md5": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.1.8.tgz",
@@ -41346,21 +44467,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/archiver-utils/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/archiver-utils/node_modules/path-scurry": {
       "version": "1.11.1",
@@ -42483,18 +45589,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -42987,10 +46081,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/cdk-from-cfn": {
-      "version": "0.236.0",
-      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.236.0.tgz",
-      "integrity": "sha512-D7yG+9ywyasNZFYjRFan06JfoA328N2TF+m67K51BWEqGJs7AowRS5yLb0tkJU67QONyuBLENx3/hIaPLCJ3PA==",
-      "license": "MIT OR Apache-2.0"
+      "version": "0.263.0",
+      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.263.0.tgz",
+      "integrity": "sha512-k2gr6iA1WC6MKO8tJzNA603Ov+jAXGmYSJHJtTrMNFpoiCDNSvWixB8gDJ8bsnFnha5oAq68siTz1Ia/eixbcQ=="
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -43068,27 +46161,17 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/ci-info": {
@@ -46944,18 +50027,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -50897,15 +53968,15 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/real-require": {
@@ -55777,13 +58848,13 @@
     },
     "packages/auth-construct": {
       "name": "@aws-amplify/auth-construct",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/backend-output-storage": "^1.3.4",
+        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/plugin-types": "^1.12.0",
         "@aws-sdk/util-arn-parser": "^3.893.0"
       },
       "peerDependencies": {
@@ -55793,20 +58864,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.21.0",
+      "version": "1.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.9.2",
         "@aws-amplify/backend-data": "^1.6.4",
         "@aws-amplify/backend-function": "^1.17.0",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
+        "@aws-amplify/backend-output-storage": "^1.3.4",
         "@aws-amplify/backend-secret": "^1.4.2",
         "@aws-amplify/backend-storage": "^1.4.3",
-        "@aws-amplify/client-config": "^1.10.0",
+        "@aws-amplify/client-config": "^1.10.1",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/plugin-types": "^1.12.0",
         "@aws-sdk/client-amplify": "^3.936.0"
       },
       "devDependencies": {
@@ -55884,11 +58955,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/plugin-types": "^1.12.0",
         "@aws-cdk/toolkit-lib": "1.16.0",
         "execa": "^9.5.1",
         "minimatch": "10.0.1",
@@ -55898,141 +58969,6 @@
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
         "typescript": "^5.0.0"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.1.1.tgz",
-      "integrity": "sha512-lIFgatwM/jmeKU629aaPv+VR+wYYIBXHmId+UBxR65JxhZ+TQD6QWDzkpjPRPKlGw7Rz8gNXs4eEYv98voxvAw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/toolkit-lib": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.16.0.tgz",
-      "integrity": "sha512-zytduPrbKjb3lyM6+xcgRrZ+YcXXbeiYst76W1jg9fMWP3yP0i1/plD81LuO6VpDhj++fedpAADGXIqDbIlMlg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-cdk/cdk-assets-lib": "^1",
-        "@aws-cdk/cloud-assembly-api": "2.1.1",
-        "@aws-cdk/cloud-assembly-schema": ">=52.2.0",
-        "@aws-cdk/cloudformation-diff": "^2",
-        "@aws-cdk/cx-api": "^2",
-        "@aws-sdk/client-appsync": "^3",
-        "@aws-sdk/client-bedrock-agentcore-control": "^3",
-        "@aws-sdk/client-cloudcontrol": "^3",
-        "@aws-sdk/client-cloudformation": "^3",
-        "@aws-sdk/client-cloudwatch-logs": "^3",
-        "@aws-sdk/client-codebuild": "^3",
-        "@aws-sdk/client-ec2": "^3",
-        "@aws-sdk/client-ecr": "^3",
-        "@aws-sdk/client-ecs": "^3",
-        "@aws-sdk/client-elastic-load-balancing-v2": "^3",
-        "@aws-sdk/client-iam": "^3",
-        "@aws-sdk/client-kms": "^3",
-        "@aws-sdk/client-lambda": "^3",
-        "@aws-sdk/client-route-53": "^3",
-        "@aws-sdk/client-s3": "^3",
-        "@aws-sdk/client-secrets-manager": "^3",
-        "@aws-sdk/client-sfn": "^3",
-        "@aws-sdk/client-ssm": "^3",
-        "@aws-sdk/client-sts": "^3",
-        "@aws-sdk/credential-providers": "^3",
-        "@aws-sdk/ec2-metadata-service": "^3",
-        "@aws-sdk/lib-storage": "^3",
-        "@smithy/middleware-endpoint": "^4",
-        "@smithy/property-provider": "^4",
-        "@smithy/shared-ini-file-loader": "^4",
-        "@smithy/util-retry": "^4",
-        "@smithy/util-waiter": "^4",
-        "archiver": "^7.0.1",
-        "cdk-from-cfn": "^0.263.0",
-        "chalk": "^4",
-        "chokidar": "^4",
-        "fast-deep-equal": "^3.1.3",
-        "fast-glob": "^3.3.3",
-        "fs-extra": "^9",
-        "p-limit": "^3",
-        "picomatch": "^4",
-        "semver": "^7.7.3",
-        "split2": "^4.2.0",
-        "uuid": "^11.1.0",
-        "wrap-ansi": "^7",
-        "yaml": "^1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cli-plugin-contract": "^2"
       }
     },
     "packages/backend-deployer/node_modules/ansi-regex": {
@@ -56045,82 +58981,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "packages/backend-deployer/node_modules/cdk-from-cfn": {
-      "version": "0.263.0",
-      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.263.0.tgz",
-      "integrity": "sha512-k2gr6iA1WC6MKO8tJzNA603Ov+jAXGmYSJHJtTrMNFpoiCDNSvWixB8gDJ8bsnFnha5oAq68siTz1Ia/eixbcQ==",
-      "license": "MIT OR Apache-2.0"
-    },
-    "packages/backend-deployer/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/backend-deployer/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/backend-deployer/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/backend-deployer/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "packages/backend-deployer/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/backend-deployer/node_modules/strip-ansi": {
@@ -56175,12 +59035,12 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2"
+        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/plugin-types": "^1.12.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1"
@@ -56296,10 +59156,10 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.10.3",
+        "@aws-amplify/platform-core": "^1.11.0",
         "@aws-sdk/client-cloudformation": "^3.936.0",
         "@inquirer/prompts": "^7.3.2",
         "@opentelemetry/api": "^1.9.0",
@@ -56422,14 +59282,14 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/deployed-backend-client": "^1.8.1",
         "@aws-amplify/model-generator": "^1.2.2",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/plugin-types": "^1.12.0",
         "zod": "3.25.17"
       },
       "devDependencies": {
@@ -56781,10 +59641,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.10.4",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/plugin-types": "^1.12.0",
         "@aws-sdk/client-sts": "^3.936.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.0.0",
@@ -56808,7 +59668,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.11.2",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/toolkit-lib": "1.16.0"
@@ -56817,217 +59677,6 @@
         "@aws-sdk/types": "^3.734.0",
         "aws-cdk-lib": "^2.234.1",
         "constructs": "^10.0.0"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.1.1.tgz",
-      "integrity": "sha512-lIFgatwM/jmeKU629aaPv+VR+wYYIBXHmId+UBxR65JxhZ+TQD6QWDzkpjPRPKlGw7Rz8gNXs4eEYv98voxvAw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/toolkit-lib": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.16.0.tgz",
-      "integrity": "sha512-zytduPrbKjb3lyM6+xcgRrZ+YcXXbeiYst76W1jg9fMWP3yP0i1/plD81LuO6VpDhj++fedpAADGXIqDbIlMlg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-cdk/cdk-assets-lib": "^1",
-        "@aws-cdk/cloud-assembly-api": "2.1.1",
-        "@aws-cdk/cloud-assembly-schema": ">=52.2.0",
-        "@aws-cdk/cloudformation-diff": "^2",
-        "@aws-cdk/cx-api": "^2",
-        "@aws-sdk/client-appsync": "^3",
-        "@aws-sdk/client-bedrock-agentcore-control": "^3",
-        "@aws-sdk/client-cloudcontrol": "^3",
-        "@aws-sdk/client-cloudformation": "^3",
-        "@aws-sdk/client-cloudwatch-logs": "^3",
-        "@aws-sdk/client-codebuild": "^3",
-        "@aws-sdk/client-ec2": "^3",
-        "@aws-sdk/client-ecr": "^3",
-        "@aws-sdk/client-ecs": "^3",
-        "@aws-sdk/client-elastic-load-balancing-v2": "^3",
-        "@aws-sdk/client-iam": "^3",
-        "@aws-sdk/client-kms": "^3",
-        "@aws-sdk/client-lambda": "^3",
-        "@aws-sdk/client-route-53": "^3",
-        "@aws-sdk/client-s3": "^3",
-        "@aws-sdk/client-secrets-manager": "^3",
-        "@aws-sdk/client-sfn": "^3",
-        "@aws-sdk/client-ssm": "^3",
-        "@aws-sdk/client-sts": "^3",
-        "@aws-sdk/credential-providers": "^3",
-        "@aws-sdk/ec2-metadata-service": "^3",
-        "@aws-sdk/lib-storage": "^3",
-        "@smithy/middleware-endpoint": "^4",
-        "@smithy/property-provider": "^4",
-        "@smithy/shared-ini-file-loader": "^4",
-        "@smithy/util-retry": "^4",
-        "@smithy/util-waiter": "^4",
-        "archiver": "^7.0.1",
-        "cdk-from-cfn": "^0.263.0",
-        "chalk": "^4",
-        "chokidar": "^4",
-        "fast-deep-equal": "^3.1.3",
-        "fast-glob": "^3.3.3",
-        "fs-extra": "^9",
-        "p-limit": "^3",
-        "picomatch": "^4",
-        "semver": "^7.7.3",
-        "split2": "^4.2.0",
-        "uuid": "^11.1.0",
-        "wrap-ansi": "^7",
-        "yaml": "^1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cli-plugin-contract": "^2"
-      }
-    },
-    "packages/plugin-types/node_modules/cdk-from-cfn": {
-      "version": "0.263.0",
-      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.263.0.tgz",
-      "integrity": "sha512-k2gr6iA1WC6MKO8tJzNA603Ov+jAXGmYSJHJtTrMNFpoiCDNSvWixB8gDJ8bsnFnha5oAq68siTz1Ia/eixbcQ==",
-      "license": "MIT OR Apache-2.0"
-    },
-    "packages/plugin-types/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/plugin-types/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/plugin-types/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/plugin-types/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "packages/plugin-types/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/sandbox": {
@@ -57083,14 +59732,14 @@
     },
     "packages/seed": {
       "name": "@aws-amplify/seed",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.3",
-        "@aws-amplify/client-config": "^1.9.1",
-        "@aws-amplify/platform-core": "^1.10.3",
-        "@aws-amplify/plugin-types": "^1.11.1",
+        "@aws-amplify/cli-core": "^2.2.4",
+        "@aws-amplify/client-config": "^1.10.1",
+        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/plugin-types": "^1.12.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
         "aws-amplify": "^6.0.16"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59121,6 +59121,7 @@
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-cloudformation": "^3.936.0",
         "@aws-sdk/client-s3": "^3.936.0",
+        "@aws-sdk/client-ssm": "^3.936.0",
         "@aws-sdk/client-sts": "^3.936.0",
         "@aws-sdk/credential-provider-ini": "^3.936.0",
         "@aws-sdk/credential-providers": "^3.936.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -736,9 +736,9 @@
       }
     },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.17.0.tgz",
-      "integrity": "sha512-hhV08oh5TWjgR1cluXgFJf+1ebRgB+MFwlccXZ+9WAmpj0IW3Pmafdud5iuvsjuzOBR3Ug+QGIbEQDI1M9308w==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.17.1.tgz",
+      "integrity": "sha512-DuwRm2n2iRnIAKuvv760KII+P2V/i1hrnMRXexIeftKWf/fv6azVqEyHNb/PPR2u8+jfdJlzg6FFBwDGQt2qbA==",
       "bundleDependencies": [
         "@aws-amplify/ai-constructs",
         "@aws-amplify/backend-output-schemas",
@@ -55866,7 +55866,7 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.3",
-        "@aws-amplify/data-construct": "^1.15.1",
+        "@aws-amplify/data-construct": "^1.17.1",
         "@aws-amplify/data-schema-types": "^1.2.0",
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/plugin-types": "^1.11.2",

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -23,8 +23,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-amplify/data-schema": "^1.13.4",
     "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
+    "@aws-amplify/data-schema": "^1.13.4",
     "@aws-amplify/platform-core": "^1.10.4"
   },
   "peerDependencies": {
@@ -32,9 +32,9 @@
     "constructs": "^10.0.0"
   },
   "dependencies": {
-    "@aws-amplify/backend-output-storage": "^1.3.3",
     "@aws-amplify/backend-output-schemas": "^1.8.0",
-    "@aws-amplify/data-construct": "^1.15.1",
+    "@aws-amplify/backend-output-storage": "^1.3.3",
+    "@aws-amplify/data-construct": "^1.17.1",
     "@aws-amplify/data-schema-types": "^1.2.0",
     "@aws-amplify/graphql-generator": "^0.5.1",
     "@aws-amplify/plugin-types": "^1.11.2",

--- a/packages/backend-data/tsconfig.json
+++ b/packages/backend-data/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
   "exclude": ["src/assets", "lib"],
   "references": [
-    { "path": "../backend-output-schemas" },
     { "path": "../backend-output-storage" },
+    { "path": "../backend-output-schemas" },
     { "path": "../plugin-types" },
     { "path": "../backend-platform-test-stubs" },
     { "path": "../platform-core" },

--- a/packages/backend-data/tsconfig.json
+++ b/packages/backend-data/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": { "rootDir": "src", "outDir": "lib" },
   "exclude": ["src/assets", "lib"],
   "references": [
-    { "path": "../backend-output-storage" },
     { "path": "../backend-output-schemas" },
+    { "path": "../backend-output-storage" },
     { "path": "../plugin-types" },
     { "path": "../backend-platform-test-stubs" },
     { "path": "../platform-core" },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/client-amplify": "^3.936.0",
     "@aws-sdk/client-cloudformation": "^3.936.0",
     "@aws-sdk/client-s3": "^3.936.0",
+    "@aws-sdk/client-ssm": "^3.936.0",
     "@aws-sdk/client-sts": "^3.936.0",
     "@aws-sdk/credential-provider-ini": "^3.936.0",
     "@aws-sdk/credential-providers": "^3.936.0",

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert';
 import { DeployCommand, DeployCommandOptions } from './deploy_command.js';
 import { BackendDeployer } from '@aws-amplify/backend-deployer';
 import { DEFAULT_CLIENT_CONFIG_VERSION } from '@aws-amplify/client-config';
+import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 import {
   TestCommandError,
   TestCommandRunner,
@@ -54,8 +55,8 @@ void describe('deploy command', () => {
     const callArgs = mockDeployFn.mock.calls[0]
       .arguments as unknown as unknown[];
     assert.deepStrictEqual(callArgs[0], {
-      namespace: 'amplify-my-app-prod',
-      name: 'default',
+      namespace: 'my-app-prod',
+      name: 'stack',
       type: 'standalone',
     });
     assert.deepStrictEqual(callArgs[1], {
@@ -75,7 +76,12 @@ void describe('deploy command', () => {
     assert.strictEqual(generateClientConfigMock.mock.callCount(), 1);
     const configArgs = generateClientConfigMock.mock.calls[0]
       .arguments as unknown as unknown[];
-    assert.deepStrictEqual(configArgs[0], { stackName: 'amplify-my-app-prod' });
+    const expectedStackName = BackendIdentifierConversions.toStackName({
+      namespace: 'my-app-prod',
+      name: 'stack',
+      type: 'standalone',
+    });
+    assert.deepStrictEqual(configArgs[0], { stackName: expectedStackName });
     assert.deepStrictEqual(configArgs[1], DEFAULT_CLIENT_CONFIG_VERSION);
   });
 

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -98,4 +98,49 @@ void describe('deploy command', () => {
       .arguments as unknown as unknown[];
     assert.deepStrictEqual(configArgs[2], 'src');
   });
+
+  void it('rejects identifier with spaces', async () => {
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier "my app"'),
+      (err: { error: { name: string } }) => {
+        assert.strictEqual(err.error.name, 'InvalidCommandInputError');
+        return true;
+      },
+    );
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('rejects identifier starting with a number', async () => {
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier 123app'),
+      (err: { error: { name: string } }) => {
+        assert.strictEqual(err.error.name, 'InvalidCommandInputError');
+        return true;
+      },
+    );
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('rejects identifier with special characters', async () => {
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier my_app!'),
+      (err: { error: { name: string } }) => {
+        assert.strictEqual(err.error.name, 'InvalidCommandInputError');
+        return true;
+      },
+    );
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('accepts valid identifier with hyphens', async () => {
+    mockDeployFn.mock.mockImplementationOnce(() =>
+      Promise.resolve({
+        deploymentTimes: { synthesisTime: 0, totalTime: 0 },
+      }),
+    );
+
+    await getCommandRunner().runCommand('deploy --identifier my-app-prod-v2');
+
+    assert.strictEqual(mockDeployFn.mock.callCount(), 1);
+  });
 });

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -54,7 +54,7 @@ void describe('deploy command', () => {
     const callArgs = mockDeployFn.mock.calls[0]
       .arguments as unknown as unknown[];
     assert.deepStrictEqual(callArgs[0], {
-      namespace: 'my-app-prod',
+      namespace: 'amplify-my-app-prod',
       name: 'default',
       type: 'standalone',
     });
@@ -75,7 +75,7 @@ void describe('deploy command', () => {
     assert.strictEqual(generateClientConfigMock.mock.callCount(), 1);
     const configArgs = generateClientConfigMock.mock.calls[0]
       .arguments as unknown as unknown[];
-    assert.deepStrictEqual(configArgs[0], { stackName: 'my-app-prod' });
+    assert.deepStrictEqual(configArgs[0], { stackName: 'amplify-my-app-prod' });
     assert.deepStrictEqual(configArgs[1], DEFAULT_CLIENT_CONFIG_VERSION);
   });
 

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -5,6 +5,7 @@ import { DeployCommand, DeployCommandOptions } from './deploy_command.js';
 import { BackendDeployer } from '@aws-amplify/backend-deployer';
 import { DEFAULT_CLIENT_CONFIG_VERSION } from '@aws-amplify/client-config';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import { ParameterNotFound } from '@aws-sdk/client-ssm';
 import {
   TestCommandError,
   TestCommandRunner,
@@ -28,10 +29,25 @@ void describe('deploy command', () => {
     destroy: mockDestroyFn,
   };
 
+  const mockMiddleware = {
+    ensureAwsCredentialAndRegion: mock.fn(() => undefined),
+  };
+
+  // Default: bootstrapped (version 21)
+  const mockSsmSend = mock.fn(() =>
+    Promise.resolve({ Parameter: { Value: '21' } }),
+  );
+  const mockSsmClient = {
+    send: mockSsmSend,
+    config: { region: () => Promise.resolve('us-east-1') },
+  };
+
   const getCommandRunner = () => {
     const deployCommand = new DeployCommand(
       clientConfigGenerator as never,
       mockDeployer,
+      mockMiddleware as never,
+      mockSsmClient as never,
     ) as unknown as import('yargs').CommandModule<object, DeployCommandOptions>;
     const parser = yargs().command(deployCommand);
     return new TestCommandRunner(parser);
@@ -40,6 +56,11 @@ void describe('deploy command', () => {
   beforeEach(() => {
     generateClientConfigMock.mock.resetCalls();
     mockDeployFn.mock.resetCalls();
+    mockSsmSend.mock.resetCalls();
+    // Reset to bootstrapped by default
+    mockSsmSend.mock.mockImplementation(() =>
+      Promise.resolve({ Parameter: { Value: '21' } }),
+    );
   });
 
   void it('deploys with standalone type and correct identifier', async () => {
@@ -108,6 +129,20 @@ void describe('deploy command', () => {
     assert.deepStrictEqual(configArgs[2], 'src');
   });
 
+  void it('passes --profile argument through', async () => {
+    mockDeployFn.mock.mockImplementationOnce(() =>
+      Promise.resolve({
+        deploymentTimes: { synthesisTime: 0, totalTime: 0 },
+      }),
+    );
+
+    await getCommandRunner().runCommand(
+      'deploy --identifier my-app --profile my-profile',
+    );
+
+    assert.strictEqual(mockDeployFn.mock.callCount(), 1);
+  });
+
   void it('rejects identifier with spaces', async () => {
     await assert.rejects(
       () => getCommandRunner().runCommand('deploy --identifier "my app"'),
@@ -151,5 +186,27 @@ void describe('deploy command', () => {
     await getCommandRunner().runCommand('deploy --identifier my-app-prod-v2');
 
     assert.strictEqual(mockDeployFn.mock.callCount(), 1);
+  });
+
+  void it('shows bootstrap message when region is not bootstrapped', async () => {
+    mockSsmSend.mock.mockImplementation(() =>
+      Promise.reject(
+        new ParameterNotFound({
+          message: 'Parameter not found',
+          $metadata: {},
+        }),
+      ),
+    );
+
+    const output = await getCommandRunner().runCommand(
+      'deploy --identifier my-app',
+    );
+
+    assert.match(output, /has not been bootstrapped/);
+    assert.match(
+      output,
+      /console\.aws\.amazon\.com\/amplify\/create\/bootstrap/,
+    );
+    assert.equal(mockDeployFn.mock.callCount(), 0);
   });
 });

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -100,35 +100,26 @@ void describe('deploy command', () => {
   });
 
   void it('rejects identifier with spaces', async () => {
-    await assert.rejects(
-      () => getCommandRunner().runCommand('deploy --identifier "my app"'),
-      (err: { error: { name: string } }) => {
-        assert.strictEqual(err.error.name, 'InvalidCommandInputError');
-        return true;
-      },
+    const output = await getCommandRunner().runCommand(
+      'deploy --identifier "my app"',
     );
+    assert.match(output, /Invalid --identifier/);
     assert.equal(mockDeployFn.mock.callCount(), 0);
   });
 
   void it('rejects identifier starting with a number', async () => {
-    await assert.rejects(
-      () => getCommandRunner().runCommand('deploy --identifier 123app'),
-      (err: { error: { name: string } }) => {
-        assert.strictEqual(err.error.name, 'InvalidCommandInputError');
-        return true;
-      },
+    const output = await getCommandRunner().runCommand(
+      'deploy --identifier 123app',
     );
+    assert.match(output, /Invalid --identifier/);
     assert.equal(mockDeployFn.mock.callCount(), 0);
   });
 
   void it('rejects identifier with special characters', async () => {
-    await assert.rejects(
-      () => getCommandRunner().runCommand('deploy --identifier my_app!'),
-      (err: { error: { name: string } }) => {
-        assert.strictEqual(err.error.name, 'InvalidCommandInputError');
-        return true;
-      },
+    const output = await getCommandRunner().runCommand(
+      'deploy --identifier my_app!',
     );
+    assert.match(output, /Invalid --identifier/);
     assert.equal(mockDeployFn.mock.callCount(), 0);
   });
 

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -238,6 +238,19 @@ void describe('deploy command', () => {
     assert.strictEqual(mockDeployFn.mock.callCount(), 1);
   });
 
+  void it('handles non-numeric bootstrap version string', async () => {
+    mockSsmSend.mock.mockImplementation(() =>
+      Promise.resolve({ Parameter: { Value: 'corrupted' } }),
+    );
+
+    const output = await getCommandRunner().runCommand(
+      'deploy --identifier my-app',
+    );
+
+    assert.match(output, /has not been bootstrapped/);
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
   void it('wraps AccessDeniedException in SSMCredentialsError', async () => {
     mockSsmSend.mock.mockImplementation(() => {
       throw new SSMServiceException({

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -203,9 +203,9 @@ void describe('deploy command', () => {
     );
 
     assert.match(output, /has not been bootstrapped/);
-    assert.match(
-      output,
-      /console\.aws\.amazon\.com\/amplify\/create\/bootstrap/,
+    assert.ok(
+      output.includes('console.aws.amazon.com/amplify/create/bootstrap'),
+      'output should contain the bootstrap URL',
     );
     assert.equal(mockDeployFn.mock.callCount(), 0);
   });

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -5,7 +5,7 @@ import { DeployCommand, DeployCommandOptions } from './deploy_command.js';
 import { BackendDeployer } from '@aws-amplify/backend-deployer';
 import { DEFAULT_CLIENT_CONFIG_VERSION } from '@aws-amplify/client-config';
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
-import { ParameterNotFound } from '@aws-sdk/client-ssm';
+import { ParameterNotFound, SSMServiceException } from '@aws-sdk/client-ssm';
 import {
   TestCommandError,
   TestCommandRunner,
@@ -208,5 +208,107 @@ void describe('deploy command', () => {
       'output should contain the bootstrap URL',
     );
     assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('skips deploy when bootstrap version is too low', async () => {
+    mockSsmSend.mock.mockImplementation(() =>
+      Promise.resolve({ Parameter: { Value: '3' } }),
+    );
+
+    const output = await getCommandRunner().runCommand(
+      'deploy --identifier my-app',
+    );
+
+    assert.match(output, /has not been bootstrapped/);
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('proceeds with deploy when bootstrap version is exactly minimum', async () => {
+    mockSsmSend.mock.mockImplementation(() =>
+      Promise.resolve({ Parameter: { Value: '6' } }),
+    );
+    mockDeployFn.mock.mockImplementationOnce(() =>
+      Promise.resolve({
+        deploymentTimes: { synthesisTime: 0, totalTime: 0 },
+      }),
+    );
+
+    await getCommandRunner().runCommand('deploy --identifier my-app');
+
+    assert.strictEqual(mockDeployFn.mock.callCount(), 1);
+  });
+
+  void it('wraps AccessDeniedException in SSMCredentialsError', async () => {
+    mockSsmSend.mock.mockImplementation(() => {
+      throw new SSMServiceException({
+        name: 'AccessDeniedException',
+        message: 'User is not authorized',
+        $fault: 'client',
+        $metadata: {},
+      });
+    });
+
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      (err: TestCommandError) => {
+        assert.match(err.output, /AccessDeniedException/);
+        return true;
+      },
+    );
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('wraps ExpiredTokenException in SSMCredentialsError', async () => {
+    mockSsmSend.mock.mockImplementation(() => {
+      throw new SSMServiceException({
+        name: 'ExpiredTokenException',
+        message: 'The security token included in the request is expired',
+        $fault: 'client',
+        $metadata: {},
+      });
+    });
+
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      (err: TestCommandError) => {
+        assert.match(err.output, /ExpiredTokenException/);
+        return true;
+      },
+    );
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('wraps InvalidSignatureException in SSMCredentialsError', async () => {
+    mockSsmSend.mock.mockImplementation(() => {
+      throw new SSMServiceException({
+        name: 'InvalidSignatureException',
+        message: 'The request signature does not match',
+        $fault: 'client',
+        $metadata: {},
+      });
+    });
+
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      (err: TestCommandError) => {
+        assert.match(err.output, /InvalidSignatureException/);
+        return true;
+      },
+    );
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('propagates deployment failures', async () => {
+    mockDeployFn.mock.mockImplementationOnce(() =>
+      Promise.reject(new Error('CFN deployment failed')),
+    );
+
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      (err: TestCommandError) => {
+        assert.match(err.error.message, /CFN deployment failed/);
+        return true;
+      },
+    );
   });
 });

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -4,7 +4,10 @@ import assert from 'node:assert';
 import { DeployCommand, DeployCommandOptions } from './deploy_command.js';
 import { BackendDeployer } from '@aws-amplify/backend-deployer';
 import { DEFAULT_CLIENT_CONFIG_VERSION } from '@aws-amplify/client-config';
-import { TestCommandRunner } from '../../test-utils/command_runner.js';
+import {
+  TestCommandError,
+  TestCommandRunner,
+} from '../../test-utils/command_runner.js';
 
 void describe('deploy command', () => {
   const clientConfigGenerator = {
@@ -100,26 +103,35 @@ void describe('deploy command', () => {
   });
 
   void it('rejects identifier with spaces', async () => {
-    const output = await getCommandRunner().runCommand(
-      'deploy --identifier "my app"',
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier "my app"'),
+      (err: TestCommandError) => {
+        assert.match(err.output, /Invalid --identifier/);
+        return true;
+      },
     );
-    assert.match(output, /Invalid --identifier/);
     assert.equal(mockDeployFn.mock.callCount(), 0);
   });
 
   void it('rejects identifier starting with a number', async () => {
-    const output = await getCommandRunner().runCommand(
-      'deploy --identifier 123app',
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier 123app'),
+      (err: TestCommandError) => {
+        assert.match(err.output, /Invalid --identifier/);
+        return true;
+      },
     );
-    assert.match(output, /Invalid --identifier/);
     assert.equal(mockDeployFn.mock.callCount(), 0);
   });
 
   void it('rejects identifier with special characters', async () => {
-    const output = await getCommandRunner().runCommand(
-      'deploy --identifier my_app!',
+    await assert.rejects(
+      () => getCommandRunner().runCommand('deploy --identifier my_app!'),
+      (err: TestCommandError) => {
+        assert.match(err.output, /Invalid --identifier/);
+        return true;
+      },
     );
-    assert.match(output, /Invalid --identifier/);
     assert.equal(mockDeployFn.mock.callCount(), 0);
   });
 

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, it, mock } from 'node:test';
+import yargs from 'yargs';
+import assert from 'node:assert';
+import { DeployCommand, DeployCommandOptions } from './deploy_command.js';
+import { BackendDeployer } from '@aws-amplify/backend-deployer';
+import { DEFAULT_CLIENT_CONFIG_VERSION } from '@aws-amplify/client-config';
+import { TestCommandRunner } from '../../test-utils/command_runner.js';
+
+void describe('deploy command', () => {
+  const clientConfigGenerator = {
+    generateClientConfigToFile: mock.fn(() => Promise.resolve()),
+    generateClientConfig: mock.fn(() => Promise.resolve({})),
+  };
+  const generateClientConfigMock = mock.method(
+    clientConfigGenerator,
+    'generateClientConfigToFile',
+    () => Promise.resolve(),
+  );
+
+  const mockDeployFn = mock.fn<BackendDeployer['deploy']>();
+  const mockDestroyFn = mock.fn<BackendDeployer['destroy']>();
+  const mockDeployer: BackendDeployer = {
+    deploy: mockDeployFn,
+    destroy: mockDestroyFn,
+  };
+
+  const getCommandRunner = (isCI = false) => {
+    const deployCommand = new DeployCommand(
+      clientConfigGenerator as never,
+      mockDeployer,
+      isCI,
+    ) as unknown as import('yargs').CommandModule<object, DeployCommandOptions>;
+    const parser = yargs().command(deployCommand);
+    return new TestCommandRunner(parser);
+  };
+
+  beforeEach(() => {
+    generateClientConfigMock.mock.resetCalls();
+    mockDeployFn.mock.resetCalls();
+  });
+
+  void it('throws error if not in CI environment', async () => {
+    await assert.rejects(
+      () =>
+        getCommandRunner(false).runCommand('deploy --identifier my-app-prod'),
+      (err: { error: { name: string } }) => {
+        assert.strictEqual(err.error.name, 'DeployNotInCiError');
+        return true;
+      },
+    );
+    assert.equal(generateClientConfigMock.mock.callCount(), 0);
+  });
+
+  void it('deploys with standalone type and correct identifier', async () => {
+    mockDeployFn.mock.mockImplementationOnce(() =>
+      Promise.resolve({
+        deploymentTimes: { synthesisTime: 0, totalTime: 0 },
+      }),
+    );
+
+    await getCommandRunner(true).runCommand('deploy --identifier my-app-prod');
+
+    assert.strictEqual(mockDeployFn.mock.callCount(), 1);
+    const [deployedId, deployProps] = mockDeployFn.mock.calls[0].arguments;
+    assert.deepStrictEqual(deployedId, {
+      namespace: 'my-app-prod',
+      name: 'default',
+      type: 'standalone',
+    });
+    assert.deepStrictEqual(deployProps, {
+      validateAppSources: true,
+    });
+  });
+
+  void it('generates client config with stackName identifier', async () => {
+    mockDeployFn.mock.mockImplementationOnce(() =>
+      Promise.resolve({
+        deploymentTimes: { synthesisTime: 0, totalTime: 0 },
+      }),
+    );
+
+    await getCommandRunner(true).runCommand('deploy --identifier my-app-prod');
+
+    assert.strictEqual(generateClientConfigMock.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      generateClientConfigMock.mock.calls[0].arguments[0],
+      { stackName: 'my-app-prod' },
+    );
+    assert.deepStrictEqual(
+      generateClientConfigMock.mock.calls[0].arguments[1],
+      DEFAULT_CLIENT_CONFIG_VERSION,
+    );
+  });
+
+  void it('fails if --identifier is not provided', async () => {
+    const output = await getCommandRunner(true).runCommand('deploy');
+    assert.match(output, /Missing required argument/);
+    assert.equal(mockDeployFn.mock.callCount(), 0);
+  });
+
+  void it('allows --outputs-out-dir argument', async () => {
+    mockDeployFn.mock.mockImplementationOnce(() =>
+      Promise.resolve({
+        deploymentTimes: { synthesisTime: 0, totalTime: 0 },
+      }),
+    );
+
+    await getCommandRunner(true).runCommand(
+      'deploy --identifier my-app --outputs-out-dir src',
+    );
+
+    assert.strictEqual(generateClientConfigMock.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      generateClientConfigMock.mock.calls[0].arguments[2],
+      'src',
+    );
+  });
+});

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -24,11 +24,10 @@ void describe('deploy command', () => {
     destroy: mockDestroyFn,
   };
 
-  const getCommandRunner = (isCI = false) => {
+  const getCommandRunner = () => {
     const deployCommand = new DeployCommand(
       clientConfigGenerator as never,
       mockDeployer,
-      isCI,
     ) as unknown as import('yargs').CommandModule<object, DeployCommandOptions>;
     const parser = yargs().command(deployCommand);
     return new TestCommandRunner(parser);
@@ -39,18 +38,6 @@ void describe('deploy command', () => {
     mockDeployFn.mock.resetCalls();
   });
 
-  void it('throws error if not in CI environment', async () => {
-    await assert.rejects(
-      () =>
-        getCommandRunner(false).runCommand('deploy --identifier my-app-prod'),
-      (err: { error: { name: string } }) => {
-        assert.strictEqual(err.error.name, 'DeployNotInCiError');
-        return true;
-      },
-    );
-    assert.equal(generateClientConfigMock.mock.callCount(), 0);
-  });
-
   void it('deploys with standalone type and correct identifier', async () => {
     mockDeployFn.mock.mockImplementationOnce(() =>
       Promise.resolve({
@@ -58,16 +45,17 @@ void describe('deploy command', () => {
       }),
     );
 
-    await getCommandRunner(true).runCommand('deploy --identifier my-app-prod');
+    await getCommandRunner().runCommand('deploy --identifier my-app-prod');
 
     assert.strictEqual(mockDeployFn.mock.callCount(), 1);
-    const [deployedId, deployProps] = mockDeployFn.mock.calls[0].arguments;
-    assert.deepStrictEqual(deployedId, {
+    const callArgs = mockDeployFn.mock.calls[0]
+      .arguments as unknown as unknown[];
+    assert.deepStrictEqual(callArgs[0], {
       namespace: 'my-app-prod',
       name: 'default',
       type: 'standalone',
     });
-    assert.deepStrictEqual(deployProps, {
+    assert.deepStrictEqual(callArgs[1], {
       validateAppSources: true,
     });
   });
@@ -79,21 +67,17 @@ void describe('deploy command', () => {
       }),
     );
 
-    await getCommandRunner(true).runCommand('deploy --identifier my-app-prod');
+    await getCommandRunner().runCommand('deploy --identifier my-app-prod');
 
     assert.strictEqual(generateClientConfigMock.mock.callCount(), 1);
-    assert.deepStrictEqual(
-      generateClientConfigMock.mock.calls[0].arguments[0],
-      { stackName: 'my-app-prod' },
-    );
-    assert.deepStrictEqual(
-      generateClientConfigMock.mock.calls[0].arguments[1],
-      DEFAULT_CLIENT_CONFIG_VERSION,
-    );
+    const configArgs = generateClientConfigMock.mock.calls[0]
+      .arguments as unknown as unknown[];
+    assert.deepStrictEqual(configArgs[0], { stackName: 'my-app-prod' });
+    assert.deepStrictEqual(configArgs[1], DEFAULT_CLIENT_CONFIG_VERSION);
   });
 
   void it('fails if --identifier is not provided', async () => {
-    const output = await getCommandRunner(true).runCommand('deploy');
+    const output = await getCommandRunner().runCommand('deploy');
     assert.match(output, /Missing required argument/);
     assert.equal(mockDeployFn.mock.callCount(), 0);
   });
@@ -105,14 +89,13 @@ void describe('deploy command', () => {
       }),
     );
 
-    await getCommandRunner(true).runCommand(
+    await getCommandRunner().runCommand(
       'deploy --identifier my-app --outputs-out-dir src',
     );
 
     assert.strictEqual(generateClientConfigMock.mock.callCount(), 1);
-    assert.deepStrictEqual(
-      generateClientConfigMock.mock.calls[0].arguments[2],
-      'src',
-    );
+    const configArgs = generateClientConfigMock.mock.calls[0]
+      .arguments as unknown as unknown[];
+    assert.deepStrictEqual(configArgs[2], 'src');
   });
 });

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -103,6 +103,11 @@ export class DeployCommand
       );
       const bootstrapUrl = getBootstrapUrl(region);
       printer.log(`Open ${bootstrapUrl} in the browser.`);
+      printer.log(
+        format.dim(
+          'Note: This check requires ssm:GetParameter permission on /cdk-bootstrap/* resources.',
+        ),
+      );
       return;
     }
 
@@ -195,9 +200,11 @@ export class DeployCommand
       );
 
       const bootstrapVersion = parameter?.Value;
+      const versionNumber = Number(bootstrapVersion);
       if (
         !bootstrapVersion ||
-        Number(bootstrapVersion) < CDK_MIN_BOOTSTRAP_VERSION
+        isNaN(versionNumber) ||
+        versionNumber < CDK_MIN_BOOTSTRAP_VERSION
       ) {
         return false;
       }

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -62,6 +62,17 @@ export class DeployCommand
   handler = async (
     args: ArgumentsCamelCase<DeployCommandOptions>,
   ): Promise<void> => {
+    // Validate identifier before deploying
+    if (
+      !IDENTIFIER_PATTERN.test(args.identifier) ||
+      args.identifier.length > IDENTIFIER_MAX_LENGTH
+    ) {
+      throw new AmplifyUserError('InvalidCommandInputError', {
+        message: `Invalid --identifier: "${args.identifier}"`,
+        resolution: `--identifier must be 1-${IDENTIFIER_MAX_LENGTH} characters, start with a letter, and contain only alphanumeric characters and hyphens.`,
+      });
+    }
+
     // Standalone deployments use a single stack per identifier.
     // The 'default' name is a convention: standalone does not have
     // branch-based naming, so a fixed name is used.
@@ -127,18 +138,6 @@ export class DeployCommand
         type: 'string',
         array: false,
         choices: Object.values(ClientConfigFormat),
-      })
-      .check((argv) => {
-        if (
-          !IDENTIFIER_PATTERN.test(argv.identifier) ||
-          argv.identifier.length > IDENTIFIER_MAX_LENGTH
-        ) {
-          throw new AmplifyUserError('InvalidCommandInputError', {
-            message: `Invalid --identifier: "${argv.identifier}"`,
-            resolution: `--identifier must be 1-${IDENTIFIER_MAX_LENGTH} characters, start with a letter, and contain only alphanumeric characters and hyphens.`,
-          });
-        }
-        return true;
       });
   };
 }

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -1,0 +1,133 @@
+import _isCI from 'is-ci';
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
+import { BackendDeployer } from '@aws-amplify/backend-deployer';
+import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
+import { ArgumentsKebabCase } from '../../kebab_case.js';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import {
+  ClientConfigFormat,
+  ClientConfigVersion,
+  ClientConfigVersionOption,
+  DEFAULT_CLIENT_CONFIG_VERSION,
+} from '@aws-amplify/client-config';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
+import { format } from '@aws-amplify/cli-core';
+
+export type DeployCommandOptions =
+  ArgumentsKebabCase<DeployCommandOptionsCamelCase>;
+
+type DeployCommandOptionsCamelCase = {
+  identifier: string;
+  outputsFormat: ClientConfigFormat | undefined;
+  outputsVersion: string;
+  outputsOutDir?: string;
+};
+
+/**
+ * Deploys Amplify backend resources without Amplify Hosting.
+ */
+export class DeployCommand
+  implements CommandModule<object, DeployCommandOptions>
+{
+  /**
+   * @inheritDoc
+   */
+  readonly command: string;
+
+  /**
+   * @inheritDoc
+   */
+  readonly describe: string;
+
+  /**
+   * Creates the deploy command.
+   */
+  constructor(
+    private readonly clientConfigGenerator: ClientConfigGeneratorAdapter,
+    private readonly backendDeployer: BackendDeployer,
+    private readonly isCiEnvironment: typeof _isCI = _isCI,
+  ) {
+    this.command = 'deploy';
+    this.describe = 'Deploy Amplify backend resources without Amplify Hosting.';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handler = async (
+    args: ArgumentsCamelCase<DeployCommandOptions>,
+  ): Promise<void> => {
+    if (!this.isCiEnvironment) {
+      throw new AmplifyUserError('DeployNotInCiError', {
+        message:
+          'It looks like this command is being run outside of a CI/CD workflow.',
+        resolution: `To deploy locally use ${format.normalizeAmpxCommand(
+          'sandbox',
+        )} instead. To deploy in CI, set CI=true in your environment.`,
+      });
+    }
+
+    const backendId: BackendIdentifier = {
+      namespace: args.identifier,
+      name: 'default',
+      type: 'standalone',
+    };
+
+    await this.backendDeployer.deploy(backendId, {
+      validateAppSources: true,
+    });
+
+    const clientConfigIdentifier = { stackName: args.identifier };
+
+    await this.clientConfigGenerator.generateClientConfigToFile(
+      clientConfigIdentifier,
+      args.outputsVersion as ClientConfigVersion,
+      args.outputsOutDir,
+      args.outputsFormat,
+    );
+  };
+
+  /**
+   * @inheritDoc
+   */
+  builder = (yargs: Argv): Argv<DeployCommandOptions> => {
+    return yargs
+      .version(false)
+      .option('identifier', {
+        describe:
+          'Unique identifier for this deployment. Used as the CloudFormation stack name.',
+        demandOption: true,
+        type: 'string',
+        array: false,
+      })
+      .option('outputs-out-dir', {
+        describe:
+          'A path to directory where amplify_outputs is written. If not provided defaults to current process working directory.',
+        type: 'string',
+        array: false,
+      })
+      .option('outputs-version', {
+        describe:
+          'Version of the configuration. Version 0 represents classic amplify-cli config file amplify-configuration and 1 represents newer config file amplify_outputs',
+        type: 'string',
+        array: false,
+        choices: Object.values(ClientConfigVersionOption),
+        default: DEFAULT_CLIENT_CONFIG_VERSION,
+      })
+      .option('outputs-format', {
+        describe: 'amplify_outputs file format',
+        type: 'string',
+        array: false,
+        choices: Object.values(ClientConfigFormat),
+      })
+      .check((argv) => {
+        if (argv.identifier.length === 0) {
+          throw new AmplifyUserError('InvalidCommandInputError', {
+            message: 'Invalid --identifier',
+            resolution: '--identifier must be at least 1 character',
+          });
+        }
+        return true;
+      });
+  };
+}

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -77,8 +77,8 @@ export class DeployCommand
     // The 'default' name is a convention: standalone does not have
     // branch-based naming, so a fixed name is used.
     const backendId: BackendIdentifier = {
-      namespace: `amplify-${args.identifier}`,
-      name: 'default',
+      namespace: args.identifier,
+      name: 'stack',
       type: 'standalone',
     };
 
@@ -88,8 +88,11 @@ export class DeployCommand
 
     // Client config for standalone uses { stackName } instead of
     // { appId, branch } because there is no Amplify Hosting app.
-    // This resolves via the StackIdentifier path in deployed-backend-client.
-    const clientConfigIdentifier = { stackName: `amplify-${args.identifier}` };
+    // This resolves via the StackIdentifier path in deployed-backend-client,
+    // which passes stackName directly to CloudFormation APIs like
+    // GetTemplateSummary — so it must be the full CFN stack name.
+    const stackName = BackendIdentifierConversions.toStackName(backendId);
+    const clientConfigIdentifier = { stackName };
 
     await this.clientConfigGenerator.generateClientConfigToFile(
       clientConfigIdentifier,
@@ -98,7 +101,6 @@ export class DeployCommand
       args.outputsFormat,
     );
 
-    const stackName = BackendIdentifierConversions.toStackName(backendId);
     printer.log(`Deployment complete.`);
     printer.log(`Stack name: ${stackName}`);
     printer.log(

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -112,7 +112,7 @@ export class DeployCommand
     }
 
     // Standalone deployments use a single stack per identifier.
-    // The 'default' name is a convention: standalone does not have
+    // The 'stack' name is a convention: standalone does not have
     // branch-based naming, so a fixed name is used.
     const backendId: BackendIdentifier = {
       namespace: args.identifier,

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -77,7 +77,7 @@ export class DeployCommand
     // The 'default' name is a convention: standalone does not have
     // branch-based naming, so a fixed name is used.
     const backendId: BackendIdentifier = {
-      namespace: args.identifier,
+      namespace: `amplify-${args.identifier}`,
       name: 'default',
       type: 'standalone',
     };
@@ -89,7 +89,7 @@ export class DeployCommand
     // Client config for standalone uses { stackName } instead of
     // { appId, branch } because there is no Amplify Hosting app.
     // This resolves via the StackIdentifier path in deployed-backend-client.
-    const clientConfigIdentifier = { stackName: args.identifier };
+    const clientConfigIdentifier = { stackName: `amplify-${args.identifier}` };
 
     await this.clientConfigGenerator.generateClientConfigToFile(
       clientConfigIdentifier,

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -13,13 +13,21 @@ import {
   AmplifyUserError,
   BackendIdentifierConversions,
 } from '@aws-amplify/platform-core';
-import { printer } from '@aws-amplify/cli-core';
+import { format, printer } from '@aws-amplify/cli-core';
+import { CommandMiddleware } from '../../command_middleware.js';
+import {
+  GetParameterCommand,
+  ParameterNotFound,
+  SSMClient,
+  SSMServiceException,
+} from '@aws-sdk/client-ssm';
 
 export type DeployCommandOptions =
   ArgumentsKebabCase<DeployCommandOptionsCamelCase>;
 
 type DeployCommandOptionsCamelCase = {
   identifier: string;
+  profile: string | undefined;
   outputsFormat: ClientConfigFormat | undefined;
   outputsVersion: string;
   outputsOutDir?: string;
@@ -28,6 +36,15 @@ type DeployCommandOptionsCamelCase = {
 // CloudFormation stack name constraints
 const IDENTIFIER_PATTERN = /^[A-Za-z][A-Za-z0-9-]*$/;
 const IDENTIFIER_MAX_LENGTH = 128;
+
+// CDK bootstrap version parameter (same as sandbox uses)
+const CDK_DEFAULT_BOOTSTRAP_VERSION_PARAMETER_NAME =
+  // eslint-disable-next-line spellcheck/spell-checker
+  '/cdk-bootstrap/hnb659fds/version';
+const CDK_MIN_BOOTSTRAP_VERSION = 6;
+
+const getBootstrapUrl = (region: string) =>
+  `https://${region}.console.aws.amazon.com/amplify/create/bootstrap?region=${region}`;
 
 /**
  * Deploys Amplify backend resources without Amplify Hosting.
@@ -51,6 +68,8 @@ export class DeployCommand
   constructor(
     private readonly clientConfigGenerator: ClientConfigGeneratorAdapter,
     private readonly backendDeployer: BackendDeployer,
+    private readonly commandMiddleware: CommandMiddleware,
+    private readonly ssmClient: SSMClient,
   ) {
     this.command = 'deploy';
     this.describe = 'Deploy Amplify backend resources without Amplify Hosting.';
@@ -71,6 +90,20 @@ export class DeployCommand
         message: `Invalid --identifier: "${args.identifier}"`,
         resolution: `--identifier must be 1-${IDENTIFIER_MAX_LENGTH} characters, start with a letter, and contain only alphanumeric characters and hyphens.`,
       });
+    }
+
+    // Check CDK bootstrap before deploying
+    const bootstrapped = await this.isBootstrapped();
+    const region = await this.ssmClient.config.region();
+    if (!bootstrapped) {
+      printer.log(
+        `The region ${format.highlight(
+          region,
+        )} has not been bootstrapped. Sign in to the AWS console as a Root user or Admin to complete the bootstrap process, then re-run the deploy command.`,
+      );
+      const bootstrapUrl = getBootstrapUrl(region);
+      printer.log(`Open ${bootstrapUrl} in the browser.`);
+      return;
     }
 
     // Standalone deployments use a single stack per identifier.
@@ -140,6 +173,61 @@ export class DeployCommand
         type: 'string',
         array: false,
         choices: Object.values(ClientConfigFormat),
-      });
+      })
+      .option('profile', {
+        describe: 'An AWS profile name.',
+        type: 'string',
+        array: false,
+      })
+      .middleware([this.commandMiddleware.ensureAwsCredentialAndRegion]);
+  };
+
+  /**
+   * Checks if a given region has been bootstrapped with >= min version using
+   * CDK bootstrap version parameter stored in parameter store.
+   */
+  private isBootstrapped = async (): Promise<boolean> => {
+    try {
+      const { Parameter: parameter } = await this.ssmClient.send(
+        new GetParameterCommand({
+          Name: CDK_DEFAULT_BOOTSTRAP_VERSION_PARAMETER_NAME,
+        }),
+      );
+
+      const bootstrapVersion = parameter?.Value;
+      if (
+        !bootstrapVersion ||
+        Number(bootstrapVersion) < CDK_MIN_BOOTSTRAP_VERSION
+      ) {
+        return false;
+      }
+      return true;
+    } catch (e) {
+      if (e instanceof ParameterNotFound) {
+        return false;
+      }
+      if (
+        e instanceof SSMServiceException &&
+        [
+          'UnrecognizedClientException',
+          'AccessDeniedException',
+          'NotAuthorized',
+          'ExpiredTokenException',
+          'ExpiredToken',
+          'InvalidSignatureException',
+        ].includes(e.name)
+      ) {
+        throw new AmplifyUserError(
+          'SSMCredentialsError',
+          {
+            message: `${e.name}: ${e.message}`,
+            resolution:
+              'Make sure your AWS credentials are set up correctly and have permissions to call SSM:GetParameter',
+          },
+          e,
+        );
+      }
+      throw e;
+    }
   };
 }

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -9,7 +9,11 @@ import {
   ClientConfigVersionOption,
   DEFAULT_CLIENT_CONFIG_VERSION,
 } from '@aws-amplify/client-config';
-import { AmplifyUserError } from '@aws-amplify/platform-core';
+import {
+  AmplifyUserError,
+  BackendIdentifierConversions,
+} from '@aws-amplify/platform-core';
+import { printer } from '@aws-amplify/cli-core';
 
 export type DeployCommandOptions =
   ArgumentsKebabCase<DeployCommandOptionsCamelCase>;
@@ -20,6 +24,10 @@ type DeployCommandOptionsCamelCase = {
   outputsVersion: string;
   outputsOutDir?: string;
 };
+
+// CloudFormation stack name constraints
+const IDENTIFIER_PATTERN = /^[A-Za-z][A-Za-z0-9-]*$/;
+const IDENTIFIER_MAX_LENGTH = 128;
 
 /**
  * Deploys Amplify backend resources without Amplify Hosting.
@@ -54,6 +62,9 @@ export class DeployCommand
   handler = async (
     args: ArgumentsCamelCase<DeployCommandOptions>,
   ): Promise<void> => {
+    // Standalone deployments use a single stack per identifier.
+    // The 'default' name is a convention: standalone does not have
+    // branch-based naming, so a fixed name is used.
     const backendId: BackendIdentifier = {
       namespace: args.identifier,
       name: 'default',
@@ -64,6 +75,9 @@ export class DeployCommand
       validateAppSources: true,
     });
 
+    // Client config for standalone uses { stackName } instead of
+    // { appId, branch } because there is no Amplify Hosting app.
+    // This resolves via the StackIdentifier path in deployed-backend-client.
     const clientConfigIdentifier = { stackName: args.identifier };
 
     await this.clientConfigGenerator.generateClientConfigToFile(
@@ -71,6 +85,13 @@ export class DeployCommand
       args.outputsVersion as ClientConfigVersion,
       args.outputsOutDir,
       args.outputsFormat,
+    );
+
+    const stackName = BackendIdentifierConversions.toStackName(backendId);
+    printer.log(`Deployment complete.`);
+    printer.log(`Stack name: ${stackName}`);
+    printer.log(
+      `To remove this deployment: aws cloudformation delete-stack --stack-name ${stackName}`,
     );
   };
 
@@ -108,10 +129,13 @@ export class DeployCommand
         choices: Object.values(ClientConfigFormat),
       })
       .check((argv) => {
-        if (argv.identifier.length === 0) {
+        if (
+          !IDENTIFIER_PATTERN.test(argv.identifier) ||
+          argv.identifier.length > IDENTIFIER_MAX_LENGTH
+        ) {
           throw new AmplifyUserError('InvalidCommandInputError', {
-            message: 'Invalid --identifier',
-            resolution: '--identifier must be at least 1 character',
+            message: `Invalid --identifier: "${argv.identifier}"`,
+            resolution: `--identifier must be 1-${IDENTIFIER_MAX_LENGTH} characters, start with a letter, and contain only alphanumeric characters and hyphens.`,
           });
         }
         return true;

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -1,4 +1,3 @@
-import _isCI from 'is-ci';
 import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 import { BackendDeployer } from '@aws-amplify/backend-deployer';
 import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
@@ -11,7 +10,6 @@ import {
   DEFAULT_CLIENT_CONFIG_VERSION,
 } from '@aws-amplify/client-config';
 import { AmplifyUserError } from '@aws-amplify/platform-core';
-import { format } from '@aws-amplify/cli-core';
 
 export type DeployCommandOptions =
   ArgumentsKebabCase<DeployCommandOptionsCamelCase>;
@@ -45,7 +43,6 @@ export class DeployCommand
   constructor(
     private readonly clientConfigGenerator: ClientConfigGeneratorAdapter,
     private readonly backendDeployer: BackendDeployer,
-    private readonly isCiEnvironment: typeof _isCI = _isCI,
   ) {
     this.command = 'deploy';
     this.describe = 'Deploy Amplify backend resources without Amplify Hosting.';
@@ -57,16 +54,6 @@ export class DeployCommand
   handler = async (
     args: ArgumentsCamelCase<DeployCommandOptions>,
   ): Promise<void> => {
-    if (!this.isCiEnvironment) {
-      throw new AmplifyUserError('DeployNotInCiError', {
-        message:
-          'It looks like this command is being run outside of a CI/CD workflow.',
-        resolution: `To deploy locally use ${format.normalizeAmpxCommand(
-          'sandbox',
-        )} instead. To deploy in CI, set CI=true in your environment.`,
-      });
-    }
-
     const backendId: BackendIdentifier = {
       namespace: args.identifier,
       name: 'default',

--- a/packages/cli/src/commands/deploy/deploy_command_factory.ts
+++ b/packages/cli/src/commands/deploy/deploy_command_factory.ts
@@ -4,6 +4,7 @@ import {
   AmplifyIOEventsBridgeSingletonFactory,
   PackageManagerControllerFactory,
   format,
+  printer,
 } from '@aws-amplify/cli-core';
 
 import { DeployCommand, DeployCommandOptions } from './deploy_command.js';
@@ -12,6 +13,8 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { SDKProfileResolverProvider } from '../../sdk_profile_resolver_provider.js';
+import { CommandMiddleware } from '../../command_middleware.js';
+import { SSMClient } from '@aws-sdk/client-ssm';
 
 /**
  * Creates the deploy command.
@@ -43,5 +46,12 @@ export const createDeployCommand = (): CommandModule<
     new SDKProfileResolverProvider().resolve,
   );
   const backendDeployer = backendDeployerFactory.getInstance();
-  return new DeployCommand(clientConfigGenerator, backendDeployer);
+  const commandMiddleware = new CommandMiddleware(printer);
+  const ssmClient = new SSMClient();
+  return new DeployCommand(
+    clientConfigGenerator,
+    backendDeployer,
+    commandMiddleware,
+    ssmClient,
+  );
 };

--- a/packages/cli/src/commands/deploy/deploy_command_factory.ts
+++ b/packages/cli/src/commands/deploy/deploy_command_factory.ts
@@ -1,0 +1,47 @@
+import { CommandModule } from 'yargs';
+import { BackendDeployerFactory } from '@aws-amplify/backend-deployer';
+import {
+  AmplifyIOEventsBridgeSingletonFactory,
+  PackageManagerControllerFactory,
+  format,
+} from '@aws-amplify/cli-core';
+
+import { DeployCommand, DeployCommandOptions } from './deploy_command.js';
+import { ClientConfigGeneratorAdapter } from '../../client-config/client_config_generator_adapter.js';
+import { S3Client } from '@aws-sdk/client-s3';
+import { AmplifyClient } from '@aws-sdk/client-amplify';
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { SDKProfileResolverProvider } from '../../sdk_profile_resolver_provider.js';
+
+/**
+ * Creates the deploy command.
+ */
+export const createDeployCommand = (): CommandModule<
+  object,
+  DeployCommandOptions
+> => {
+  const s3Client = new S3Client();
+  const amplifyClient = new AmplifyClient();
+  const cloudFormationClient = new CloudFormationClient();
+
+  const awsClientProvider = {
+    getS3Client: () => s3Client,
+    getAmplifyClient: () => amplifyClient,
+    getCloudFormationClient: () => cloudFormationClient,
+  };
+  const clientConfigGenerator = new ClientConfigGeneratorAdapter(
+    awsClientProvider,
+  );
+  const packageManagerControllerFactory = new PackageManagerControllerFactory();
+  const cdkEventsBridgeIoHost =
+    new AmplifyIOEventsBridgeSingletonFactory().getInstance();
+
+  const backendDeployerFactory = new BackendDeployerFactory(
+    packageManagerControllerFactory.getPackageManagerController(),
+    format,
+    cdkEventsBridgeIoHost,
+    new SDKProfileResolverProvider().resolve,
+  );
+  const backendDeployer = backendDeployerFactory.getInstance();
+  return new DeployCommand(clientConfigGenerator, backendDeployer);
+};

--- a/packages/cli/src/main_parser_factory.ts
+++ b/packages/cli/src/main_parser_factory.ts
@@ -2,6 +2,7 @@ import yargs, { Argv } from 'yargs';
 import { createGenerateCommand } from './commands/generate/generate_command_factory.js';
 import { createSandboxCommand } from './commands/sandbox/sandbox_command_factory.js';
 import { createPipelineDeployCommand } from './commands/pipeline-deploy/pipeline_deploy_command_factory.js';
+import { createDeployCommand } from './commands/deploy/deploy_command_factory.js';
 import { createConfigureCommand } from './commands/configure/configure_command_factory.js';
 import { createInfoCommand } from './commands/info/info_command_factory.js';
 import { createNoticesCommand } from './commands/notices/notices_command_factory.js';
@@ -31,6 +32,7 @@ export const createMainParser = (
     .command(createGenerateCommand())
     .command(createSandboxCommand(noticesRenderer))
     .command(createPipelineDeployCommand())
+    .command(createDeployCommand())
     .command(createConfigureCommand())
     .command(createInfoCommand())
     .command(createNoticesCommand())

--- a/packages/integration-tests/src/define_backend_template_harness.ts
+++ b/packages/integration-tests/src/define_backend_template_harness.ts
@@ -54,7 +54,7 @@ export const synthesizeStandaloneBackendTemplates: SynthesizeBackendTemplates =
     try {
       process.env.CDK_CONTEXT_JSON = JSON.stringify({
         [CDKContextKey.BACKEND_NAMESPACE]: 'testStandaloneId',
-        [CDKContextKey.BACKEND_NAME]: 'default',
+        [CDKContextKey.BACKEND_NAME]: 'stack',
         [CDKContextKey.DEPLOYMENT_TYPE]: 'standalone',
       });
       return backendTemplatesCollector(constructFactories);

--- a/packages/integration-tests/src/define_backend_template_harness.ts
+++ b/packages/integration-tests/src/define_backend_template_harness.ts
@@ -44,6 +44,25 @@ export const synthesizeBackendTemplates: SynthesizeBackendTemplates = <
   }
 };
 
+/**
+ * Synthesizes deterministic `defineBackend` CDK templates using standalone deployment type.
+ */
+export const synthesizeStandaloneBackendTemplates: SynthesizeBackendTemplates =
+  <T extends Record<string, ConstructFactory<ResourceProvider>>>(
+    constructFactories: T,
+  ) => {
+    try {
+      process.env.CDK_CONTEXT_JSON = JSON.stringify({
+        [CDKContextKey.BACKEND_NAMESPACE]: 'testStandaloneId',
+        [CDKContextKey.BACKEND_NAME]: 'default',
+        [CDKContextKey.DEPLOYMENT_TYPE]: 'standalone',
+      });
+      return backendTemplatesCollector(constructFactories);
+    } finally {
+      delete process.env.CDK_CONTEXT_JSON;
+    }
+  };
+
 const backendTemplatesCollector: SynthesizeBackendTemplates = <
   T extends Record<string, ConstructFactory<ResourceProvider>>,
 >(

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_auth.deployment.test.ts
@@ -1,0 +1,4 @@
+import { StandaloneAuthTestProjectCreator } from '../../test-project-setup/standalone_auth.js';
+import { defineStandaloneDeploymentTest } from './standalone_deployment.test.template.js';
+
+defineStandaloneDeploymentTest(new StandaloneAuthTestProjectCreator());

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_basic.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_basic.deployment.test.ts
@@ -1,4 +1,7 @@
 import { StandaloneAuthTestProjectCreator } from '../../test-project-setup/standalone_auth.js';
 import { defineStandaloneDeploymentTest } from './standalone_deployment.test.template.js';
 
+// Basic standalone deployment test: deploys a minimal backend via ampx deploy,
+// verifies the stack exists, uses the correct identifier, and contains no
+// Amplify Hosting resources.
 defineStandaloneDeploymentTest(new StandaloneAuthTestProjectCreator());

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
@@ -1,0 +1,6 @@
+import { DataStorageAuthWithTriggerTestProjectCreator } from '../../test-project-setup/data_storage_auth_with_triggers.js';
+import { defineStandaloneDeploymentTest } from './standalone_deployment.test.template.js';
+
+defineStandaloneDeploymentTest(
+  new DataStorageAuthWithTriggerTestProjectCreator(),
+);

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
@@ -1,6 +1,100 @@
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
+import {
+  createTestDirectory,
+  deleteTestDirectory,
+  rootTestDir,
+} from '../../setup_test_directory.js';
 import { DataStorageAuthWithTriggerTestProjectCreator } from '../../test-project-setup/data_storage_auth_with_triggers.js';
-import { defineStandaloneDeploymentTest } from './standalone_deployment.test.template.js';
+import { TestProjectBase } from '../../test-project-setup/test_project_base.js';
+import assert from 'node:assert';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { testConcurrencyLevel } from '../test_concurrency.js';
+import { shortUuid } from '../../short_uuid.js';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from '@aws-sdk/client-cloudformation';
+import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import { e2eToolingClientConfig } from '../../e2e_tooling_client_config.js';
+import fsp from 'fs/promises';
 
-defineStandaloneDeploymentTest(
-  new DataStorageAuthWithTriggerTestProjectCreator(),
+const testProjectCreator = new DataStorageAuthWithTriggerTestProjectCreator();
+
+void describe(
+  'standalone data-storage-auth deployment tests',
+  { concurrency: testConcurrencyLevel },
+  () => {
+    const cfnClient = new CloudFormationClient(e2eToolingClientConfig);
+
+    before(async () => {
+      await createTestDirectory(rootTestDir);
+    });
+    after(async () => {
+      await deleteTestDirectory(rootTestDir);
+    });
+
+    let standaloneBackendIdentifier: BackendIdentifier;
+    let testProject: TestProjectBase;
+
+    beforeEach(async () => {
+      testProject = await testProjectCreator.createProject(rootTestDir);
+      standaloneBackendIdentifier = {
+        namespace: `standalone-e2e-${shortUuid()}`,
+        name: 'default',
+        type: 'standalone',
+      };
+    });
+
+    afterEach(async () => {
+      await testProject.tearDown(standaloneBackendIdentifier, true);
+    });
+
+    void it('deploys and verifies full stack via standalone', async () => {
+      await testProject.deploy(standaloneBackendIdentifier);
+      await testProject.assertPostDeployment(standaloneBackendIdentifier);
+    });
+
+    void it('redeploys with modifications and verifies update succeeds', async () => {
+      // Initial deploy
+      await testProject.deploy(standaloneBackendIdentifier);
+
+      const stackName = BackendIdentifierConversions.toStackName(
+        standaloneBackendIdentifier,
+      );
+
+      // Verify initial deploy
+      const initialResult = await cfnClient.send(
+        new DescribeStacksCommand({ StackName: stackName }),
+      );
+      assert.ok(
+        initialResult.Stacks?.[0]?.StackStatus === 'CREATE_COMPLETE' ||
+          initialResult.Stacks?.[0]?.StackStatus === 'UPDATE_COMPLETE',
+        `initial deploy should succeed, got: ${initialResult.Stacks?.[0]?.StackStatus}`,
+      );
+
+      // Apply project updates (modified data schema, updated Lambda handler)
+      const updates = await testProject.getUpdates();
+      for (const update of updates) {
+        for (const replacement of update.replacements) {
+          await fsp.cp(replacement.source, replacement.destination, {
+            force: true,
+          });
+        }
+      }
+
+      // Redeploy with the same identifier
+      await testProject.deploy(standaloneBackendIdentifier);
+
+      // Verify update succeeded
+      const updateResult = await cfnClient.send(
+        new DescribeStacksCommand({ StackName: stackName }),
+      );
+      assert.ok(
+        updateResult.Stacks?.[0]?.StackStatus === 'UPDATE_COMPLETE',
+        `redeploy should result in UPDATE_COMPLETE, got: ${updateResult.Stacks?.[0]?.StackStatus}`,
+      );
+
+      await testProject.assertPostDeployment(standaloneBackendIdentifier);
+    });
+  },
 );

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
@@ -55,24 +55,17 @@ void describe(
     });
 
     void it('redeploys with modifications and verifies update succeeds', async () => {
-      // Initial deploy
+      // 1. Initial deploy
       await testProject.deploy(standaloneBackendIdentifier);
+
+      // 2. Verify initial deployment
+      await testProject.assertPostDeployment(standaloneBackendIdentifier);
 
       const stackName = BackendIdentifierConversions.toStackName(
         standaloneBackendIdentifier,
       );
 
-      // Verify initial deploy
-      const initialResult = await cfnClient.send(
-        new DescribeStacksCommand({ StackName: stackName }),
-      );
-      assert.ok(
-        initialResult.Stacks?.[0]?.StackStatus === 'CREATE_COMPLETE' ||
-          initialResult.Stacks?.[0]?.StackStatus === 'UPDATE_COMPLETE',
-        `initial deploy should succeed, got: ${initialResult.Stacks?.[0]?.StackStatus}`,
-      );
-
-      // Apply project updates (modified data schema, updated Lambda handler)
+      // 3. Apply project updates (modified data schema, updated Lambda handler)
       const updates = await testProject.getUpdates();
       for (const update of updates) {
         for (const replacement of update.replacements) {
@@ -82,10 +75,10 @@ void describe(
         }
       }
 
-      // Redeploy with the same identifier
+      // 4. Redeploy with the same identifier
       await testProject.deploy(standaloneBackendIdentifier);
 
-      // Verify update succeeded
+      // 5. Verify update succeeded and resources are correct
       const updateResult = await cfnClient.send(
         new DescribeStacksCommand({ StackName: stackName }),
       );

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
@@ -1,4 +1,4 @@
-import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import {
   createTestDirectory,
   deleteTestDirectory,
@@ -37,66 +37,69 @@ void describe(
       await deleteTestDirectory(rootTestDir);
     });
 
-    let standaloneBackendIdentifier: BackendIdentifier;
-    let testProject: TestProjectBase;
+    void describe('standalone deploys data-storage-auth', () => {
+      let testProject: TestProjectBase;
+      let standaloneBackendIdentifier: BackendIdentifier;
 
-    beforeEach(async () => {
-      testProject = await testProjectCreator.createProject(rootTestDir);
-      standaloneBackendIdentifier = {
-        namespace: `standalone-e2e-${shortUuid()}`,
-        name: 'stack',
-        type: 'standalone',
-      };
-    });
-
-    afterEach(async () => {
-      await testProject.tearDown(standaloneBackendIdentifier, true);
-    });
-
-    void it('deploys and verifies full stack via standalone', async () => {
-      await testProject.deploy(standaloneBackendIdentifier);
-      await testProject.assertPostDeployment(standaloneBackendIdentifier);
-    });
-
-    void it('redeploys with modifications and verifies update succeeds', async () => {
-      // Use a consistent shared secret name across both deploys (same pattern as sandbox tests)
       const sharedSecretsEnv = {
         [amplifySharedSecretNameKey]: createAmplifySharedSecretName(),
       };
 
-      // 1. Initial deploy
-      await testProject.deploy(standaloneBackendIdentifier, sharedSecretsEnv);
+      before(async () => {
+        testProject = await testProjectCreator.createProject(rootTestDir);
+        standaloneBackendIdentifier = {
+          namespace: `standalone-e2e-${shortUuid()}`,
+          name: 'stack',
+          type: 'standalone',
+        };
+      });
 
-      // 2. Verify initial deployment
-      await testProject.assertPostDeployment(standaloneBackendIdentifier);
+      after(async () => {
+        await testProject.tearDown(standaloneBackendIdentifier, true);
+      });
 
-      const stackName = BackendIdentifierConversions.toStackName(
-        standaloneBackendIdentifier,
-      );
+      void describe('in sequence', { concurrency: false }, () => {
+        void it('deploys and verifies full stack via standalone', async () => {
+          await testProject.deploy(
+            standaloneBackendIdentifier,
+            sharedSecretsEnv,
+          );
+          await testProject.assertPostDeployment(standaloneBackendIdentifier);
+        });
 
-      // 3. Apply project updates (modified data schema, updated Lambda handler)
-      const updates = await testProject.getUpdates();
-      for (const update of updates) {
-        for (const replacement of update.replacements) {
-          await fsp.cp(replacement.source, replacement.destination, {
-            force: true,
-          });
-        }
-      }
+        void it('redeploys with modifications and verifies update succeeds', async () => {
+          const stackName = BackendIdentifierConversions.toStackName(
+            standaloneBackendIdentifier,
+          );
 
-      // 4. Redeploy with the same identifier and shared secret
-      await testProject.deploy(standaloneBackendIdentifier, sharedSecretsEnv);
+          // Apply project updates (modified data schema, updated Lambda handler)
+          const updates = await testProject.getUpdates();
+          for (const update of updates) {
+            for (const replacement of update.replacements) {
+              await fsp.cp(replacement.source, replacement.destination, {
+                force: true,
+              });
+            }
+          }
 
-      // 5. Verify update succeeded and resources are correct
-      const updateResult = await cfnClient.send(
-        new DescribeStacksCommand({ StackName: stackName }),
-      );
-      assert.ok(
-        updateResult.Stacks?.[0]?.StackStatus === 'UPDATE_COMPLETE',
-        `redeploy should result in UPDATE_COMPLETE, got: ${updateResult.Stacks?.[0]?.StackStatus}`,
-      );
+          // Redeploy with the same identifier and shared secret
+          await testProject.deploy(
+            standaloneBackendIdentifier,
+            sharedSecretsEnv,
+          );
 
-      await testProject.assertPostDeployment(standaloneBackendIdentifier);
+          // Verify update succeeded and resources are correct
+          const updateResult = await cfnClient.send(
+            new DescribeStacksCommand({ StackName: stackName }),
+          );
+          assert.ok(
+            updateResult.Stacks?.[0]?.StackStatus === 'UPDATE_COMPLETE',
+            `redeploy should result in UPDATE_COMPLETE, got: ${updateResult.Stacks?.[0]?.StackStatus}`,
+          );
+
+          await testProject.assertPostDeployment(standaloneBackendIdentifier);
+        });
+      });
     });
   },
 );

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
@@ -17,6 +17,10 @@ import {
 import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
 import { e2eToolingClientConfig } from '../../e2e_tooling_client_config.js';
 import fsp from 'fs/promises';
+import {
+  amplifySharedSecretNameKey,
+  createAmplifySharedSecretName,
+} from '../../shared_secret.js';
 
 const testProjectCreator = new DataStorageAuthWithTriggerTestProjectCreator();
 
@@ -55,8 +59,13 @@ void describe(
     });
 
     void it('redeploys with modifications and verifies update succeeds', async () => {
+      // Use a consistent shared secret name across both deploys (same pattern as sandbox tests)
+      const sharedSecretsEnv = {
+        [amplifySharedSecretNameKey]: createAmplifySharedSecretName(),
+      };
+
       // 1. Initial deploy
-      await testProject.deploy(standaloneBackendIdentifier);
+      await testProject.deploy(standaloneBackendIdentifier, sharedSecretsEnv);
 
       // 2. Verify initial deployment
       await testProject.assertPostDeployment(standaloneBackendIdentifier);
@@ -75,8 +84,8 @@ void describe(
         }
       }
 
-      // 4. Redeploy with the same identifier
-      await testProject.deploy(standaloneBackendIdentifier);
+      // 4. Redeploy with the same identifier and shared secret
+      await testProject.deploy(standaloneBackendIdentifier, sharedSecretsEnv);
 
       // 5. Verify update succeeded and resources are correct
       const updateResult = await cfnClient.send(

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_data_storage_auth.deployment.test.ts
@@ -40,7 +40,7 @@ void describe(
       testProject = await testProjectCreator.createProject(rootTestDir);
       standaloneBackendIdentifier = {
         namespace: `standalone-e2e-${shortUuid()}`,
-        name: 'default',
+        name: 'stack',
         type: 'standalone',
       };
     });

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
@@ -93,42 +93,6 @@ export const defineStandaloneDeploymentTest = (
 
           await testProject.assertPostDeployment(standaloneBackendIdentifier);
         });
-
-        void it(`[${testProjectCreator.name}] redeploys with same identifier`, async () => {
-          // Initial deploy
-          await testProject.deploy(standaloneBackendIdentifier);
-
-          const stackName = BackendIdentifierConversions.toStackName(
-            standaloneBackendIdentifier,
-          );
-
-          // Verify initial deploy succeeded
-          const initialResult = await cfnClient.send(
-            new DescribeStacksCommand({ StackName: stackName }),
-          );
-          const initialStatus = initialResult.Stacks?.[0]?.StackStatus;
-          assert.ok(
-            initialStatus === 'CREATE_COMPLETE' ||
-              initialStatus === 'UPDATE_COMPLETE',
-            `initial deploy should succeed, got: ${initialStatus}`,
-          );
-
-          // Redeploy with the same identifier (CloudFormation update)
-          await testProject.deploy(standaloneBackendIdentifier);
-
-          // Verify update succeeded
-          const updateResult = await cfnClient.send(
-            new DescribeStacksCommand({ StackName: stackName }),
-          );
-          const updateStatus = updateResult.Stacks?.[0]?.StackStatus;
-          assert.ok(
-            updateStatus === 'UPDATE_COMPLETE' ||
-              updateStatus === 'CREATE_COMPLETE',
-            `redeploy should succeed, got: ${updateStatus}`,
-          );
-
-          await testProject.assertPostDeployment(standaloneBackendIdentifier);
-        });
       });
     },
   );

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
@@ -1,0 +1,99 @@
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
+import {
+  createTestDirectory,
+  deleteTestDirectory,
+  rootTestDir,
+} from '../../setup_test_directory.js';
+import { TestProjectCreator } from '../../test-project-setup/test_project_creator.js';
+import { TestProjectBase } from '../../test-project-setup/test_project_base.js';
+import assert from 'node:assert';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { testConcurrencyLevel } from '../test_concurrency.js';
+import { shortUuid } from '../../short_uuid.js';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  ListStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+import { BackendIdentifierConversions } from '@aws-amplify/platform-core';
+import { e2eToolingClientConfig } from '../../e2e_tooling_client_config.js';
+
+/**
+ * Defines standalone deployment E2E test.
+ */
+export const defineStandaloneDeploymentTest = (
+  testProjectCreator: TestProjectCreator,
+) => {
+  void describe(
+    'standalone deployment tests',
+    { concurrency: testConcurrencyLevel },
+    () => {
+      const cfnClient = new CloudFormationClient(e2eToolingClientConfig);
+
+      before(async () => {
+        await createTestDirectory(rootTestDir);
+      });
+      after(async () => {
+        await deleteTestDirectory(rootTestDir);
+      });
+
+      void describe(`standalone deploys ${testProjectCreator.name}`, () => {
+        let standaloneBackendIdentifier: BackendIdentifier;
+        let testProject: TestProjectBase;
+
+        beforeEach(async () => {
+          testProject = await testProjectCreator.createProject(rootTestDir);
+          standaloneBackendIdentifier = {
+            namespace: `standalone-e2e-${shortUuid()}`,
+            name: 'default',
+            type: 'standalone',
+          };
+        });
+
+        afterEach(async () => {
+          await testProject.tearDown(standaloneBackendIdentifier, true);
+        });
+
+        void it(`[${testProjectCreator.name}] deploys via standalone`, async () => {
+          await testProject.deploy(standaloneBackendIdentifier);
+
+          const stackName = BackendIdentifierConversions.toStackName(
+            standaloneBackendIdentifier,
+          );
+
+          const describeResult = await cfnClient.send(
+            new DescribeStacksCommand({ StackName: stackName }),
+          );
+          assert.ok(
+            describeResult.Stacks && describeResult.Stacks.length > 0,
+            'standalone stack should exist after deployment',
+          );
+          const stack = describeResult.Stacks![0];
+          assert.ok(
+            stack.StackStatus === 'CREATE_COMPLETE' ||
+              stack.StackStatus === 'UPDATE_COMPLETE',
+            `stack should be in a successful state, got: ${stack.StackStatus}`,
+          );
+
+          // Verify no Amplify Hosting resources
+          const resources = await cfnClient.send(
+            new ListStackResourcesCommand({ StackName: stackName }),
+          );
+          const resourceTypes = (resources.StackResourceSummaries ?? []).map(
+            (r) => r.ResourceType,
+          );
+          assert.ok(
+            !resourceTypes.includes('AWS::Amplify::App'),
+            'standalone stack should not contain AWS::Amplify::App',
+          );
+          assert.ok(
+            !resourceTypes.includes('AWS::Amplify::Branch'),
+            'standalone stack should not contain AWS::Amplify::Branch',
+          );
+
+          await testProject.assertPostDeployment(standaloneBackendIdentifier);
+        });
+      });
+    },
+  );
+};

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
@@ -45,7 +45,7 @@ export const defineStandaloneDeploymentTest = (
           testProject = await testProjectCreator.createProject(rootTestDir);
           standaloneBackendIdentifier = {
             namespace: `standalone-e2e-${shortUuid()}`,
-            name: 'default',
+            name: 'stack',
             type: 'standalone',
           };
         });

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_deployment.test.template.ts
@@ -93,6 +93,42 @@ export const defineStandaloneDeploymentTest = (
 
           await testProject.assertPostDeployment(standaloneBackendIdentifier);
         });
+
+        void it(`[${testProjectCreator.name}] redeploys with same identifier`, async () => {
+          // Initial deploy
+          await testProject.deploy(standaloneBackendIdentifier);
+
+          const stackName = BackendIdentifierConversions.toStackName(
+            standaloneBackendIdentifier,
+          );
+
+          // Verify initial deploy succeeded
+          const initialResult = await cfnClient.send(
+            new DescribeStacksCommand({ StackName: stackName }),
+          );
+          const initialStatus = initialResult.Stacks?.[0]?.StackStatus;
+          assert.ok(
+            initialStatus === 'CREATE_COMPLETE' ||
+              initialStatus === 'UPDATE_COMPLETE',
+            `initial deploy should succeed, got: ${initialStatus}`,
+          );
+
+          // Redeploy with the same identifier (CloudFormation update)
+          await testProject.deploy(standaloneBackendIdentifier);
+
+          // Verify update succeeded
+          const updateResult = await cfnClient.send(
+            new DescribeStacksCommand({ StackName: stackName }),
+          );
+          const updateStatus = updateResult.Stacks?.[0]?.StackStatus;
+          assert.ok(
+            updateStatus === 'UPDATE_COMPLETE' ||
+              updateStatus === 'CREATE_COMPLETE',
+            `redeploy should succeed, got: ${updateStatus}`,
+          );
+
+          await testProject.assertPostDeployment(standaloneBackendIdentifier);
+        });
       });
     },
   );

--- a/packages/integration-tests/src/test-in-memory/standalone_data_deployment.test.ts
+++ b/packages/integration-tests/src/test-in-memory/standalone_data_deployment.test.ts
@@ -1,0 +1,27 @@
+import { it } from 'node:test';
+import assert from 'node:assert';
+import { synthesizeStandaloneBackendTemplates } from '../define_backend_template_harness.js';
+import { dataWithoutAuth } from '../test-projects/standalone-data-auth-modes/amplify/test_factories.js';
+
+/**
+ * Verifies that defineData works under standalone deployment type.
+ * This confirms that data-construct handles the standalone context value.
+ */
+void it('standalone deployment with data (no auth)', () => {
+  const templates = synthesizeStandaloneBackendTemplates(dataWithoutAuth);
+
+  assert.ok(templates.root, 'should produce a root template');
+  assert.ok(templates.data, 'should produce a data template');
+
+  // Verify no Amplify Hosting resources
+  assert.strictEqual(
+    Object.keys(templates.root.findResources('AWS::Amplify::App')).length,
+    0,
+    'should not contain AWS::Amplify::App resources',
+  );
+  assert.strictEqual(
+    Object.keys(templates.root.findResources('AWS::Amplify::Branch')).length,
+    0,
+    'should not contain AWS::Amplify::Branch resources',
+  );
+});

--- a/packages/integration-tests/src/test-in-memory/standalone_deployment.test.ts
+++ b/packages/integration-tests/src/test-in-memory/standalone_deployment.test.ts
@@ -1,0 +1,47 @@
+import { it } from 'node:test';
+import assert from 'node:assert';
+import { synthesizeStandaloneBackendTemplates } from '../define_backend_template_harness.js';
+import { standaloneAuthWithWebAuthn } from '../test-projects/standalone-auth/amplify/test_factories.js';
+
+/**
+ * Verifies that defineBackend with DEPLOYMENT_TYPE=standalone and an explicit
+ * WebAuthn relyingPartyId produces correct CloudFormation templates.
+ */
+void it('standalone deployment with explicit WebAuthn relyingPartyId', () => {
+  const templates = synthesizeStandaloneBackendTemplates(
+    standaloneAuthWithWebAuthn,
+  );
+
+  assert.ok(templates.root, 'should produce a root template');
+  assert.ok(templates.auth, 'should produce an auth template');
+
+  const nestedStacks = templates.root.findResources(
+    'AWS::CloudFormation::Stack',
+  );
+  assert.ok(
+    Object.keys(nestedStacks).length > 0,
+    'should have at least one nested stack',
+  );
+
+  // Auth template should have the explicit relyingPartyId
+  templates.auth.hasResourceProperties('AWS::Cognito::UserPool', {
+    WebAuthnRelyingPartyID: 'app.example.com',
+  });
+
+  // Verify no Amplify Hosting artifacts in standalone templates
+  const rootJson = JSON.stringify(templates.root.toJSON());
+  assert.ok(
+    !rootJson.includes('amplifyapp.com'),
+    'root template should not reference amplifyapp.com',
+  );
+  assert.strictEqual(
+    Object.keys(templates.root.findResources('AWS::Amplify::App')).length,
+    0,
+    'should not contain AWS::Amplify::App resources',
+  );
+  assert.strictEqual(
+    Object.keys(templates.root.findResources('AWS::Amplify::Branch')).length,
+    0,
+    'should not contain AWS::Amplify::Branch resources',
+  );
+});

--- a/packages/integration-tests/src/test-in-memory/standalone_deployment_auto_webauthn.test.ts
+++ b/packages/integration-tests/src/test-in-memory/standalone_deployment_auto_webauthn.test.ts
@@ -1,0 +1,26 @@
+import { it } from 'node:test';
+import assert from 'node:assert';
+import { synthesizeStandaloneBackendTemplates } from '../define_backend_template_harness.js';
+import { standaloneAuthAutoWebAuthn } from '../test-projects/standalone-auth-auto-webauthn/amplify/test_factories.js';
+
+/**
+ * Verifies that using webAuthn: true (AUTO relyingPartyId) throws an error
+ * under standalone deployment context, since AUTO requires Amplify Hosting.
+ */
+void it('standalone deployment rejects WebAuthn AUTO relyingPartyId', () => {
+  assert.throws(
+    () => synthesizeStandaloneBackendTemplates(standaloneAuthAutoWebAuthn),
+    (err: Error) => {
+      const fullMessage = JSON.stringify(err, Object.getOwnPropertyNames(err));
+      assert.ok(
+        fullMessage.includes('AUTO'),
+        `error chain should mention AUTO, got: ${fullMessage}`,
+      );
+      assert.ok(
+        fullMessage.includes('standalone'),
+        `error chain should mention standalone, got: ${fullMessage}`,
+      );
+      return true;
+    },
+  );
+});

--- a/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
+++ b/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
@@ -206,8 +206,11 @@ class DataStorageAuthWithTriggerTestProject extends TestProjectBase {
   /**
    * @inheritdoc
    */
-  override async tearDown(backendIdentifier: BackendIdentifier) {
-    await super.tearDown(backendIdentifier);
+  override async tearDown(
+    backendIdentifier: BackendIdentifier,
+    waitForStackDeletion: boolean = false,
+  ) {
+    await super.tearDown(backendIdentifier, waitForStackDeletion);
     await this.clearDeployEnvironment(backendIdentifier);
     await this.assertExpectedCleanup();
   }

--- a/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
+++ b/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
@@ -35,6 +35,19 @@ import {
   gql,
 } from '@apollo/client/core';
 import { AUTH_TYPE, createAuthLink } from 'aws-appsync-auth-link';
+import crypto from 'node:crypto';
+import { SemVer } from 'semver';
+
+// TODO: this is a work around
+// it seems like as of amplify v6 , some of the code only runs in the browser ...
+// see https://github.com/aws-amplify/amplify-js/issues/12751
+if (process.versions.node) {
+  // node >= 20 now exposes crypto by default. This workaround is not needed: https://github.com/nodejs/node/pull/42083
+  if (new SemVer(process.versions.node).major < 20) {
+    // @ts-expect-error altering typing for global to make compiler happy is not worth the effort assuming this is temporary workaround
+    globalThis.crypto = crypto;
+  }
+}
 
 /**
  * Creates test projects with data, storage, and auth categories.

--- a/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
+++ b/packages/integration-tests/src/test-project-setup/data_storage_auth_with_triggers.ts
@@ -17,6 +17,7 @@ import {
 import { HeadBucketCommand, S3Client } from '@aws-sdk/client-s3';
 import { GetRoleCommand, IAMClient } from '@aws-sdk/client-iam';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
+import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
 
 import {
   CloudTrailClient,
@@ -24,6 +25,16 @@ import {
 } from '@aws-sdk/client-cloudtrail';
 import { e2eToolingClientConfig } from '../e2e_tooling_client_config.js';
 import isMatch from 'lodash.ismatch';
+import { generateClientConfig } from '@aws-amplify/client-config';
+import { AmplifyAuthCredentialsFactory } from '../amplify_auth_credentials_factory.js';
+import {
+  ApolloClient,
+  ApolloLink,
+  HttpLink,
+  InMemoryCache,
+  gql,
+} from '@apollo/client/core';
+import { AUTH_TYPE, createAuthLink } from 'aws-appsync-auth-link';
 
 /**
  * Creates test projects with data, storage, and auth categories.
@@ -57,6 +68,9 @@ export class DataStorageAuthWithTriggerTestProjectCreator
       e2eToolingClientConfig,
     ),
     private readonly resourceFinder: DeployedResourcesFinder = new DeployedResourcesFinder(),
+    private readonly cognitoIdentityProviderClient: CognitoIdentityProviderClient = new CognitoIdentityProviderClient(
+      e2eToolingClientConfig,
+    ),
   ) {}
 
   createProject = async (e2eProjectDir: string): Promise<TestProjectBase> => {
@@ -75,6 +89,7 @@ export class DataStorageAuthWithTriggerTestProjectCreator
       this.iamClient,
       this.cloudTrailClient,
       this.resourceFinder,
+      this.cognitoIdentityProviderClient,
     );
     await fs.cp(
       project.sourceProjectAmplifyDirURL,
@@ -141,6 +156,7 @@ class DataStorageAuthWithTriggerTestProject extends TestProjectBase {
     private readonly iamClient: IAMClient,
     private readonly cloudTrailClient: CloudTrailClient,
     private readonly resourceFinder: DeployedResourcesFinder,
+    private readonly cognitoIdentityProviderClient: CognitoIdentityProviderClient,
   ) {
     super(
       name,
@@ -333,6 +349,69 @@ class DataStorageAuthWithTriggerTestProject extends TestProjectBase {
           },
         },
       ]),
+    );
+
+    // Verify Cognito auth sign-up/sign-in works
+    const clientConfig = await generateClientConfig(backendId, '1.4');
+    assert.ok(clientConfig.auth, 'Client config should have auth section');
+    assert.ok(clientConfig.data, 'Client config should have data section');
+
+    const authFactory = new AmplifyAuthCredentialsFactory(
+      this.cognitoIdentityProviderClient,
+      clientConfig.auth,
+    );
+    const { iamCredentials, accessToken } =
+      await authFactory.getNewAuthenticatedUserCredentials();
+    assert.ok(accessToken, 'Should receive a valid JWT access token');
+    assert.ok(iamCredentials, 'Should receive valid IAM credentials');
+
+    // Verify GraphQL API works with a mutation and query
+    const httpLink = new HttpLink({ uri: clientConfig.data.url });
+    const link = ApolloLink.from([
+      createAuthLink({
+        url: clientConfig.data.url,
+        region: clientConfig.data.aws_region,
+        auth: {
+          type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+          jwtToken: accessToken,
+        },
+      }),
+      httpLink,
+    ]);
+    const apolloClient = new ApolloClient({ link, cache: new InMemoryCache() });
+
+    const createResult = await apolloClient.mutate({
+      mutation: gql`
+        mutation CreateTodo($input: CreateTodoInput!) {
+          createTodo(input: $input) {
+            id
+            content
+          }
+        }
+      `,
+      variables: { input: { content: 'standalone-e2e-test' } },
+    });
+    assert.ok(
+      createResult.data.createTodo.id,
+      'Mutation should return created record with id',
+    );
+
+    const queryResult = await apolloClient.query({
+      query: gql`
+        query ListTodos {
+          listTodos {
+            items {
+              id
+              content
+            }
+          }
+        }
+      `,
+      fetchPolicy: 'no-cache',
+    });
+    assert.ok(
+      queryResult.data.listTodos.items.length > 0,
+      'Query should return at least one Todo record',
     );
   }
 

--- a/packages/integration-tests/src/test-project-setup/standalone_auth.ts
+++ b/packages/integration-tests/src/test-project-setup/standalone_auth.ts
@@ -1,0 +1,55 @@
+import { TestProjectBase } from './test_project_base.js';
+import fs from 'fs/promises';
+import { createEmptyAmplifyProject } from './create_empty_amplify_project.js';
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { TestProjectCreator } from './test_project_creator.js';
+import { AmplifyClient } from '@aws-sdk/client-amplify';
+import { e2eToolingClientConfig } from '../e2e_tooling_client_config.js';
+
+/**
+ * Creates a minimal auth project for standalone deployment E2E testing.
+ */
+export class StandaloneAuthTestProjectCreator implements TestProjectCreator {
+  readonly name = 'standalone-auth';
+
+  /**
+   * Creates project creator.
+   */
+  constructor(
+    private readonly cfnClient: CloudFormationClient = new CloudFormationClient(
+      e2eToolingClientConfig,
+    ),
+    private readonly amplifyClient: AmplifyClient = new AmplifyClient(
+      e2eToolingClientConfig,
+    ),
+  ) {}
+
+  createProject = async (e2eProjectDir: string): Promise<TestProjectBase> => {
+    const { projectName, projectRoot, projectAmplifyDir } =
+      await createEmptyAmplifyProject(this.name, e2eProjectDir);
+
+    const project = new StandaloneAuthTestProject(
+      projectName,
+      projectRoot,
+      projectAmplifyDir,
+      this.cfnClient,
+      this.amplifyClient,
+    );
+    await fs.cp(
+      project.sourceProjectAmplifyDirURL,
+      project.projectAmplifyDirPath,
+      { recursive: true },
+    );
+    return project;
+  };
+}
+
+class StandaloneAuthTestProject extends TestProjectBase {
+  readonly sourceProjectDirPath =
+    '../../src/test-projects/standalone-auth-email-only';
+
+  readonly sourceProjectAmplifyDirURL: URL = new URL(
+    `${this.sourceProjectDirPath}/amplify`,
+    import.meta.url,
+  );
+}

--- a/packages/integration-tests/src/test-project-setup/test_project_base.ts
+++ b/packages/integration-tests/src/test-project-setup/test_project_base.ts
@@ -81,6 +81,14 @@ export abstract class TestProjectBase {
         .do(waitForSandboxDeploymentToPrintTotalTime())
         .do(interruptSandbox())
         .run();
+    } else if (backendIdentifier.type === 'standalone') {
+      await ampxCli(
+        ['deploy', '--identifier', backendIdentifier.namespace],
+        this.projectDirPath,
+        {
+          env: environment,
+        },
+      ).run();
     } else {
       await ampxCli(
         [

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
@@ -84,7 +84,7 @@ const s3RoundTrip = async (): Promise<string> => {
 // if the action fails a second time, the error is re-thrown
 const retry = async <T>(action: () => Promise<T>) => {
   try {
-    return action();
+    return await action();
   } catch (err) {
     console.log(err);
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
+++ b/packages/integration-tests/src/test-projects/data-storage-auth-with-triggers-ts/amplify/func-src/response_generator.ts
@@ -88,6 +88,6 @@ const retry = async <T>(action: () => Promise<T>) => {
   } catch (err) {
     console.log(err);
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    return action();
+    return await action();
   }
 };

--- a/packages/integration-tests/src/test-projects/standalone-auth-auto-webauthn/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth-auto-webauthn/amplify/auth/resource.ts
@@ -1,0 +1,8 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+    webAuthn: true,
+  },
+});

--- a/packages/integration-tests/src/test-projects/standalone-auth-auto-webauthn/amplify/test_factories.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth-auto-webauthn/amplify/test_factories.ts
@@ -1,0 +1,3 @@
+import { auth } from './auth/resource.js';
+
+export const standaloneAuthAutoWebAuthn = { auth };

--- a/packages/integration-tests/src/test-projects/standalone-auth-email-only/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth-email-only/amplify/auth/resource.ts
@@ -1,0 +1,7 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+  },
+});

--- a/packages/integration-tests/src/test-projects/standalone-auth-email-only/amplify/backend.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth-email-only/amplify/backend.ts
@@ -1,0 +1,6 @@
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource.js';
+
+defineBackend({
+  auth,
+});

--- a/packages/integration-tests/src/test-projects/standalone-auth/amplify/auth/resource.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth/amplify/auth/resource.ts
@@ -1,0 +1,10 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+    webAuthn: {
+      relyingPartyId: 'app.example.com',
+    },
+  },
+});

--- a/packages/integration-tests/src/test-projects/standalone-auth/amplify/test_factories.ts
+++ b/packages/integration-tests/src/test-projects/standalone-auth/amplify/test_factories.ts
@@ -1,0 +1,3 @@
+import { auth } from './auth/resource.js';
+
+export const standaloneAuthWithWebAuthn = { auth };


### PR DESCRIPTION
Health_checks: https://github.com/aws-amplify/amplify-backend/actions/runs/23565784157

## Add `ampx deploy` command for standalone deployments

Deploy Gen2 backends without Amplify Hosting. This PR introduces `npx ampx deploy --identifier <name>`, which deploys backend resources using the `standalone` deployment type introduced in #3132.

```
npx ampx deploy --identifier my-app-prod
```

The `--identifier` flag sets the CloudFormation stack namespace. No `--app-id` or `--branch` required. The command can be run from any environment (local, CI/CD, GitHub Actions, Jenkins, etc.).

## How it works

1. The CLI constructs a `BackendIdentifier` with `type: 'standalone'` and `namespace` set to the provided identifier.
2. The deployer sets CDK context with `DEPLOYMENT_TYPE=standalone`, which skips all Amplify Hosting resources (BranchLinker, App ID tags).
3. After deployment, client config (`amplify_outputs.json`) is generated using the resolved stack name as the identifier.
4. Supports `--profile` for named AWS credential profiles, with early credential and region validation.
5. Runs a CDK bootstrap pre-flight check — fails early with a helpful message if the target account/region isn't bootstrapped.

## Key design decisions

- **Stack naming**: Uses `BackendIdentifierConversions.toStackName()` for both deployment and client config generation, ensuring consistency with sandbox/branch patterns. Stack names follow the format `amplify-{identifier}-stack-standalone-{hash}` (where hyphens in the identifier are stripped by `sanitizeChars`).
- **Client config resolution**: Uses the resolved stack name (via `toStackName`) rather than the raw identifier, matching how sandbox and pipeline-deploy resolve stack names through `BackendIdentifierMainStackNameResolver`.
- **Credential handling**: Mirrors sandbox's `--profile` option and `ensureAwsCredentialAndRegion` middleware for early validation with clear error messages.
- **Bootstrap check**: Like sandbox, validates CDK bootstrap status before attempting deployment, preventing cryptic CloudFormation errors for first-time users.
- **WebAuthn AUTO rejection**: Standalone deployments don't have Amplify Hosting to resolve the relying party ID, so `webAuthn: true` (AUTO mode) throws a clear error. Explicit `relyingPartyId` is required.
- **Identifier validation**: Validates the identifier format in the command handler (not yargs `.check()`) to ensure consistent `AmplifyUserError` formatting.

## Validation

### Unit Tests
- `deploy_command.test.ts` — Verifies the deploy command passes the correct `standalone` BackendIdentifier to the deployer, generates client config with `{ stackName }`, rejects missing `--identifier`, validates identifier format, forwards `--outputs-out-dir` and `--profile`.

### In-Memory Integration Tests
- `standalone_deployment.test.ts` — Synthesizes a standalone backend with explicit WebAuthn `relyingPartyId` and verifies correct CloudFormation output with no Amplify Hosting artifacts (`AWS::Amplify::App`, `AWS::Amplify::Branch`, `amplifyapp.com` references).
- `standalone_deployment_auto_webauthn.test.ts` — Verifies that WebAuthn AUTO (`webAuthn: true`) throws under standalone context, since AUTO requires Amplify Hosting to resolve the relying party ID.
- `standalone_data_deployment.test.ts` — Verifies that `defineData` works under standalone deployment type.

### E2E Tests
- `standalone_basic.deployment.test.ts` — Deploys a minimal backend via `ampx deploy --identifier`, verifies the CloudFormation stack reaches a successful state, and asserts no Amplify Hosting resources are present.
- `standalone_data_storage_auth.deployment.test.ts` — Full E2E test reusing `DataStorageAuthWithTriggerTestProjectCreator` (the same project used by sandbox and branch deployment tests). Deploys data, storage, auth, and Lambda triggers via standalone, then runs post-deployment assertions including Lambda invocation, S3 bucket verification, secret resolution, Cognito sign-up/sign-in authentication, GraphQL API mutation and query verification, and `amplify_outputs.json` validation. Also tests the update/redeploy cycle — modifies the backend definition and redeploys with the same identifier, verifying resources continue to work after update.
