### PR TITLE
feat(auth): add managedLogin option to externalProviders

### DIFF
--- a/.changeset/cognito-managed-login.md
+++ b/.changeset/cognito-managed-login.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth-construct': minor
+---
+
+Add managedLogin option to externalProviders for enabling Cognito Managed Login

--- a/packages/auth-construct/src/construct.test.ts
+++ b/packages/auth-construct/src/construct.test.ts
@@ -1389,6 +1389,30 @@ void describe('Auth construct', () => {
         ],
       });
     });
+
+    void it('configures managed login version when managedLogin is true', () => {
+      new AmplifyAuth(stack, 'test', {
+        name: 'test_name',
+        loginWith: {
+          email: true,
+          externalProviders: {
+            google: {
+              clientId: googleClientId,
+              clientSecret: SecretValue.unsafePlainText(googleClientSecret),
+            },
+            domainPrefix: 'test-prefix',
+            callbackUrls: ['http://callback.com'],
+            logoutUrls: ['http://logout.com'],
+            managedLogin: true,
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::Cognito::UserPoolDomain', {
+        Domain: 'test-prefix',
+        ManagedLoginVersion: 2,
+      });
+    });
   });
 
   void describe('storeOutput strategy', () => {

--- a/packages/auth-construct/src/construct.ts
+++ b/packages/auth-construct/src/construct.ts
@@ -18,6 +18,7 @@ import {
   CfnUserPoolIdentityProvider,
   CustomAttributeConfig,
   ICustomAttribute,
+  ManagedLoginVersion,
   Mfa,
   MfaSecondFactor,
   OAuthScope,
@@ -1077,6 +1078,9 @@ export class AmplifyAuth
     if (this.domainPrefix) {
       this.userPool.addDomain(`${this.name}UserPoolDomain`, {
         cognitoDomain: { domainPrefix: this.domainPrefix },
+        managedLoginVersion: external.managedLogin
+          ? ManagedLoginVersion.NEWER_MANAGED_LOGIN
+          : undefined,
       });
     } else {
       throw new Error(

--- a/packages/auth-construct/src/types.ts
+++ b/packages/auth-construct/src/types.ts
@@ -374,6 +374,14 @@ export type ExternalProviderOptions = {
    * List of allowed logout URLs for the identity providers.
    */
   logoutUrls: string[];
+  /**
+   * Enable Cognito Managed Login instead of the classic Hosted UI.
+   * Managed Login provides modern authentication flows including the
+   * OIDC prompt parameter and a no-code branding designer.
+   * Requires User Pool to be on the Essentials tier or higher (default for new pools).
+   * @default false
+   */
+  managedLogin?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

Add `managedLogin` option to `externalProviders` in `defineAuth` to enable Cognito Managed Login instead of the classic Hosted UI.

### Usage

```typescript
import { defineAuth, secret } from '@aws-amplify/backend';

export const auth = defineAuth({
  loginWith: {
    email: true,
    externalProviders: {
      managedLogin: true,
      google: {
        clientId: secret('GOOGLE_CLIENT_ID'),
        clientSecret: secret('GOOGLE_CLIENT_SECRET'),
      },
      domainPrefix: 'myapp',
      callbackUrls: ['http://localhost:3000/'],
      logoutUrls: ['http://localhost:3000/'],
    },
  },
});
```

### Why

AWS introduced [Managed Login](https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-cognito-managed-login/) for Cognito in November 2024. It provides:
- OIDC `prompt` parameter support (e.g. `prompt=select_account` for forced account selection — the [#1 requested feature](https://github.com/aws-amplify/amplify-js/issues/4044) in amplify-js)
- Modern no-code branding designer
- All current and future sign-in features

amplify-js already supports the `prompt` parameter via [PR #14464](https://github.com/aws-amplify/amplify-js/pull/14464), but the backend had no way to configure Managed Login.

### Notes

- Managed Login requires the Essentials tier, which is already the **default for all new User Pools** since November 2024
- Existing Amplify Gen2 User Pools are already on Essentials (confirmed via API)
- The implementation sets `ManagedLoginVersion.NEWER_MANAGED_LOGIN` on the User Pool domain when `managedLogin: true`

**Issue number:** https://github.com/aws-amplify/amplify-backend/issues/2920

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._