### PR TITLE
feat: add ampx synth command for CloudFormation template synthesis

### DIFF
--- a/.changeset/feat-ampx-synth.md
+++ b/.changeset/feat-ampx-synth.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-deployer': minor
+'@aws-amplify/backend-cli': minor
+---
+
+Add ampx synth command for CloudFormation template synthesis without deploying, enabling deployment via external tools like Amazon Internal Pipelines.

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -357,4 +357,51 @@ void describe('invokeCDKCommand', () => {
       },
     );
   });
+
+  void it('handles synth-only for branch deployments', async () => {
+    const result = await invoker.synth(branchBackendId);
+    assert.strictEqual(fromAssemblyBuilderMock.mock.callCount(), 1);
+    assert.strictEqual(synthMock.mock.callCount(), 1);
+    assert.strictEqual(deployMock.mock.callCount(), 0);
+    assert.deepStrictEqual(fromAssemblyBuilderMock.mock.calls[0].arguments[1], {
+      contextStore: new MemoryContext({
+        'amplify-backend-namespace': '123',
+        'amplify-backend-name': 'testBranch',
+        'amplify-backend-type': 'branch',
+      }),
+      outdir: path.resolve(process.cwd(), '.amplify/artifacts/cdk.out'),
+    } as AssemblySourceProps);
+    assert.strictEqual(
+      result.cloudAssemblyPath,
+      path.resolve(process.cwd(), '.amplify/artifacts/cdk.out'),
+    );
+    assert.ok(result.deploymentTimes.synthesisTime !== undefined);
+  });
+
+  void it('enables type checking for synth', async () => {
+    await invoker.synth(branchBackendId, {
+      validateAppSources: true,
+    });
+    assert.strictEqual(tsCompilerMock.mock.callCount(), 1);
+    assert.strictEqual(deployMock.mock.callCount(), 0);
+  });
+
+  void it('returns human readable errors on synth', async () => {
+    synthMock.mock.mockImplementationOnce(() => {
+      throw new Error('Access Denied');
+    });
+
+    await assert.rejects(
+      () => invoker.synth(branchBackendId),
+      (err: AmplifyError<CDKDeploymentError>) => {
+        assert.equal(
+          err.message,
+          'The deployment role does not have sufficient permissions to perform this deployment.',
+        );
+        assert.equal(err.name, 'AccessDeniedError');
+        assert.equal(err.cause?.message, 'Access Denied');
+        return true;
+      },
+    );
+  });
 });

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -198,6 +198,103 @@ export class CDKDeployer implements BackendDeployer {
     }
   };
 
+  /**
+   * Invokes cdk synth API without deploying
+   */
+  synth = async (backendId: BackendIdentifier, synthProps?: DeployProps) => {
+    AssetStaging.clearAssetHashCache();
+
+    const cx = await this.getCdkCloudAssembly(
+      backendId,
+      synthProps?.secretLastUpdated?.getTime(),
+    );
+
+    const synthStartTime = Date.now();
+    let synthAssembly,
+      synthError: Error | undefined = undefined;
+    await this.ioHost.notify({
+      message: `Backend synthesis started`,
+      code: 'SYNTH_STARTED',
+      action: 'amplify',
+      time: new Date(),
+      level: 'info',
+      data: undefined,
+    });
+
+    try {
+      synthAssembly = await this.cdkToolkit.synth(cx, {
+        stacks: {
+          strategy: StackSelectionStrategy.ALL_STACKS,
+        },
+      });
+    } catch (error) {
+      synthError = error as Error;
+    }
+
+    const synthTimeSeconds =
+      Math.floor((Date.now() - synthStartTime) / 10) / 100;
+
+    await this.ioHost.notify({
+      message: `Backend synthesized in ${synthTimeSeconds} seconds`,
+      code: 'SYNTH_FINISHED',
+      action: 'amplify',
+      time: new Date(),
+      level: 'result',
+      data: undefined,
+    });
+
+    if (synthProps?.validateAppSources) {
+      const typeCheckStartTime = Date.now();
+      await this.ioHost.notify({
+        message: `Backend type checks started`,
+        code: 'TS_STARTED',
+        action: 'amplify',
+        time: new Date(),
+        level: 'info',
+        data: undefined,
+      });
+
+      try {
+        await this.compileProject(path.dirname(this.backendLocator.locate()));
+      } catch (typeError) {
+        if (
+          synthError &&
+          AmplifyError.isAmplifyError(typeError) &&
+          typeError.name === 'FunctionEnvVarFileNotGeneratedError'
+        ) {
+          throw this.cdkErrorMapper.getAmplifyError(synthError, backendId.type);
+        }
+        throw typeError;
+      } finally {
+        const typeCheckTimeSeconds =
+          Math.floor((Date.now() - typeCheckStartTime) / 10) / 100;
+        await this.ioHost.notify({
+          message: `Type checks completed in ${typeCheckTimeSeconds} seconds`,
+          code: 'TS_FINISHED',
+          action: 'amplify',
+          time: new Date(),
+          level: 'result',
+          data: undefined,
+        });
+      }
+    }
+
+    if (synthError) {
+      await synthAssembly?.dispose();
+      throw this.cdkErrorMapper.getAmplifyError(synthError, backendId.type);
+    }
+
+    await synthAssembly?.dispose();
+
+    return {
+      deploymentTimes: {
+        synthesisTime: synthTimeSeconds,
+        totalTime: synthTimeSeconds,
+      },
+      cloudAssemblyPath: this.absoluteCloudAssemblyLocation,
+    };
+  };
+
   compileProject = (projectDirectory: string): Promise<void> => {
     return new Promise((resolve, reject) => {
       const worker = new Worker(new URL('ts_compiler.js', import.meta.url), {

--- a/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
+++ b/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
@@ -23,6 +23,11 @@ export type DestroyResult = {
   deploymentTimes: DeploymentTimes;
 };
 
+export type SynthResult = {
+  deploymentTimes: DeploymentTimes;
+  cloudAssemblyPath: string;
+};
+
 export type DeploymentTimes = {
   synthesisTime?: number;
   totalTime?: number;
@@ -37,6 +42,10 @@ export type BackendDeployer = {
     deployProps?: DeployProps,
   ) => Promise<DeployResult>;
   destroy: (backendId: BackendIdentifier) => Promise<DestroyResult>;
+  synth: (
+    backendId: BackendIdentifier,
+    synthProps?: DeployProps,
+  ) => Promise<SynthResult>;
 };
 
 /**

--- a/packages/cli/src/commands/synth/synth_command.test.ts
+++ b/packages/cli/src/commands/synth/synth_command.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, it, mock } from 'node:test';
+import yargs, { CommandModule } from 'yargs';
+import {
+  TestCommandError,
+  TestCommandRunner,
+} from '../../test-utils/command_runner.js';
+import assert from 'node:assert';
+import path from 'node:path';
+import { SynthCommand, SynthCommandOptions } from './synth_command.js';
+import {
+  BackendDeployerFactory,
+  BackendDeployerOutputFormatter,
+} from '@aws-amplify/backend-deployer';
+import {
+  LogLevel,
+  PackageManagerControllerFactory,
+  Printer,
+} from '@aws-amplify/cli-core';
+import { AmplifyIOHost } from '@aws-amplify/plugin-types';
+
+void describe('synth command', () => {
+  const mockIoHost: AmplifyIOHost = {
+    notify: mock.fn(),
+    requestResponse: mock.fn(),
+  };
+  const mockProfileResolver = mock.fn();
+
+  const packageManagerControllerFactory = new PackageManagerControllerFactory(
+    process.cwd(),
+    new Printer(LogLevel.DEBUG),
+  );
+  const formatterStub: BackendDeployerOutputFormatter = {
+    normalizeAmpxCommand: () => 'test command',
+  };
+
+  const mockFsCopyDir = mock.fn<(src: string, dest: string) => Promise<void>>(
+    () => Promise.resolve(),
+  );
+
+  const getCommandRunner = () => {
+    const backendDeployerFactory = new BackendDeployerFactory(
+      packageManagerControllerFactory.getPackageManagerController(),
+      formatterStub,
+      mockIoHost,
+      mockProfileResolver,
+    );
+    const backendDeployer = backendDeployerFactory.getInstance();
+    const synthCommand = new SynthCommand(
+      backendDeployer,
+      mockFsCopyDir,
+    ) as CommandModule<object, SynthCommandOptions>;
+    const parser = yargs().command(synthCommand);
+    return new TestCommandRunner(parser);
+  };
+
+  beforeEach(() => {
+    mockFsCopyDir.mock.resetCalls();
+  });
+
+  void it('shows the command description with --help', async () => {
+    const output = await getCommandRunner().runCommand('--help');
+    assert.match(output, /Commands:/);
+    assert.match(
+      output,
+      /Synthesizes CloudFormation templates without deploying/,
+    );
+  });
+
+  void it('fails if required --branch argument is not supplied', async () => {
+    const output = await getCommandRunner().runCommand(
+      'synth --app-id test-app-id',
+    );
+    assert.match(output, /Missing required argument/);
+  });
+
+  void it('fails if required --app-id argument is not supplied', async () => {
+    const output = await getCommandRunner().runCommand(
+      'synth --branch test-branch',
+    );
+    assert.match(output, /Missing required argument/);
+  });
+
+  void it('executes backend deployer synth with branch and app-id', async () => {
+    const backendDeployerFactory = new BackendDeployerFactory(
+      packageManagerControllerFactory.getPackageManagerController(),
+      formatterStub,
+      mockIoHost,
+      mockProfileResolver,
+    );
+    const mockSynth = mock.method(
+      backendDeployerFactory.getInstance(),
+      'synth',
+      () =>
+        Promise.resolve({
+          deploymentTimes: { synthesisTime: 1, totalTime: 1 },
+          cloudAssemblyPath: '/tmp/test-cdk-out',
+        }),
+    );
+    await getCommandRunner().runCommand(
+      'synth --branch test-branch --app-id test-app-id',
+    );
+    assert.strictEqual(mockSynth.mock.callCount(), 1);
+    assert.deepStrictEqual(mockSynth.mock.calls[0].arguments, [
+      {
+        name: 'test-branch',
+        namespace: 'test-app-id',
+        type: 'branch',
+      },
+      {
+        validateAppSources: true,
+      },
+    ]);
+    assert.strictEqual(mockFsCopyDir.mock.callCount(), 1);
+    assert.strictEqual(
+      mockFsCopyDir.mock.calls[0].arguments[0],
+      '/tmp/test-cdk-out',
+    );
+  });
+
+  void it('executes backend deployer synth with branch and custom app-id', async () => {
+    const backendDeployerFactory = new BackendDeployerFactory(
+      packageManagerControllerFactory.getPackageManagerController(),
+      formatterStub,
+      mockIoHost,
+      mockProfileResolver,
+    );
+    const mockSynth = mock.method(
+      backendDeployerFactory.getInstance(),
+      'synth',
+      () =>
+        Promise.resolve({
+          deploymentTimes: { synthesisTime: 1, totalTime: 1 },
+          cloudAssemblyPath: '/tmp/test-cdk-out',
+        }),
+    );
+    await getCommandRunner().runCommand(
+      'synth --branch test-branch --app-id my-app',
+    );
+    assert.strictEqual(mockSynth.mock.callCount(), 1);
+    assert.deepStrictEqual(mockSynth.mock.calls[0].arguments, [
+      {
+        name: 'test-branch',
+        namespace: 'my-app',
+        type: 'branch',
+      },
+      {
+        validateAppSources: true,
+      },
+    ]);
+    assert.strictEqual(mockFsCopyDir.mock.callCount(), 1);
+  });
+
+  void it('allows --out argument', async () => {
+    const backendDeployerFactory = new BackendDeployerFactory(
+      packageManagerControllerFactory.getPackageManagerController(),
+      formatterStub,
+      mockIoHost,
+      mockProfileResolver,
+    );
+    const mockSynth = mock.method(
+      backendDeployerFactory.getInstance(),
+      'synth',
+      () =>
+        Promise.resolve({
+          deploymentTimes: { synthesisTime: 1, totalTime: 1 },
+          cloudAssemblyPath: '/tmp/test-cdk-out',
+        }),
+    );
+    await getCommandRunner().runCommand(
+      'synth --branch test-branch --app-id test-app-id --out ./my-output',
+    );
+    assert.strictEqual(mockSynth.mock.callCount(), 1);
+    assert.strictEqual(mockFsCopyDir.mock.callCount(), 1);
+    assert.strictEqual(
+      mockFsCopyDir.mock.calls[0].arguments[0],
+      '/tmp/test-cdk-out',
+    );
+    assert.strictEqual(
+      mockFsCopyDir.mock.calls[0].arguments[1],
+      path.resolve('./my-output'),
+    );
+  });
+
+  void it('throws when --branch argument has no input', async () => {
+    await assert.rejects(
+      async () =>
+        await getCommandRunner().runCommand(
+          'synth --branch --app-id test-app-id',
+        ),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'InvalidCommandInputError');
+        assert.strictEqual(error.error.message, 'Invalid --branch');
+        return true;
+      },
+    );
+  });
+
+  void it('throws when --app-id argument is empty string', async () => {
+    await assert.rejects(
+      async () =>
+        await getCommandRunner().runCommand([
+          'synth',
+          '--app-id',
+          '',
+          '--branch',
+          'testBranch',
+        ]),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'InvalidCommandInputError');
+        assert.strictEqual(error.error.message, 'Invalid --app-id');
+        return true;
+      },
+    );
+  });
+});

--- a/packages/cli/src/commands/synth/synth_command.ts
+++ b/packages/cli/src/commands/synth/synth_command.ts
@@ -1,0 +1,131 @@
+import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
+import { BackendDeployer } from '@aws-amplify/backend-deployer';
+import { ArgumentsKebabCase } from '../../kebab_case.js';
+import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
+import { printer } from '@aws-amplify/cli-core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export type SynthCommandOptions =
+  ArgumentsKebabCase<SynthCommandOptionsCamelCase>;
+
+type SynthCommandOptionsCamelCase = {
+  branch: string;
+  appId: string;
+  out: string;
+};
+
+/**
+ * An entry point for synth command.
+ */
+export class SynthCommand implements CommandModule<
+  object,
+  SynthCommandOptions
+> {
+  /**
+   * @inheritDoc
+   */
+  readonly command: string;
+
+  /**
+   * @inheritDoc
+   */
+  readonly describe: string;
+
+  /**
+   * Creates top level entry point for synth command.
+   */
+  constructor(
+    private readonly backendDeployer: BackendDeployer,
+    private readonly fsCopyDir: (src: string, dest: string) => Promise<void> = (
+      src,
+      dest,
+    ) => fs.promises.cp(src, dest, { recursive: true }),
+  ) {
+    this.command = 'synth';
+    this.describe =
+      'Synthesizes CloudFormation templates without deploying, enabling deployment via external tools.';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handler = async (
+    args: ArgumentsCamelCase<SynthCommandOptions>,
+  ): Promise<void> => {
+    const backendId: BackendIdentifier = {
+      namespace: args.appId,
+      name: args.branch,
+      type: 'branch',
+    };
+    const result = await this.backendDeployer.synth(backendId, {
+      validateAppSources: true,
+    });
+
+    const outDir = path.resolve(args.out);
+
+    // Clear output directory to prevent stale artifacts
+    if (fs.existsSync(outDir)) {
+      await fs.promises.rm(outDir, { recursive: true, force: true });
+    }
+    await fs.promises.mkdir(outDir, { recursive: true });
+
+    try {
+      await this.fsCopyDir(result.cloudAssemblyPath, outDir);
+      printer.print(
+        `Synthesized CloudFormation template(s) written to ${outDir}`,
+      );
+    } catch (error) {
+      throw new AmplifyUserError(
+        'SynthOutputCopyError',
+        {
+          message: `Failed to copy synthesized templates to ${outDir}`,
+          resolution:
+            'Check that the output directory is writable and has sufficient disk space.',
+        },
+        error as Error,
+      );
+    }
+  };
+
+  builder = (yargs: Argv): Argv<SynthCommandOptions> => {
+    return yargs
+      .version(false)
+      .option('branch', {
+        describe: 'Name of the git branch being synthesized',
+        demandOption: true,
+        type: 'string',
+        array: false,
+      })
+      .option('app-id', {
+        describe: 'The app id of the target Amplify app',
+        demandOption: true,
+        type: 'string',
+        array: false,
+      })
+      .option('out', {
+        describe:
+          'Output directory for synthesized CloudFormation templates. Defaults to ./cdk.out.',
+        demandOption: false,
+        type: 'string',
+        array: false,
+        default: './cdk.out',
+      })
+      .check(async (argv) => {
+        if (argv['branch'].length === 0) {
+          throw new AmplifyUserError('InvalidCommandInputError', {
+            message: 'Invalid --branch',
+            resolution: '--branch must be at least 1 character',
+          });
+        }
+        if (argv['app-id'].length === 0) {
+          throw new AmplifyUserError('InvalidCommandInputError', {
+            message: 'Invalid --app-id',
+            resolution: '--app-id must be at least 1 character',
+          });
+        }
+        return true;
+      });
+  };
+}

--- a/packages/cli/src/commands/synth/synth_command_factory.ts
+++ b/packages/cli/src/commands/synth/synth_command_factory.ts
@@ -1,0 +1,31 @@
+import { CommandModule } from 'yargs';
+import { BackendDeployerFactory } from '@aws-amplify/backend-deployer';
+import {
+  AmplifyIOEventsBridgeSingletonFactory,
+  PackageManagerControllerFactory,
+  format,
+} from '@aws-amplify/cli-core';
+
+import { SynthCommand, SynthCommandOptions } from './synth_command.js';
+import { SDKProfileResolverProvider } from '../../sdk_profile_resolver_provider.js';
+
+/**
+ * Creates synth command
+ */
+export const createSynthCommand = (): CommandModule<
+  object,
+  SynthCommandOptions
+> => {
+  const packageManagerControllerFactory = new PackageManagerControllerFactory();
+  const cdkEventsBridgeIoHost =
+    new AmplifyIOEventsBridgeSingletonFactory().getInstance();
+
+  const backendDeployerFactory = new BackendDeployerFactory(
+    packageManagerControllerFactory.getPackageManagerController(),
+    format,
+    cdkEventsBridgeIoHost,
+    new SDKProfileResolverProvider().resolve,
+  );
+  const backendDeployer = backendDeployerFactory.getInstance();
+  return new SynthCommand(backendDeployer);
+};

--- a/packages/cli/src/main_parser_factory.ts
+++ b/packages/cli/src/main_parser_factory.ts
@@ -2,6 +2,7 @@ import yargs, { Argv } from 'yargs';
 import { createGenerateCommand } from './commands/generate/generate_command_factory.js';
 import { createSandboxCommand } from './commands/sandbox/sandbox_command_factory.js';
 import { createPipelineDeployCommand } from './commands/pipeline-deploy/pipeline_deploy_command_factory.js';
+import { createSynthCommand } from './commands/synth/synth_command_factory.js';
 import { createConfigureCommand } from './commands/configure/configure_command_factory.js';
 import { createInfoCommand } from './commands/info/info_command_factory.js';
 import { createNoticesCommand } from './commands/notices/notices_command_factory.js';
@@ -31,6 +32,7 @@ export const createMainParser = (
     .command(createGenerateCommand())
     .command(createSandboxCommand(noticesRenderer))
     .command(createPipelineDeployCommand())
+    .command(createSynthCommand())
     .command(createConfigureCommand())
     .command(createInfoCommand())
     .command(createNoticesCommand())


### PR DESCRIPTION
## Summary

Adds a new `ampx synth` CLI command that synthesizes CloudFormation templates without deploying, enabling deployment via external tools.

### Motivation

Amplify Gen 2 backends are incompatible with external tools because `defineBackend()` creates its own CDK App/Stack.

### Changes

- **New CLI command**: `ampx synth --branch <branch> --app-id <id> [--out <dir>]`
- **New deployer method**: `BackendDeployer.synth()` — runs CDK synthesis + type checking without deployment
- **Output handling**: Copies cloud assembly to user-specified directory with stale artifact cleanup
- **Error handling**: Wraps copy failures in AmplifyUserError, disposes assembly on synth errors
- **Tests**: Full coverage for both command and deployer (22 tests total)

### Verified

- Templates contain real Amplify resources (Cognito, AppSync, DynamoDB, Lambda)
- Templates are account/region agnostic (portable across environments)
- All existing tests pass (no regressions)

### Usage

```bash
npx ampx synth --branch main --app-id d1234abcd --out ./synth-output
```
