### PR TITLE
feat: add metrics and usage to conversation streaming responses

### DIFF
--- a/.changeset/spotty-dragons-hug.md
+++ b/.changeset/spotty-dragons-hug.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ai-constructs': minor
+---
+
+Add metrics (latencyMs) and usage (inputTokens, outputTokens, totalTokens) to streaming conversation responses from Bedrock Converse API

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.test.ts
@@ -201,6 +201,8 @@ void describe('Bedrock converse adapter', () => {
               associatedUserMessageId: event.currentMessageId,
               contentBlockIndex: 1,
               stopReason: 'end_turn',
+              metrics: { latencyMs: 150 },
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
             },
           ]);
         } else {
@@ -712,6 +714,8 @@ void describe('Bedrock converse adapter', () => {
               associatedUserMessageId: event.currentMessageId,
               contentBlockIndex: 0,
               stopReason: 'tool_use',
+              metrics: { latencyMs: 150 },
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
             },
           ]);
         } else {
@@ -1033,12 +1037,42 @@ void describe('Bedrock converse adapter', () => {
       progressCalls[1].arguments[0],
       'Processed 2000 chunks from Bedrock Converse Stream response, requestId=testRequestId',
     );
-    // each block is decomposed into 4 chunks + start and stop of whole message.
-    const expectedNumberOfAllChunks = numberOfBlocks * 4 + 2;
+    // each block is decomposed into 4 chunks + start, stop, and metadata of whole message.
+    const expectedNumberOfAllChunks = numberOfBlocks * 4 + 3;
     assert.strictEqual(
       progressCalls[2].arguments[0],
       `Completed processing ${expectedNumberOfAllChunks.toString()} chunks from Bedrock Converse Stream response, requestId=testRequestId`,
     );
+  });
+
+  void it('includes metrics and usage in the final streaming chunk', async () => {
+    const event: ConversationTurnEvent = {
+      ...commonEvent,
+    };
+
+    const bedrockClient = new BedrockRuntimeClient();
+    const content = [{ text: 'block1' }];
+    const bedrockResponse = mockBedrockResponse(content, true);
+    mock.method(bedrockClient, 'send', () => Promise.resolve(bedrockResponse));
+
+    const adapter = new BedrockConverseAdapter(
+      event,
+      [],
+      bedrockClient,
+      undefined,
+      messageHistoryRetriever,
+    );
+
+    const chunks: Array<StreamingResponseChunk> =
+      await askBedrockWithStreaming(adapter);
+    const lastChunk = chunks[chunks.length - 1];
+    assert.ok(lastChunk.stopReason);
+    assert.deepStrictEqual(lastChunk.metrics, { latencyMs: 150 });
+    assert.deepStrictEqual(lastChunk.usage, {
+      inputTokens: 10,
+      outputTokens: 20,
+      totalTokens: 30,
+    });
   });
 
   void it('throws if tool is duplicated', () => {
@@ -1302,6 +1336,12 @@ const mockConverseStreamCommandOutput = (
   streamItems.push({
     messageStop: {
       stopReason: stopReason,
+    },
+  });
+  streamItems.push({
+    metadata: {
+      metrics: { latencyMs: 150 },
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
     },
   });
   return {

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
@@ -11,6 +11,7 @@ import {
   Tool,
   ToolConfiguration,
   ToolInputSchema,
+  //TokenUsage, //check if this exists
 } from '@aws-sdk/client-bedrock-runtime';
 import {
   ConversationTurnEvent,
@@ -113,7 +114,7 @@ export class BedrockConverseAdapter {
         inferenceConfig: inferenceConfiguration,
         toolConfig,
       };
-      this.logger.info('Sending Bedrock Converse request');
+      this.logger.info('Sending Bedrock Converse request'); //converse
       this.logger.debug('Bedrock Converse request:', converseCommandInput);
       bedrockResponse = await this.bedrockClient.send(
         new ConverseCommand(converseCommandInput),
@@ -175,6 +176,10 @@ export class BedrockConverseAdapter {
     let blockIndex = 0;
     let lastBlockIndex = 0;
     let stopReason = '';
+    let latencyMs = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let totalTokens = 0;
     // Accumulates client facing content per turn.
     // So that upstream can persist full message at the end of the streaming.
     const accumulatedTurnContent: Array<bedrock.ContentBlock> = [];
@@ -195,7 +200,7 @@ export class BedrockConverseAdapter {
       bedrockResponse = await this.bedrockClient.send(
         new ConverseStreamCommand(converseCommandInput),
       );
-      this.logger.info(
+      this.logger.info( //stream
         `Received Bedrock Converse Stream response, requestId=${bedrockResponse.$metadata.requestId}`,
       );
       if (!bedrockResponse.stream) {
@@ -304,6 +309,11 @@ export class BedrockConverseAdapter {
             }
           } else if (chunk.messageStop) {
             stopReason = chunk.messageStop.stopReason ?? '';
+          } else if (chunk.metadata) {
+            latencyMs = chunk.metadata.metrics.latencyMs; //check this
+            inputTokens = chunk.metadata.usage.inputTokens;
+            outputTokens = chunk.metadata.usage.outputTokens;
+            totalTokens = chunk.metadata.usage.totalTokens;
           }
           processedBedrockChunks++;
           if (processedBedrockChunks % 1000 === 0) {
@@ -330,6 +340,8 @@ export class BedrockConverseAdapter {
           associatedUserMessageId: this.event.currentMessageId,
           contentBlockIndex: lastBlockIndex,
           stopReason: stopReason,
+          metrics: {latencyMs},
+          usage: {inputTokens, outputTokens, totalTokens,}, //check this
         };
         return;
       }
@@ -359,6 +371,8 @@ export class BedrockConverseAdapter {
       associatedUserMessageId: this.event.currentMessageId,
       contentBlockIndex: lastBlockIndex,
       stopReason: stopReason,
+      metrics: {latencyMs},
+      usage: {inputTokens, outputTokens, totalTokens,}, //check this
     };
   }
 

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
@@ -175,6 +175,9 @@ export class BedrockConverseAdapter {
     let blockIndex = 0;
     let lastBlockIndex = 0;
     let stopReason = '';
+    // The following metadata´ are overwritten on each iteration of the tool-use loop.
+    // Only the final iteration's values are reported, as intermediate iterations
+    // are tool-use round-trips and the final iteration contains the actual model response.
     let latencyMs = 0;
     let inputTokens = 0;
     let outputTokens = 0;

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
@@ -200,7 +200,8 @@ export class BedrockConverseAdapter {
       bedrockResponse = await this.bedrockClient.send(
         new ConverseStreamCommand(converseCommandInput),
       );
-      this.logger.info( //stream
+      this.logger.info(
+        //stream
         `Received Bedrock Converse Stream response, requestId=${bedrockResponse.$metadata.requestId}`,
       );
       if (!bedrockResponse.stream) {
@@ -264,6 +265,7 @@ export class BedrockConverseAdapter {
               blockDeltaIndex++;
             }
           } else if (chunk.contentBlockStop) {
+            this.logger.debug(`now in chunk.contentBlockStop`);
             if (toolUseBlock) {
               if (toolUseInput) {
                 toolUseBlock.toolUse.input = JSON.parse(toolUseInput);
@@ -309,11 +311,14 @@ export class BedrockConverseAdapter {
             }
           } else if (chunk.messageStop) {
             stopReason = chunk.messageStop.stopReason ?? '';
+            this.logger.debug(
+              `Bedrock stop reason received: stopReason=${chunk.messageStop.stopReason ?? ''}`,
+            );
           } else if (chunk.metadata) {
-            latencyMs = chunk.metadata.metrics.latencyMs; //check this
-            inputTokens = chunk.metadata.usage.inputTokens;
-            outputTokens = chunk.metadata.usage.outputTokens;
-            totalTokens = chunk.metadata.usage.totalTokens;
+            latencyMs = chunk.metadata.metrics?.latencyMs ?? 0;
+            inputTokens = chunk.metadata.usage?.inputTokens ?? 0;
+            outputTokens = chunk.metadata.usage?.outputTokens ?? 0;
+            totalTokens = chunk.metadata.usage?.totalTokens ?? 0;
           }
           processedBedrockChunks++;
           if (processedBedrockChunks % 1000 === 0) {
@@ -340,8 +345,8 @@ export class BedrockConverseAdapter {
           associatedUserMessageId: this.event.currentMessageId,
           contentBlockIndex: lastBlockIndex,
           stopReason: stopReason,
-          metrics: {latencyMs},
-          usage: {inputTokens, outputTokens, totalTokens,}, //check this
+          metrics: { latencyMs },
+          usage: { inputTokens, outputTokens, totalTokens }, //check this
         };
         return;
       }
@@ -371,8 +376,8 @@ export class BedrockConverseAdapter {
       associatedUserMessageId: this.event.currentMessageId,
       contentBlockIndex: lastBlockIndex,
       stopReason: stopReason,
-      metrics: {latencyMs},
-      usage: {inputTokens, outputTokens, totalTokens,}, //check this
+      metrics: { latencyMs },
+      usage: { inputTokens, outputTokens, totalTokens }, //check this
     };
   }
 

--- a/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
+++ b/packages/ai-constructs/src/conversation/runtime/bedrock_converse_adapter.ts
@@ -11,7 +11,6 @@ import {
   Tool,
   ToolConfiguration,
   ToolInputSchema,
-  //TokenUsage, //check if this exists
 } from '@aws-sdk/client-bedrock-runtime';
 import {
   ConversationTurnEvent,
@@ -114,7 +113,7 @@ export class BedrockConverseAdapter {
         inferenceConfig: inferenceConfiguration,
         toolConfig,
       };
-      this.logger.info('Sending Bedrock Converse request'); //converse
+      this.logger.info('Sending Bedrock Converse request');
       this.logger.debug('Bedrock Converse request:', converseCommandInput);
       bedrockResponse = await this.bedrockClient.send(
         new ConverseCommand(converseCommandInput),
@@ -201,7 +200,6 @@ export class BedrockConverseAdapter {
         new ConverseStreamCommand(converseCommandInput),
       );
       this.logger.info(
-        //stream
         `Received Bedrock Converse Stream response, requestId=${bedrockResponse.$metadata.requestId}`,
       );
       if (!bedrockResponse.stream) {
@@ -265,7 +263,6 @@ export class BedrockConverseAdapter {
               blockDeltaIndex++;
             }
           } else if (chunk.contentBlockStop) {
-            this.logger.debug(`now in chunk.contentBlockStop`);
             if (toolUseBlock) {
               if (toolUseInput) {
                 toolUseBlock.toolUse.input = JSON.parse(toolUseInput);
@@ -346,7 +343,7 @@ export class BedrockConverseAdapter {
           contentBlockIndex: lastBlockIndex,
           stopReason: stopReason,
           metrics: { latencyMs },
-          usage: { inputTokens, outputTokens, totalTokens }, //check this
+          usage: { inputTokens, outputTokens, totalTokens },
         };
         return;
       }
@@ -377,7 +374,7 @@ export class BedrockConverseAdapter {
       contentBlockIndex: lastBlockIndex,
       stopReason: stopReason,
       metrics: { latencyMs },
-      usage: { inputTokens, outputTokens, totalTokens }, //check this
+      usage: { inputTokens, outputTokens, totalTokens },
     };
   }
 

--- a/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
@@ -92,7 +92,7 @@ const messageItemSelectionSet = `
                     toolUseId
                   }
                 }
-                  metrics {
+                metrics {
                   latencyMs
                 }
                 usage {
@@ -172,7 +172,7 @@ export class ConversationMessageHistoryRetriever {
       }
       const aiContext = current.aiContext;
       const content = aiContext
-        ? [...current.content, { text: JSON.stringify(aiContext) }]//TODO add usage and latency! but only for the response!!
+        ? [...current.content, { text: JSON.stringify(aiContext) }]
         : current.content;
 
       acc.push({ role: current.role, content });
@@ -184,7 +184,7 @@ export class ConversationMessageHistoryRetriever {
       if (correspondingAssistantMessage) {
         acc.push({
           role: correspondingAssistantMessage.role,
-          content: correspondingAssistantMessage.content, //TODO add usage and latency! but only for the response!!
+          content: correspondingAssistantMessage.content,
         });
       }
       return acc;

--- a/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
@@ -92,14 +92,6 @@ const messageItemSelectionSet = `
                     toolUseId
                   }
                 }
-                metrics {
-                  latencyMs
-                }
-                usage {
-                  inputTokens
-                  outputTokens
-                  totalTokens
-                }
 `;
 
 /**

--- a/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_message_history_retriever.ts
@@ -92,6 +92,14 @@ const messageItemSelectionSet = `
                     toolUseId
                   }
                 }
+                  metrics {
+                  latencyMs
+                }
+                usage {
+                  inputTokens
+                  outputTokens
+                  totalTokens
+                }
 `;
 
 /**
@@ -164,7 +172,7 @@ export class ConversationMessageHistoryRetriever {
       }
       const aiContext = current.aiContext;
       const content = aiContext
-        ? [...current.content, { text: JSON.stringify(aiContext) }]
+        ? [...current.content, { text: JSON.stringify(aiContext) }]//TODO add usage and latency! but only for the response!!
         : current.content;
 
       acc.push({ role: current.role, content });
@@ -176,7 +184,7 @@ export class ConversationMessageHistoryRetriever {
       if (correspondingAssistantMessage) {
         acc.push({
           role: correspondingAssistantMessage.role,
-          content: correspondingAssistantMessage.content,
+          content: correspondingAssistantMessage.content, //TODO add usage and latency! but only for the response!!
         });
       }
       return acc;

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
@@ -300,6 +300,51 @@ void describe('Conversation turn response sender', () => {
     });
   });
 
+  void it('serializes metrics and usage to JSON when streaming', async () => {
+    const userAgentProvider = new UserAgentProvider(
+      {} as unknown as ConversationTurnEvent,
+    );
+    mock.method(userAgentProvider, 'getUserAgent', () => '');
+    const graphqlRequestExecutor = new GraphqlRequestExecutor(
+      '',
+      '',
+      userAgentProvider,
+    );
+    const executeGraphqlMock = mock.method(
+      graphqlRequestExecutor,
+      'executeGraphql',
+      () => Promise.resolve(),
+    );
+    const sender = new ConversationTurnResponseSender(
+      event,
+      userAgentProvider,
+      graphqlRequestExecutor,
+    );
+    const chunk: StreamingResponseChunk = {
+      accumulatedTurnContent: [{ text: 'testContent' }],
+      associatedUserMessageId: 'testAssociatedUserMessageId',
+      contentBlockIndex: 0,
+      conversationId: 'testConversationId',
+      stopReason: 'end_turn',
+      metrics: { latencyMs: 150 },
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    };
+    await sender.sendResponseChunk(chunk);
+
+    assert.strictEqual(executeGraphqlMock.mock.calls.length, 1);
+    const request = executeGraphqlMock.mock.calls[0]
+      .arguments[0] as GraphqlRequest<MutationStreamingResponseInput>;
+    // metrics and usage should be serialized to JSON strings
+    assert.strictEqual(
+      (request.variables.input as Record<string, unknown>).metrics,
+      JSON.stringify({ latencyMs: 150 }),
+    );
+    assert.strictEqual(
+      (request.variables.input as Record<string, unknown>).usage,
+      JSON.stringify({ inputTokens: 10, outputTokens: 20, totalTokens: 30 }),
+    );
+  });
+
   void it('sends errors response back to appsync', async () => {
     const userAgentProvider = new UserAgentProvider(
       {} as unknown as ConversationTurnEvent,

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
@@ -345,6 +345,44 @@ void describe('Conversation turn response sender', () => {
     );
   });
 
+  void it('does not include metrics and usage for non-stop-reason chunks', async () => {
+    const userAgentProvider = new UserAgentProvider(
+      {} as unknown as ConversationTurnEvent,
+    );
+    mock.method(userAgentProvider, 'getUserAgent', () => '');
+    const graphqlRequestExecutor = new GraphqlRequestExecutor(
+      '',
+      '',
+      userAgentProvider,
+    );
+    const executeGraphqlMock = mock.method(
+      graphqlRequestExecutor,
+      'executeGraphql',
+      () => Promise.resolve(),
+    );
+    const sender = new ConversationTurnResponseSender(
+      event,
+      userAgentProvider,
+      graphqlRequestExecutor,
+    );
+    const chunk: StreamingResponseChunk = {
+      accumulatedTurnContent: [{ text: 'testContent' }],
+      associatedUserMessageId: 'testAssociatedUserMessageId',
+      contentBlockIndex: 0,
+      contentBlockDeltaIndex: 0,
+      conversationId: 'testConversationId',
+      contentBlockText: 'testBlockText',
+    };
+    await sender.sendResponseChunk(chunk);
+
+    assert.strictEqual(executeGraphqlMock.mock.calls.length, 1);
+    const request = executeGraphqlMock.mock.calls[0]
+      .arguments[0] as GraphqlRequest<MutationStreamingResponseInput>;
+    const input = request.variables.input as Record<string, unknown>;
+    assert.strictEqual(input.metrics, undefined);
+    assert.strictEqual(input.usage, undefined);
+  });
+
   void it('sends errors response back to appsync', async () => {
     const userAgentProvider = new UserAgentProvider(
       {} as unknown as ConversationTurnEvent,

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
@@ -15,8 +15,16 @@ export type MutationResponseInput = {
   };
 };
 
+export type SerializedStreamingResponseChunk = Omit<
+  StreamingResponseChunk,
+  'metrics' | 'usage'
+> & {
+  metrics?: string;
+  usage?: string;
+};
+
 export type MutationStreamingResponseInput = {
-  input: StreamingResponseChunk;
+  input: SerializedStreamingResponseChunk;
 };
 
 export type MutationErrorsResponseInput = {
@@ -133,17 +141,19 @@ export class ConversationTurnResponseSender {
             }
         }
     `;
-    const serializedChunk = {
-      ...chunk,
+
+    const { metrics, usage, ...rest } = chunk;
+    const serializedChunk: SerializedStreamingResponseChunk = {
+      ...rest,
       accumulatedTurnContent: this.serializeContent(
         chunk.accumulatedTurnContent,
       ),
-      ...(chunk.metrics && { metrics: JSON.stringify(chunk.metrics) }),
-      ...(chunk.usage && { usage: JSON.stringify(chunk.usage) }),
+      ...(metrics && { metrics: JSON.stringify(metrics) }),
+      ...(usage && { usage: JSON.stringify(usage) }),
     };
     const variables = {
       input: serializedChunk,
-    } as MutationStreamingResponseInput;
+    };
     return { query, variables };
   };
 

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
@@ -126,22 +126,24 @@ export class ConversationTurnResponseSender {
   };
 
   private createStreamingMutationRequest = (chunk: StreamingResponseChunk) => {
-    const query = `
-        mutation PublishModelResponse($input: ${this.event.responseMutation.inputTypeName}!) {
-            ${this.event.responseMutation.name}(input: $input) {
-                ${this.event.responseMutation.selectionSet}
-            }
-        }
+    const query = `                                                                                                                                                                                            
+        mutation PublishModelResponse($input: ${this.event.responseMutation.inputTypeName}!) {                                                                                                                 
+            ${this.event.responseMutation.name}(input: $input) {                                                                                                                                               
+                ${this.event.responseMutation.selectionSet}                                                                                                                                                    
+            }                                                                                                                                                                                                  
+        }                                                                                                                                                                                                      
     `;
-    chunk = {
+    const serializedChunk = {
       ...chunk,
       accumulatedTurnContent: this.serializeContent(
         chunk.accumulatedTurnContent,
       ),
+      ...(chunk.metrics && { metrics: JSON.stringify(chunk.metrics) }),
+      ...(chunk.usage && { usage: JSON.stringify(chunk.usage) }),
     };
-    const variables: MutationStreamingResponseInput = {
-      input: chunk,
-    };
+    const variables = {
+      input: serializedChunk,
+    } as MutationStreamingResponseInput;
     return { query, variables };
   };
 

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
@@ -126,12 +126,12 @@ export class ConversationTurnResponseSender {
   };
 
   private createStreamingMutationRequest = (chunk: StreamingResponseChunk) => {
-    const query = `                                                                                                                                                                                            
-        mutation PublishModelResponse($input: ${this.event.responseMutation.inputTypeName}!) {                                                                                                                 
-            ${this.event.responseMutation.name}(input: $input) {                                                                                                                                               
-                ${this.event.responseMutation.selectionSet}                                                                                                                                                    
-            }                                                                                                                                                                                                  
-        }                                                                                                                                                                                                      
+    const query = `
+        mutation PublishModelResponse($input: ${this.event.responseMutation.inputTypeName}!) {
+            ${this.event.responseMutation.name}(input: $input) {
+                ${this.event.responseMutation.selectionSet}
+            }
+        }
     `;
     const serializedChunk = {
       ...chunk,

--- a/packages/ai-constructs/src/conversation/runtime/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/types.ts
@@ -133,6 +133,8 @@ export type StreamingResponseChunk = {
       contentBlockDoneAtIndex?: never;
       contentBlockToolUse?: never;
       stopReason?: never;
+      metrics?: never;
+      usage?: never;
     }
   | {
       // end of block. applicable to text blocks
@@ -141,6 +143,8 @@ export type StreamingResponseChunk = {
       contentBlockDeltaIndex?: never;
       contentBlockToolUse?: never;
       stopReason?: never;
+      metrics?: never;
+      usage?: never;
     }
   | {
       // tool use
@@ -149,12 +153,14 @@ export type StreamingResponseChunk = {
       contentBlockText?: never;
       contentBlockDeltaIndex?: never;
       stopReason?: never;
+      metrics?: never;
+      usage?: never;
     }
   | {
       // turn complete
       stopReason: string;
-      metrics: {latencyMs: number};
-      usage: {inputTokens: number, outputTokens: number, totalTokens: number};
+      metrics: { latencyMs: number };
+      usage: { inputTokens: number; outputTokens: number; totalTokens: number };
       contentBlockDoneAtIndex?: never;
       contentBlockText?: never;
       contentBlockDeltaIndex?: never;

--- a/packages/ai-constructs/src/conversation/runtime/types.ts
+++ b/packages/ai-constructs/src/conversation/runtime/types.ts
@@ -153,6 +153,8 @@ export type StreamingResponseChunk = {
   | {
       // turn complete
       stopReason: string;
+      metrics: {latencyMs: number};
+      usage: {inputTokens: number, outputTokens: number, totalTokens: number};
       contentBlockDoneAtIndex?: never;
       contentBlockText?: never;
       contentBlockDeltaIndex?: never;

--- a/packages/integration-tests/src/test-projects/conversation-handler/amplify/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/conversation-handler/amplify/data/resource.ts
@@ -119,6 +119,8 @@ const schema = a.schema({
 
       // when message is complete
       stopReason: a.string(),
+      metrics: {latency: a.integer()}, //check this
+      usage: {inputTokens: a.integer(), outputTokens: a.integer(), totalTokens: a.integer()},
 
       // error
       errors: a.ref('MockConversationTurnError').array(),

--- a/packages/integration-tests/src/test-projects/conversation-handler/amplify/data/resource.ts
+++ b/packages/integration-tests/src/test-projects/conversation-handler/amplify/data/resource.ts
@@ -91,6 +91,16 @@ const schema = a.schema({
     message: a.string(),
   }),
 
+  MockMetrics: a.customType({
+    latencyMs: a.integer(),
+  }),
+
+  MockUsage: a.customType({
+    inputTokens: a.integer(),
+    outputTokens: a.integer(),
+    totalTokens: a.integer(),
+  }),
+
   ConversationMessageAssistantResponse: a
     .model({
       conversationId: a.id(),
@@ -119,8 +129,8 @@ const schema = a.schema({
 
       // when message is complete
       stopReason: a.string(),
-      metrics: {latency: a.integer()}, //check this
-      usage: {inputTokens: a.integer(), outputTokens: a.integer(), totalTokens: a.integer()},
+      metrics: a.ref('MockMetrics'),
+      usage: a.ref('MockUsage'),
 
       // error
       errors: a.ref('MockConversationTurnError').array(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->
Streaming conversation responses from the Bedrock Converse API do not expose model usage or latency information. Consumers have no way to track token consumption or response latency for conversation turns.

**Issue number, if available:** aws-amplify/amplify-backend#2355

## Related PRs (all required for aws-amplify/amplify-backend#2355)
                                                                                                                                                                                                               
This feature spans 4 repositories. PRs should be merged in this order:                                                                                                                                         
                                                                                                                                                                                                               
1. **amplify-category-api** — [aws-amplify/amplify-category-api#3448](https://github.com/aws-amplify/amplify-category-api/pull/3448) — Defines `AmplifyAIMetrics`/`AmplifyAIUsage` GraphQL types and updates resolvers                                                                                                                                                                                                        
2. **amplify-data** — [aws-amplify/amplify-data#697](https://github.com/aws-amplify/amplify-data/pull/697) — Adds TypeScript types and client-side deserializers                                               
3. **amplify-backend** — [aws-amplify/amplify-backend#3148](https://github.com/aws-amplify/amplify-backend/pull/3148) — Captures metrics/usage from Bedrock streaming response                                 
4. **amplify-codegen** — [aws-amplify/amplify-codegen#1008](https://github.com/aws-amplify/amplify-codegen/pull/1008) — Adds fields to generated introspection metadata    

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->
- Added `metrics` (`latencyMs`) and `usage` (`inputTokens`, `outputTokens`, `totalTokens`) fields to the `StreamingResponseChunk` type, included in the final chunk when a turn completes.
- Extracted metrics and usage from the Bedrock `metadata` stream chunk in `BedrockConverseAdapter`.
- Serialized `metrics` and `usage` to JSON strings in `ConversationTurnResponseSender` before sending to AppSync.
- Added `metrics` and `usage` to the GraphQL message selection set in `ConversationMessageHistoryRetriever`.
- Updated the integration test schema with `MockMetrics` and `MockUsage` custom types on `ConversationMessageAssistantResponse`.
**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->
- Added unit test: `includes metrics and usage in the final streaming chunk` (bedrock converse adapter)
- Added unit test: `serializes metrics and usage to JSON when streaming` (response sender)
- Updated existing streaming test assertions to account for the new metadata chunk
- All 77 unit tests in `@aws-amplify/ai-constructs` pass
## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
