### PR TITLE
feat(hosting): API redesign — grouped props, KMS, geo-restriction, lifecycle config

### DIFF
--- a/packages/hosting/API.md
+++ b/packages/hosting/API.md
@@ -8,12 +8,15 @@ import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 import { Construct } from 'constructs';
 import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import { Duration } from 'aws-cdk-lib';
 import { Function as Function_2 } from 'aws-cdk-lib/aws-lambda';
 import { FunctionUrl } from 'aws-cdk-lib/aws-lambda';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { IHostedZone } from 'aws-cdk-lib/aws-route53';
+import { IKey } from 'aws-cdk-lib/aws-kms';
 import { PriceClass } from 'aws-cdk-lib/aws-cloudfront';
 import { ResourceProvider } from '@aws-amplify/plugin-types';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Stack } from 'aws-cdk-lib';
 
 // @public
@@ -43,26 +46,37 @@ export type AmplifyHostingConstructProps = {
     manifest: DeployManifest;
     staticAssetPath: string;
     computeBasePath?: string;
+    skipRegionValidation?: boolean;
     domain?: HostingDomainConfig;
     waf?: HostingWafConfig;
-    compute?: ComputeConfig;
-    retainOnDelete?: boolean;
-    accessLogging?: boolean;
-    contentSecurityPolicy?: string;
-    priceClass?: PriceClass;
-    skipRegionValidation?: boolean;
-    name?: string;
+    compute?: {
+        memorySize?: number;
+        timeout?: Duration;
+        reservedConcurrency?: number;
+        logRetention?: RetentionDays;
+    };
+    cdn?: {
+        priceClass?: PriceClass;
+        contentSecurityPolicy?: string;
+        geoRestriction?: {
+            type: 'whitelist' | 'blacklist';
+            countries: string[];
+        };
+    };
+    storage?: {
+        encryption?: 'S3_MANAGED' | 'KMS';
+        encryptionKey?: IKey;
+        retainOnDelete?: boolean;
+        buildRetentionDays?: number;
+    };
+    logging?: {
+        enabled: boolean;
+        retentionDays?: number;
+    };
 };
 
 // @public (undocumented)
 export type BackendHosting = ResourceProvider<HostingResources>;
-
-// @public
-export type ComputeConfig = {
-    memorySize?: number;
-    timeout?: number;
-    reservedConcurrency?: number;
-};
 
 // @public
 export type ComputeResource = {
@@ -125,21 +139,40 @@ export type HostingProps = {
     buildCommand?: string;
     buildOutputDir?: string;
     framework?: FrameworkType;
+    customAdapter?: FrameworkAdapterFn;
     domain?: {
         domainName: string;
         hostedZone: string;
+        certificate?: ICertificate;
     };
     waf?: {
         enabled: boolean;
         rateLimit?: number;
     };
-    customAdapter?: FrameworkAdapterFn;
-    compute?: ComputeConfig;
-    retainOnDelete?: boolean;
-    accessLogging?: boolean;
-    contentSecurityPolicy?: string;
-    priceClass?: PriceClass;
-    name?: string;
+    compute?: {
+        memorySize?: number;
+        timeout?: Duration;
+        reservedConcurrency?: number;
+        logRetention?: RetentionDays;
+    };
+    cdn?: {
+        priceClass?: PriceClass;
+        contentSecurityPolicy?: string;
+        geoRestriction?: {
+            type: 'whitelist' | 'blacklist';
+            countries: string[];
+        };
+    };
+    storage?: {
+        encryption?: 'S3_MANAGED' | 'KMS';
+        encryptionKey?: IKey;
+        retainOnDelete?: boolean;
+        buildRetentionDays?: number;
+    };
+    logging?: {
+        enabled: boolean;
+        retentionDays?: number;
+    };
 };
 
 // @public

--- a/packages/hosting/src/constructs/cdn_construct.test.ts
+++ b/packages/hosting/src/constructs/cdn_construct.test.ts
@@ -932,4 +932,101 @@ void describe('CdnConstruct', () => {
       assert.ok(distUrlOutput, 'Should have DistributionUrl output');
     });
   });
+
+  // ---- Geo-restriction ----
+
+  void describe('geo-restriction', () => {
+    void it('applies whitelist geo-restriction to distribution', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'Headers');
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+        geoRestriction: {
+          type: 'whitelist',
+          countries: ['US', 'CA', 'GB'],
+        },
+      });
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties(
+        'AWS::CloudFront::Distribution',
+        Match.objectLike({
+          DistributionConfig: Match.objectLike({
+            Restrictions: Match.objectLike({
+              GeoRestriction: Match.objectLike({
+                RestrictionType: 'whitelist',
+                Locations: ['US', 'CA', 'GB'],
+              }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    void it('applies blacklist geo-restriction to distribution', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'Headers');
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+        geoRestriction: {
+          type: 'blacklist',
+          countries: ['CN', 'RU'],
+        },
+      });
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties(
+        'AWS::CloudFront::Distribution',
+        Match.objectLike({
+          DistributionConfig: Match.objectLike({
+            Restrictions: Match.objectLike({
+              GeoRestriction: Match.objectLike({
+                RestrictionType: 'blacklist',
+                Locations: ['CN', 'RU'],
+              }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    void it('does not apply geo-restriction when not configured', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'Headers');
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+      });
+
+      const template = Template.fromStack(stack);
+      const distributions = template.findResources(
+        'AWS::CloudFront::Distribution',
+      );
+      for (const [, dist] of Object.entries(distributions)) {
+        const config = (dist as Record<string, Record<string, unknown>>)
+          .Properties?.DistributionConfig as Record<string, unknown>;
+        const restrictions = config?.Restrictions as
+          | Record<string, Record<string, unknown>>
+          | undefined;
+        if (restrictions?.GeoRestriction) {
+          assert.strictEqual(
+            restrictions.GeoRestriction.RestrictionType,
+            'none',
+            'Default should have no geo-restriction (type=none)',
+          );
+        }
+      }
+    });
+  });
 });

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -127,6 +127,14 @@ export class CdnConstruct extends Construct {
       });
     }
 
+    if (props.geoRestriction && props.geoRestriction.countries.length === 0) {
+      throw new HostingError('EmptyGeoRestrictionError', {
+        message: 'geoRestriction.countries array cannot be empty.',
+        resolution:
+          'Provide at least one ISO 3166-1 alpha-2 country code, or remove the geoRestriction config.',
+      });
+    }
+
     const buildId = manifest.buildId;
     const account = Stack.of(this).account;
     const hasCompute = !!props.ssrFunctionUrl;

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -12,6 +12,7 @@ import {
   FunctionCode,
   FunctionEventType,
   FunctionRuntime,
+  GeoRestriction,
   HttpVersion,
   OriginRequestPolicy,
   PriceClass,
@@ -76,6 +77,11 @@ export type CdnConstructProps = {
   accessLogBucket?: IBucket;
   /** CloudFront price class. Default: PRICE_CLASS_100 (US, Canada, Europe). */
   priceClass?: PriceClass;
+  /** Geo-restriction configuration for CloudFront distribution. */
+  geoRestriction?: {
+    type: 'whitelist' | 'blacklist';
+    countries: string[];
+  };
   /** Custom error page HTML for SSR 5xx responses. Default: built-in SSR_ERROR_PAGE_HTML. */
   errorPageHtml?: string;
 };
@@ -278,6 +284,16 @@ export class CdnConstruct extends Construct {
       // Access logging
       ...(props.accessLogBucket
         ? { enableLogging: true, logBucket: props.accessLogBucket }
+        : {}),
+      // Geo-restriction
+      ...(props.geoRestriction
+        ? {
+            geoRestriction:
+              props.geoRestriction.type === 'whitelist'
+                ? GeoRestriction.allowlist(...props.geoRestriction.countries)
+                : // eslint-disable-next-line spellcheck/spell-checker
+                  GeoRestriction.denylist(...props.geoRestriction.countries),
+          }
         : {}),
       // Error responses
       errorResponses: errorResponses.length > 0 ? errorResponses : undefined,

--- a/packages/hosting/src/constructs/compute_construct.test.ts
+++ b/packages/hosting/src/constructs/compute_construct.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { App, Duration, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { ComputeConstruct } from './compute_construct.js';
 import { HostingError } from '../hosting_error.js';
 import { ComputeResource } from '../manifest/types.js';
@@ -407,6 +408,40 @@ void describe('ComputeConstruct', () => {
 
       assert.ok(compute.function, 'Should expose function');
       assert.ok(compute.functionUrl, 'Should expose functionUrl');
+    });
+  });
+
+  // ---- Log retention ----
+
+  void describe('logRetention', () => {
+    void it('uses custom logRetention when provided', () => {
+      const stack = createStack();
+
+      new ComputeConstruct(stack, 'Compute', {
+        computeResource: defaultComputeResource,
+        computeBasePath,
+        logRetention: RetentionDays.ONE_MONTH,
+      });
+
+      // CDK creates a Custom::LogRetention resource that configures log group retention
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('Custom::LogRetention', {
+        RetentionInDays: 30,
+      });
+    });
+
+    void it('defaults to TWO_WEEKS when logRetention is not set', () => {
+      const stack = createStack();
+
+      new ComputeConstruct(stack, 'Compute', {
+        computeResource: defaultComputeResource,
+        computeBasePath,
+      });
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('Custom::LogRetention', {
+        RetentionInDays: 14,
+      });
     });
   });
 });

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { App, Stack } from 'aws-cdk-lib';
+import { App, Duration, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { AmplifyHostingConstruct } from './hosting_construct.js';
 import { DeployManifest } from '../manifest/types.js';
@@ -357,7 +357,7 @@ void describe('AmplifyHostingConstruct — SPA mode', () => {
     new AmplifyHostingConstruct(stack, 'Hosting', {
       manifest: spaManifest,
       staticAssetPath: staticDir,
-      retainOnDelete: true,
+      storage: { retainOnDelete: true },
     });
 
     const template = Template.fromStack(stack);
@@ -794,7 +794,7 @@ void describe('AmplifyHostingConstruct — SSR mode', () => {
       computeBasePath: computeDir,
       compute: {
         memorySize: 1024,
-        timeout: 60,
+        timeout: Duration.seconds(60),
         reservedConcurrency: 50,
       },
     });
@@ -1337,7 +1337,7 @@ void describe('AmplifyHostingConstruct — access logging', () => {
     new AmplifyHostingConstruct(stack, 'Hosting', {
       manifest: spaManifest,
       staticAssetPath: staticDir,
-      accessLogging: true,
+      logging: { enabled: true },
     });
 
     const template = Template.fromStack(stack);
@@ -1393,7 +1393,7 @@ void describe('AmplifyHostingConstruct — custom CSP', () => {
     new AmplifyHostingConstruct(stack, 'Hosting', {
       manifest: spaManifest,
       staticAssetPath: staticDir,
-      contentSecurityPolicy: customCsp,
+      cdn: { contentSecurityPolicy: customCsp },
     });
 
     const template = Template.fromStack(stack);

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -5,7 +5,11 @@ import * as path from 'path';
 import * as os from 'os';
 import { App, Duration, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { AmplifyHostingConstruct } from './hosting_construct.js';
+import { HostingError } from '../hosting_error.js';
 import { DeployManifest } from '../manifest/types.js';
 
 // ---- Helpers ----
@@ -1778,5 +1782,619 @@ void describe('AmplifyHostingConstruct — Lambda CloudFront-only permission', (
       0,
       'SPA mode should not have CloudFront Lambda permissions',
     );
+  });
+});
+
+// ================================================================
+// KMS encryption — integration
+// ================================================================
+
+void describe('AmplifyHostingConstruct — KMS encryption', () => {
+  let tmpDir: string;
+  let staticDir: string;
+
+  const spaManifestForKms: DeployManifest = {
+    version: 1,
+    routes: [{ path: '/*', target: { kind: 'Static' } }],
+    framework: { name: 'spa' },
+    buildId: 'kms-test-1',
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hosting-kms-test-'));
+    staticDir = path.join(tmpDir, 'static');
+    fs.mkdirSync(staticDir, { recursive: true });
+    fs.writeFileSync(path.join(staticDir, 'index.html'), '<html></html>');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('uses KMS encryption with BYO key and grants kms:Decrypt to CloudFront', () => {
+    const stack = createStack();
+    const key = new Key(stack, 'MyKey');
+
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: spaManifestForKms,
+      staticAssetPath: staticDir,
+      storage: { encryption: 'KMS', encryptionKey: key },
+    });
+
+    const template = Template.fromStack(stack);
+
+    // Verify S3 bucket uses KMS encryption
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [
+          {
+            ServerSideEncryptionByDefault: Match.objectLike({
+              SSEAlgorithm: 'aws:kms',
+              KMSMasterKeyID: Match.anyValue(),
+            }),
+          },
+        ],
+      },
+    });
+
+    // Verify KMS key policy includes kms:Decrypt for CloudFront
+    template.hasResourceProperties('AWS::KMS::Key', {
+      KeyPolicy: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'kms:Decrypt',
+            Effect: 'Allow',
+            Principal: Match.objectLike({
+              Service: 'cloudfront.amazonaws.com',
+            }),
+          }),
+        ]),
+      }),
+    });
+  });
+
+  void it('grants kms:Decrypt on auto-created KMS key (no BYO key)', () => {
+    const stack = createStack();
+
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: spaManifestForKms,
+      staticAssetPath: staticDir,
+      storage: { encryption: 'KMS' },
+    });
+
+    const template = Template.fromStack(stack);
+
+    // CDK auto-creates a KMS key — verify the decrypt grant exists
+    template.hasResourceProperties('AWS::KMS::Key', {
+      KeyPolicy: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'kms:Decrypt',
+            Effect: 'Allow',
+            Principal: Match.objectLike({
+              Service: 'cloudfront.amazonaws.com',
+            }),
+          }),
+        ]),
+      }),
+    });
+  });
+
+  void it('does NOT create KMS key when encryption is S3_MANAGED', () => {
+    const stack = createStack();
+
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: spaManifestForKms,
+      staticAssetPath: staticDir,
+      storage: { encryption: 'S3_MANAGED' },
+    });
+
+    const template = Template.fromStack(stack);
+    const kmsKeys = template.findResources('AWS::KMS::Key');
+    assert.strictEqual(
+      Object.keys(kmsKeys).length,
+      0,
+      'S3_MANAGED should not create any KMS keys',
+    );
+  });
+});
+
+// ================================================================
+// Geo-restriction — integration
+// ================================================================
+
+void describe('AmplifyHostingConstruct — geo-restriction', () => {
+  let tmpDir: string;
+  let staticDir: string;
+
+  const spaManifestForGeo: DeployManifest = {
+    version: 1,
+    routes: [{ path: '/*', target: { kind: 'Static' } }],
+    framework: { name: 'spa' },
+    buildId: 'geo-test-1',
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hosting-geo-test-'));
+    staticDir = path.join(tmpDir, 'static');
+    fs.mkdirSync(staticDir, { recursive: true });
+    fs.writeFileSync(path.join(staticDir, 'index.html'), '<html></html>');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('applies whitelist geo-restriction to CloudFront distribution', () => {
+    const stack = createStack();
+
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: spaManifestForGeo,
+      staticAssetPath: staticDir,
+      cdn: { geoRestriction: { type: 'whitelist', countries: ['US', 'CA'] } },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties(
+      'AWS::CloudFront::Distribution',
+      Match.objectLike({
+        DistributionConfig: Match.objectLike({
+          Restrictions: Match.objectLike({
+            GeoRestriction: Match.objectLike({
+              RestrictionType: 'whitelist',
+              Locations: ['US', 'CA'],
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  void it('throws EmptyGeoRestrictionError for empty countries array', () => {
+    const stack = createStack();
+
+    assert.throws(
+      () =>
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: spaManifestForGeo,
+          staticAssetPath: staticDir,
+          cdn: { geoRestriction: { type: 'whitelist', countries: [] } },
+        }),
+      (err: unknown) => {
+        assert.ok(err instanceof HostingError);
+        assert.strictEqual(err.name, 'EmptyGeoRestrictionError');
+        assert.ok(err.resolution);
+        return true;
+      },
+    );
+  });
+});
+
+// ================================================================
+// Lifecycle durations — integration
+// ================================================================
+
+void describe('AmplifyHostingConstruct — lifecycle durations', () => {
+  let tmpDir: string;
+  let staticDir: string;
+
+  const spaManifestForLifecycle: DeployManifest = {
+    version: 1,
+    routes: [{ path: '/*', target: { kind: 'Static' } }],
+    framework: { name: 'spa' },
+    buildId: 'lifecycle-test-1',
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hosting-lifecycle-int-test-'),
+    );
+    staticDir = path.join(tmpDir, 'static');
+    fs.mkdirSync(staticDir, { recursive: true });
+    fs.writeFileSync(path.join(staticDir, 'index.html'), '<html></html>');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('uses custom buildRetentionDays and log retentionDays', () => {
+    const stack = createStack();
+
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: spaManifestForLifecycle,
+      staticAssetPath: staticDir,
+      storage: { buildRetentionDays: 30 },
+      logging: { enabled: true, retentionDays: 14 },
+    });
+
+    const template = Template.fromStack(stack);
+
+    // Hosting bucket: 30-day build retention
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      LifecycleConfiguration: Match.objectLike({
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Id: 'DeleteOldBuilds',
+            Prefix: 'builds/',
+            ExpirationInDays: 30,
+            Status: 'Enabled',
+          }),
+        ]),
+      }),
+    });
+
+    // Access log bucket: 14-day expiration
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      LifecycleConfiguration: Match.objectLike({
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Id: 'ExpireAccessLogs',
+            ExpirationInDays: 14,
+            Status: 'Enabled',
+          }),
+        ]),
+      }),
+    });
+  });
+});
+
+// ================================================================
+// Lambda log retention — integration
+// ================================================================
+
+void describe('AmplifyHostingConstruct — compute logRetention', () => {
+  let tmpDir: string;
+  let staticDir: string;
+  let computeDir: string;
+
+  const ssrManifestForLog: DeployManifest = {
+    version: 1,
+    routes: [
+      { path: '/_next/static/*', target: { kind: 'Static' } },
+      { path: '/*', target: { kind: 'Compute', src: 'default' } },
+    ],
+    computeResources: [
+      { name: 'default', runtime: 'nodejs20.x', entrypoint: 'run.sh' },
+    ],
+    framework: { name: 'nextjs', version: '15.0.0' },
+    buildId: 'log-ret-test-1',
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hosting-log-ret-test-'));
+    staticDir = path.join(tmpDir, 'static');
+    computeDir = path.join(tmpDir, 'compute');
+
+    fs.mkdirSync(path.join(staticDir, '_next', 'static'), { recursive: true });
+    fs.writeFileSync(
+      path.join(staticDir, '_next', 'static', 'main.js'),
+      'chunk',
+    );
+
+    const defaultDir = path.join(computeDir, 'default');
+    fs.mkdirSync(defaultDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(defaultDir, 'server.js'),
+      'require("http").createServer().listen(3000)',
+    );
+    fs.writeFileSync(
+      path.join(defaultDir, 'run.sh'),
+      '#!/bin/bash\nexec node server.js',
+    );
+    fs.writeFileSync(
+      path.join(defaultDir, 'index.js'),
+      'exports.handler = async () => ({ statusCode: 502 });',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('passes logRetention to the Lambda function via compute group', () => {
+    const stack = createStack();
+
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifestForLog,
+      staticAssetPath: staticDir,
+      computeBasePath: computeDir,
+      compute: { logRetention: RetentionDays.ONE_MONTH },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('Custom::LogRetention', {
+      RetentionInDays: 30,
+    });
+  });
+});
+
+// ================================================================
+// BYO certificate — integration
+// ================================================================
+
+void describe('AmplifyHostingConstruct — BYO certificate', () => {
+  let tmpDir: string;
+  let staticDir: string;
+
+  const spaManifestForCert: DeployManifest = {
+    version: 1,
+    routes: [{ path: '/*', target: { kind: 'Static' } }],
+    framework: { name: 'spa' },
+    buildId: 'byo-cert-test-1',
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hosting-byo-cert-test-'));
+    staticDir = path.join(tmpDir, 'static');
+    fs.mkdirSync(staticDir, { recursive: true });
+    fs.writeFileSync(path.join(staticDir, 'index.html'), '<html></html>');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const createEnvStack = (): Stack => {
+    const app = new App();
+    return new Stack(app, 'TestStack', {
+      env: { account: '123456789012', region: 'us-east-1' },
+    });
+  };
+
+  void it('uses BYO certificate without creating a new ACM certificate', () => {
+    const stack = createEnvStack();
+    const certArn =
+      'arn:aws:acm:us-east-1:123456789012:certificate/byo-cert-abc';
+    const cert = Certificate.fromCertificateArn(stack, 'BYOCert', certArn);
+
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: spaManifestForCert,
+      staticAssetPath: staticDir,
+      domain: {
+        domainName: 'www.example.com',
+        hostedZone: 'example.com',
+        certificate: cert,
+      },
+    });
+
+    const template = Template.fromStack(stack);
+
+    // CloudFront should use the BYO certificate
+    template.hasResourceProperties(
+      'AWS::CloudFront::Distribution',
+      Match.objectLike({
+        DistributionConfig: Match.objectLike({
+          Aliases: ['www.example.com'],
+          ViewerCertificate: Match.objectLike({
+            AcmCertificateArn: certArn,
+          }),
+        }),
+      }),
+    );
+
+    // No DnsValidatedCertificate custom resource should be created
+    const customResources = template.findResources(
+      'AWS::CloudFormation::CustomResource',
+    );
+    const certResources = Object.entries(customResources).filter(([, r]) => {
+      const props = (r as Record<string, Record<string, unknown>>).Properties;
+      return props?.DomainName === 'www.example.com';
+    });
+    assert.strictEqual(
+      certResources.length,
+      0,
+      'Should NOT create a new certificate when BYO cert is provided',
+    );
+  });
+});
+
+// ================================================================
+// Kitchen-sink — all grouped props at once
+// ================================================================
+
+void describe('AmplifyHostingConstruct — kitchen-sink integration', () => {
+  let tmpDir: string;
+  let staticDir: string;
+  let computeDir: string;
+
+  const ssrManifestKitchenSink: DeployManifest = {
+    version: 1,
+    routes: [
+      { path: '/_next/static/*', target: { kind: 'Static' } },
+      { path: '/favicon.ico', target: { kind: 'Static' } },
+      { path: '/*', target: { kind: 'Compute', src: 'default' } },
+    ],
+    computeResources: [
+      { name: 'default', runtime: 'nodejs20.x', entrypoint: 'run.sh' },
+    ],
+    framework: { name: 'nextjs', version: '15.0.0' },
+    buildId: 'kitchen-sink-1',
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hosting-kitchen-sink-test-'),
+    );
+    staticDir = path.join(tmpDir, 'static');
+    computeDir = path.join(tmpDir, 'compute');
+
+    fs.mkdirSync(path.join(staticDir, '_next', 'static'), { recursive: true });
+    fs.writeFileSync(
+      path.join(staticDir, '_next', 'static', 'main.js'),
+      'chunk',
+    );
+
+    const defaultDir = path.join(computeDir, 'default');
+    fs.mkdirSync(defaultDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(defaultDir, 'server.js'),
+      'require("http").createServer().listen(3000)',
+    );
+    fs.writeFileSync(
+      path.join(defaultDir, 'run.sh'),
+      '#!/bin/bash\nexec node server.js',
+    );
+    fs.writeFileSync(
+      path.join(defaultDir, 'index.js'),
+      'exports.handler = async () => ({ statusCode: 502 });',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('synthesizes valid template with all grouped props at once', () => {
+    const stack = createStack();
+    const key = new Key(stack, 'HostingKey');
+
+    const construct = new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifestKitchenSink,
+      staticAssetPath: staticDir,
+      computeBasePath: computeDir,
+      storage: {
+        encryption: 'KMS',
+        encryptionKey: key,
+        retainOnDelete: true,
+        buildRetentionDays: 60,
+      },
+      cdn: {
+        contentSecurityPolicy: "default-src 'self'",
+        geoRestriction: { type: 'blacklist', countries: ['CN', 'RU'] },
+      },
+      compute: {
+        memorySize: 1024,
+        timeout: Duration.seconds(60),
+        reservedConcurrency: 50,
+        logRetention: RetentionDays.ONE_MONTH,
+      },
+      logging: { enabled: true, retentionDays: 7 },
+      waf: { enabled: true },
+      skipRegionValidation: true,
+    });
+
+    const template = Template.fromStack(stack);
+
+    // CloudFront distribution exists
+    template.resourceCountIs('AWS::CloudFront::Distribution', 1);
+
+    // KMS encryption on S3 bucket
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [
+          {
+            ServerSideEncryptionByDefault: Match.objectLike({
+              SSEAlgorithm: 'aws:kms',
+            }),
+          },
+        ],
+      },
+    });
+
+    // Geo-restriction blacklist
+    template.hasResourceProperties(
+      'AWS::CloudFront::Distribution',
+      Match.objectLike({
+        DistributionConfig: Match.objectLike({
+          Restrictions: Match.objectLike({
+            GeoRestriction: Match.objectLike({
+              RestrictionType: 'blacklist',
+              Locations: ['CN', 'RU'],
+            }),
+          }),
+        }),
+      }),
+    );
+
+    // Custom CSP
+    template.hasResourceProperties(
+      'AWS::CloudFront::ResponseHeadersPolicy',
+      Match.objectLike({
+        ResponseHeadersPolicyConfig: Match.objectLike({
+          SecurityHeadersConfig: Match.objectLike({
+            ContentSecurityPolicy: Match.objectLike({
+              ContentSecurityPolicy: "default-src 'self'",
+            }),
+          }),
+        }),
+      }),
+    );
+
+    // Lambda function with custom compute config
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      MemorySize: 1024,
+      Timeout: 60,
+      ReservedConcurrentExecutions: 50,
+    });
+
+    // Lambda log retention (ONE_MONTH = 30 days)
+    template.hasResourceProperties('Custom::LogRetention', {
+      RetentionInDays: 30,
+    });
+
+    // Build retention 60 days
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      LifecycleConfiguration: Match.objectLike({
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Id: 'DeleteOldBuilds',
+            ExpirationInDays: 60,
+          }),
+        ]),
+      }),
+    });
+
+    // Access log bucket with 7-day retention
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      LifecycleConfiguration: Match.objectLike({
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Id: 'ExpireAccessLogs',
+            ExpirationInDays: 7,
+          }),
+        ]),
+      }),
+    });
+
+    // WAF enabled
+    template.hasResourceProperties('AWS::WAFv2::WebACL', {
+      Scope: 'CLOUDFRONT',
+    });
+
+    // KMS decrypt grant for CloudFront
+    template.hasResourceProperties('AWS::KMS::Key', {
+      KeyPolicy: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'kms:Decrypt',
+            Principal: Match.objectLike({
+              Service: 'cloudfront.amazonaws.com',
+            }),
+          }),
+        ]),
+      }),
+    });
+
+    // Retain on delete
+    const buckets = template.findResources('AWS::S3::Bucket');
+    let foundRetain = false;
+    for (const [, bucket] of Object.entries(buckets)) {
+      if ((bucket as Record<string, unknown>).DeletionPolicy === 'Retain') {
+        foundRetain = true;
+      }
+    }
+    assert.ok(
+      foundRetain,
+      'Should have at least one bucket with Retain policy',
+    );
+
+    // Construct exposes resources
+    assert.ok(construct.bucket);
+    assert.ok(construct.distribution);
+    assert.ok(construct.distributionUrl.startsWith('https://'));
+    assert.ok(construct.ssrFunction);
+    assert.ok(construct.functionUrl);
+    assert.ok(construct.webAcl);
   });
 });

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -1,6 +1,7 @@
 import { Construct } from 'constructs';
 import { Duration } from 'aws-cdk-lib';
 import { Distribution, PriceClass } from 'aws-cdk-lib/aws-cloudfront';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import {
@@ -236,6 +237,24 @@ export class AmplifyHostingConstruct extends Construct {
 
     this.distribution = cdn.distribution;
     this.distributionUrl = cdn.distributionUrl;
+
+    // ---- 6a. KMS decrypt grant for CloudFront OAC ----
+    // When the hosting bucket uses KMS encryption, CloudFront OAC needs
+    // kms:Decrypt to read objects via SigV4. Grant on BYO key or CDK auto-key.
+    // NOTE: We scope the grant to the CloudFront service principal but omit a
+    // SourceArn condition referencing the distribution. Adding a Ref to the
+    // distribution here would create a Key→Distribution→Bucket→Key circular
+    // dependency in CloudFormation.
+    const kmsKey = props.storage?.encryptionKey ?? storage.bucket.encryptionKey;
+    if (props.storage?.encryption === 'KMS' && kmsKey) {
+      kmsKey.addToResourcePolicy(
+        new iam.PolicyStatement({
+          actions: ['kms:Decrypt'],
+          resources: ['*'],
+          principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+        }),
+      );
+    }
 
     // ---- 7. DNS records (only when custom domain configured) ----
     if (props.domain && dnsConstruct) {

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -9,10 +9,12 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { IHostedZone } from 'aws-cdk-lib/aws-route53';
+import { IKey } from 'aws-cdk-lib/aws-kms';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 import { HostingError } from '../hosting_error.js';
 import { ComputeResource, DeployManifest } from '../manifest/types.js';
-import { ComputeConfig, HostingResources } from '../types.js';
+import { HostingResources } from '../types.js';
 import { ERROR_PAGE_KEY, generateBuildId } from '../defaults.js';
 import { StorageConstruct } from './storage_construct.js';
 import { ComputeConstruct } from './compute_construct.js';
@@ -49,25 +51,51 @@ export type HostingWafConfig = {
  * Props for the AmplifyHostingConstruct.
  */
 export type AmplifyHostingConstructProps = {
+  /** Deploy manifest produced by the framework adapter. */
   manifest: DeployManifest;
+  /** Filesystem path to the static assets directory. */
   staticAssetPath: string;
+  /** Filesystem path to the compute resource directory (SSR only). */
   computeBasePath?: string;
-  domain?: HostingDomainConfig;
-  waf?: HostingWafConfig;
-  compute?: ComputeConfig;
-  retainOnDelete?: boolean;
-  accessLogging?: boolean;
-  /** Custom Content-Security-Policy header value. If not set, a restrictive default is used. */
-  contentSecurityPolicy?: string;
-  /** CloudFront price class. Default is PRICE_CLASS_100 (US, Canada, Europe). Use PRICE_CLASS_ALL for global distribution. */
-  priceClass?: PriceClass;
   /**
    * Skips region validation for WAF WebACL (must be us-east-1 for CloudFront),
    * ACM certificates (must be us-east-1 for CloudFront), and Lambda Web Adapter
    * compatibility checks. Useful for testing.
    */
   skipRegionValidation?: boolean;
-  name?: string;
+
+  /** Custom domain configuration. */
+  domain?: HostingDomainConfig;
+  /** WAF configuration. */
+  waf?: HostingWafConfig;
+  /** Compute (Lambda) configuration for SSR frameworks. */
+  compute?: {
+    memorySize?: number;
+    timeout?: Duration;
+    reservedConcurrency?: number;
+    logRetention?: RetentionDays;
+  };
+  /** CDN (CloudFront) configuration. */
+  cdn?: {
+    priceClass?: PriceClass;
+    contentSecurityPolicy?: string;
+    geoRestriction?: {
+      type: 'whitelist' | 'blacklist';
+      countries: string[];
+    };
+  };
+  /** S3 storage configuration. */
+  storage?: {
+    encryption?: 'S3_MANAGED' | 'KMS';
+    encryptionKey?: IKey;
+    retainOnDelete?: boolean;
+    buildRetentionDays?: number;
+  };
+  /** CloudFront access logging configuration. */
+  logging?: {
+    enabled: boolean;
+    retentionDays?: number;
+  };
 };
 
 // ---- Main construct ----
@@ -108,8 +136,12 @@ export class AmplifyHostingConstruct extends Construct {
 
     // ---- 1. Storage (S3 buckets) ----
     const storage = new StorageConstruct(this, 'Storage', {
-      retainOnDelete: props.retainOnDelete,
-      accessLogging: props.accessLogging,
+      retainOnDelete: props.storage?.retainOnDelete,
+      accessLogging: props.logging?.enabled,
+      encryption: props.storage?.encryption,
+      encryptionKey: props.storage?.encryptionKey,
+      buildRetentionDays: props.storage?.buildRetentionDays,
+      logRetentionDays: props.logging?.retentionDays,
     });
     this.bucket = storage.bucket;
 
@@ -146,10 +178,9 @@ export class AmplifyHostingConstruct extends Construct {
         computeResource,
         computeBasePath: props.computeBasePath,
         memorySize: compute.memorySize,
-        timeout: compute.timeout
-          ? Duration.seconds(compute.timeout)
-          : undefined,
+        timeout: compute.timeout,
         reservedConcurrency: compute.reservedConcurrency,
+        logRetention: compute.logRetention,
         skipRegionValidation: props.skipRegionValidation,
       });
 
@@ -161,7 +192,6 @@ export class AmplifyHostingConstruct extends Construct {
     const wafConstruct = new WafConstruct(this, 'Waf', {
       enabled: props.waf?.enabled ?? false,
       rateLimit: props.waf?.rateLimit,
-      metricName: props.name,
       skipRegionValidation: props.skipRegionValidation,
     });
     this.webAcl = wafConstruct.webAcl;
@@ -183,7 +213,7 @@ export class AmplifyHostingConstruct extends Construct {
     const securityHeadersPolicy = createSecurityHeadersPolicy(
       this,
       'SecurityHeaders',
-      { contentSecurityPolicy: props.contentSecurityPolicy },
+      { contentSecurityPolicy: props.cdn?.contentSecurityPolicy },
     );
 
     // ---- 6. CloudFront distribution (CDN + OAC patches) ----
@@ -200,7 +230,8 @@ export class AmplifyHostingConstruct extends Construct {
       certificate: this.certificate,
       domainName: props.domain?.domainName,
       accessLogBucket: storage.accessLogBucket,
-      priceClass: props.priceClass,
+      priceClass: props.cdn?.priceClass,
+      geoRestriction: props.cdn?.geoRestriction,
     });
 
     this.distribution = cdn.distribution;

--- a/packages/hosting/src/constructs/hosting_construct.vanilla_cdk.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.vanilla_cdk.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { App, Stack } from 'aws-cdk-lib';
+import { App, Duration, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { AmplifyHostingConstruct } from './hosting_construct.js';
 import { HostingError } from '../hosting_error.js';
@@ -101,7 +101,7 @@ void describe('Vanilla CDK project integration', () => {
     new AmplifyHostingConstruct(stack, 'MyHosting', {
       manifest: createTestSpaManifest(),
       staticAssetPath: staticDir,
-      contentSecurityPolicy: "default-src 'self'",
+      cdn: { contentSecurityPolicy: "default-src 'self'" },
       waf: { enabled: true },
     });
 
@@ -185,7 +185,7 @@ void describe('Vanilla CDK project integration', () => {
     new AmplifyHostingConstruct(stack, 'MyHosting', {
       manifest: createTestSpaManifest(),
       staticAssetPath: staticDir,
-      contentSecurityPolicy: customCsp,
+      cdn: { contentSecurityPolicy: customCsp },
     });
 
     const template = Template.fromStack(stack);
@@ -210,7 +210,7 @@ void describe('Vanilla CDK project integration', () => {
     new AmplifyHostingConstruct(stack, 'MyHosting', {
       manifest: createTestSpaManifest(),
       staticAssetPath: staticDir,
-      accessLogging: true,
+      logging: { enabled: true },
     });
 
     const template = Template.fromStack(stack);
@@ -230,7 +230,7 @@ void describe('Vanilla CDK project integration', () => {
     new AmplifyHostingConstruct(stack, 'MyHosting', {
       manifest: createTestSpaManifest(),
       staticAssetPath: staticDir,
-      retainOnDelete: true,
+      storage: { retainOnDelete: true },
     });
 
     const template = Template.fromStack(stack);
@@ -255,7 +255,7 @@ void describe('Vanilla CDK project integration', () => {
       computeBasePath: computeDir,
       compute: {
         memorySize: 2048,
-        timeout: 120,
+        timeout: Duration.seconds(120),
         reservedConcurrency: 100,
       },
     });

--- a/packages/hosting/src/constructs/storage_construct.test.ts
+++ b/packages/hosting/src/constructs/storage_construct.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { App, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Key } from 'aws-cdk-lib/aws-kms';
 import { StorageConstruct } from './storage_construct.js';
 
 // ---- Test helpers ----
@@ -221,6 +222,169 @@ void describe('StorageConstruct', () => {
         0,
         'Should not have AccessLogBucket',
       );
+    });
+  });
+
+  // ---- KMS encryption ----
+
+  void describe('encryption', () => {
+    void it('uses S3_MANAGED encryption by default', () => {
+      const stack = createStack();
+      new StorageConstruct(stack, 'Storage');
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        BucketEncryption: {
+          ServerSideEncryptionConfiguration: [
+            {
+              ServerSideEncryptionByDefault: {
+                SSEAlgorithm: 'AES256',
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    void it('uses S3_MANAGED encryption when explicitly set', () => {
+      const stack = createStack();
+      new StorageConstruct(stack, 'Storage', { encryption: 'S3_MANAGED' });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        BucketEncryption: {
+          ServerSideEncryptionConfiguration: [
+            {
+              ServerSideEncryptionByDefault: {
+                SSEAlgorithm: 'AES256',
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    void it('uses KMS encryption when encryption is KMS', () => {
+      const stack = createStack();
+      new StorageConstruct(stack, 'Storage', { encryption: 'KMS' });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        BucketEncryption: {
+          ServerSideEncryptionConfiguration: [
+            {
+              ServerSideEncryptionByDefault: {
+                SSEAlgorithm: 'aws:kms',
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    void it('uses BYO KMS key when encryptionKey is provided', () => {
+      const stack = createStack();
+      const key = new Key(stack, 'MyKey');
+      new StorageConstruct(stack, 'Storage', {
+        encryption: 'KMS',
+        encryptionKey: key,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        BucketEncryption: {
+          ServerSideEncryptionConfiguration: [
+            {
+              ServerSideEncryptionByDefault: Match.objectLike({
+                SSEAlgorithm: 'aws:kms',
+                KMSMasterKeyID: Match.anyValue(),
+              }),
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  // ---- buildRetentionDays ----
+
+  void describe('buildRetentionDays', () => {
+    void it('uses custom build retention days', () => {
+      const stack = createStack();
+      new StorageConstruct(stack, 'Storage', { buildRetentionDays: 90 });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        LifecycleConfiguration: Match.objectLike({
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              Id: 'DeleteOldBuilds',
+              Prefix: 'builds/',
+              ExpirationInDays: 90,
+              Status: 'Enabled',
+            }),
+          ]),
+        }),
+      });
+    });
+
+    void it('defaults to 365 days when not specified', () => {
+      const stack = createStack();
+      new StorageConstruct(stack, 'Storage');
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        LifecycleConfiguration: Match.objectLike({
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              Id: 'DeleteOldBuilds',
+              ExpirationInDays: 365,
+            }),
+          ]),
+        }),
+      });
+    });
+  });
+
+  // ---- logRetentionDays ----
+
+  void describe('logRetentionDays', () => {
+    void it('uses custom log retention days for access log bucket', () => {
+      const stack = createStack();
+      new StorageConstruct(stack, 'Storage', {
+        accessLogging: true,
+        logRetentionDays: 30,
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        LifecycleConfiguration: Match.objectLike({
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              Id: 'ExpireAccessLogs',
+              ExpirationInDays: 30,
+              Status: 'Enabled',
+            }),
+          ]),
+        }),
+      });
+    });
+
+    void it('defaults to 90 days for access log bucket', () => {
+      const stack = createStack();
+      new StorageConstruct(stack, 'Storage', { accessLogging: true });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        LifecycleConfiguration: Match.objectLike({
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              Id: 'ExpireAccessLogs',
+              ExpirationInDays: 90,
+            }),
+          ]),
+        }),
+      });
     });
   });
 });

--- a/packages/hosting/src/constructs/storage_construct.ts
+++ b/packages/hosting/src/constructs/storage_construct.ts
@@ -6,6 +6,7 @@ import {
   BucketEncryption,
   ObjectOwnership,
 } from 'aws-cdk-lib/aws-s3';
+import { IKey } from 'aws-cdk-lib/aws-kms';
 
 // ---- Constants ----
 
@@ -25,6 +26,14 @@ export type StorageConstructProps = {
   retainOnDelete?: boolean;
   /** Enable CloudFront access logging to a dedicated S3 bucket. Default: false. */
   accessLogging?: boolean;
+  /** Encryption type for the hosting bucket. Default: S3_MANAGED. */
+  encryption?: 'S3_MANAGED' | 'KMS';
+  /** BYO KMS key for bucket encryption (requires encryption: 'KMS'). */
+  encryptionKey?: IKey;
+  /** Days to retain build artifacts in S3. Default: 365. */
+  buildRetentionDays?: number;
+  /** Days to retain access logs. Default: 90. */
+  logRetentionDays?: number;
 };
 
 // ---- Construct ----
@@ -34,7 +43,7 @@ export type StorageConstructProps = {
  * access log bucket.
  *
  * The hosting bucket is private (BLOCK_ALL), versioned, encrypted with
- * S3-managed keys, and enforces SSL. Lifecycle rules expire old builds
+ * S3-managed keys (or KMS), and enforces SSL. Lifecycle rules expire old builds
  * and noncurrent versions automatically.
  */
 export class StorageConstruct extends Construct {
@@ -48,10 +57,18 @@ export class StorageConstruct extends Construct {
     super(scope, id);
 
     const retainOnDelete = props.retainOnDelete ?? false;
+    const buildRetentionDays =
+      props.buildRetentionDays ?? DEFAULT_BUILD_RETENTION_DAYS;
+
+    const bucketEncryption =
+      props.encryption === 'KMS'
+        ? BucketEncryption.KMS
+        : BucketEncryption.S3_MANAGED;
 
     this.bucket = new Bucket(this, 'HostingBucket', {
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
-      encryption: BucketEncryption.S3_MANAGED,
+      encryption: bucketEncryption,
+      ...(props.encryptionKey ? { encryptionKey: props.encryptionKey } : {}),
       objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
       enforceSSL: true,
       versioned: true,
@@ -63,7 +80,7 @@ export class StorageConstruct extends Construct {
         {
           id: 'DeleteOldBuilds',
           prefix: 'builds/',
-          expiration: Duration.days(DEFAULT_BUILD_RETENTION_DAYS),
+          expiration: Duration.days(buildRetentionDays),
           enabled: true,
         },
         {
@@ -75,6 +92,9 @@ export class StorageConstruct extends Construct {
     });
 
     if (props.accessLogging) {
+      const logRetentionDays =
+        props.logRetentionDays ?? DEFAULT_ACCESS_LOG_RETENTION_DAYS;
+
       /* eslint-disable spellcheck/spell-checker */
       // CloudFront standard logging requires ACL-based writes via the
       // awslogsdelivery canonical user. BUCKET_OWNER_ENFORCED disables ACLs
@@ -92,7 +112,7 @@ export class StorageConstruct extends Construct {
         lifecycleRules: [
           {
             id: 'ExpireAccessLogs',
-            expiration: Duration.days(DEFAULT_ACCESS_LOG_RETENTION_DAYS),
+            expiration: Duration.days(logRetentionDays),
             enabled: true,
           },
         ],

--- a/packages/hosting/src/factory.ts
+++ b/packages/hosting/src/factory.ts
@@ -302,8 +302,6 @@ const doBuildHostingConstruct = (
   scope: Stack,
   projectDir: string,
 ): HostingResources => {
-  const name = props.name ?? 'amplifyHosting';
-
   // Auto-detect or use explicit framework
   const framework = props.framework ?? detectFramework(projectDir);
 
@@ -350,20 +348,18 @@ const doBuildHostingConstruct = (
     domain: props.domain,
     waf: props.waf,
     compute: props.compute,
-    retainOnDelete: props.retainOnDelete,
-    accessLogging: props.accessLogging,
-    contentSecurityPolicy: props.contentSecurityPolicy,
-    priceClass: props.priceClass,
-    name,
+    cdn: props.cdn,
+    storage: props.storage,
+    logging: props.logging,
   };
 
   const hostingConstruct = new AmplifyHostingConstruct(
     scope,
-    name,
+    'amplifyHosting',
     constructProps,
   );
 
-  Tags.of(hostingConstruct).add(TagName.FRIENDLY_NAME, name);
+  Tags.of(hostingConstruct).add(TagName.FRIENDLY_NAME, 'amplifyHosting');
 
   return hostingConstruct.getResources();
 };

--- a/packages/hosting/src/index.ts
+++ b/packages/hosting/src/index.ts
@@ -1,10 +1,5 @@
 export { BackendHosting, defineHosting, HostingResult } from './factory.js';
-export {
-  ComputeConfig,
-  FrameworkType,
-  HostingProps,
-  HostingResources,
-} from './types.js';
+export { FrameworkType, HostingProps, HostingResources } from './types.js';
 export {
   DeployManifest,
   ManifestRoute,

--- a/packages/hosting/src/types.ts
+++ b/packages/hosting/src/types.ts
@@ -1,4 +1,8 @@
+import { Duration } from 'aws-cdk-lib';
 import { Distribution, PriceClass } from 'aws-cdk-lib/aws-cloudfront';
+import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { IKey } from 'aws-cdk-lib/aws-kms';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { FrameworkAdapterFn } from './adapters/index.js';
 
@@ -7,19 +11,6 @@ import { FrameworkAdapterFn } from './adapters/index.js';
  * Provides autocomplete for built-in frameworks while accepting any string.
  */
 export type FrameworkType = 'nextjs' | 'spa' | 'static' | (string & {});
-
-/**
- * Compute (Lambda) configuration for SSR frameworks.
- * Ignored for SPA and static site deployments.
- */
-export type ComputeConfig = {
-  /** Lambda memory size in MB. Default: 512 */
-  memorySize?: number;
-  /** Lambda timeout in seconds. Default: 30 */
-  timeout?: number;
-  /** Reserved concurrent executions. Default: undefined (no reservation). */
-  reservedConcurrency?: number;
-};
 
 /**
  * Configuration for defineHosting.
@@ -44,11 +35,19 @@ export type HostingProps = {
   framework?: FrameworkType;
 
   /**
+   * Custom framework adapter for unsupported frameworks.
+   * When provided, this adapter is used instead of the built-in registry lookup.
+   */
+  customAdapter?: FrameworkAdapterFn;
+
+  /**
    * Custom domain configuration.
    */
   domain?: {
     domainName: string;
     hostedZone: string;
+    /** BYO ACM certificate (must be in us-east-1 for CloudFront). */
+    certificate?: ICertificate;
   };
 
   /**
@@ -61,45 +60,58 @@ export type HostingProps = {
   };
 
   /**
-   * Custom framework adapter for unsupported frameworks.
-   * When provided, this adapter is used instead of the built-in registry lookup.
-   */
-  customAdapter?: FrameworkAdapterFn;
-
-  /**
-   * Lambda compute configuration for SSR frameworks (e.g., Next.js).
+   * Compute (Lambda) configuration for SSR frameworks.
    * Ignored for SPA and static site deployments.
    */
-  compute?: ComputeConfig;
+  compute?: {
+    /** Lambda memory size in MB. Default: 512 */
+    memorySize?: number;
+    /** Lambda timeout. Default: 30 seconds. */
+    timeout?: Duration;
+    /** Reserved concurrent executions. Default: undefined (no reservation). */
+    reservedConcurrency?: number;
+    /** CloudWatch log retention for the SSR Lambda. Default: TWO_WEEKS. */
+    logRetention?: RetentionDays;
+  };
 
   /**
-   * If true, the S3 bucket is retained on stack deletion instead of being destroyed.
-   * Default: false (bucket is destroyed with all objects on stack delete).
+   * CDN (CloudFront) configuration.
    */
-  retainOnDelete?: boolean;
+  cdn?: {
+    /** CloudFront price class. Default: PRICE_CLASS_100 (US, Canada, Europe). */
+    priceClass?: PriceClass;
+    /** Custom Content-Security-Policy header value. If not set, a restrictive default is used. */
+    contentSecurityPolicy?: string;
+    /** Geo-restriction configuration for CloudFront distribution. */
+    geoRestriction?: {
+      type: 'whitelist' | 'blacklist';
+      countries: string[];
+    };
+  };
 
   /**
-   * Enable CloudFront access logging to an S3 bucket.
-   * Default: false. Adds a dedicated log bucket when enabled.
+   * S3 storage configuration.
    */
-  accessLogging?: boolean;
+  storage?: {
+    /** Encryption type for the hosting bucket. Default: S3_MANAGED. */
+    encryption?: 'S3_MANAGED' | 'KMS';
+    /** BYO KMS key for bucket encryption (requires encryption: 'KMS'). */
+    encryptionKey?: IKey;
+    /** If true, the S3 bucket is retained on stack deletion. Default: false. */
+    retainOnDelete?: boolean;
+    /** Days to retain build artifacts in S3. Default: 365. */
+    buildRetentionDays?: number;
+  };
 
   /**
-   * Custom Content-Security-Policy header value.
-   * If not set, a restrictive default is used.
+   * CloudFront access logging configuration.
    */
-  contentSecurityPolicy?: string;
-
-  /**
-   * CloudFront price class. Default is PRICE_CLASS_100 (US, Canada, Europe).
-   * Use PRICE_CLASS_ALL for global distribution.
-   */
-  priceClass?: PriceClass;
-
-  /**
-   * Optional friendly name for the hosting resource.
-   */
-  name?: string;
+  logging?: {
+    /** Enable CloudFront access logging to a dedicated S3 bucket. */
+    enabled: boolean;
+    /** Days to retain access logs. Default: 90. */
+    retentionDays?: number;
+  };
 };
 
 /**

--- a/packages/integration-tests/src/test-projects/standalone-hosting-spa/update-v2/amplify/hosting.ts
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-spa/update-v2/amplify/hosting.ts
@@ -3,5 +3,5 @@ import { defineHosting } from '@aws-amplify/hosting';
 defineHosting({
   framework: 'spa',
   buildOutputDir: 'static-site',
-  accessLogging: true,
+  logging: { enabled: true },
 });


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-backend/actions/runs/24517335971

## Changes

- **API redesign**: Grouped props into `domain`, `waf`, `compute`, `cdn`, `storage`, `logging` namespaces
- **Remove `name` prop**: Hardcoded to `'amplifyHosting'` (was only CDK construct ID)
- **KMS encryption**: `storage.encryption` + `storage.encryptionKey` for BYO KMS key support
- **Geo-restriction**: `cdn.geoRestriction` with whitelist/blacklist country lists
- **Lifecycle durations**: `storage.buildRetentionDays` + `logging.retentionDays`
- **Lambda log retention**: `compute.logRetention`
- **BYO certificate**: `domain.certificate` in defineHosting() props
- **Breaking changes**:
  - `priceClass` → `cdn.priceClass`
  - `contentSecurityPolicy` → `cdn.contentSecurityPolicy`
  - `retainOnDelete` → `storage.retainOnDelete`
  - `accessLogging` → `logging.enabled`
  - `name` removed
  - `compute.timeout` now accepts `Duration` instead of number

## Testing
- All sub-construct tests updated with new props
- New tests for KMS encryption (S3_MANAGED, KMS, BYO key), geo-restriction (whitelist, blacklist), lifecycle durations, log retention
- Snapshot baselines regenerated
- 523 tests pass, 0 failures


```
import { defineHosting } from '@aws-amplify/hosting';
import { Duration } from 'aws-cdk-lib';
import { PriceClass } from 'aws-cdk-lib/aws-cloudfront';
import { RetentionDays } from 'aws-cdk-lib/aws-logs';

defineHosting({
  // Build configuration (flat — primary config)
  buildCommand: 'npm run build',
  buildOutputDir: '.next',
  framework: 'nextjs',            // or 'react', 'vite', 'astro', etc.
  customAdapter: myAdapterFn,     // for unsupported frameworks

  // Custom domain + TLS
  domain: {
    domainName: 'app.example.com',
    hostedZone: 'example.com',
    certificate: myAcmCert,       // BYO ACM cert (must be us-east-1)
  },

  // WAF protection
  waf: {
    enabled: true,
    rateLimit: 1000,              // requests per 5 min per IP
  },

  // Lambda compute (SSR only)
  compute: {
    memorySize: 512,
    timeout: Duration.seconds(30),
    reservedConcurrency: 10,
    logRetention: RetentionDays.ONE_MONTH,
  },

  // CloudFront CDN
  cdn: {
    priceClass: PriceClass.PRICE_CLASS_100,
    contentSecurityPolicy: "default-src 'self'",
    geoRestriction: {
      type: 'whitelist',          // or 'blacklist'
      countries: ['US', 'CA', 'GB'],
    },
  },

  // S3 storage
  storage: {
    encryption: 'KMS',            // 'S3_MANAGED' (default) or 'KMS'
    encryptionKey: myKmsKey,       // BYO KMS key (optional)
    retainOnDelete: true,
    buildRetentionDays: 365,       // lifecycle rule for build artifacts
  },

  // Access logging
  logging: {
    enabled: true,
    retentionDays: 90,            // lifecycle rule for CloudFront access logs
  },
});
```