### PR TITLE
fix(sandbox): add debounce delay to prevent MultipleSandboxInstancesError

### DIFF
--- a/.changeset/sandbox-debounce-ms.md
+++ b/.changeset/sandbox-debounce-ms.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/sandbox': patch
+'@aws-amplify/backend-cli': patch
+---
+
+Add 300ms default debounce to sandbox file watcher and expose --debounce-ms CLI option to prevent MultipleSandboxInstancesError on rapid file changes

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -27,6 +27,7 @@ export type SandboxCommandOptionsKebabCase = ArgumentsKebabCase<
   {
     dirToWatch: string | undefined;
     exclude: string[] | undefined;
+    debounceMs: number | undefined;
     outputsFormat: ClientConfigFormat | undefined;
     outputsOutDir: string | undefined;
     outputsVersion: string;
@@ -155,6 +156,7 @@ export class SandboxCommand implements CommandModule<
       exclude: watchExclusions,
       identifier: args.identifier,
       watchForChanges: !args.once,
+      debounceMs: args.debounceMs,
       functionStreamingOptions,
     });
     process.once('SIGINT', () => void this.sigIntHandler());
@@ -182,6 +184,14 @@ export class SandboxCommand implements CommandModule<
           type: 'string',
           array: true,
           global: false,
+        })
+        .option('debounce-ms', {
+          describe:
+            'Delay in milliseconds to wait after a file change before triggering a deployment. Increase this value when using AI coding tools or format-on-save to batch rapid file changes into a single deployment.',
+          type: 'number',
+          array: false,
+          global: false,
+          default: 300,
         })
         .option('identifier', {
           describe:

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -613,12 +613,15 @@ void describe('Sandbox using local project name resolver', () => {
   });
 
   void it('queues deployment if a file change is detected during an ongoing deployment', async () => {
-    ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
-      executor: sandboxExecutor,
-      ssmClient: ssmClientMock,
-      functionsLogStreamer:
-        functionsLogStreamerMock as unknown as LambdaFunctionLogStreamer,
-    }));
+    ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
+      {
+        executor: sandboxExecutor,
+        ssmClient: ssmClientMock,
+        functionsLogStreamer:
+          functionsLogStreamerMock as unknown as LambdaFunctionLogStreamer,
+      },
+      { debounceMs: 0 },
+    ));
     // Mimic BackendDeployer taking 200 ms.
     backendDeployerDeployMock.mock.mockImplementationOnce(async () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
@@ -678,12 +681,15 @@ void describe('Sandbox using local project name resolver', () => {
   });
 
   void it('handles error thrown by BackendDeployer and does not crash while deploying', async (contextual) => {
-    ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox({
-      executor: sandboxExecutor,
-      ssmClient: ssmClientMock,
-      functionsLogStreamer:
-        functionsLogStreamerMock as unknown as LambdaFunctionLogStreamer,
-    }));
+    ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
+      {
+        executor: sandboxExecutor,
+        ssmClient: ssmClientMock,
+        functionsLogStreamer:
+          functionsLogStreamerMock as unknown as LambdaFunctionLogStreamer,
+      },
+      { debounceMs: 0 },
+    ));
     const mockEmit = mock.fn();
     contextual.mock.method(sandboxInstance, 'emit', mockEmit);
     const contextualBackendDeployerMock = contextual.mock.method(

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -179,6 +179,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
     // --------  'cdk deploy' done  --------------  'cdk deploy' done  --------------
 
     let latch: 'open' | 'deploying' | 'queued' = 'open';
+    const debounceMs = options.debounceMs ?? 300;
 
     const deployAndWatch = debounce(async () => {
       latch = 'deploying';
@@ -209,7 +210,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
         await this.backendIdSandboxResolver(options.identifier),
         options.functionStreamingOptions,
       );
-    });
+    }, debounceMs);
 
     if (watchForChanges) {
       this.watcherSubscription = await this.subscribe(

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -36,6 +36,7 @@ export type SandboxOptions = {
   identifier?: string;
   format?: ClientConfigFormat;
   watchForChanges?: boolean;
+  debounceMs?: number;
   functionStreamingOptions?: SandboxFunctionStreamingOptions;
 };
 


### PR DESCRIPTION
## Summary

- Set default debounce delay to 300ms for the sandbox file watcher (previously 0ms)
- Add `--debounce-ms` CLI option to allow customization
- Add `debounceMs` to `SandboxOptions` type

### Problem

When VS Code format-on-save or AI coding tools trigger rapid consecutive file writes, the sandbox detects multiple file change events before the first deployment finishes. With 0ms debounce, both events invoke `deployAndWatch()` simultaneously, racing for the CDK lock file and crashing with:

```
[ERROR] [MultipleSandboxInstancesError] Multiple sandbox instances detected.
  ∟ Caused by: Other CLIs (PID=53816) are currently reading from .amplify/artifacts/cdk.out.
```

### Solution

A 300ms debounce batches rapid file changes into a single deployment trigger. Users who need longer delays (e.g., AI agents writing many files over several seconds) can specify:

```
npx ampx sandbox --debounce-ms 2000
```

**Issue number:** https://github.com/aws-amplify/amplify-backend/issues/2856

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._