### PR TITLE
feat(backend-data): expose stackMappings for distributing resolvers across nested stacks

### DIFF
--- a/.changeset/stack-mappings-feature.md
+++ b/.changeset/stack-mappings-feature.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': minor
+---
+
+Added `stackMappings` option to `defineData()` for distributing resolvers across multiple nested CloudFormation stacks. This helps avoid the 500-resource limit for projects with complex data models.

--- a/packages/backend-data/API.md
+++ b/packages/backend-data/API.md
@@ -53,6 +53,7 @@ export type DataProps = {
     functions?: Record<string, ConstructFactory<AmplifyFunction>>;
     logging?: DataLoggingOptions;
     migratedAmplifyGen1DynamoDbTableMappings?: AmplifyGen1DynamoDbTableMapping[];
+    stackMappings?: Record<string, string>;
 };
 
 // @public

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -1199,6 +1199,305 @@ void describe('Table Import', () => {
   });
 });
 
+void describe('DataFactory stackMappings', () => {
+  beforeEach(() => {
+    resetFactoryCount();
+  });
+
+  void it('passes stackMappings to the underlying construct', () => {
+    const schema = /* GraphQL */ `
+      type Todo @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        content: String!
+        done: Boolean
+      }
+
+      type Order @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        item: String!
+        quantity: Int
+        status: String
+      }
+    `;
+
+    const dataFactory = defineData({
+      schema,
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+      stackMappings: {
+        CreateOrderResolver: 'OrderMutations',
+        UpdateOrderResolver: 'OrderMutations',
+        DeleteOrderResolver: 'OrderMutations',
+      },
+    });
+
+    const getInstanceProps = createInstancePropsBySetupCDKApp({
+      isSandboxMode: false,
+    });
+    const dataConstruct = dataFactory.getInstance(getInstanceProps);
+
+    // Verify that the OrderMutations nested stack was created
+    assert(
+      'OrderMutations' in dataConstruct.resources.nestedStacks,
+      'Expected OrderMutations nested stack to be created via stackMappings',
+    );
+
+    // Verify resolvers were placed in the OrderMutations stack
+    const orderMutationsTemplate = Template.fromStack(
+      dataConstruct.resources.nestedStacks['OrderMutations'],
+    );
+    orderMutationsTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'createOrder',
+      TypeName: 'Mutation',
+    });
+    orderMutationsTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'updateOrder',
+      TypeName: 'Mutation',
+    });
+    orderMutationsTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'deleteOrder',
+      TypeName: 'Mutation',
+    });
+  });
+
+  void it('works without stackMappings (default behavior)', () => {
+    const schema = /* GraphQL */ `
+      type Todo @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        content: String!
+        done: Boolean
+      }
+    `;
+
+    const dataFactory = defineData({
+      schema,
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+    });
+
+    const getInstanceProps = createInstancePropsBySetupCDKApp({
+      isSandboxMode: false,
+    });
+    const dataConstruct = dataFactory.getInstance(getInstanceProps);
+
+    // Verify the default nested stacks exist
+    assert(
+      'Todo' in dataConstruct.resources.nestedStacks,
+      'Expected Todo nested stack to exist by default',
+    );
+    // Verify no extra stacks were created
+    assert(
+      !('OrderMutations' in dataConstruct.resources.nestedStacks),
+      'OrderMutations stack should not exist without stackMappings',
+    );
+  });
+
+  void it('distributes resolvers across multiple custom stacks', () => {
+    const schema = /* GraphQL */ `
+      type Todo @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        content: String!
+        done: Boolean
+      }
+
+      type Order @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        item: String!
+        quantity: Int
+        status: String
+      }
+
+      type Product @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        name: String!
+        price: Float
+      }
+    `;
+
+    const dataFactory = defineData({
+      schema,
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+      stackMappings: {
+        CreateOrderResolver: 'OrderMutations',
+        UpdateOrderResolver: 'OrderMutations',
+        DeleteOrderResolver: 'OrderMutations',
+        CreateProductResolver: 'ProductMutations',
+        UpdateProductResolver: 'ProductMutations',
+        DeleteProductResolver: 'ProductMutations',
+        CreateTodoResolver: 'TodoMutations',
+        UpdateTodoResolver: 'TodoMutations',
+        DeleteTodoResolver: 'TodoMutations',
+      },
+    });
+
+    const getInstanceProps = createInstancePropsBySetupCDKApp({
+      isSandboxMode: false,
+    });
+    const dataConstruct = dataFactory.getInstance(getInstanceProps);
+
+    assert(
+      'OrderMutations' in dataConstruct.resources.nestedStacks,
+      'Expected OrderMutations nested stack to be created',
+    );
+    assert(
+      'ProductMutations' in dataConstruct.resources.nestedStacks,
+      'Expected ProductMutations nested stack to be created',
+    );
+    assert(
+      'TodoMutations' in dataConstruct.resources.nestedStacks,
+      'Expected TodoMutations nested stack to be created',
+    );
+
+    const orderMutationsTemplate = Template.fromStack(
+      dataConstruct.resources.nestedStacks['OrderMutations'],
+    );
+    orderMutationsTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'createOrder',
+      TypeName: 'Mutation',
+    });
+
+    const productMutationsTemplate = Template.fromStack(
+      dataConstruct.resources.nestedStacks['ProductMutations'],
+    );
+    productMutationsTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'createProduct',
+      TypeName: 'Mutation',
+    });
+
+    const todoMutationsTemplate = Template.fromStack(
+      dataConstruct.resources.nestedStacks['TodoMutations'],
+    );
+    todoMutationsTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'createTodo',
+      TypeName: 'Mutation',
+    });
+  });
+
+  void it('handles empty stackMappings object', () => {
+    const schema = /* GraphQL */ `
+      type Todo @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        content: String!
+        done: Boolean
+      }
+    `;
+
+    const dataFactory = defineData({
+      schema,
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+      stackMappings: {},
+    });
+
+    const getInstanceProps = createInstancePropsBySetupCDKApp({
+      isSandboxMode: false,
+    });
+    const dataConstruct = dataFactory.getInstance(getInstanceProps);
+
+    // Verify default behavior when stackMappings is empty
+    assert(
+      'Todo' in dataConstruct.resources.nestedStacks,
+      'Expected Todo nested stack to exist with empty stackMappings',
+    );
+
+    const todoTemplate = Template.fromStack(
+      dataConstruct.resources.nestedStacks['Todo'],
+    );
+    todoTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'createTodo',
+      TypeName: 'Mutation',
+    });
+  });
+
+  void it('maps some resolvers while leaving others in default stacks', () => {
+    const schema = /* GraphQL */ `
+      type Todo @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        content: String!
+        done: Boolean
+      }
+
+      type Order @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        item: String!
+        quantity: Int
+        status: String
+      }
+    `;
+
+    const dataFactory = defineData({
+      schema,
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+      stackMappings: {
+        CreateOrderResolver: 'OrderMutations',
+        UpdateOrderResolver: 'OrderMutations',
+      },
+    });
+
+    const getInstanceProps = createInstancePropsBySetupCDKApp({
+      isSandboxMode: false,
+    });
+    const dataConstruct = dataFactory.getInstance(getInstanceProps);
+
+    // Verify the custom stack was created for mapped resolvers
+    assert(
+      'OrderMutations' in dataConstruct.resources.nestedStacks,
+      'Expected OrderMutations nested stack to be created',
+    );
+
+    // Verify Todo resolvers without mapping remain in the default Todo stack
+    assert(
+      'Todo' in dataConstruct.resources.nestedStacks,
+      'Expected Todo nested stack to exist for resolvers without custom mapping',
+    );
+    const todoTemplate = Template.fromStack(
+      dataConstruct.resources.nestedStacks['Todo'],
+    );
+    todoTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'createTodo',
+      TypeName: 'Mutation',
+    });
+
+    // Verify mapped resolvers are in the custom stack
+    const orderMutationsTemplate = Template.fromStack(
+      dataConstruct.resources.nestedStacks['OrderMutations'],
+    );
+    orderMutationsTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'createOrder',
+      TypeName: 'Mutation',
+    });
+    orderMutationsTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'updateOrder',
+      TypeName: 'Mutation',
+    });
+
+    // Verify resolver without mapping stays in default stack
+    assert(
+      'Order' in dataConstruct.resources.nestedStacks,
+      'Expected Order nested stack to exist for resolvers without custom mapping',
+    );
+    const orderDefaultTemplate = Template.fromStack(
+      dataConstruct.resources.nestedStacks['Order'],
+    );
+    orderDefaultTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
+      FieldName: 'deleteOrder',
+      TypeName: 'Mutation',
+    });
+  });
+});
+
 const resetFactoryCount = () => {
   DataFactory.factoryCount = 0;
 };

--- a/packages/backend-data/src/factory.ts
+++ b/packages/backend-data/src/factory.ts
@@ -305,6 +305,7 @@ class DataGenerator implements ConstructContainerEntryGenerator {
           _provisionHotswapFriendlyResources: isSandboxDeployment,
         },
         logging: cdkLoggingOptions,
+        stackMappings: this.props.stackMappings,
       });
     } catch (error) {
       throw new AmplifyUserError(

--- a/packages/backend-data/src/types.ts
+++ b/packages/backend-data/src/types.ts
@@ -155,6 +155,22 @@ export type DataProps = {
    * Each element in the array represents a mapping for a specific branch.
    */
   migratedAmplifyGen1DynamoDbTableMappings?: AmplifyGen1DynamoDbTableMapping[];
+
+  /**
+   * Override the assigned nested stack on a per-resource basis.
+   * Only applies to resolvers, and takes the form { <logicalId>: <stackName> }.
+   * Use this to distribute resolver resources across multiple stacks.
+   * You can discover resolver logical IDs by running `npx ampx sandbox` and
+   * examining the CloudFormation output, or by running `cdk synth`.
+   * @example
+   * ```typescript
+   * stackMappings: {
+   *   "CreateOrderResolver": "OrderMutations",
+   *   "UpdateOrderResolver": "OrderMutations",
+   * }
+   * ```
+   */
+  stackMappings?: Record<string, string>;
 };
 
 export type AmplifyDataError =


### PR DESCRIPTION
## Description

Adds a `stackMappings` option to `defineData()` that allows distributing AppSync resolvers across multiple nested CloudFormation stacks. This is a pass-through to the existing [`stackMappings` property](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-api-construct/src/types.ts) in `@aws-amplify/graphql-api-construct`.

### Problem

CloudFormation has a 500-resource limit per stack. Projects with complex data models (many types, relationships, auth rules, indexes) can exceed this limit because all resolvers for a model are placed in a single nested stack. This is a Gen 1 → Gen 2 migration blocker — Gen 1 supported `stackMappings` to work around this, but Gen 2 did not expose it.

Related: [amplify-category-api#2550](https://github.com/aws-amplify/amplify-category-api/issues/2550)

### Solution

Expose the existing construct-level `stackMappings` property through `DataProps` as an optional pass-through. When provided, the mapping tells the transformer which nested stack to place each resolver in (by logical ID).

```typescript
export const data = defineData({
  schema,
  authorizationModes: { defaultAuthorizationMode: 'apiKey' },
  stackMappings: {
    CreateOrderResolver: 'OrderMutations',
    UpdateOrderResolver: 'OrderMutations',
    DeleteOrderResolver: 'OrderMutations',
  },
});
```
### Validation

Invalid mapping keys (typos or stale entries that don't match any generated resolver) are detected during synthesis and reported as a warning:

```
[WARNING] stackMappings contains keys that don't match any generated resource: [CreateOrdersResolver].
These keys are ignored. Valid patterns: Create{Model}Resolver, Get{Model}Resolver, etc.
```

This validation logic will be in `amplify-category-api` repo.

Companion PR: https://github.com/aws-amplify/amplify-category-api/pull/3486

### Changes

| File | Change |
|------|--------|
| `packages/backend-data/src/types.ts` | Added `stackMappings?: Record<string, string>` to `DataProps` |
| `packages/backend-data/src/factory.ts` | Pass-through to underlying construct |
| `packages/backend-data/src/factory.test.ts` | 2 new tests verifying resolver placement and backward compatibility |
| `packages/backend-data/API.md` | Updated public API surface |

### How it works

The mapping flows through: `defineData()` → `AmplifyData` construct → `GraphQLTransform` → `StackManager.getScopeFor()`. When a resolver is created, the `StackManager` checks the mapping and places it in the specified CDK `NestedStack` (created on demand). Each nested stack synthesizes as a separate CloudFormation template, staying under the 500-resource limit.

Mapping keys are resolver logical IDs (e.g., `Create{Model}Resolver`, `Get{Model}Resolver`). Users can discover them via `npx ampx sandbox` output or `cdk synth`.

### Testing

- Unit tests verify resolvers are placed in custom nested stacks via CDK `Template` assertions
- Unit tests verify backward compatibility when `stackMappings` is omitted
- Manually verified via `npx ampx sandbox --once` deployment (resolvers distributed correctly, API functional, `amplify_outputs.json` generated correctly)

### Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the Project-Level Configuration Schema, I have added the schema change.
