### PR TITLE
Feat/resolver partitioning

### DIFF
--- a/.changeset/feat-custom-resolver-partitioning.md
+++ b/.changeset/feat-custom-resolver-partitioning.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': minor
+---
+
+Add support for partitioning custom JS resolvers into dedicated nested stacks using the `customResolverStackMap` property in `defineData`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34719,6 +34719,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -37806,6 +37807,7 @@
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
       "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -38578,6 +38580,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -39676,6 +39679,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
       "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -40679,6 +40683,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -40691,6 +40696,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -45192,6 +45198,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -45718,6 +45725,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/packages/backend-data/src/convert_js_resolvers.ts
+++ b/packages/backend-data/src/convert_js_resolvers.ts
@@ -1,7 +1,9 @@
 import { Construct } from 'constructs';
 import { AmplifyData } from '@aws-amplify/data-construct';
+import { NestedStack } from 'aws-cdk-lib';
 import { CfnFunctionConfiguration, CfnResolver } from 'aws-cdk-lib/aws-appsync';
 import { JsResolver } from '@aws-amplify/data-schema-types';
+import { CustomResolverStackMap } from './types.js';
 import { resolve } from 'path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'fs';
@@ -42,6 +44,18 @@ export const defaultJsResolverCode = (
 };
 
 /**
+ * Resolves the nested stack ID by appending the capitalized target stack name to the base name.
+ */
+export const resolveNestedStackId = (
+  baseName: string,
+  targetStackName: string,
+): string => {
+  const capitalizedStackName =
+    targetStackName.charAt(0).toUpperCase() + targetStackName.slice(1);
+  return `${baseName}Custom${capitalizedStackName}`;
+};
+
+/**
  * Converts JS Resolver definition emitted by data-schema into AppSync pipeline
  * resolvers via L1 construct
  */
@@ -49,21 +63,40 @@ export const convertJsResolverDefinition = (
   scope: Construct,
   amplifyApi: AmplifyData,
   jsResolvers: JsResolver[] | undefined,
+  customResolverStackMap?: CustomResolverStackMap,
 ): void => {
   if (!jsResolvers || jsResolvers.length < 1) {
     return;
   }
 
+  const nestedStacks: Record<string, NestedStack> = {};
+
   for (const resolver of jsResolvers) {
+    const resolverMapKey =
+      `${resolver.typeName}.${resolver.fieldName}` as const;
+    const targetStackName = customResolverStackMap?.[resolverMapKey];
+    let targetScope = scope;
+
+    if (targetStackName && targetStackName !== 'data') {
+      const nestedStackId = resolveNestedStackId(
+        amplifyApi.node.id,
+        targetStackName,
+      );
+      if (!nestedStacks[nestedStackId]) {
+        nestedStacks[nestedStackId] = new NestedStack(scope, nestedStackId);
+      }
+      targetScope = nestedStacks[nestedStackId];
+    }
+
     const functions: string[] = resolver.handlers.map((handler, idx) => {
       const fnName = `Fn_${resolver.typeName}_${resolver.fieldName}_${idx + 1}`;
       const s3AssetName = `${fnName}_asset`;
 
-      const asset = new Asset(scope, s3AssetName, {
+      const asset = new Asset(targetScope, s3AssetName, {
         path: resolveEntryPath(handler.entry),
       });
 
-      const fn = new CfnFunctionConfiguration(scope, fnName, {
+      const fn = new CfnFunctionConfiguration(targetScope, fnName, {
         apiId: amplifyApi.apiId,
         dataSourceName: handler.dataSource,
         name: fnName,
@@ -84,7 +117,7 @@ export const convertJsResolverDefinition = (
     const amplifyApiEnvironmentName = isSandboxDeployment
       ? 'NONE'
       : scope.node.tryGetContext(CDKContextKey.BACKEND_NAME);
-    new CfnResolver(scope, resolverName, {
+    new CfnResolver(targetScope, resolverName, {
       apiId: amplifyApi.apiId,
       fieldName: resolver.fieldName,
       typeName: resolver.typeName,

--- a/packages/backend-data/src/convert_js_resolvers_partitioning.test.ts
+++ b/packages/backend-data/src/convert_js_resolvers_partitioning.test.ts
@@ -1,0 +1,143 @@
+import { Template } from 'aws-cdk-lib/assertions';
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+import { App, Duration, NestedStack, Stack } from 'aws-cdk-lib';
+import {
+  AmplifyData,
+  AmplifyDataDefinition,
+} from '@aws-amplify/data-construct';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+import {
+  convertJsResolverDefinition,
+  resolveNestedStackId,
+} from './convert_js_resolvers.js';
+import { a } from '@aws-amplify/data-schema';
+
+const testSchema = /* GraphQL */ `
+  type Todo @model {
+    id: ID!
+  }
+`;
+
+void describe('resolveNestedStackId', () => {
+  void it('capitalizes the first character of targetStackName', () => {
+    const result = resolveNestedStackId('amplifyData', 'orders');
+    assert.strictEqual(result, 'amplifyDataCustomOrders');
+  });
+
+  void it('works correctly when targetStackName is already capitalized', () => {
+    const result = resolveNestedStackId('amplifyData', 'Orders');
+    assert.strictEqual(result, 'amplifyDataCustomOrders');
+  });
+
+  void it('works with a single character targetStackName', () => {
+    const result = resolveNestedStackId('amplifyData', 'a');
+    assert.strictEqual(result, 'amplifyDataCustomA');
+  });
+
+  void it('works with numbers and special characters in targetStackName', () => {
+    const result = resolveNestedStackId('amplifyData', 'stack1_new');
+    assert.strictEqual(result, 'amplifyDataCustomStack1_new');
+  });
+
+  void it('handles empty baseName', () => {
+    const result = resolveNestedStackId('', 'orders');
+    assert.strictEqual(result, 'CustomOrders');
+  });
+});
+
+const createStackAndSetContext = (backendType: 'sandbox' | 'branch'): Stack => {
+  const app = new App();
+  app.node.setContext('amplify-backend-name', 'testEnvName');
+  app.node.setContext('amplify-backend-namespace', 'testBackendId');
+  app.node.setContext('amplify-backend-type', backendType);
+  const stack = new Stack(app);
+  return stack;
+};
+
+void describe('convertJsResolverDefinition - partitioning', () => {
+  let stack: Stack;
+  let amplifyApi: AmplifyData;
+  const authorizationModes = { apiKeyConfig: { expires: Duration.days(7) } };
+
+  void beforeEach(() => {
+    stack = createStackAndSetContext('branch');
+    amplifyApi = new AmplifyData(stack, 'amplifyData', {
+      apiName: 'amplifyData',
+      definition: AmplifyDataDefinition.fromString(testSchema),
+      authorizationModes,
+    });
+  });
+
+  void it('partitions resolvers into nested stacks based on customResolverStackMap', () => {
+    const absolutePath = resolve(
+      fileURLToPath(import.meta.url),
+      '../../lib/assets',
+      'js_resolver_handler.js',
+    );
+
+    const schema = a.schema({
+      queryOne: a
+        .query()
+        .authorization((allow) => allow.publicApiKey())
+        .returns(a.string())
+        .handler(
+          a.handler.custom({
+            entry: absolutePath,
+          }),
+        ),
+      queryTwo: a
+        .query()
+        .authorization((allow) => allow.publicApiKey())
+        .returns(a.string())
+        .handler(
+          a.handler.custom({
+            entry: absolutePath,
+          }),
+        ),
+    });
+
+    const { jsFunctions } = schema.transform();
+
+    // Assign queryTwo to 'orders' stack
+    const customResolverStackMap = {
+      'Query.queryTwo': 'orders',
+    } as const;
+
+    convertJsResolverDefinition(
+      stack,
+      amplifyApi,
+      jsFunctions,
+      customResolverStackMap,
+    );
+
+    // Verify main stack
+    const mainTemplate = Template.fromStack(stack);
+    mainTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'queryOne',
+      TypeName: 'Query',
+    });
+
+    // Verify queryTwo is NOT in the main stack
+    mainTemplate.resourceCountIs('AWS::AppSync::Resolver', 1);
+
+    // Verify nested stack existence
+    const nestedStackId = resolveNestedStackId(amplifyApi.node.id, 'orders');
+    const nestedStack = stack.node.findChild(nestedStackId) as NestedStack;
+
+    // Verify queryTwo is in the nested stack
+    const nestedTemplate = Template.fromStack(nestedStack);
+    nestedTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'queryTwo',
+      TypeName: 'Query',
+    });
+
+    nestedTemplate.hasResourceProperties(
+      'AWS::AppSync::FunctionConfiguration',
+      {
+        Name: 'Fn_Query_queryTwo_1',
+      },
+    );
+  });
+});

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -345,7 +345,12 @@ class DataGenerator implements ConstructContainerEntryGenerator {
       Aspects.of(amplifyApi).add(new ReplaceTableUponGsiUpdateOverrideAspect());
     }
 
-    convertJsResolverDefinition(scope, amplifyApi, schemasJsFunctions);
+    convertJsResolverDefinition(
+      scope,
+      amplifyApi,
+      schemasJsFunctions,
+      this.props.customResolverStackMap,
+    );
 
     const namePrefix = this.name === defaultName ? '' : defaultName;
 

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -122,6 +122,16 @@ export type DataSchemaInput =
 export type DataSchema = string | DerivedModelSchema;
 
 /**
+ * A map of resolver names to stack names.
+ * Keys must be in the format `TypeName.FieldName` (e.g., `Mutation.createUser`).
+ * Values are the names of the nested stacks where the resolvers should be placed.
+ */
+export type CustomResolverStackMap = Record<
+  `${'Mutation' | 'Query' | 'Subscription'}.${string}`,
+  string
+>;
+
+/**
  * Exposed props for Data which are configurable by the end user.
  */
 export type DataProps = {
@@ -155,6 +165,24 @@ export type DataProps = {
    * Each element in the array represents a mapping for a specific branch.
    */
   migratedAmplifyGen1DynamoDbTableMappings?: AmplifyGen1DynamoDbTableMapping[];
+
+  /**
+   * Optional mapping of custom resolver names to nested stack names.
+   * This allows you to split JS resolvers into multiple CloudFormation stacks to avoid template size limits.
+   * Resolvers not specified in this map will be placed in the main Data stack by default.
+   * @example
+   * ```typescript
+   * customResolverStackMap: {
+   *   'Mutation.createUser': 'auth',
+   *   'Mutation.deleteCompany': 'core',
+   *   'Mutation.updateCompany': 'core',
+   *   'Query.getCompany': 'core',
+   * }
+   * ```
+   * Each nested stack will be named by appending 'Custom' and the capitalized stack name to the Data construct ID
+   * (e.g., `amplifyDataCustomAuth`, `amplifyDataCustomCore`).
+   */
+  customResolverStackMap?: CustomResolverStackMap;
 };
 
 export type AmplifyDataError =


### PR DESCRIPTION
<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

Amplify Data projects with a large number of custom JavaScript resolvers can exceed the 1MB CloudFormation template size limit. Currently, all custom JS resolvers are placed within the main Data stack, which contributes directly to this limit and restricts the scalability of complex backends.

**Issue number, if available: Closes #3066**

## Changes

This PR introduces the ability to programmatically partition custom JavaScript resolvers into dedicated nested stacks, allowing developers to bypass CloudFormation template size constraints.

Key changes:

- **Added `customResolverStackMap`** to `DataProps`: A new optional property in `defineData` that allows mapping `TypeName.FieldName` to a specific stack identifier.
- **Nested Stack Resolution**: Implemented logic in the backend data factory to intercept JS resolver definitions and delegate them to the specified nested stacks.
- **Automated Naming Convention**: Nested stacks are automatically named using the pattern `amplifyDataCustom<StackName>` to avoid collisions with internal Amplify model-driven stacks.
- **Default Behavior**: Resolvers not specified in the map continue to be placed in the main Data stack by default, ensuring full backward compatibility.

**Corresponding docs PR, if applicable:**

## Validation

The changes have been validated through new unit tests and verification of the existing suite:

- **New Test Suite**: Added `packages/backend-data/src/convert_js_resolvers_partitioning.test.ts` which verifies:
  - Correct capitalization and ID generation for nested stacks.
  - Successful routing of resolvers to targeted nested stacks.
  - Isolation of resolvers (verifying they are moved out of the main stack).
- **Regression Testing*: Ran the full test suite for `packages/backend-data` (`npm run test:dir packages/backend-data)` to ensure no impact on existing resolver conversion or data factory logic.

## Example
```typescript
export const data = defineData({
  schema,
  name: 'customName',
  authorizationModes: {
    defaultAuthorizationMode: 'userPool',
    apiKeyAuthorizationMode: { expiresInDays: 30 },
  },
  customResolverStackMap: {
    // --- Auth Domain ---
    'Mutation.acceptInvitation': 'auth',
    'Mutation.createInvitations': 'auth',
    'Mutation.declineInvitation': 'auth',
    'Mutation.deleteInvitations': 'auth',
})
```
The optimal way should be adding a custom method to the  `a ` helper funciton. Something like:
```typescript
acceptInvitation: a
    .mutation()
    .arguments({
      email: a.email().required(),
      createdBy: a.string().required(),
      createdAt: a.datetime().required(),
      message: a.string(),
    })
    .handler([
      a.handler.custom({
        entry: './0.authorize.handler.js',
        dataSource: a.ref('Auth'),
      }),
      a.handler.custom({
        dataSource: a.ref('Auth'),
        entry: './1.save.handler.js',
      }),
      a.handler.custom({
        dataSource: 'EventBus',
        entry: './2.publish.handler.js',
      }),
    ])
    .stack('auth')
    .authorization(allow => [
      allow.group('superuser'),
    ])
    .returns(a.ref('InvitationResource').required()),
```

However this is not currently possible because it impacts another module. If you could implement that (or I can also submit another PR for that module), it will be easy to adapt this PR to work with new property stack of the *customJsResolver*.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
