### PR TITLE
feat(deploy): add preview confirmation prompt and --yes flag

### DIFF
--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -13,6 +13,7 @@ import {
   TestCommandError,
   TestCommandRunner,
 } from '../../test-utils/command_runner.js';
+import { AmplifyPrompter } from '@aws-amplify/cli-core';
 import fs from 'fs';
 
 const deployResult = () =>
@@ -111,7 +112,9 @@ void describe('deploy command', () => {
   void it('bare deploy with hosting.ts present deploys both', async () => {
     hostingExists = true;
 
-    await getCommandRunner().runCommand('deploy --identifier my-app-prod');
+    await getCommandRunner().runCommand(
+      'deploy --identifier my-app-prod --yes',
+    );
 
     // Backend deployer called once
     assert.strictEqual(mockBackendDeployFn.mock.callCount(), 1);
@@ -144,7 +147,7 @@ void describe('deploy command', () => {
     hostingExists = false;
 
     const output = await getCommandRunner().runCommand(
-      'deploy --identifier my-app',
+      'deploy --identifier my-app --yes',
     );
 
     assert.strictEqual(mockBackendDeployFn.mock.callCount(), 1);
@@ -157,7 +160,9 @@ void describe('deploy command', () => {
   });
 
   void it('--backend deploys only backend stack', async () => {
-    await getCommandRunner().runCommand('deploy --identifier my-app --backend');
+    await getCommandRunner().runCommand(
+      'deploy --identifier my-app --backend --yes',
+    );
 
     assert.strictEqual(mockBackendDeployFn.mock.callCount(), 1);
     const callArgs = mockBackendDeployFn.mock.calls[0]
@@ -181,7 +186,7 @@ void describe('deploy command', () => {
     hostingExists = true;
 
     await getCommandRunner().runCommand(
-      'deploy --identifier my-app --frontend',
+      'deploy --identifier my-app --frontend --yes',
     );
 
     assert.strictEqual(
@@ -204,7 +209,9 @@ void describe('deploy command', () => {
 
     await assert.rejects(
       () =>
-        getCommandRunner().runCommand('deploy --identifier my-app --frontend'),
+        getCommandRunner().runCommand(
+          'deploy --identifier my-app --frontend --yes',
+        ),
       (err: TestCommandError) => {
         assert.match(
           err.error.message,
@@ -218,7 +225,9 @@ void describe('deploy command', () => {
   });
 
   void it('generates client config from backend stack', async () => {
-    await getCommandRunner().runCommand('deploy --identifier my-app-prod');
+    await getCommandRunner().runCommand(
+      'deploy --identifier my-app-prod --yes',
+    );
 
     assert.strictEqual(generateClientConfigMock.mock.callCount(), 1);
     const configArgs = generateClientConfigMock.mock.calls[0]
@@ -236,7 +245,7 @@ void describe('deploy command', () => {
     hostingExists = true;
 
     await getCommandRunner().runCommand(
-      'deploy --identifier my-app --frontend',
+      'deploy --identifier my-app --frontend --yes',
     );
 
     // Should generate client config (from existing backend stack) before hosting deploy
@@ -259,7 +268,9 @@ void describe('deploy command', () => {
 
     await assert.rejects(
       () =>
-        getCommandRunner().runCommand('deploy --identifier my-app --frontend'),
+        getCommandRunner().runCommand(
+          'deploy --identifier my-app --frontend --yes',
+        ),
       (err: TestCommandError) => {
         assert.match(err.error.message, /Backend has not been deployed yet/);
         return true;
@@ -276,7 +287,7 @@ void describe('deploy command', () => {
 
   void it('allows --outputs-out-dir argument', async () => {
     await getCommandRunner().runCommand(
-      'deploy --identifier my-app --outputs-out-dir src --backend',
+      'deploy --identifier my-app --outputs-out-dir src --backend --yes',
     );
 
     assert.strictEqual(generateClientConfigMock.mock.callCount(), 1);
@@ -287,7 +298,7 @@ void describe('deploy command', () => {
 
   void it('passes --profile argument through', async () => {
     await getCommandRunner().runCommand(
-      'deploy --identifier my-app --profile my-profile',
+      'deploy --identifier my-app --profile my-profile --yes',
     );
 
     assert.ok(mockBackendDeployFn.mock.callCount() > 0);
@@ -327,7 +338,9 @@ void describe('deploy command', () => {
   });
 
   void it('accepts valid identifier with hyphens', async () => {
-    await getCommandRunner().runCommand('deploy --identifier my-app-prod-v2');
+    await getCommandRunner().runCommand(
+      'deploy --identifier my-app-prod-v2 --yes',
+    );
 
     assert.ok(mockBackendDeployFn.mock.callCount() > 0);
   });
@@ -343,7 +356,7 @@ void describe('deploy command', () => {
     );
 
     const output = await getCommandRunner().runCommand(
-      'deploy --identifier my-app',
+      'deploy --identifier my-app --yes',
     );
 
     assert.match(output, /has not been bootstrapped/);
@@ -360,7 +373,7 @@ void describe('deploy command', () => {
     );
 
     const output = await getCommandRunner().runCommand(
-      'deploy --identifier my-app',
+      'deploy --identifier my-app --yes',
     );
 
     assert.match(output, /has not been bootstrapped/);
@@ -372,7 +385,7 @@ void describe('deploy command', () => {
       Promise.resolve({ Parameter: { Value: '6' } }),
     );
 
-    await getCommandRunner().runCommand('deploy --identifier my-app');
+    await getCommandRunner().runCommand('deploy --identifier my-app --yes');
 
     assert.ok(mockBackendDeployFn.mock.callCount() > 0);
   });
@@ -383,7 +396,7 @@ void describe('deploy command', () => {
     );
 
     const output = await getCommandRunner().runCommand(
-      'deploy --identifier my-app',
+      'deploy --identifier my-app --yes',
     );
 
     assert.match(output, /has not been bootstrapped/);
@@ -401,7 +414,7 @@ void describe('deploy command', () => {
     });
 
     await assert.rejects(
-      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      () => getCommandRunner().runCommand('deploy --identifier my-app --yes'),
       (err: TestCommandError) => {
         assert.match(err.output, /AccessDeniedException/);
         return true;
@@ -421,7 +434,7 @@ void describe('deploy command', () => {
     });
 
     await assert.rejects(
-      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      () => getCommandRunner().runCommand('deploy --identifier my-app --yes'),
       (err: TestCommandError) => {
         assert.match(err.output, /ExpiredTokenException/);
         return true;
@@ -441,7 +454,7 @@ void describe('deploy command', () => {
     });
 
     await assert.rejects(
-      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      () => getCommandRunner().runCommand('deploy --identifier my-app --yes'),
       (err: TestCommandError) => {
         assert.match(err.output, /InvalidSignatureException/);
         return true;
@@ -456,7 +469,7 @@ void describe('deploy command', () => {
     );
 
     await assert.rejects(
-      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      () => getCommandRunner().runCommand('deploy --identifier my-app --yes'),
       (err: TestCommandError) => {
         assert.match(err.error.message, /CFN deployment failed/);
         return true;
@@ -471,7 +484,7 @@ void describe('deploy command', () => {
     );
 
     await assert.rejects(
-      () => getCommandRunner().runCommand('deploy --identifier my-app'),
+      () => getCommandRunner().runCommand('deploy --identifier my-app --yes'),
       (err: TestCommandError) => {
         assert.match(err.error.message, /Frontend deployment failed/);
         return true;
@@ -494,7 +507,9 @@ void describe('deploy command', () => {
 
     await assert.rejects(
       () =>
-        getCommandRunner().runCommand('deploy --identifier my-app --frontend'),
+        getCommandRunner().runCommand(
+          'deploy --identifier my-app --frontend --yes',
+        ),
       (err: TestCommandError) => {
         assert.match(err.error.message, /Access Denied/);
         return true;
@@ -519,5 +534,79 @@ void describe('deploy command', () => {
     );
     assert.strictEqual(mockBackendDeployFn.mock.callCount(), 0);
     assert.strictEqual(mockHostingDeployFn.mock.callCount(), 0);
+  });
+
+  void describe('preview confirmation prompt', () => {
+    void it('shows prompt when --yes is not passed and proceeds on confirmation', async (contextual) => {
+      contextual.mock.method(AmplifyPrompter, 'yesOrNo', () =>
+        Promise.resolve(true),
+      );
+
+      await getCommandRunner().runCommand('deploy --identifier my-app');
+
+      assert.ok(
+        mockBackendDeployFn.mock.callCount() > 0,
+        'deploy should proceed after user confirms',
+      );
+    });
+
+    void it('aborts deployment when user declines the prompt', async (contextual) => {
+      contextual.mock.method(AmplifyPrompter, 'yesOrNo', () =>
+        Promise.resolve(false),
+      );
+
+      const output = await getCommandRunner().runCommand(
+        'deploy --identifier my-app',
+      );
+
+      assert.match(output, /Deployment cancelled/);
+      assert.strictEqual(mockBackendDeployFn.mock.callCount(), 0);
+      assert.strictEqual(mockHostingDeployFn.mock.callCount(), 0);
+    });
+
+    void it('--yes bypasses the prompt entirely', async (contextual) => {
+      const yesOrNoMock = contextual.mock.method(
+        AmplifyPrompter,
+        'yesOrNo',
+        () => Promise.resolve(false),
+      );
+
+      await getCommandRunner().runCommand('deploy --identifier my-app --yes');
+
+      assert.strictEqual(
+        yesOrNoMock.mock.callCount(),
+        0,
+        'prompt should not be called when --yes is passed',
+      );
+      assert.ok(
+        mockBackendDeployFn.mock.callCount() > 0,
+        'deploy should proceed without prompting',
+      );
+    });
+
+    void it('-y alias bypasses the prompt', async (contextual) => {
+      const yesOrNoMock = contextual.mock.method(
+        AmplifyPrompter,
+        'yesOrNo',
+        () => Promise.resolve(false),
+      );
+
+      await getCommandRunner().runCommand('deploy --identifier my-app -y');
+
+      assert.strictEqual(
+        yesOrNoMock.mock.callCount(),
+        0,
+        'prompt should not be called when -y is passed',
+      );
+      assert.ok(
+        mockBackendDeployFn.mock.callCount() > 0,
+        'deploy should proceed without prompting',
+      );
+    });
+
+    void it('shows --yes in help output', async () => {
+      const output = await getCommandRunner().runCommand('deploy --help');
+      assert.match(output, /--yes/);
+    });
   });
 });

--- a/packages/cli/src/commands/deploy/deploy_command.test.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.test.ts
@@ -559,7 +559,7 @@ void describe('deploy command', () => {
         'deploy --identifier my-app',
       );
 
-      assert.match(output, /Deployment cancelled/);
+      assert.match(output, /Deployment canceled/);
       assert.strictEqual(mockBackendDeployFn.mock.callCount(), 0);
       assert.strictEqual(mockHostingDeployFn.mock.callCount(), 0);
     });

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -14,7 +14,7 @@ import {
   BackendIdentifierConversions,
   BackendLocator,
 } from '@aws-amplify/platform-core';
-import { format, printer } from '@aws-amplify/cli-core';
+import { AmplifyPrompter, format, printer } from '@aws-amplify/cli-core';
 import { CommandMiddleware } from '../../command_middleware.js';
 import {
   GetParameterCommand,
@@ -35,6 +35,7 @@ type DeployCommandOptionsCamelCase = {
   outputsOutDir?: string;
   backend: boolean;
   frontend: boolean;
+  yes: boolean | undefined;
 };
 
 // CloudFormation stack name constraints
@@ -102,6 +103,18 @@ export class DeployCommand
         resolution:
           'Use one flag to deploy selectively, or omit both to deploy everything.',
       });
+    }
+
+    // ampx deploy is a preview feature — confirm before proceeding
+    if (!args.yes) {
+      const confirmed = await AmplifyPrompter.yesOrNo({
+        message:
+          '⚠️  ampx deploy is a PREVIEW release — not intended for production use. Please confirm you are using this only for testing',
+      });
+      if (!confirmed) {
+        printer.log('Deployment cancelled.');
+        return;
+      }
     }
 
     // Check CDK bootstrap before deploying
@@ -269,6 +282,13 @@ export class DeployCommand
           'Deploy only hosting resources. Requires backend to be deployed first.',
         type: 'boolean',
         default: false,
+      })
+      .option('yes', {
+        describe:
+          'Skip the preview confirmation prompt (useful for CI/testing).',
+        type: 'boolean',
+        array: false,
+        alias: 'y',
       })
       .middleware([this.commandMiddleware.ensureAwsCredentialAndRegion]);
   };

--- a/packages/cli/src/commands/deploy/deploy_command.ts
+++ b/packages/cli/src/commands/deploy/deploy_command.ts
@@ -109,10 +109,10 @@ export class DeployCommand
     if (!args.yes) {
       const confirmed = await AmplifyPrompter.yesOrNo({
         message:
-          '⚠️  ampx deploy is a PREVIEW release — not intended for production use. Please confirm you are using this only for testing',
+          '⚠️  ampx deploy is a PREVIEW release — not intended for production use. Do you want to continue?',
       });
       if (!confirmed) {
-        printer.log('Deployment cancelled.');
+        printer.log('Deployment canceled.');
         return;
       }
     }

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -20,7 +20,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "update:api": "api-extractor run --local",
-    "postinstall": "echo '\\n⚠️  @aws-amplify/hosting is a PREVIEW release — not for production use\\n'"
+    "postinstall": "node -e \"console.log('\\n⚠️  @aws-amplify/hosting is a PREVIEW release — not for production use\\n')\""
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -19,7 +19,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "update:api": "api-extractor run --local"
+    "update:api": "api-extractor run --local",
+    "postinstall": "echo '\\n⚠️  @aws-amplify/hosting is a PREVIEW release — not for production use\\n'"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/integration-tests/src/test-project-setup/test_project_base.ts
+++ b/packages/integration-tests/src/test-project-setup/test_project_base.ts
@@ -82,7 +82,12 @@ export abstract class TestProjectBase {
         .do(interruptSandbox())
         .run();
     } else if (backendIdentifier.type === 'standalone') {
-      const args = ['deploy', '--identifier', backendIdentifier.namespace];
+      const args = [
+        'deploy',
+        '--identifier',
+        backendIdentifier.namespace,
+        '--yes',
+      ];
       // Derive deploy flag from identifier name
       if (backendIdentifier.name === 'backend') {
         args.push('--backend');


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-backend/actions/runs/23871607458

ampx deploy is a preview feature. Add an interactive confirmation prompt that shows every time the command runs unless --yes/-y is passed.

- Add AmplifyPrompter.yesOrNo prompt at handler entry (after validation)
- Add --yes/-y boolean flag to skip the prompt (for CI/testing)
- Update all unit tests to pass --yes where deployment is expected
- Update integration test_project_base to pass --yes for standalone deploys
- Add postinstall warning to @aws-amplify/hosting package.json
- Add dedicated test suite for prompt logic (confirm/decline/bypass/alias)

<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
