### PR TITLE
refactor(storage): export bucketSchema and remove inline type duplication

### DIFF
--- a/.changeset/export-bucket-schema.md
+++ b/.changeset/export-bucket-schema.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/backend-output-schemas': patch
+'@aws-amplify/client-config': patch
+---
+
+Export bucketSchema and BucketOutput type from storage output schemas. Remove inline type duplication in client config contributor.

--- a/packages/backend-output-schemas/src/storage/index.ts
+++ b/packages/backend-output-schemas/src/storage/index.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { storageOutputSchema as storageOutputSchemaV1 } from './v1.js';
 
+export { bucketSchema, type BucketOutput } from './v1.js';
+
 export const versionedStorageOutputSchema = z.discriminatedUnion('version', [
   storageOutputSchemaV1,
   // this is where additional storage major version schemas would go

--- a/packages/backend-output-schemas/src/storage/v1.ts
+++ b/packages/backend-output-schemas/src/storage/v1.ts
@@ -20,12 +20,14 @@ const pathSchema = z.record(
   ),
 );
 
-const bucketSchema = z.object({
+export const bucketSchema = z.object({
   name: z.string(),
   bucketName: z.string(),
   storageRegion: z.string(),
   paths: pathSchema.optional(),
 });
+
+export type BucketOutput = z.infer<typeof bucketSchema>;
 
 export const storageOutputSchema = z.object({
   version: z.literal('1'),

--- a/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
+++ b/packages/client-config/src/client-config-contributor/client_config_contributor_v1.ts
@@ -1,5 +1,6 @@
 import { ClientConfigContributor } from '../client-config-types/client_config_contributor.js';
 import {
+  type BucketOutput,
   UnifiedBackendOutput,
   authOutputKey,
   customOutputKey,
@@ -17,7 +18,6 @@ import {
 } from '../client-config-types/client_config.js';
 import { ModelIntrospectionSchemaAdapter } from '../model_introspection_schema_adapter.js';
 import { AwsAppsyncAuthorizationType } from '../client-config-schema/client_config_v1.1.js';
-import { AmplifyStorageAccessRule } from '../client-config-schema/client_config_v1.2.js';
 
 // All categories client config contributors are included here to mildly enforce them using
 // the same schema (version and other types)
@@ -673,32 +673,18 @@ export class StorageClientConfigContributor implements ClientConfigContributor {
       return {};
     }
     const config: Partial<clientConfigTypesV1_2.AWSAmplifyBackendOutputs> = {};
-    const bucketsStringArray = JSON.parse(
+    const buckets: BucketOutput[] = JSON.parse(
       storageOutput.payload.buckets ?? '[]',
-    );
+    ).map((b: string) => JSON.parse(b));
     config.storage = {
       aws_region: storageOutput.payload.storageRegion,
       bucket_name: storageOutput.payload.bucketName,
-      buckets: bucketsStringArray
-        .map((b: string) => JSON.parse(b))
-        .map(
-          ({
-            name,
-            bucketName,
-            storageRegion,
-            paths,
-          }: {
-            name: string;
-            bucketName: string;
-            storageRegion: string;
-            paths: Record<string, AmplifyStorageAccessRule>;
-          }) => ({
-            name,
-            bucket_name: bucketName,
-            aws_region: storageRegion,
-            paths,
-          }),
-        ),
+      buckets: buckets.map(({ name, bucketName, storageRegion, paths }) => ({
+        name,
+        bucket_name: bucketName,
+        aws_region: storageRegion,
+        paths,
+      })),
     };
 
     return config;
@@ -720,29 +706,17 @@ export class StorageClientConfigContributorV1_1 implements ClientConfigContribut
       return {};
     }
     const config: Partial<clientConfigTypesV1_1.AWSAmplifyBackendOutputs> = {};
-    const bucketsStringArray = JSON.parse(
+    const buckets: BucketOutput[] = JSON.parse(
       storageOutput.payload.buckets ?? '[]',
-    );
+    ).map((b: string) => JSON.parse(b));
     config.storage = {
       aws_region: storageOutput.payload.storageRegion,
       bucket_name: storageOutput.payload.bucketName,
-      buckets: bucketsStringArray
-        .map((b: string) => JSON.parse(b))
-        .map(
-          ({
-            name,
-            bucketName,
-            storageRegion,
-          }: {
-            name: string;
-            bucketName: string;
-            storageRegion: string;
-          }) => ({
-            name,
-            bucket_name: bucketName,
-            aws_region: storageRegion,
-          }),
-        ),
+      buckets: buckets.map(({ name, bucketName, storageRegion }) => ({
+        name,
+        bucket_name: bucketName,
+        aws_region: storageRegion,
+      })),
     };
 
     return config;


### PR DESCRIPTION
## Summary

- Export `bucketSchema` and `BucketOutput` type from `@aws-amplify/backend-output-schemas` so consumers can reference the canonical bucket type
- Remove inline type duplication in `client_config_contributor_v1.ts` by using the exported `BucketOutput` type directly

The bucket type was previously defined only internally in `storage/v1.ts` and duplicated as inline type annotations in two places in the client config contributor.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._