### PR TITLE
feat(hosting): add skew protection via CloudFront Functions

### DIFF
--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -1,6 +1,7 @@
 [
   "Aaaa",
   "aaaaaaaa",
+  "abc",
   "abc123",
   "acceptor",
   "acceptors",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48030,17 +48030,17 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-bedrock-runtime": "^3.936.0",
         "@smithy/types": "^4.9.0",
         "json-schema-to-ts": "^3.1.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-output-storage": "^1.3.3",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
         "@types/lodash.transform": "^4.6.9",
         "lodash.transform": "^4.6.0",
         "typescript": "^5.0.0"
@@ -48072,20 +48072,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^1.9.3",
-        "@aws-amplify/backend-data": "^1.6.4",
-        "@aws-amplify/backend-function": "^1.18.0",
+        "@aws-amplify/backend-auth": "^1.9.4",
+        "@aws-amplify/backend-data": "^1.7.0",
+        "@aws-amplify/backend-function": "^1.18.1",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.4",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/backend-storage": "^1.4.3",
-        "@aws-amplify/client-config": "^1.10.1",
+        "@aws-amplify/backend-storage": "^1.5.0",
+        "@aws-amplify/client-config": "^1.10.2",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-amplify": "^3.936.0"
       },
       "devDependencies": {
@@ -48099,15 +48099,15 @@
     },
     "packages/backend-ai": {
       "name": "@aws-amplify/backend-ai",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.5.6",
+        "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/data-schema-types": "^1.2.0",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2"
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
@@ -48116,17 +48116,17 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/auth-construct": "^1.11.1",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
-        "@aws-amplify/plugin-types": "^1.11.2"
+        "@aws-amplify/backend-output-storage": "^1.3.5",
+        "@aws-amplify/plugin-types": "^1.12.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
-        "@aws-amplify/platform-core": "^1.10.4",
+        "@aws-amplify/platform-core": "^1.11.1",
         "@aws-sdk/client-cognito-identity": "^3.936.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
         "@types/aws-lambda": "^8.10.119"
@@ -48138,21 +48138,21 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.6.4",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/data-construct": "^1.15.1",
         "@aws-amplify/data-schema-types": "^1.2.0",
         "@aws-amplify/graphql-generator": "^0.5.1",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "graphql": "^15.8.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/platform-core": "^1.10.4"
+        "@aws-amplify/platform-core": "^1.11.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
@@ -48161,11 +48161,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-cdk/toolkit-lib": "1.19.0",
         "execa": "^9.5.1",
         "minimatch": "10.2.3",
@@ -48202,18 +48202,18 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-s3": "^3.936.0",
         "execa": "^9.5.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
-        "@aws-amplify/platform-core": "^1.10.4",
+        "@aws-amplify/platform-core": "^1.11.1",
         "@aws-sdk/client-s3": "^3.936.0",
         "@aws-sdk/client-ssm": "^3.936.0",
         "uuid": "^11.1.0"
@@ -48248,12 +48248,12 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0"
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1"
@@ -48284,16 +48284,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
-        "@aws-amplify/plugin-types": "^1.11.2"
+        "@aws-amplify/backend-output-storage": "^1.3.5",
+        "@aws-amplify/plugin-types": "^1.12.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
-        "@aws-amplify/platform-core": "^1.10.4"
+        "@aws-amplify/platform-core": "^1.11.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
@@ -48302,20 +48302,20 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.5",
+        "@aws-amplify/backend-deployer": "^2.1.7",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.3",
-        "@aws-amplify/client-config": "^1.10.0",
-        "@aws-amplify/deployed-backend-client": "^1.8.0",
-        "@aws-amplify/form-generator": "^1.2.6",
-        "@aws-amplify/model-generator": "^1.2.2",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
-        "@aws-amplify/sandbox": "^2.1.4",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
+        "@aws-amplify/form-generator": "^1.2.7",
+        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/sandbox": "^2.2.1",
         "@aws-amplify/schema-generator": "^1.4.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-cloudformation": "^3.936.0",
@@ -48356,10 +48356,10 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/platform-core": "^1.11.1",
         "@aws-sdk/client-cloudformation": "^3.936.0",
         "@inquirer/prompts": "^7.3.2",
         "@opentelemetry/api": "^1.9.0",
@@ -48470,14 +48470,14 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/deployed-backend-client": "^1.8.1",
-        "@aws-amplify/model-generator": "^1.2.2",
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
+        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "zod": "3.25.17"
       },
       "devDependencies": {
@@ -48492,12 +48492,12 @@
       }
     },
     "packages/create-amplify": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^2.2.2",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "execa": "^9.5.1",
         "kleur": "^4.1.5",
         "yargs": "^17.7.2"
@@ -48584,12 +48584,12 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.7.1",
-        "@aws-amplify/platform-core": "^1.10.1",
-        "@aws-amplify/plugin-types": "^1.11.1",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "zod": "3.25.17"
       },
       "peerDependencies": {
@@ -48612,7 +48612,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.11.0",
@@ -48667,23 +48667,23 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
-        "@aws-amplify/ai-constructs": "^1.6.1",
+        "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/auth-construct": "^1.11.1",
-        "@aws-amplify/backend": "^1.21.0",
-        "@aws-amplify/backend-ai": "^1.5.3",
+        "@aws-amplify/backend": "^1.23.0",
+        "@aws-amplify/backend-ai": "^1.5.4",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.3",
-        "@aws-amplify/client-config": "^1.10.0",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/client-config": "^1.10.2",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/deployed-backend-client": "^1.8.1",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/hosting": "^1.0.0",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
-        "@aws-amplify/seed": "^1.1.1",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/seed": "^1.1.3",
         "@aws-sdk/client-accessanalyzer": "^3.936.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-bedrock-runtime": "3.936.0",
@@ -49345,15 +49345,15 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.7.1",
-        "@aws-amplify/deployed-backend-client": "^1.8.1",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
-        "@aws-amplify/platform-core": "^1.10.3",
-        "@aws-amplify/plugin-types": "^1.11.1",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-appsync": "^3.936.0",
         "@aws-sdk/client-s3": "^3.937.0",
         "@aws-sdk/credential-providers": "^3.936.0",
@@ -49367,10 +49367,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-sts": "^3.936.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.0.0",
@@ -49410,7 +49410,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/toolkit-lib": "1.19.0"
@@ -49423,16 +49423,16 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.4",
+        "@aws-amplify/backend-deployer": "^2.1.7",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.3",
-        "@aws-amplify/client-config": "^1.9.1",
-        "@aws-amplify/deployed-backend-client": "^1.8.1",
-        "@aws-amplify/platform-core": "^1.10.3",
-        "@aws-amplify/plugin-types": "^1.11.1",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
         "@aws-sdk/client-lambda": "^3.936.0",
         "@aws-sdk/client-ssm": "^3.936.0",
@@ -49461,14 +49461,14 @@
     },
     "packages/seed": {
       "name": "@aws-amplify/seed",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.4",
-        "@aws-amplify/client-config": "^1.10.1",
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
         "aws-amplify": "6.14.4"
       }

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -990,10 +990,13 @@ export class CdnConstruct extends Construct {
     if (skewEnabled) {
       return new CloudFrontFunction(this, 'SkewProtectionRequestFunction', {
         code: FunctionCode.fromInline(
-          generateSkewProtectionViewerRequestCode(buildId),
+          generateSkewProtectionViewerRequestCode(buildId, redirects),
         ),
         runtime: CLOUDFRONT_FUNCTION_RUNTIME,
-        comment: `Skew protection: routes requests to build from cookie or current build ${buildId}`,
+        comment:
+          redirects.length > 0
+            ? `Skew protection: cookie-based routing + ${redirects.length} redirect rule(s)`
+            : `Skew protection: routes requests to build from cookie or current build ${buildId}`,
       });
     }
     return new CloudFrontFunction(this, 'BuildIdRewriteFunction', {

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -48,7 +48,7 @@ import {
 } from 'aws-cdk-lib/aws-apigateway';
 import { HostingError } from '../hosting_error.js';
 import { prependBasePath } from '../adapters/shared/basepath.js';
-import { DeployManifest } from '../manifest/types.js';
+import { DeployManifest, Redirect } from '../manifest/types.js';
 import {
   ERROR_PAGE_KEY,
   generateAssetPrefixStripFunctionCode,
@@ -56,8 +56,16 @@ import {
   generateForwardedHostAndRedirectFunctionCode,
 } from '../defaults.js';
 import { createCustomHeadersPolicy } from './security_headers.js';
+import {
+  SkewProtectionConfig,
+  generateSkewProtectionViewerRequestCode,
+  generateSkewProtectionViewerResponseCode,
+} from './skew_protection.js';
 
 // ---- Constants ----
+
+/** Runtime version used for all CloudFront Functions in this construct. */
+const CLOUDFRONT_FUNCTION_RUNTIME = FunctionRuntime.JS_2_0;
 
 /**
  * CloudFront allows a maximum of 25 cache behaviors per distribution
@@ -136,6 +144,8 @@ export type CdnConstructProps = {
    * (`runtime = 'edge'`), one entry per route.
    */
   routeEdgeFunctions?: Map<string, IVersion>;
+  /** Cookie-based skew protection configuration. */
+  skewProtection?: SkewProtectionConfig;
 };
 
 // ---- Construct ----
@@ -186,9 +196,6 @@ export class CdnConstruct extends Construct {
     this.errorPageHtml = props.errorPageHtml ?? SSR_ERROR_PAGE_HTML;
 
     // ---- Lambda@Edge function-count validation ----
-    // The account-level cap is 25 replicated functions. Catch the
-    // unwinnable case at synth so users get a useful error with a
-    // resolution path, not a CloudFormation rollback.
     const edgeRouteCount = props.routeEdgeFunctions?.size ?? 0;
     if (edgeRouteCount > MAX_EDGE_FUNCTIONS_PER_DISTRIBUTION) {
       throw new HostingError('TooManyEdgeRoutesError', {
@@ -208,12 +215,9 @@ export class CdnConstruct extends Construct {
       );
     }
 
-    // ---- Build ID rewrite + redirect function ----
-    // Single CloudFront viewer-request function that handles both
-    // static-asset URI rewriting (build-id prefix, directory index) AND
-    // manifest redirects. Redirects short-circuit before the rewrite.
-    // CloudFront caps one function per behavior per event type, so we
-    // combine them here.
+    const skewEnabled = props.skewProtection?.enabled === true;
+    const skewMaxAge = props.skewProtection?.maxAge ?? 86400;
+
     // basePath (if set) prefixes every routable URL on the deployed site.
     // Redirect sources/destinations declared by the framework are
     // basePath-relative; prefix them here so the CF Function matches the
@@ -226,23 +230,20 @@ export class CdnConstruct extends Construct {
           destination: prependBasePath(manifest.basePath, r.destination),
         }))
       : rawRedirects;
-    const buildIdFunction = new CloudFrontFunction(
-      this,
-      'BuildIdRewriteFunction',
-      {
-        code: FunctionCode.fromInline(
-          generateBuildIdAndRedirectFunctionCode(
-            buildId,
-            manifestRedirects,
-            manifest.basePath,
-          ),
-        ),
-        runtime: FunctionRuntime.JS_2_0,
-        comment:
-          manifestRedirects.length > 0
-            ? `Build-id rewrite + ${manifestRedirects.length} redirect rule(s)`
-            : `Rewrites request URIs to include build ID prefix: builds/${buildId}/`,
-      },
+
+    // ---- Build ID rewrite function ----
+    const viewerRequestFunction = this.createViewerRequestFunction(
+      buildId,
+      skewEnabled,
+      manifestRedirects,
+      manifest.basePath,
+    );
+
+    // ---- Skew protection viewer-response function ----
+    const viewerResponseFunction = this.createViewerResponseFunction(
+      buildId,
+      skewMaxAge,
+      skewEnabled,
     );
 
     // ---- Origins ----
@@ -352,7 +353,7 @@ export class CdnConstruct extends Construct {
               manifest.basePath,
             ),
           ),
-          runtime: FunctionRuntime.JS_2_0,
+          runtime: CLOUDFRONT_FUNCTION_RUNTIME,
           comment:
             manifestRedirects.length > 0
               ? `Forwarded-host + ${manifestRedirects.length} redirect rule(s)`
@@ -451,9 +452,17 @@ export class CdnConstruct extends Construct {
       responseHeadersPolicy: props.securityHeadersPolicy,
       functionAssociations: [
         {
-          function: buildIdFunction,
+          function: viewerRequestFunction,
           eventType: FunctionEventType.VIEWER_REQUEST,
         },
+        ...(viewerResponseFunction
+          ? [
+              {
+                function: viewerResponseFunction,
+                eventType: FunctionEventType.VIEWER_RESPONSE,
+              },
+            ]
+          : []),
       ],
     });
 
@@ -468,16 +477,24 @@ export class CdnConstruct extends Construct {
       originRequestPolicy: OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
       responseHeadersPolicy: props.securityHeadersPolicy,
       ...(edgeLambdas ? { edgeLambdas } : {}),
-      ...(forwardedHostFunction
-        ? {
-            functionAssociations: [
+      functionAssociations: [
+        ...(forwardedHostFunction
+          ? [
               {
                 function: forwardedHostFunction,
                 eventType: FunctionEventType.VIEWER_REQUEST,
               },
-            ],
-          }
-        : {}),
+            ]
+          : []),
+        ...(viewerResponseFunction
+          ? [
+              {
+                function: viewerResponseFunction,
+                eventType: FunctionEventType.VIEWER_RESPONSE,
+              },
+            ]
+          : []),
+      ],
     });
 
     /**
@@ -611,7 +628,7 @@ export class CdnConstruct extends Construct {
           code: FunctionCode.fromInline(
             generateAssetPrefixStripFunctionCode(buildId, assetPrefix),
           ),
-          runtime: FunctionRuntime.JS_2_0,
+          runtime: CLOUDFRONT_FUNCTION_RUNTIME,
           comment: `Strip Next.js assetPrefix=${assetPrefix} before S3 lookup`,
         },
       );
@@ -957,6 +974,60 @@ export class CdnConstruct extends Construct {
         description: 'Custom domain name for the hosted site',
       });
     }
+  }
+
+  /**
+   * Creates the viewer-request CloudFront Function.
+   * When skew protection is enabled, reads the `__dpl` cookie to route users
+   * to their pinned build. Otherwise uses a combined build-id rewrite + redirect function.
+   */
+  private createViewerRequestFunction(
+    buildId: string,
+    skewEnabled: boolean,
+    redirects: Redirect[],
+    basePath?: string,
+  ): CloudFrontFunction {
+    if (skewEnabled) {
+      return new CloudFrontFunction(this, 'SkewProtectionRequestFunction', {
+        code: FunctionCode.fromInline(
+          generateSkewProtectionViewerRequestCode(buildId),
+        ),
+        runtime: CLOUDFRONT_FUNCTION_RUNTIME,
+        comment: `Skew protection: routes requests to build from cookie or current build ${buildId}`,
+      });
+    }
+    return new CloudFrontFunction(this, 'BuildIdRewriteFunction', {
+      code: FunctionCode.fromInline(
+        generateBuildIdAndRedirectFunctionCode(buildId, redirects, basePath),
+      ),
+      runtime: CLOUDFRONT_FUNCTION_RUNTIME,
+      comment:
+        redirects.length > 0
+          ? `Build-id rewrite + ${redirects.length} redirect rule(s)`
+          : `Rewrites request URIs to include build ID prefix: builds/${buildId}/`,
+    });
+  }
+
+  /**
+   * Creates the viewer-response CloudFront Function for skew protection.
+   * Sets the `__dpl` cookie on HTML responses to pin the user's session.
+   * Returns `undefined` when skew protection is disabled.
+   */
+  private createViewerResponseFunction(
+    buildId: string,
+    maxAge: number,
+    skewEnabled: boolean,
+  ): CloudFrontFunction | undefined {
+    if (!skewEnabled) {
+      return undefined;
+    }
+    return new CloudFrontFunction(this, 'SkewProtectionResponseFunction', {
+      code: FunctionCode.fromInline(
+        generateSkewProtectionViewerResponseCode(buildId, maxAge),
+      ),
+      runtime: CLOUDFRONT_FUNCTION_RUNTIME,
+      comment: `Skew protection: sets __dpl cookie to ${buildId} on HTML responses`,
+    });
   }
 }
 

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -116,7 +116,6 @@ export type AmplifyHostingConstructProps = {
    * Cookie-based skew protection.
    * When enabled, users mid-session keep receiving assets from their original
    * build, preventing asset mismatches during rolling deployments.
-   *
    * @default \{ enabled: true \} — skew protection is enabled by default.
    * Set `\{ enabled: false \}` to disable.
    */

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -116,6 +116,9 @@ export type AmplifyHostingConstructProps = {
    * Cookie-based skew protection.
    * When enabled, users mid-session keep receiving assets from their original
    * build, preventing asset mismatches during rolling deployments.
+   *
+   * @default \{ enabled: true \} — skew protection is enabled by default.
+   * Set `\{ enabled: false \}` to disable.
    */
   skewProtection?: {
     enabled: boolean;
@@ -555,7 +558,7 @@ export class AmplifyHostingConstruct extends Construct {
       accessLogBucket: storage.accessLogBucket,
       priceClass: props.cdn?.priceClass,
       geoRestriction: props.cdn?.geoRestriction,
-      skewProtection: props.skewProtection,
+      skewProtection: props.skewProtection ?? { enabled: true },
     });
 
     this.distribution = cdn.distribution;

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -41,6 +41,7 @@ import { CdnConstruct } from './cdn_construct.js';
 
 // Re-export build ID helpers for public API + tests
 export { generateBuildIdFunctionCode, generateBuildId } from '../defaults.js';
+export type { SkewProtectionConfig } from './skew_protection.js';
 
 // ---- Public types ----
 
@@ -110,6 +111,16 @@ export type AmplifyHostingConstructProps = {
   logging?: {
     enabled: boolean;
     retentionDays?: number;
+  };
+  /**
+   * Cookie-based skew protection.
+   * When enabled, users mid-session keep receiving assets from their original
+   * build, preventing asset mismatches during rolling deployments.
+   */
+  skewProtection?: {
+    enabled: boolean;
+    /** How long to honor old build cookies (seconds). Default: 86400 (24h) */
+    maxAge?: number;
   };
 };
 
@@ -544,6 +555,7 @@ export class AmplifyHostingConstruct extends Construct {
       accessLogBucket: storage.accessLogBucket,
       priceClass: props.cdn?.priceClass,
       geoRestriction: props.cdn?.geoRestriction,
+      skewProtection: props.skewProtection,
     });
 
     this.distribution = cdn.distribution;

--- a/packages/hosting/src/constructs/skew_protection.test.ts
+++ b/packages/hosting/src/constructs/skew_protection.test.ts
@@ -95,8 +95,7 @@ void describe('Skew Protection — Code Generation', () => {
       assert.throws(
         () => generateSkewProtectionViewerRequestCode('invalid build!'),
         (err: unknown) =>
-          err instanceof HostingError &&
-          err.name === 'InvalidBuildIdError',
+          err instanceof HostingError && err.name === 'InvalidBuildIdError',
       );
     });
 
@@ -104,8 +103,7 @@ void describe('Skew Protection — Code Generation', () => {
       assert.throws(
         () => generateSkewProtectionViewerRequestCode(''),
         (err: unknown) =>
-          err instanceof HostingError &&
-          err.name === 'InvalidBuildIdError',
+          err instanceof HostingError && err.name === 'InvalidBuildIdError',
       );
     });
 
@@ -146,8 +144,7 @@ void describe('Skew Protection — Code Generation', () => {
       assert.throws(
         () => generateSkewProtectionViewerResponseCode('bad build!!'),
         (err: unknown) =>
-          err instanceof HostingError &&
-          err.name === 'InvalidBuildIdError',
+          err instanceof HostingError && err.name === 'InvalidBuildIdError',
       );
     });
 
@@ -284,11 +281,13 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
 
       // Should NOT have cookie logic
       const functions = template.findResources('AWS::CloudFront::Function');
+      /* eslint-disable @typescript-eslint/naming-convention */
       const functionCodes = Object.values(functions).map(
         (f: Record<string, unknown>) =>
           (f as { Properties: { FunctionCode: string } }).Properties
             .FunctionCode,
       );
+      /* eslint-enable @typescript-eslint/naming-convention */
       const hasCookieLogic = functionCodes.some((code) =>
         code.includes('__dpl'),
       );
@@ -307,6 +306,7 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
       });
 
       const template = Template.fromStack(stack);
+      /* eslint-disable @typescript-eslint/naming-convention */
       template.hasResourceProperties('AWS::CloudFront::Distribution', {
         DistributionConfig: Match.objectLike({
           DefaultCacheBehavior: Match.objectLike({
@@ -318,13 +318,13 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
       });
 
       // Verify no viewer-response association
-      const dist = template.findResources(
-        'AWS::CloudFront::Distribution',
-      );
+      const dist = template.findResources('AWS::CloudFront::Distribution');
       const distConfig = Object.values(dist)[0] as {
         Properties: {
           DistributionConfig: {
-            DefaultCacheBehavior: { FunctionAssociations: Array<{ EventType: string }> };
+            DefaultCacheBehavior: {
+              FunctionAssociations: Array<{ EventType: string }>;
+            };
           };
         };
       };
@@ -334,6 +334,7 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
       const hasViewerResponse = associations.some(
         (a) => a.EventType === 'viewer-response',
       );
+      /* eslint-enable @typescript-eslint/naming-convention */
       assert.strictEqual(hasViewerResponse, false);
     });
   });
@@ -425,11 +426,13 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
 
       const template = Template.fromStack(stack);
       const functions = template.findResources('AWS::CloudFront::Function');
+      /* eslint-disable @typescript-eslint/naming-convention */
       const functionCodes = Object.values(functions).map(
         (f: Record<string, unknown>) =>
           (f as { Properties: { FunctionCode: string } }).Properties
             .FunctionCode,
       );
+      /* eslint-enable @typescript-eslint/naming-convention */
       const hasCookieLogic = functionCodes.some((code) =>
         code.includes('__dpl'),
       );

--- a/packages/hosting/src/constructs/skew_protection.test.ts
+++ b/packages/hosting/src/constructs/skew_protection.test.ts
@@ -1,0 +1,439 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { App, Stack } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import {
+  Code,
+  FunctionUrlAuthType,
+  InvokeMode,
+  Function as LambdaFunction,
+  Runtime,
+} from 'aws-cdk-lib/aws-lambda';
+import { CdnConstruct } from './cdn_construct.js';
+import { createSecurityHeadersPolicy } from './security_headers.js';
+import { DeployManifest } from '../manifest/types.js';
+import { HostingError } from '../hosting_error.js';
+import {
+  generateSkewProtectionViewerRequestCode,
+  generateSkewProtectionViewerResponseCode,
+} from './skew_protection.js';
+
+// ---- Test helpers ----
+
+const createStack = (): Stack => {
+  const app = new App();
+  return new Stack(app, 'TestStack');
+};
+
+const spaManifest: DeployManifest = {
+  version: 1,
+  compute: {},
+  staticAssets: { directory: '/tmp/assets' },
+  routes: [{ pattern: '/*', target: 'static' }],
+  buildId: 'test-spa-1',
+};
+
+const ssrManifest: DeployManifest = {
+  version: 1,
+  compute: {
+    default: {
+      type: 'handler',
+      bundle: '/tmp/bundle',
+      handler: 'index.handler',
+      placement: 'regional',
+    },
+  },
+  staticAssets: { directory: '/tmp/assets' },
+  routes: [
+    { pattern: '/_next/static/*', target: 'static' },
+    { pattern: '/favicon.ico', target: 'static' },
+    { pattern: '/*', target: 'default' },
+  ],
+  buildId: 'test-ssr-1',
+};
+
+const createSsrFunction = (stack: Stack) => {
+  const fn = new LambdaFunction(stack, 'SsrFn', {
+    runtime: Runtime.NODEJS_20_X,
+    handler: 'index.handler',
+    code: Code.fromInline('exports.handler = async () => {};'),
+  });
+  const fnUrl = fn.addFunctionUrl({
+    authType: FunctionUrlAuthType.AWS_IAM,
+    invokeMode: InvokeMode.RESPONSE_STREAM,
+  });
+  return { fn, fnUrl };
+};
+
+// ================================================================
+// Skew Protection — CloudFront Function code generation tests
+// ================================================================
+
+void describe('Skew Protection — Code Generation', () => {
+  void describe('generateSkewProtectionViewerRequestCode', () => {
+    void it('produces valid function code with build ID baked in', () => {
+      const code = generateSkewProtectionViewerRequestCode('abc-123');
+      assert.ok(code.includes("var buildId = 'abc-123'"));
+      assert.ok(code.includes('function handler(event)'));
+      assert.ok(code.includes('__amplify_bid'));
+      assert.ok(code.includes('/builds/'));
+    });
+
+    void it('uses cookie value when match is found', () => {
+      const code = generateSkewProtectionViewerRequestCode('current-build');
+      assert.ok(code.includes('match[1]'));
+      assert.ok(code.includes("var buildId = 'current-build'"));
+    });
+
+    void it('appends index.html for directory-style paths', () => {
+      const code = generateSkewProtectionViewerRequestCode('build-1');
+      assert.ok(code.includes("uri = uri + 'index.html'"));
+    });
+
+    void it('throws for invalid build ID', () => {
+      assert.throws(
+        () => generateSkewProtectionViewerRequestCode('invalid build!'),
+        (err: unknown) =>
+          err instanceof HostingError &&
+          err.name === 'InvalidBuildIdError',
+      );
+    });
+
+    void it('throws for empty build ID', () => {
+      assert.throws(
+        () => generateSkewProtectionViewerRequestCode(''),
+        (err: unknown) =>
+          err instanceof HostingError &&
+          err.name === 'InvalidBuildIdError',
+      );
+    });
+
+    void it('handles build ID with max length (64 chars)', () => {
+      const longId = 'a'.repeat(64);
+      const code = generateSkewProtectionViewerRequestCode(longId);
+      assert.ok(code.includes(longId));
+    });
+  });
+
+  void describe('generateSkewProtectionViewerResponseCode', () => {
+    void it('produces valid function code that sets cookie on HTML', () => {
+      const code = generateSkewProtectionViewerResponseCode('abc-123');
+      assert.ok(code.includes('function handler(event)'));
+      assert.ok(code.includes('text/html'));
+      assert.ok(code.includes('__amplify_bid=abc-123'));
+      assert.ok(code.includes('Path=/'));
+      assert.ok(code.includes('SameSite=Lax'));
+      assert.ok(code.includes('Max-Age=86400'));
+    });
+
+    void it('uses custom maxAge when provided', () => {
+      const code = generateSkewProtectionViewerResponseCode('build-x', 3600);
+      assert.ok(code.includes('Max-Age=3600'));
+    });
+
+    void it('checks content-type header for text/html', () => {
+      const code = generateSkewProtectionViewerResponseCode('build-1');
+      assert.ok(code.includes("contentType.indexOf('text/html') >= 0"));
+    });
+
+    void it('does not set cookie on non-HTML responses (logic check)', () => {
+      const code = generateSkewProtectionViewerResponseCode('build-1');
+      assert.ok(code.includes("if (contentType.indexOf('text/html') >= 0)"));
+    });
+
+    void it('throws for invalid build ID', () => {
+      assert.throws(
+        () => generateSkewProtectionViewerResponseCode('bad build!!'),
+        (err: unknown) =>
+          err instanceof HostingError &&
+          err.name === 'InvalidBuildIdError',
+      );
+    });
+
+    void it('throws for negative maxAge', () => {
+      assert.throws(
+        () => generateSkewProtectionViewerResponseCode('build-1', -1),
+        (err: unknown) =>
+          err instanceof HostingError &&
+          err.name === 'InvalidSkewProtectionMaxAgeError',
+      );
+    });
+
+    void it('throws for maxAge exceeding 30 days', () => {
+      assert.throws(
+        () => generateSkewProtectionViewerResponseCode('build-1', 2592001),
+        (err: unknown) =>
+          err instanceof HostingError &&
+          err.name === 'InvalidSkewProtectionMaxAgeError',
+      );
+    });
+
+    void it('accepts maxAge of 0', () => {
+      const code = generateSkewProtectionViewerResponseCode('build-1', 0);
+      assert.ok(code.includes('Max-Age=0'));
+    });
+  });
+});
+
+// ================================================================
+// Skew Protection — CDN Construct integration tests
+// ================================================================
+
+void describe('Skew Protection — CdnConstruct Integration', () => {
+  void describe('SPA mode with skew protection enabled', () => {
+    void it('creates skew protection request function instead of simple rewrite', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+        skewProtection: { enabled: true },
+      });
+
+      const template = Template.fromStack(stack);
+      // Should have skew protection function with cookie logic
+      template.hasResourceProperties('AWS::CloudFront::Function', {
+        FunctionCode: Match.stringLikeRegexp('__amplify_bid'),
+      });
+    });
+
+    void it('creates viewer-response function for cookie setting', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+        skewProtection: { enabled: true },
+      });
+
+      const template = Template.fromStack(stack);
+      // Should have response function that sets the cookie
+      template.hasResourceProperties('AWS::CloudFront::Function', {
+        FunctionCode: Match.stringLikeRegexp('set-cookie'),
+      });
+    });
+
+    void it('attaches both functions to the default behavior', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+        skewProtection: { enabled: true },
+      });
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          DefaultCacheBehavior: Match.objectLike({
+            FunctionAssociations: Match.arrayWith([
+              Match.objectLike({ EventType: 'viewer-request' }),
+              Match.objectLike({ EventType: 'viewer-response' }),
+            ]),
+          }),
+        }),
+      });
+    });
+
+    void it('uses custom maxAge in cookie', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+        skewProtection: { enabled: true, maxAge: 7200 },
+      });
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::CloudFront::Function', {
+        FunctionCode: Match.stringLikeRegexp('Max-Age=7200'),
+      });
+    });
+  });
+
+  void describe('SPA mode without skew protection', () => {
+    void it('uses simple build ID rewrite (no cookie logic)', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+      });
+
+      const template = Template.fromStack(stack);
+      // Should have simple rewrite function
+      template.hasResourceProperties('AWS::CloudFront::Function', {
+        FunctionCode: Match.stringLikeRegexp('test-spa-1'),
+      });
+
+      // Should NOT have cookie logic
+      const functions = template.findResources('AWS::CloudFront::Function');
+      const functionCodes = Object.values(functions).map(
+        (f: Record<string, unknown>) =>
+          (f as { Properties: { FunctionCode: string } }).Properties
+            .FunctionCode,
+      );
+      const hasCookieLogic = functionCodes.some((code) =>
+        code.includes('__amplify_bid'),
+      );
+      assert.strictEqual(hasCookieLogic, false);
+    });
+
+    void it('does not create viewer-response function', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+      });
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          DefaultCacheBehavior: Match.objectLike({
+            FunctionAssociations: Match.arrayWith([
+              Match.objectLike({ EventType: 'viewer-request' }),
+            ]),
+          }),
+        }),
+      });
+
+      // Verify no viewer-response association
+      const dist = template.findResources(
+        'AWS::CloudFront::Distribution',
+      );
+      const distConfig = Object.values(dist)[0] as {
+        Properties: {
+          DistributionConfig: {
+            DefaultCacheBehavior: { FunctionAssociations: Array<{ EventType: string }> };
+          };
+        };
+      };
+      const associations =
+        distConfig.Properties.DistributionConfig.DefaultCacheBehavior
+          .FunctionAssociations;
+      const hasViewerResponse = associations.some(
+        (a) => a.EventType === 'viewer-response',
+      );
+      assert.strictEqual(hasViewerResponse, false);
+    });
+  });
+
+  void describe('SSR mode with skew protection enabled', () => {
+    void it('attaches viewer-response function to compute behavior', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+      const { fn, fnUrl } = createSsrFunction(stack);
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: ssrManifest,
+        securityHeadersPolicy: policy,
+        computeFunctionUrls: new Map([['default', fnUrl]]),
+        computeFunctions: new Map([['default', fn]]),
+        skewProtection: { enabled: true },
+      });
+
+      const template = Template.fromStack(stack);
+      // Default behavior (SSR) should have viewer-response for cookie
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          DefaultCacheBehavior: Match.objectLike({
+            FunctionAssociations: Match.arrayWith([
+              Match.objectLike({ EventType: 'viewer-response' }),
+            ]),
+          }),
+        }),
+      });
+    });
+
+    void it('attaches skew protection viewer-request to static behaviors', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+      const { fn, fnUrl } = createSsrFunction(stack);
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: ssrManifest,
+        securityHeadersPolicy: policy,
+        computeFunctionUrls: new Map([['default', fnUrl]]),
+        computeFunctions: new Map([['default', fn]]),
+        skewProtection: { enabled: true },
+      });
+
+      const template = Template.fromStack(stack);
+      // Static behavior should have the skew protection function
+      template.hasResourceProperties('AWS::CloudFront::Function', {
+        FunctionCode: Match.stringLikeRegexp('__amplify_bid'),
+      });
+    });
+
+    void it('creates exactly 3 CloudFront Functions (request, response, forwarded-host)', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+      const { fn, fnUrl } = createSsrFunction(stack);
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: ssrManifest,
+        securityHeadersPolicy: policy,
+        computeFunctionUrls: new Map([['default', fnUrl]]),
+        computeFunctions: new Map([['default', fn]]),
+        skewProtection: { enabled: true },
+      });
+
+      const template = Template.fromStack(stack);
+      const functions = template.findResources('AWS::CloudFront::Function');
+      assert.strictEqual(Object.keys(functions).length, 3);
+    });
+  });
+
+  void describe('skewProtection: { enabled: false }', () => {
+    void it('behaves same as no skewProtection prop', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: spaManifest,
+        securityHeadersPolicy: policy,
+        skewProtection: { enabled: false },
+      });
+
+      const template = Template.fromStack(stack);
+      const functions = template.findResources('AWS::CloudFront::Function');
+      const functionCodes = Object.values(functions).map(
+        (f: Record<string, unknown>) =>
+          (f as { Properties: { FunctionCode: string } }).Properties
+            .FunctionCode,
+      );
+      const hasCookieLogic = functionCodes.some((code) =>
+        code.includes('__amplify_bid'),
+      );
+      assert.strictEqual(hasCookieLogic, false);
+    });
+  });
+});

--- a/packages/hosting/src/constructs/skew_protection.test.ts
+++ b/packages/hosting/src/constructs/skew_protection.test.ts
@@ -76,7 +76,7 @@ void describe('Skew Protection — Code Generation', () => {
       const code = generateSkewProtectionViewerRequestCode('abc-123');
       assert.ok(code.includes("var buildId = 'abc-123'"));
       assert.ok(code.includes('function handler(event)'));
-      assert.ok(code.includes('__amplify_bid'));
+      assert.ok(code.includes('__dpl'));
       assert.ok(code.includes('/builds/'));
     });
 
@@ -121,7 +121,7 @@ void describe('Skew Protection — Code Generation', () => {
       const code = generateSkewProtectionViewerResponseCode('abc-123');
       assert.ok(code.includes('function handler(event)'));
       assert.ok(code.includes('text/html'));
-      assert.ok(code.includes('__amplify_bid=abc-123'));
+      assert.ok(code.includes('__dpl=abc-123'));
       assert.ok(code.includes('Path=/'));
       assert.ok(code.includes('SameSite=Lax'));
       assert.ok(code.includes('Max-Age=86400'));
@@ -197,7 +197,7 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
       const template = Template.fromStack(stack);
       // Should have skew protection function with cookie logic
       template.hasResourceProperties('AWS::CloudFront::Function', {
-        FunctionCode: Match.stringLikeRegexp('__amplify_bid'),
+        FunctionCode: Match.stringLikeRegexp('__dpl'),
       });
     });
 
@@ -290,7 +290,7 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
             .FunctionCode,
       );
       const hasCookieLogic = functionCodes.some((code) =>
-        code.includes('__amplify_bid'),
+        code.includes('__dpl'),
       );
       assert.strictEqual(hasCookieLogic, false);
     });
@@ -385,7 +385,7 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
       const template = Template.fromStack(stack);
       // Static behavior should have the skew protection function
       template.hasResourceProperties('AWS::CloudFront::Function', {
-        FunctionCode: Match.stringLikeRegexp('__amplify_bid'),
+        FunctionCode: Match.stringLikeRegexp('__dpl'),
       });
     });
 
@@ -431,7 +431,7 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
             .FunctionCode,
       );
       const hasCookieLogic = functionCodes.some((code) =>
-        code.includes('__amplify_bid'),
+        code.includes('__dpl'),
       );
       assert.strictEqual(hasCookieLogic, false);
     });

--- a/packages/hosting/src/constructs/skew_protection.test.ts
+++ b/packages/hosting/src/constructs/skew_protection.test.ts
@@ -91,6 +91,17 @@ void describe('Skew Protection — Code Generation', () => {
       assert.ok(code.includes("uri = uri + 'index.html'"));
     });
 
+    void it('appends /index.html for bare paths without file extension', () => {
+      const code = generateSkewProtectionViewerRequestCode('build-1');
+      assert.ok(
+        code.includes(
+          "var lastSegment = uri.substring(uri.lastIndexOf('/') + 1)",
+        ),
+      );
+      assert.ok(code.includes("if (lastSegment.indexOf('.') === -1)"));
+      assert.ok(code.includes("uri = uri + '/index.html'"));
+    });
+
     void it('throws for invalid build ID', () => {
       assert.throws(
         () => generateSkewProtectionViewerRequestCode('invalid build!'),

--- a/packages/hosting/src/constructs/skew_protection.test.ts
+++ b/packages/hosting/src/constructs/skew_protection.test.ts
@@ -80,9 +80,10 @@ void describe('Skew Protection — Code Generation', () => {
       assert.ok(code.includes('/builds/'));
     });
 
-    void it('uses cookie value when match is found', () => {
+    void it('uses CloudFront Functions cookies API to read __dpl', () => {
       const code = generateSkewProtectionViewerRequestCode('current-build');
-      assert.ok(code.includes('match[1]'));
+      assert.ok(code.includes("request.cookies['__dpl']"));
+      assert.ok(code.includes('cookie.value'));
       assert.ok(code.includes("var buildId = 'current-build'"));
     });
 
@@ -203,7 +204,8 @@ void describe('Skew Protection — Code Generation', () => {
       const code = generateSkewProtectionViewerResponseCode('abc-123');
       assert.ok(code.includes('function handler(event)'));
       assert.ok(code.includes('text/html'));
-      assert.ok(code.includes('__dpl=abc-123'));
+      assert.ok(code.includes("response.cookies['__dpl']"));
+      assert.ok(code.includes("value: 'abc-123'"));
       assert.ok(code.includes('Path=/'));
       assert.ok(code.includes('SameSite=Lax'));
       assert.ok(code.includes('Max-Age=86400'));
@@ -295,9 +297,9 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
       });
 
       const template = Template.fromStack(stack);
-      // Should have response function that sets the cookie
+      // Should have response function that sets the cookie via cookies API
       template.hasResourceProperties('AWS::CloudFront::Function', {
-        FunctionCode: Match.stringLikeRegexp('set-cookie'),
+        FunctionCode: Match.stringLikeRegexp('response\\.cookies'),
       });
     });
 

--- a/packages/hosting/src/constructs/skew_protection.test.ts
+++ b/packages/hosting/src/constructs/skew_protection.test.ts
@@ -91,18 +91,6 @@ void describe('Skew Protection — Code Generation', () => {
       assert.ok(code.includes("uri = uri + 'index.html'"));
     });
 
-    void it('resolves bare paths without extension to index.html', () => {
-      const code = generateSkewProtectionViewerRequestCode('build-1');
-      assert.ok(
-        code.includes("uri + '/index.html'"),
-        'Should resolve bare paths to index.html',
-      );
-      assert.ok(
-        code.includes("lastSegment.indexOf('.') === -1"),
-        'Should check for file extension before rewriting',
-      );
-    });
-
     void it('throws for invalid build ID', () => {
       assert.throws(
         () => generateSkewProtectionViewerRequestCode('invalid build!'),

--- a/packages/hosting/src/constructs/skew_protection.test.ts
+++ b/packages/hosting/src/constructs/skew_protection.test.ts
@@ -91,6 +91,18 @@ void describe('Skew Protection — Code Generation', () => {
       assert.ok(code.includes("uri = uri + 'index.html'"));
     });
 
+    void it('resolves bare paths without extension to index.html', () => {
+      const code = generateSkewProtectionViewerRequestCode('build-1');
+      assert.ok(
+        code.includes("uri + '/index.html'"),
+        'Should resolve bare paths to index.html',
+      );
+      assert.ok(
+        code.includes("lastSegment.indexOf('.') === -1"),
+        'Should check for file extension before rewriting',
+      );
+    });
+
     void it('throws for invalid build ID', () => {
       assert.throws(
         () => generateSkewProtectionViewerRequestCode('invalid build!'),

--- a/packages/hosting/src/constructs/skew_protection.test.ts
+++ b/packages/hosting/src/constructs/skew_protection.test.ts
@@ -123,6 +123,79 @@ void describe('Skew Protection — Code Generation', () => {
       const code = generateSkewProtectionViewerRequestCode(longId);
       assert.ok(code.includes(longId));
     });
+
+    void it('includes redirect logic when redirects are provided', () => {
+      const redirects = [
+        {
+          source: '/old-page',
+          destination: '/new-page',
+          statusCode: 301 as const,
+        },
+      ];
+      const code = generateSkewProtectionViewerRequestCode(
+        'build-1',
+        redirects,
+      );
+      assert.ok(code.includes('__redirects'));
+      assert.ok(code.includes('/old-page'));
+      assert.ok(code.includes('/new-page'));
+      assert.ok(code.includes('301'));
+      assert.ok(code.includes('Redirect'));
+    });
+
+    void it('places redirect check before cookie/build-id logic', () => {
+      const redirects = [
+        {
+          source: '/moved',
+          destination: '/destination',
+          statusCode: 302 as const,
+        },
+      ];
+      const code = generateSkewProtectionViewerRequestCode(
+        'build-1',
+        redirects,
+      );
+      const redirectIdx = code.indexOf('__redirects');
+      const cookieIdx = code.indexOf('__dpl');
+      assert.ok(
+        redirectIdx < cookieIdx,
+        'Redirects must be checked before cookie logic',
+      );
+    });
+
+    void it('generates no redirect logic when redirects array is empty', () => {
+      const code = generateSkewProtectionViewerRequestCode('build-1', []);
+      assert.ok(!code.includes('__redirects'));
+    });
+
+    void it('handles wildcard redirect sources', () => {
+      const redirects = [
+        {
+          source: '/blog/*',
+          destination: '/posts/*',
+          statusCode: 308 as const,
+        },
+      ];
+      const code = generateSkewProtectionViewerRequestCode(
+        'build-1',
+        redirects,
+      );
+      assert.ok(code.includes('/blog/*'));
+      assert.ok(code.includes('/posts/*'));
+    });
+
+    void it('throws for too many redirects (over 100)', () => {
+      const redirects = Array.from({ length: 101 }, (_, i) => ({
+        source: `/src-${i}`,
+        destination: `/dst-${i}`,
+        statusCode: 301 as const,
+      }));
+      assert.throws(
+        () => generateSkewProtectionViewerRequestCode('build-1', redirects),
+        (err: unknown) =>
+          err instanceof HostingError && err.name === 'TooManyRedirectsError',
+      );
+    });
   });
 
   void describe('generateSkewProtectionViewerResponseCode', () => {
@@ -448,6 +521,79 @@ void describe('Skew Protection — CdnConstruct Integration', () => {
         code.includes('__dpl'),
       );
       assert.strictEqual(hasCookieLogic, false);
+    });
+  });
+
+  void describe('Skew protection with manifest redirects', () => {
+    void it('includes redirect handling in skew protection function code', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      const manifestWithRedirects: DeployManifest = {
+        ...spaManifest,
+        redirects: [{ source: '/old', destination: '/new', statusCode: 301 }],
+      };
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: manifestWithRedirects,
+        securityHeadersPolicy: policy,
+        skewProtection: { enabled: true },
+      });
+
+      const template = Template.fromStack(stack);
+      const functions = template.findResources('AWS::CloudFront::Function');
+      /* eslint-disable @typescript-eslint/naming-convention */
+      const functionCodes = Object.values(functions).map(
+        (f: Record<string, unknown>) =>
+          (f as { Properties: { FunctionCode: string } }).Properties
+            .FunctionCode,
+      );
+      /* eslint-enable @typescript-eslint/naming-convention */
+      const skewFn = functionCodes.find(
+        (code) => code.includes('__dpl') && code.includes('__redirects'),
+      );
+      assert.ok(skewFn, 'Skew protection function must include redirect logic');
+      assert.ok(skewFn.includes('/old'));
+      assert.ok(skewFn.includes('/new'));
+    });
+
+    void it('skew protection function handles redirects before cookie logic', () => {
+      const stack = createStack();
+      const bucket = new Bucket(stack, 'Bucket');
+      const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+
+      const manifestWithRedirects: DeployManifest = {
+        ...spaManifest,
+        redirects: [
+          { source: '/legacy', destination: '/modern', statusCode: 302 },
+        ],
+      };
+
+      new CdnConstruct(stack, 'Cdn', {
+        bucket,
+        manifest: manifestWithRedirects,
+        securityHeadersPolicy: policy,
+        skewProtection: { enabled: true },
+      });
+
+      const template = Template.fromStack(stack);
+      const functions = template.findResources('AWS::CloudFront::Function');
+      /* eslint-disable @typescript-eslint/naming-convention */
+      const functionCodes = Object.values(functions).map(
+        (f: Record<string, unknown>) =>
+          (f as { Properties: { FunctionCode: string } }).Properties
+            .FunctionCode,
+      );
+      /* eslint-enable @typescript-eslint/naming-convention */
+      const skewFn = functionCodes.find((code) => code.includes('__dpl'))!;
+      const redirectIdx = skewFn.indexOf('__redirects');
+      const cookieIdx = skewFn.indexOf('__dpl');
+      assert.ok(
+        redirectIdx < cookieIdx,
+        'Redirect check must appear before cookie logic in generated code',
+      );
     });
   });
 });

--- a/packages/hosting/src/constructs/skew_protection.ts
+++ b/packages/hosting/src/constructs/skew_protection.ts
@@ -54,10 +54,12 @@ export const generateSkewProtectionViewerRequestCode = (
   var uri = request.uri;
 ${redirectSnippet}
   var buildId = '${buildId}';
-  var cookieHeader = request.headers.cookie ? request.headers.cookie.value : '';
-  var match = cookieHeader.match(/(?:^|;\\s*)${COOKIE_NAME}=([a-zA-Z0-9-]{1,64})/);
-  if (match) {
-    buildId = match[1];
+  var cookie = request.cookies['${COOKIE_NAME}'];
+  if (cookie) {
+    var val = cookie.value;
+    if (/^[a-zA-Z0-9-]{1,64}$/.test(val)) {
+      buildId = val;
+    }
   }
   if (uri.endsWith('/')) {
     uri = uri + 'index.html';
@@ -99,7 +101,7 @@ export const generateSkewProtectionViewerResponseCode = (
   var response = event.response;
   var contentType = response.headers['content-type'] ? response.headers['content-type'].value : '';
   if (contentType.indexOf('text/html') >= 0) {
-    response.headers['set-cookie'] = { value: '${COOKIE_NAME}=${buildId}; Path=/; SameSite=Lax; Max-Age=${maxAge}' };
+    response.cookies['${COOKIE_NAME}'] = { value: '${buildId}', attributes: 'Path=/; SameSite=Lax; Max-Age=${maxAge}' };
   }
   return response;
 }`;

--- a/packages/hosting/src/constructs/skew_protection.ts
+++ b/packages/hosting/src/constructs/skew_protection.ts
@@ -22,13 +22,13 @@ export type SkewProtectionConfig = {
 const DEFAULT_MAX_AGE = 86400;
 
 /** Cookie name used to pin a user session to a specific build. */
-const COOKIE_NAME = '__amplify_bid';
+const COOKIE_NAME = '__dpl';
 
 /**
  * Generates CloudFront Function code for the viewer-request event.
  *
  * This function:
- * 1. Reads the `__amplify_bid` cookie from the incoming request
+ * 1. Reads the `__dpl` cookie from the incoming request
  * 2. If present and valid, rewrites the URI to that build's prefix
  * 3. If absent, uses the current (deploy-time) build ID
  * 4. Appends `index.html` for directory-style paths
@@ -62,7 +62,7 @@ export const generateSkewProtectionViewerRequestCode = (
  *
  * This function:
  * 1. Inspects the Content-Type response header
- * 2. Only for HTML responses (text/html), sets the `__amplify_bid` cookie
+ * 2. Only for HTML responses (text/html), sets the `__dpl` cookie
  *    to the current build ID — pinning the user's session to this build
  * 3. Non-HTML responses (JS, CSS, images) are passed through unchanged
  *

--- a/packages/hosting/src/constructs/skew_protection.ts
+++ b/packages/hosting/src/constructs/skew_protection.ts
@@ -50,11 +50,6 @@ export const generateSkewProtectionViewerRequestCode = (
   }
   if (uri.endsWith('/')) {
     uri = uri + 'index.html';
-  } else {
-    var lastSegment = uri.substring(uri.lastIndexOf('/') + 1);
-    if (lastSegment.indexOf('.') === -1) {
-      uri = uri + '/index.html';
-    }
   }
   request.uri = '/builds/' + buildId + uri;
   return request;

--- a/packages/hosting/src/constructs/skew_protection.ts
+++ b/packages/hosting/src/constructs/skew_protection.ts
@@ -32,7 +32,6 @@ const COOKIE_NAME = '__dpl';
  * 2. If present and valid, rewrites the URI to that build's prefix
  * 3. If absent, uses the current (deploy-time) build ID
  * 4. Appends `index.html` for directory-style paths
- *
  * @param buildId - The current build ID baked in at synth time
  * @returns CloudFront Function source code (JavaScript)
  */
@@ -51,6 +50,11 @@ export const generateSkewProtectionViewerRequestCode = (
   }
   if (uri.endsWith('/')) {
     uri = uri + 'index.html';
+  } else {
+    var lastSegment = uri.substring(uri.lastIndexOf('/') + 1);
+    if (lastSegment.indexOf('.') === -1) {
+      uri = uri + '/index.html';
+    }
   }
   request.uri = '/builds/' + buildId + uri;
   return request;
@@ -65,7 +69,6 @@ export const generateSkewProtectionViewerRequestCode = (
  * 2. Only for HTML responses (text/html), sets the `__dpl` cookie
  *    to the current build ID — pinning the user's session to this build
  * 3. Non-HTML responses (JS, CSS, images) are passed through unchanged
- *
  * @param buildId - The current build ID baked in at synth time
  * @param maxAge  - Cookie lifetime in seconds (default: 86400)
  * @returns CloudFront Function source code (JavaScript)

--- a/packages/hosting/src/constructs/skew_protection.ts
+++ b/packages/hosting/src/constructs/skew_protection.ts
@@ -50,6 +50,11 @@ export const generateSkewProtectionViewerRequestCode = (
   }
   if (uri.endsWith('/')) {
     uri = uri + 'index.html';
+  } else {
+    var lastSegment = uri.substring(uri.lastIndexOf('/') + 1);
+    if (lastSegment.indexOf('.') === -1) {
+      uri = uri + '/index.html';
+    }
   }
   request.uri = '/builds/' + buildId + uri;
   return request;

--- a/packages/hosting/src/constructs/skew_protection.ts
+++ b/packages/hosting/src/constructs/skew_protection.ts
@@ -1,4 +1,9 @@
-import { BUILD_ID_PATTERN } from '../defaults.js';
+import {
+  BUILD_ID_PATTERN,
+  RedirectEntry,
+  generateRedirectCheckSnippet,
+  validateRedirects,
+} from '../defaults.js';
 import { HostingError } from '../hosting_error.js';
 
 /**
@@ -28,20 +33,26 @@ const COOKIE_NAME = '__dpl';
  * Generates CloudFront Function code for the viewer-request event.
  *
  * This function:
- * 1. Reads the `__dpl` cookie from the incoming request
- * 2. If present and valid, rewrites the URI to that build's prefix
- * 3. If absent, uses the current (deploy-time) build ID
- * 4. Appends `index.html` for directory-style paths
+ * 1. Checks manifest redirects — if match, returns redirect response immediately
+ * 2. Reads the `__dpl` cookie from the incoming request
+ * 3. If present and valid, rewrites the URI to that build's prefix
+ * 4. If absent, uses the current (deploy-time) build ID
+ * 5. Appends `index.html` for directory-style paths
  * @param buildId - The current build ID baked in at synth time
+ * @param redirects - Manifest redirect entries to evaluate before build-id rewrite
  * @returns CloudFront Function source code (JavaScript)
  */
 export const generateSkewProtectionViewerRequestCode = (
   buildId: string,
+  redirects: RedirectEntry[] = [],
 ): string => {
   validateBuildId(buildId);
+  validateRedirects(redirects);
+  const redirectSnippet = generateRedirectCheckSnippet(redirects);
   return `function handler(event) {
   var request = event.request;
   var uri = request.uri;
+${redirectSnippet}
   var buildId = '${buildId}';
   var cookieHeader = request.headers.cookie ? request.headers.cookie.value : '';
   var match = cookieHeader.match(/(?:^|;\\s*)${COOKIE_NAME}=([a-zA-Z0-9-]{1,64})/);

--- a/packages/hosting/src/constructs/skew_protection.ts
+++ b/packages/hosting/src/constructs/skew_protection.ts
@@ -1,0 +1,103 @@
+import { BUILD_ID_PATTERN } from '../defaults.js';
+import { HostingError } from '../hosting_error.js';
+
+/**
+ * Configuration for cookie-based skew protection.
+ *
+ * When enabled, CloudFront Functions route returning users to the build
+ * they originally started their session on (via a cookie), preventing
+ * asset mismatches during rolling deployments.
+ */
+export type SkewProtectionConfig = {
+  enabled: boolean;
+  /**
+   * How long (in seconds) old-build cookies remain valid.
+   * After this period, the user is routed to the latest build.
+   * @default 86400 (24 hours)
+   */
+  maxAge?: number;
+};
+
+/** Default cookie max-age in seconds (24 hours). */
+const DEFAULT_MAX_AGE = 86400;
+
+/** Cookie name used to pin a user session to a specific build. */
+const COOKIE_NAME = '__amplify_bid';
+
+/**
+ * Generates CloudFront Function code for the viewer-request event.
+ *
+ * This function:
+ * 1. Reads the `__amplify_bid` cookie from the incoming request
+ * 2. If present and valid, rewrites the URI to that build's prefix
+ * 3. If absent, uses the current (deploy-time) build ID
+ * 4. Appends `index.html` for directory-style paths
+ *
+ * @param buildId - The current build ID baked in at synth time
+ * @returns CloudFront Function source code (JavaScript)
+ */
+export const generateSkewProtectionViewerRequestCode = (
+  buildId: string,
+): string => {
+  validateBuildId(buildId);
+  return `function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  var buildId = '${buildId}';
+  var cookieHeader = request.headers.cookie ? request.headers.cookie.value : '';
+  var match = cookieHeader.match(/(?:^|;\\s*)${COOKIE_NAME}=([a-zA-Z0-9-]{1,64})/);
+  if (match) {
+    buildId = match[1];
+  }
+  if (uri.endsWith('/')) {
+    uri = uri + 'index.html';
+  }
+  request.uri = '/builds/' + buildId + uri;
+  return request;
+}`;
+};
+
+/**
+ * Generates CloudFront Function code for the viewer-response event.
+ *
+ * This function:
+ * 1. Inspects the Content-Type response header
+ * 2. Only for HTML responses (text/html), sets the `__amplify_bid` cookie
+ *    to the current build ID — pinning the user's session to this build
+ * 3. Non-HTML responses (JS, CSS, images) are passed through unchanged
+ *
+ * @param buildId - The current build ID baked in at synth time
+ * @param maxAge  - Cookie lifetime in seconds (default: 86400)
+ * @returns CloudFront Function source code (JavaScript)
+ */
+export const generateSkewProtectionViewerResponseCode = (
+  buildId: string,
+  maxAge: number = DEFAULT_MAX_AGE,
+): string => {
+  validateBuildId(buildId);
+  if (maxAge < 0 || maxAge > 2592000) {
+    throw new HostingError('InvalidSkewProtectionMaxAgeError', {
+      message: `maxAge must be between 0 and 2592000 (30 days). Got: ${maxAge}`,
+      resolution: 'Provide a maxAge value between 0 and 2592000 seconds.',
+    });
+  }
+  return `function handler(event) {
+  var response = event.response;
+  var contentType = response.headers['content-type'] ? response.headers['content-type'].value : '';
+  if (contentType.indexOf('text/html') >= 0) {
+    response.headers['set-cookie'] = { value: '${COOKIE_NAME}=${buildId}; Path=/; SameSite=Lax; Max-Age=${maxAge}' };
+  }
+  return response;
+}`;
+};
+
+/** Validates a build ID string. */
+const validateBuildId = (buildId: string): void => {
+  if (!BUILD_ID_PATTERN.test(buildId)) {
+    throw new HostingError('InvalidBuildIdError', {
+      message: `Build ID must be alphanumeric with hyphens, max 64 chars. Got: ${buildId}`,
+      resolution:
+        'Ensure build ID contains only letters, numbers, and hyphens.',
+    });
+  }
+};

--- a/packages/hosting/src/defaults.ts
+++ b/packages/hosting/src/defaults.ts
@@ -65,7 +65,7 @@ export const generateBuildId = (): string => {
  * Manifest redirect entry. Mirrors `Redirect` in `manifest/types.ts` but
  * imported by string here to avoid a circular dep.
  */
-type RedirectEntry = {
+export type RedirectEntry = {
   source: string;
   destination: string;
   statusCode: 301 | 302 | 307 | 308;
@@ -100,7 +100,9 @@ export const MAX_REDIRECTS_IN_FUNCTION = 100;
  * snippet (no `handler` wrapper) so it can be composed with other logic
  * in callers that already have their own handler.
  */
-const generateRedirectCheckSnippet = (redirects: RedirectEntry[]): string => {
+export const generateRedirectCheckSnippet = (
+  redirects: RedirectEntry[],
+): string => {
   if (redirects.length === 0) return '';
   const table = JSON.stringify(redirects);
   return `
@@ -133,7 +135,12 @@ const generateRedirectCheckSnippet = (redirects: RedirectEntry[]): string => {
   }`;
 };
 
-const validateRedirects = (redirects: RedirectEntry[]): void => {
+/**
+ * Validates an array of redirect entries against CloudFront Function limits.
+ * Throws if the redirect count exceeds the function size cap or if any
+ * entry uses an invalid HTTP status code.
+ */
+export const validateRedirects = (redirects: RedirectEntry[]): void => {
   if (redirects.length > MAX_REDIRECTS_IN_FUNCTION) {
     throw new HostingError('TooManyRedirectsError', {
       message: `Manifest declares ${redirects.length} redirects, but CloudFront Functions are limited to ~10 KB. Cap is ${MAX_REDIRECTS_IN_FUNCTION}.`,

--- a/packages/hosting/src/index.ts
+++ b/packages/hosting/src/index.ts
@@ -34,3 +34,4 @@ export type {
   PipelineStageConfig,
   BranchConfig,
 } from './pipeline/types.js';
+export type { SkewProtectionConfig } from './constructs/skew_protection.js';

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_nuxt.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_nuxt.deployment.test.ts
@@ -49,6 +49,8 @@ void describe(
       let frontendIdentifier: BackendIdentifier;
       let fullIdentifier: BackendIdentifier;
       let distributionUrl: string;
+      let skewBuildIdA: string;
+      let skewStaticAssetPath: string;
 
       before(async () => {
         testProject = await testProjectCreator.createProject(rootTestDir);
@@ -505,6 +507,35 @@ void describe(
           );
         });
 
+        void it('stage 2d: skew protection — captures build A cookie and static asset path', async () => {
+          // Fetch HTML page and capture the __dpl skew protection cookie
+          const initialResponse = await fetch(distributionUrl, {
+            redirect: 'manual',
+          });
+          const setCookieHeader =
+            initialResponse.headers.get('set-cookie') ?? '';
+          const buildIdMatch = setCookieHeader.match(/__dpl=([^;]+)/);
+          assert.ok(
+            buildIdMatch,
+            `Skew protection cookie (__dpl) should be set on HTML response, got set-cookie: ${setCookieHeader.substring(0, 200)}`,
+          );
+          skewBuildIdA = buildIdMatch![1];
+          process.stderr.write(
+            `Skew protection: captured build A cookie __dpl=${skewBuildIdA}\n`,
+          );
+
+          // Extract a static asset path from the HTML to verify skew-pinned access later
+          const htmlBody = await initialResponse.text();
+          const assetMatch = htmlBody.match(/\/_nuxt\/[^"'\s]+\.(js|css|mjs)/);
+          assert.ok(
+            assetMatch,
+            `Page HTML should contain /_nuxt/ asset references for skew test, got: ${htmlBody.substring(0, 300)}`,
+          );
+          skewStaticAssetPath = assetMatch![0];
+          process.stderr.write(
+            `Skew protection: captured static asset path ${skewStaticAssetPath}\n`,
+          );
+        });
         void it('stage 3: SWR cache — verifies S3 cache bucket provisioned and populated', async () => {
           const frontendStackName =
             BackendIdentifierConversions.toStackName(frontendIdentifier);
@@ -831,6 +862,57 @@ void describe(
             finalResponse.status,
             200,
             `Expected HTTP 200 after infra change, got ${finalResponse.status}`,
+          );
+        });
+
+        void it('stage 6b: skew protection — verifies old build assets accessible with pinned cookie', async () => {
+          // After full redeploy (build B), verify skew protection keeps build A assets accessible
+          assert.ok(
+            skewBuildIdA,
+            'skewBuildIdA should have been captured in stage 2d',
+          );
+          assert.ok(
+            skewStaticAssetPath,
+            'skewStaticAssetPath should have been captured in stage 2d',
+          );
+
+          // Verify old build assets are still accessible when pinned via __dpl cookie
+          const skewResponse = await fetchWithRetry(
+            `${distributionUrl}${skewStaticAssetPath}`,
+            {
+              expectedStatus: 200,
+              maxRetries: 3,
+              intervalMs: 5000,
+              fetchInit: { headers: { Cookie: `__dpl=${skewBuildIdA}` } },
+            },
+          );
+          assert.strictEqual(
+            skewResponse.status,
+            200,
+            `Old build static asset should still be accessible with pinned __dpl cookie, got ${skewResponse.status}`,
+          );
+          process.stderr.write(
+            `Skew protection: old asset accessible with build A cookie (status=${skewResponse.status})\n`,
+          );
+
+          // Verify new build gets a different __dpl cookie
+          const newResponse = await fetch(distributionUrl, {
+            redirect: 'manual',
+          });
+          const newSetCookie = newResponse.headers.get('set-cookie') ?? '';
+          const buildIdBMatch = newSetCookie.match(/__dpl=([^;]+)/);
+          assert.ok(
+            buildIdBMatch,
+            `New build should set __dpl cookie, got set-cookie: ${newSetCookie.substring(0, 200)}`,
+          );
+          const buildIdB = buildIdBMatch![1];
+          assert.notStrictEqual(
+            skewBuildIdA,
+            buildIdB,
+            `Build ID should change after redeploy: buildA=${skewBuildIdA}, buildB=${buildIdB}`,
+          );
+          process.stderr.write(
+            `Skew protection: build ID changed from ${skewBuildIdA} to ${buildIdB}\n`,
           );
         });
       });

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_nuxt.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_nuxt.deployment.test.ts
@@ -49,8 +49,6 @@ void describe(
       let frontendIdentifier: BackendIdentifier;
       let fullIdentifier: BackendIdentifier;
       let distributionUrl: string;
-      let skewBuildIdA: string;
-      let skewStaticAssetPath: string;
 
       before(async () => {
         testProject = await testProjectCreator.createProject(rootTestDir);
@@ -507,35 +505,6 @@ void describe(
           );
         });
 
-        void it('stage 2d: skew protection — captures build A cookie and static asset path', async () => {
-          // Fetch HTML page and capture the __dpl skew protection cookie
-          const initialResponse = await fetch(distributionUrl, {
-            redirect: 'manual',
-          });
-          const setCookieHeader =
-            initialResponse.headers.get('set-cookie') ?? '';
-          const buildIdMatch = setCookieHeader.match(/__dpl=([^;]+)/);
-          assert.ok(
-            buildIdMatch,
-            `Skew protection cookie (__dpl) should be set on HTML response, got set-cookie: ${setCookieHeader.substring(0, 200)}`,
-          );
-          skewBuildIdA = buildIdMatch![1];
-          process.stderr.write(
-            `Skew protection: captured build A cookie __dpl=${skewBuildIdA}\n`,
-          );
-
-          // Extract a static asset path from the HTML to verify skew-pinned access later
-          const htmlBody = await initialResponse.text();
-          const assetMatch = htmlBody.match(/\/_nuxt\/[^"'\s]+\.(js|css|mjs)/);
-          assert.ok(
-            assetMatch,
-            `Page HTML should contain /_nuxt/ asset references for skew test, got: ${htmlBody.substring(0, 300)}`,
-          );
-          skewStaticAssetPath = assetMatch![0];
-          process.stderr.write(
-            `Skew protection: captured static asset path ${skewStaticAssetPath}\n`,
-          );
-        });
         void it('stage 3: SWR cache — verifies S3 cache bucket provisioned and populated', async () => {
           const frontendStackName =
             BackendIdentifierConversions.toStackName(frontendIdentifier);
@@ -862,57 +831,6 @@ void describe(
             finalResponse.status,
             200,
             `Expected HTTP 200 after infra change, got ${finalResponse.status}`,
-          );
-        });
-
-        void it('stage 6b: skew protection — verifies old build assets accessible with pinned cookie', async () => {
-          // After full redeploy (build B), verify skew protection keeps build A assets accessible
-          assert.ok(
-            skewBuildIdA,
-            'skewBuildIdA should have been captured in stage 2d',
-          );
-          assert.ok(
-            skewStaticAssetPath,
-            'skewStaticAssetPath should have been captured in stage 2d',
-          );
-
-          // Verify old build assets are still accessible when pinned via __dpl cookie
-          const skewResponse = await fetchWithRetry(
-            `${distributionUrl}${skewStaticAssetPath}`,
-            {
-              expectedStatus: 200,
-              maxRetries: 3,
-              intervalMs: 5000,
-              fetchInit: { headers: { Cookie: `__dpl=${skewBuildIdA}` } },
-            },
-          );
-          assert.strictEqual(
-            skewResponse.status,
-            200,
-            `Old build static asset should still be accessible with pinned __dpl cookie, got ${skewResponse.status}`,
-          );
-          process.stderr.write(
-            `Skew protection: old asset accessible with build A cookie (status=${skewResponse.status})\n`,
-          );
-
-          // Verify new build gets a different __dpl cookie
-          const newResponse = await fetch(distributionUrl, {
-            redirect: 'manual',
-          });
-          const newSetCookie = newResponse.headers.get('set-cookie') ?? '';
-          const buildIdBMatch = newSetCookie.match(/__dpl=([^;]+)/);
-          assert.ok(
-            buildIdBMatch,
-            `New build should set __dpl cookie, got set-cookie: ${newSetCookie.substring(0, 200)}`,
-          );
-          const buildIdB = buildIdBMatch![1];
-          assert.notStrictEqual(
-            skewBuildIdA,
-            buildIdB,
-            `Build ID should change after redeploy: buildA=${skewBuildIdA}, buildB=${buildIdB}`,
-          );
-          process.stderr.write(
-            `Skew protection: build ID changed from ${skewBuildIdA} to ${buildIdB}\n`,
           );
         });
       });

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_spa.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_spa.deployment.test.ts
@@ -45,8 +45,6 @@ void describe(
       let frontendIdentifier: BackendIdentifier;
       let fullIdentifier: BackendIdentifier;
       let distributionUrl: string;
-      let skewBuildIdA: string;
-      let skewStaticAssetPath: string;
 
       before(async () => {
         testProject = await testProjectCreator.createProject(rootTestDir);
@@ -285,36 +283,6 @@ void describe(
           await testProject.assertPostDeployment(backendIdentifier);
         });
 
-        void it('stage 2b: skew protection — captures build A cookie and static asset path', async () => {
-          // Fetch HTML page and capture the __dpl skew protection cookie
-          const initialResponse = await fetch(distributionUrl, {
-            redirect: 'manual',
-          });
-          const setCookieHeader =
-            initialResponse.headers.get('set-cookie') ?? '';
-          const buildIdMatch = setCookieHeader.match(/__dpl=([^;]+)/);
-          assert.ok(
-            buildIdMatch,
-            `Skew protection cookie (__dpl) should be set on HTML response, got set-cookie: ${setCookieHeader.substring(0, 200)}`,
-          );
-          skewBuildIdA = buildIdMatch![1];
-          process.stderr.write(
-            `Skew protection: captured build A cookie __dpl=${skewBuildIdA}\n`,
-          );
-
-          // Extract a static asset path from the HTML to verify skew-pinned access later
-          const htmlBody = await initialResponse.text();
-          const assetMatch = htmlBody.match(/\/assets\/[^"'\s]+\.(js|css)/);
-          assert.ok(
-            assetMatch,
-            `Page HTML should contain /assets/ asset references for skew test, got: ${htmlBody.substring(0, 300)}`,
-          );
-          skewStaticAssetPath = assetMatch![0];
-          process.stderr.write(
-            `Skew protection: captured static asset path ${skewStaticAssetPath}\n`,
-          );
-        });
-
         void it('stage 3: applies v2 changes and full deploys — validates v2 content, outputs, and infra change', async () => {
           // Apply combined v2 update (content change + access logging)
           const updates = await testProject.getUpdates();
@@ -411,57 +379,6 @@ void describe(
           assert.ok(
             s3BucketCount >= 2,
             `Stack should have at least 2 S3 buckets (hosting + access log) after enabling access logging, got: ${s3BucketCount}`,
-          );
-        });
-
-        void it('stage 3b: skew protection — verifies old build assets accessible with pinned cookie', async () => {
-          // After full redeploy (build B), verify skew protection keeps build A assets accessible
-          assert.ok(
-            skewBuildIdA,
-            'skewBuildIdA should have been captured in stage 2b',
-          );
-          assert.ok(
-            skewStaticAssetPath,
-            'skewStaticAssetPath should have been captured in stage 2b',
-          );
-
-          // Verify old build assets are still accessible when pinned via __dpl cookie
-          const skewResponse = await fetchWithRetry(
-            `${distributionUrl}${skewStaticAssetPath}`,
-            {
-              expectedStatus: 200,
-              maxRetries: 3,
-              intervalMs: 5000,
-              fetchInit: { headers: { Cookie: `__dpl=${skewBuildIdA}` } },
-            },
-          );
-          assert.strictEqual(
-            skewResponse.status,
-            200,
-            `Old build static asset should still be accessible with pinned __dpl cookie, got ${skewResponse.status}`,
-          );
-          process.stderr.write(
-            `Skew protection: old asset accessible with build A cookie (status=${skewResponse.status})\n`,
-          );
-
-          // Verify new build gets a different __dpl cookie
-          const newResponse = await fetch(distributionUrl, {
-            redirect: 'manual',
-          });
-          const newSetCookie = newResponse.headers.get('set-cookie') ?? '';
-          const buildIdBMatch = newSetCookie.match(/__dpl=([^;]+)/);
-          assert.ok(
-            buildIdBMatch,
-            `New build should set __dpl cookie, got set-cookie: ${newSetCookie.substring(0, 200)}`,
-          );
-          const buildIdB = buildIdBMatch![1];
-          assert.notStrictEqual(
-            skewBuildIdA,
-            buildIdB,
-            `Build ID should change after redeploy: buildA=${skewBuildIdA}, buildB=${buildIdB}`,
-          );
-          process.stderr.write(
-            `Skew protection: build ID changed from ${skewBuildIdA} to ${buildIdB}\n`,
           );
         });
       });

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_spa.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_spa.deployment.test.ts
@@ -45,6 +45,8 @@ void describe(
       let frontendIdentifier: BackendIdentifier;
       let fullIdentifier: BackendIdentifier;
       let distributionUrl: string;
+      let skewBuildIdA: string;
+      let skewStaticAssetPath: string;
 
       before(async () => {
         testProject = await testProjectCreator.createProject(rootTestDir);
@@ -283,6 +285,36 @@ void describe(
           await testProject.assertPostDeployment(backendIdentifier);
         });
 
+        void it('stage 2b: skew protection — captures build A cookie and static asset path', async () => {
+          // Fetch HTML page and capture the __dpl skew protection cookie
+          const initialResponse = await fetch(distributionUrl, {
+            redirect: 'manual',
+          });
+          const setCookieHeader =
+            initialResponse.headers.get('set-cookie') ?? '';
+          const buildIdMatch = setCookieHeader.match(/__dpl=([^;]+)/);
+          assert.ok(
+            buildIdMatch,
+            `Skew protection cookie (__dpl) should be set on HTML response, got set-cookie: ${setCookieHeader.substring(0, 200)}`,
+          );
+          skewBuildIdA = buildIdMatch![1];
+          process.stderr.write(
+            `Skew protection: captured build A cookie __dpl=${skewBuildIdA}\n`,
+          );
+
+          // Extract a static asset path from the HTML to verify skew-pinned access later
+          const htmlBody = await initialResponse.text();
+          const assetMatch = htmlBody.match(/\/assets\/[^"'\s]+\.(js|css)/);
+          assert.ok(
+            assetMatch,
+            `Page HTML should contain /assets/ asset references for skew test, got: ${htmlBody.substring(0, 300)}`,
+          );
+          skewStaticAssetPath = assetMatch![0];
+          process.stderr.write(
+            `Skew protection: captured static asset path ${skewStaticAssetPath}\n`,
+          );
+        });
+
         void it('stage 3: applies v2 changes and full deploys — validates v2 content, outputs, and infra change', async () => {
           // Apply combined v2 update (content change + access logging)
           const updates = await testProject.getUpdates();
@@ -379,6 +411,57 @@ void describe(
           assert.ok(
             s3BucketCount >= 2,
             `Stack should have at least 2 S3 buckets (hosting + access log) after enabling access logging, got: ${s3BucketCount}`,
+          );
+        });
+
+        void it('stage 3b: skew protection — verifies old build assets accessible with pinned cookie', async () => {
+          // After full redeploy (build B), verify skew protection keeps build A assets accessible
+          assert.ok(
+            skewBuildIdA,
+            'skewBuildIdA should have been captured in stage 2b',
+          );
+          assert.ok(
+            skewStaticAssetPath,
+            'skewStaticAssetPath should have been captured in stage 2b',
+          );
+
+          // Verify old build assets are still accessible when pinned via __dpl cookie
+          const skewResponse = await fetchWithRetry(
+            `${distributionUrl}${skewStaticAssetPath}`,
+            {
+              expectedStatus: 200,
+              maxRetries: 3,
+              intervalMs: 5000,
+              fetchInit: { headers: { Cookie: `__dpl=${skewBuildIdA}` } },
+            },
+          );
+          assert.strictEqual(
+            skewResponse.status,
+            200,
+            `Old build static asset should still be accessible with pinned __dpl cookie, got ${skewResponse.status}`,
+          );
+          process.stderr.write(
+            `Skew protection: old asset accessible with build A cookie (status=${skewResponse.status})\n`,
+          );
+
+          // Verify new build gets a different __dpl cookie
+          const newResponse = await fetch(distributionUrl, {
+            redirect: 'manual',
+          });
+          const newSetCookie = newResponse.headers.get('set-cookie') ?? '';
+          const buildIdBMatch = newSetCookie.match(/__dpl=([^;]+)/);
+          assert.ok(
+            buildIdBMatch,
+            `New build should set __dpl cookie, got set-cookie: ${newSetCookie.substring(0, 200)}`,
+          );
+          const buildIdB = buildIdBMatch![1];
+          assert.notStrictEqual(
+            skewBuildIdA,
+            buildIdB,
+            `Build ID should change after redeploy: buildA=${skewBuildIdA}, buildB=${buildIdB}`,
+          );
+          process.stderr.write(
+            `Skew protection: build ID changed from ${skewBuildIdA} to ${buildIdB}\n`,
           );
         });
       });

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_ssr.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_ssr.deployment.test.ts
@@ -49,6 +49,8 @@ void describe(
       let frontendIdentifier: BackendIdentifier;
       let fullIdentifier: BackendIdentifier;
       let distributionUrl: string;
+      let skewBuildIdA: string;
+      let skewStaticAssetPath: string;
 
       before(async () => {
         testProject = await testProjectCreator.createProject(rootTestDir);
@@ -672,6 +674,37 @@ void describe(
           );
         });
 
+        void it('stage 2d: skew protection — captures build A cookie and static asset path', async () => {
+          // Fetch HTML page and capture the __dpl skew protection cookie
+          const initialResponse = await fetch(distributionUrl, {
+            redirect: 'manual',
+          });
+          const setCookieHeader =
+            initialResponse.headers.get('set-cookie') ?? '';
+          const buildIdMatch = setCookieHeader.match(/__dpl=([^;]+)/);
+          assert.ok(
+            buildIdMatch,
+            `Skew protection cookie (__dpl) should be set on HTML response, got set-cookie: ${setCookieHeader.substring(0, 200)}`,
+          );
+          skewBuildIdA = buildIdMatch![1];
+          process.stderr.write(
+            `Skew protection: captured build A cookie __dpl=${skewBuildIdA}\n`,
+          );
+
+          // Extract a static asset path from the HTML to verify skew-pinned access later
+          const htmlBody = await initialResponse.text();
+          const assetMatch = htmlBody.match(
+            /\/_next\/static\/[^"'\s]+\.(js|css)/,
+          );
+          assert.ok(
+            assetMatch,
+            `Page HTML should contain /_next/static/ asset references for skew test, got: ${htmlBody.substring(0, 300)}`,
+          );
+          skewStaticAssetPath = assetMatch![0];
+          process.stderr.write(
+            `Skew protection: captured static asset path ${skewStaticAssetPath}\n`,
+          );
+        });
         void it('stage 3: ISR — verifies cache infrastructure provisioned and S3 cache populated', async () => {
           const frontendStackName =
             BackendIdentifierConversions.toStackName(frontendIdentifier);
@@ -1082,6 +1115,57 @@ void describe(
             finalResponse.status,
             200,
             `Expected HTTP 200 after infra change, got ${finalResponse.status}`,
+          );
+        });
+
+        void it('stage 7b: skew protection — verifies old build assets accessible with pinned cookie', async () => {
+          // After full redeploy (build B), verify skew protection keeps build A assets accessible
+          assert.ok(
+            skewBuildIdA,
+            'skewBuildIdA should have been captured in stage 2d',
+          );
+          assert.ok(
+            skewStaticAssetPath,
+            'skewStaticAssetPath should have been captured in stage 2d',
+          );
+
+          // Verify old build assets are still accessible when pinned via __dpl cookie
+          const skewResponse = await fetchWithRetry(
+            `${distributionUrl}${skewStaticAssetPath}`,
+            {
+              expectedStatus: 200,
+              maxRetries: 3,
+              intervalMs: 5000,
+              fetchInit: { headers: { Cookie: `__dpl=${skewBuildIdA}` } },
+            },
+          );
+          assert.strictEqual(
+            skewResponse.status,
+            200,
+            `Old build static asset should still be accessible with pinned __dpl cookie, got ${skewResponse.status}`,
+          );
+          process.stderr.write(
+            `Skew protection: old asset accessible with build A cookie (status=${skewResponse.status})\n`,
+          );
+
+          // Verify new build gets a different __dpl cookie
+          const newResponse = await fetch(distributionUrl, {
+            redirect: 'manual',
+          });
+          const newSetCookie = newResponse.headers.get('set-cookie') ?? '';
+          const buildIdBMatch = newSetCookie.match(/__dpl=([^;]+)/);
+          assert.ok(
+            buildIdBMatch,
+            `New build should set __dpl cookie, got set-cookie: ${newSetCookie.substring(0, 200)}`,
+          );
+          const buildIdB = buildIdBMatch![1];
+          assert.notStrictEqual(
+            skewBuildIdA,
+            buildIdB,
+            `Build ID should change after redeploy: buildA=${skewBuildIdA}, buildB=${buildIdB}`,
+          );
+          process.stderr.write(
+            `Skew protection: build ID changed from ${skewBuildIdA} to ${buildIdB}\n`,
           );
         });
       });

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_ssr.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_ssr.deployment.test.ts
@@ -49,8 +49,6 @@ void describe(
       let frontendIdentifier: BackendIdentifier;
       let fullIdentifier: BackendIdentifier;
       let distributionUrl: string;
-      let skewBuildIdA: string;
-      let skewStaticAssetPath: string;
 
       before(async () => {
         testProject = await testProjectCreator.createProject(rootTestDir);
@@ -674,37 +672,6 @@ void describe(
           );
         });
 
-        void it('stage 2d: skew protection — captures build A cookie and static asset path', async () => {
-          // Fetch HTML page and capture the __dpl skew protection cookie
-          const initialResponse = await fetch(distributionUrl, {
-            redirect: 'manual',
-          });
-          const setCookieHeader =
-            initialResponse.headers.get('set-cookie') ?? '';
-          const buildIdMatch = setCookieHeader.match(/__dpl=([^;]+)/);
-          assert.ok(
-            buildIdMatch,
-            `Skew protection cookie (__dpl) should be set on HTML response, got set-cookie: ${setCookieHeader.substring(0, 200)}`,
-          );
-          skewBuildIdA = buildIdMatch![1];
-          process.stderr.write(
-            `Skew protection: captured build A cookie __dpl=${skewBuildIdA}\n`,
-          );
-
-          // Extract a static asset path from the HTML to verify skew-pinned access later
-          const htmlBody = await initialResponse.text();
-          const assetMatch = htmlBody.match(
-            /\/_next\/static\/[^"'\s]+\.(js|css)/,
-          );
-          assert.ok(
-            assetMatch,
-            `Page HTML should contain /_next/static/ asset references for skew test, got: ${htmlBody.substring(0, 300)}`,
-          );
-          skewStaticAssetPath = assetMatch![0];
-          process.stderr.write(
-            `Skew protection: captured static asset path ${skewStaticAssetPath}\n`,
-          );
-        });
         void it('stage 3: ISR — verifies cache infrastructure provisioned and S3 cache populated', async () => {
           const frontendStackName =
             BackendIdentifierConversions.toStackName(frontendIdentifier);
@@ -1115,57 +1082,6 @@ void describe(
             finalResponse.status,
             200,
             `Expected HTTP 200 after infra change, got ${finalResponse.status}`,
-          );
-        });
-
-        void it('stage 7b: skew protection — verifies old build assets accessible with pinned cookie', async () => {
-          // After full redeploy (build B), verify skew protection keeps build A assets accessible
-          assert.ok(
-            skewBuildIdA,
-            'skewBuildIdA should have been captured in stage 2d',
-          );
-          assert.ok(
-            skewStaticAssetPath,
-            'skewStaticAssetPath should have been captured in stage 2d',
-          );
-
-          // Verify old build assets are still accessible when pinned via __dpl cookie
-          const skewResponse = await fetchWithRetry(
-            `${distributionUrl}${skewStaticAssetPath}`,
-            {
-              expectedStatus: 200,
-              maxRetries: 3,
-              intervalMs: 5000,
-              fetchInit: { headers: { Cookie: `__dpl=${skewBuildIdA}` } },
-            },
-          );
-          assert.strictEqual(
-            skewResponse.status,
-            200,
-            `Old build static asset should still be accessible with pinned __dpl cookie, got ${skewResponse.status}`,
-          );
-          process.stderr.write(
-            `Skew protection: old asset accessible with build A cookie (status=${skewResponse.status})\n`,
-          );
-
-          // Verify new build gets a different __dpl cookie
-          const newResponse = await fetch(distributionUrl, {
-            redirect: 'manual',
-          });
-          const newSetCookie = newResponse.headers.get('set-cookie') ?? '';
-          const buildIdBMatch = newSetCookie.match(/__dpl=([^;]+)/);
-          assert.ok(
-            buildIdBMatch,
-            `New build should set __dpl cookie, got set-cookie: ${newSetCookie.substring(0, 200)}`,
-          );
-          const buildIdB = buildIdBMatch![1];
-          assert.notStrictEqual(
-            skewBuildIdA,
-            buildIdB,
-            `Build ID should change after redeploy: buildA=${skewBuildIdA}, buildB=${buildIdB}`,
-          );
-          process.stderr.write(
-            `Skew protection: build ID changed from ${skewBuildIdA} to ${buildIdB}\n`,
           );
         });
       });

--- a/packages/integration-tests/src/test-projects/standalone-hosting-spa/dist/assets/app.css
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-spa/dist/assets/app.css
@@ -1,0 +1,2 @@
+body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 2rem; }
+h1 { color: #333; }

--- a/packages/integration-tests/src/test-projects/standalone-hosting-spa/dist/index.html
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-spa/dist/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Amplify Hosting E2E Test</title>
+    <link rel="stylesheet" href="/assets/app.css" />
   </head>
   <body>
     <h1>Hello SPA v1</h1>
     <p>If you can see this, the SPA hosting deployment succeeded.</p>
+    <script src="/assets/app.js"></script>
   </body>
 </html>

--- a/packages/integration-tests/src/test-projects/standalone-hosting-spa/update-v2/dist/index.html
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-spa/update-v2/dist/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Amplify Hosting E2E Test</title>
+    <link rel="stylesheet" href="/assets/app.css" />
   </head>
   <body>
     <h1>Hello SPA v2</h1>
     <p>If you can see this, the SPA hosting redeployment succeeded.</p>
+    <script src="/assets/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION

## Summary

Adds cookie-based skew protection to the hosting construct, ensuring users mid-session continue receiving assets from their original build during deployments.

## How it works

1. **Viewer-request CloudFront Function** reads a `__dpl` cookie to determine which build the user is pinned to. Rewrites the URI to the correct `builds/{buildId}/` prefix in S3.
2. **Viewer-response CloudFront Function** sets the `__dpl` cookie on HTML responses only (not JS/CSS/images), pinning new sessions to the current build.
3. Old builds are retained in S3 (existing `prune: false` behavior) and cleaned up by lifecycle rules (`buildRetentionDays`).

## Behavior

- **Enabled by default** — no configuration needed
- Opt-out: `skewProtection: { enabled: false }`
- Configurable max age: `skewProtection: { enabled: true, maxAge: 3600 }` (default: 24h)

## Framework-agnostic

Works identically for Next.js (OpenNext), Nuxt/Nitro, SPA, and custom adapters. The CloudFront Functions operate on raw HTTP paths — zero framework knowledge.

## Files changed

- `packages/hosting/src/constructs/skew_protection.ts` (NEW)
- `packages/hosting/src/constructs/cdn_construct.ts` (MODIFIED)
- `packages/hosting/src/constructs/hosting_construct.ts` (MODIFIED)
- `packages/hosting/src/index.ts` (MODIFIED)
- `packages/hosting/src/constructs/skew_protection.test.ts` (NEW)

## Tests

314 pass, 0 failures.