### PR TITLE
fix: resolve eslint restrict-template-expressions error

### DIFF
--- a/packages/backend-auth/src/reference_construct.test.ts
+++ b/packages/backend-auth/src/reference_construct.test.ts
@@ -112,7 +112,7 @@ void describe('AmplifyConstruct', () => {
     const outputs = template.findOutputs('*');
     for (const property of OUTPUT_PROPERTIES_PROVIDED_BY_AUTH_CUSTOM_RESOURCE) {
       const expectedValue = {
-        'Fn::GetAtt': ['AmplifyRefAuthCustomResource', `${property}`],
+        'Fn::GetAtt': ['AmplifyRefAuthCustomResource', property],
       };
       assert.ok(outputs[property]);
       const actualValue = outputs[property]['Value'];


### PR DESCRIPTION
Fixes CI lint failure on snapshot/iac-hosting branch:

## Changes

- **ESLint fix**: Removes unnecessary template literal wrapping of `property` variable in `reference_construct.test.ts` — resolves `@typescript-eslint/restrict-template-expressions` error that was the only lint failure (`--max-warnings 0` makes any warning a failure)
- **ESLint dictionary**: Already up-to-date with all hosting-specific terms (aaaa, allowlist, analogjs, astro, avif, denylist, evilexample, ipv, nitro, nuxt, opennext, opennextjs, prerendered, revalidat, revalidation, solidjs, subdomain, tanstack, webp)
- **Prettier**: Already clean — no formatting drift detected
- **Windows paths**: Verified correct — all file system paths use `path.join()` and URL paths correctly use forward slashes with `.replace(/\\\\/g, '/')` normalization

## Verification

```
$ npm run lint
> eslint --max-warnings 0 . && tsx scripts/check_package_json.ts && prettier --check .
Checking formatting...
All matched files use Prettier code style!
```