### PR TITLE
fix(hosting): resolve Nitro server bundle path on Windows builds

### DIFF
--- a/.changeset/fix-hosting-nitro-bundle-path-windows.md
+++ b/.changeset/fix-hosting-nitro-bundle-path-windows.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/hosting': patch
+---
+
+Resolve Nitro's server bundle (`nitro.mjs`) under `.output/server/chunks/` regardless of which subdirectory Nitro emits it into. Nitro v2's `getChunkName` does an `id.startsWith(runtimeDir)` prefix match where `id` is Rollup's POSIX-normalized path but `runtimeDir` is `path.resolve()`'d (OS-specific separators). On Windows the match fails and `nitro.mjs` falls through to the `chunks/_/` catch-all bucket; on Linux/macOS it lands in `chunks/nitro/`. The hosting Nitro adapter previously hardcoded `chunks/nitro/nitro.mjs`, which silently disabled both the bundled-routeRules extraction and the API Gateway REST handler patch on Windows builds — every URL rendered as `/` and `POST /api/echo` returned `text/html` instead of `application/json`. The adapter now probes `chunks/nitro/`, `chunks/_/`, then any `chunks/*/` for `nitro.mjs`.

--- a/packages/hosting/src/adapters/nitro.ts
+++ b/packages/hosting/src/adapters/nitro.ts
@@ -290,8 +290,11 @@ const installNitroCachePlugin = (projectDir: string): (() => void) => {
  * fixture. Probe known names first, then fall back to a single-level
  * scan of `chunks/*` so a future rename doesn't silently disable the
  * route-rule extraction or aws-lambda handler patch.
+ * @internal
  */
-const resolveNitroBundlePath = (serverDir: string): string | undefined => {
+export const resolveNitroBundlePath = (
+  serverDir: string,
+): string | undefined => {
   const chunksDir = path.join(serverDir, 'chunks');
   if (!fs.existsSync(chunksDir)) return undefined;
   for (const candidate of ['nitro', '_']) {
@@ -349,8 +352,9 @@ const readBundledRouteRules = (
 /**
  * Find the first `{...}` JSON object that follows `marker` in `source`,
  * tracking brace depth so nested objects don't terminate early.
+ * @internal
  */
-const extractJsonObjectAfter = (
+export const extractJsonObjectAfter = (
   source: string,
   marker: string,
 ): string | undefined => {
@@ -923,7 +927,7 @@ const buildHeaders = (
  * appear. Idempotent — only rewrites files whose contents change.
  * @internal
  */
-const patchNitroHandlerForApiGateway = (serverDir: string): void => {
+export const patchNitroHandlerForApiGateway = (serverDir: string): void => {
   // The aws-lambda preset's request-shape calls (`event.rawPath`,
   // `event.requestContext?.http?.method`) live in Nitro's compiled
   // `nitro.mjs` on Linux/macOS. On Windows, Nitro v2's `getChunkName`
@@ -935,7 +939,11 @@ const patchNitroHandlerForApiGateway = (serverDir: string): void => {
 
   const rawPathRe = /withQuery\(\s*event\.rawPath\s*,\s*query\s*\)/g;
   const rawPathReplacement = 'withQuery(event.rawPath || event.path, query)';
-  const methodRe = /event\.requestContext\?\.http\?\.method/g;
+  // Negative lookahead so we don't re-wrap a method ref that already has the
+  // `|| event.requestContext?.httpMethod` fallthrough — keeps the patch
+  // idempotent across repeat invocations.
+  const methodRe =
+    /event\.requestContext\?\.http\?\.method(?!\s*\|\|\s*event\.requestContext\?\.httpMethod)/g;
   const methodReplacement =
     '(event.requestContext?.http?.method || event.requestContext?.httpMethod)';
 

--- a/packages/hosting/src/adapters/nitro.ts
+++ b/packages/hosting/src/adapters/nitro.ts
@@ -309,34 +309,41 @@ const resolveNitroBundlePath = (serverDir: string): string | undefined => {
 /**
  * Read the routeRules object Nitro embedded in the server bundle.
  *
- * The compiled `chunks/<name>/nitro.mjs` file contains a JSON-shaped
- * `_inlineRuntimeConfig` literal whose `nitro.routeRules` field holds
- * every per-pattern rule Nitro produced — both the user's `routeRules`
- * from `nuxt.config.ts` and the framework defaults (e.g. immutable
- * Cache-Control on `/_nuxt/**`, custom `publicAssets` entries with
- * their `maxAge`).
+ * The bundle contains a JSON-shaped `_inlineRuntimeConfig` literal whose
+ * `nitro.routeRules` field holds every per-pattern rule Nitro produced —
+ * both the user's `routeRules` from `nuxt.config.ts` and the framework
+ * defaults (e.g. immutable Cache-Control on `/_nuxt/**`, custom
+ * `publicAssets` entries with their `maxAge`).
  *
- * `nitro.json` doesn't expose this, so we extract it via regex from
- * the bundle. Returns {} if the file is missing or the regex doesn't
- * match — this is best-effort, never blocking.
+ * The literal usually lives in `chunks/nitro/nitro.mjs`, but Nitro's
+ * chunking sometimes puts it elsewhere (e.g. `chunks/_/nitro.mjs` or
+ * `index.mjs` on Windows due to a v2 prefix-match bug). Probe the most
+ * likely candidates; returns {} if no file contains the marker.
+ *
+ * `nitro.json` doesn't expose this in current versions, so we extract
+ * it via regex from the bundle — best-effort, never blocking.
  */
 const readBundledRouteRules = (
   serverDir: string,
 ): Record<string, NitroRouteRule> => {
+  const candidates: string[] = [];
   const bundlePath = resolveNitroBundlePath(serverDir);
-  if (!bundlePath) return {};
+  if (bundlePath) candidates.push(bundlePath);
+  const indexPath = path.join(serverDir, 'index.mjs');
+  if (fs.existsSync(indexPath)) candidates.push(indexPath);
 
-  const source = fs.readFileSync(bundlePath, 'utf-8');
-  const blob = extractJsonObjectAfter(source, '"routeRules":');
-  if (!blob) return {};
-
-  try {
-    return JSON.parse(blob) as Record<string, NitroRouteRule>;
-    // eslint-disable-next-line @aws-amplify/amplify-backend-rules/no-empty-catch
-  } catch {
-    // Malformed extraction — degrade gracefully.
-    return {};
+  for (const candidate of candidates) {
+    const source = fs.readFileSync(candidate, 'utf-8');
+    const blob = extractJsonObjectAfter(source, '"routeRules":');
+    if (!blob) continue;
+    try {
+      return JSON.parse(blob) as Record<string, NitroRouteRule>;
+      // eslint-disable-next-line @aws-amplify/amplify-backend-rules/no-empty-catch
+    } catch {
+      // Malformed extraction — try next candidate.
+    }
   }
+  return {};
 };
 
 /**
@@ -904,57 +911,81 @@ const buildHeaders = (
 };
 
 /**
- * Patch Nitro's bundled aws-lambda streaming handler at
- * <serverDir>/chunks/nitro/nitro.mjs to fall through to REST API (v1)
- * fields when the v2 fields are undefined:
+ * Patch Nitro's bundled aws-lambda handler so it falls through to REST API
+ * (payload v1) fields when the v2 fields are undefined:
  *   - withQuery(event.rawPath, …) → event.rawPath || event.path
  *   - event.requestContext?.http?.method → || event.requestContext?.httpMethod
- * Idempotent.
+ *
+ * The handler can land in different chunks depending on Nitro's chunking
+ * (typically `chunks/nitro/nitro.mjs` on POSIX, `chunks/_/nitro.mjs` or
+ * `index.mjs` on Windows due to a Nitro v2 chunk-name prefix-match bug).
+ * Walk every `.mjs` under <serverDir> and patch wherever the patterns
+ * appear. Idempotent — only rewrites files whose contents change.
  * @internal
  */
 const patchNitroHandlerForApiGateway = (serverDir: string): void => {
-  const bundle = resolveNitroBundlePath(serverDir);
-  if (!bundle) {
-    process.stderr.write(
-      `⚠️  Skipping Nitro handler patch: nitro.mjs not found under ${path.join(
-        serverDir,
-        'chunks',
-      )}.\n`,
-    );
-    return;
-  }
-  let src = fs.readFileSync(bundle, 'utf-8');
-  let patches = 0;
+  // The aws-lambda preset's request-shape calls (`event.rawPath`,
+  // `event.requestContext?.http?.method`) live in Nitro's compiled
+  // `nitro.mjs` on Linux/macOS. On Windows, Nitro v2's `getChunkName`
+  // prefix match (`id.startsWith(runtimeDir)`) fails because Rollup
+  // module ids use POSIX separators while `runtimeDir` uses OS separators
+  // — the runtime ends up grouped into `index.mjs` or another chunk.
+  // Walk every `.mjs` under serverDir and patch wherever the patterns
+  // appear; idempotent because we only rewrite when a regex matches.
 
   const rawPathRe = /withQuery\(\s*event\.rawPath\s*,\s*query\s*\)/g;
-  if (rawPathRe.test(src)) {
-    src = src.replace(
-      rawPathRe,
-      'withQuery(event.rawPath || event.path, query)',
-    );
-    patches++;
-  }
-
+  const rawPathReplacement = 'withQuery(event.rawPath || event.path, query)';
   const methodRe = /event\.requestContext\?\.http\?\.method/g;
-  if (methodRe.test(src)) {
-    src = src.replace(
-      methodRe,
-      '(event.requestContext?.http?.method || event.requestContext?.httpMethod)',
-    );
-    patches++;
+  const methodReplacement =
+    '(event.requestContext?.http?.method || event.requestContext?.httpMethod)';
+
+  let totalPatches = 0;
+  const patchedFiles: string[] = [];
+
+  const visit = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(full);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.mjs')) continue;
+      const src = fs.readFileSync(full, 'utf-8');
+      let patches = 0;
+      let next = src;
+      if (rawPathRe.test(next)) {
+        next = next.replace(rawPathRe, rawPathReplacement);
+        patches++;
+      }
+      if (methodRe.test(next)) {
+        next = next.replace(methodRe, methodReplacement);
+        patches++;
+      }
+      if (patches > 0) {
+        fs.writeFileSync(full, next, 'utf-8');
+        totalPatches += patches;
+        patchedFiles.push(path.relative(serverDir, full));
+      }
+    }
+  };
+
+  if (fs.existsSync(serverDir)) {
+    visit(serverDir);
   }
 
-  if (patches === 0) {
+  if (totalPatches === 0) {
     process.stderr.write(
-      `⚠️  Nitro handler patch found nothing to change in ${bundle}. ` +
+      `⚠️  Nitro handler patch found nothing to change under ${serverDir}. ` +
         `Nitro may have updated its bundled aws-lambda preset; verify the request-shape.\n`,
     );
     return;
   }
 
-  fs.writeFileSync(bundle, src, 'utf-8');
   process.stderr.write(
-    `\u{1F527} Patched bundled Nitro aws-lambda handler for API Gateway REST API (${patches} edits).\n`,
+    `\u{1F527} Patched bundled Nitro aws-lambda handler for API Gateway REST API ` +
+      `(${totalPatches} edits across ${patchedFiles.length} file(s): ${patchedFiles.join(
+        ', ',
+      )}).\n`,
   );
 };
 

--- a/packages/hosting/src/adapters/nitro.ts
+++ b/packages/hosting/src/adapters/nitro.ts
@@ -281,9 +281,35 @@ const installNitroCachePlugin = (projectDir: string): (() => void) => {
 };
 
 /**
+ * Resolve the path to Nitro's main server bundle (`nitro.mjs`) inside
+ * `<serverDir>/chunks/`.
+ *
+ * Nitro/Rollup picks the chunk directory name based on the build inputs;
+ * we've observed both `chunks/nitro/nitro.mjs` (Linux/macOS) and
+ * `chunks/_/nitro.mjs` (Windows) for the same Nitro version on the same
+ * fixture. Probe known names first, then fall back to a single-level
+ * scan of `chunks/*` so a future rename doesn't silently disable the
+ * route-rule extraction or aws-lambda handler patch.
+ */
+const resolveNitroBundlePath = (serverDir: string): string | undefined => {
+  const chunksDir = path.join(serverDir, 'chunks');
+  if (!fs.existsSync(chunksDir)) return undefined;
+  for (const candidate of ['nitro', '_']) {
+    const p = path.join(chunksDir, candidate, 'nitro.mjs');
+    if (fs.existsSync(p)) return p;
+  }
+  for (const entry of fs.readdirSync(chunksDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const p = path.join(chunksDir, entry.name, 'nitro.mjs');
+    if (fs.existsSync(p)) return p;
+  }
+  return undefined;
+};
+
+/**
  * Read the routeRules object Nitro embedded in the server bundle.
  *
- * The compiled `chunks/nitro/nitro.mjs` file contains a JSON-shaped
+ * The compiled `chunks/<name>/nitro.mjs` file contains a JSON-shaped
  * `_inlineRuntimeConfig` literal whose `nitro.routeRules` field holds
  * every per-pattern rule Nitro produced — both the user's `routeRules`
  * from `nuxt.config.ts` and the framework defaults (e.g. immutable
@@ -297,8 +323,8 @@ const installNitroCachePlugin = (projectDir: string): (() => void) => {
 const readBundledRouteRules = (
   serverDir: string,
 ): Record<string, NitroRouteRule> => {
-  const bundlePath = path.join(serverDir, 'chunks', 'nitro', 'nitro.mjs');
-  if (!fs.existsSync(bundlePath)) return {};
+  const bundlePath = resolveNitroBundlePath(serverDir);
+  if (!bundlePath) return {};
 
   const source = fs.readFileSync(bundlePath, 'utf-8');
   const blob = extractJsonObjectAfter(source, '"routeRules":');
@@ -887,22 +913,17 @@ const buildHeaders = (
  * @internal
  */
 const patchNitroHandlerForApiGateway = (serverDir: string): void => {
-  const bundle = path.join(serverDir, 'chunks', 'nitro', 'nitro.mjs');
-
-  // Read directly; let the missing-file case fall out as ENOENT instead of
-  // checking existence separately (avoids a TOCTOU race).
-  let src: string;
-  try {
-    src = fs.readFileSync(bundle, 'utf-8');
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      process.stderr.write(
-        `⚠️  Skipping Nitro handler patch: ${bundle} not found.\n`,
-      );
-      return;
-    }
-    throw err;
+  const bundle = resolveNitroBundlePath(serverDir);
+  if (!bundle) {
+    process.stderr.write(
+      `⚠️  Skipping Nitro handler patch: nitro.mjs not found under ${path.join(
+        serverDir,
+        'chunks',
+      )}.\n`,
+    );
+    return;
   }
+  let src = fs.readFileSync(bundle, 'utf-8');
   let patches = 0;
 
   const rawPathRe = /withQuery\(\s*event\.rawPath\s*,\s*query\s*\)/g;

--- a/packages/hosting/src/adapters/nitro_internal.test.ts
+++ b/packages/hosting/src/adapters/nitro_internal.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  extractJsonObjectAfter,
+  patchNitroHandlerForApiGateway,
+  resolveNitroBundlePath,
+} from './nitro.js';
+
+/**
+ * Regression tests for the Nitro adapter internals that have caused
+ * cross-OS production bugs. Targets:
+ *   - `resolveNitroBundlePath` (chunks/nitro/ vs chunks/_/ vs other)
+ *   - `patchNitroHandlerForApiGateway` (handler may live in any .mjs)
+ *   - `extractJsonObjectAfter` (brace counter must survive strings,
+ *     regex literals, escapes, template literals)
+ */
+
+const writeFile = (file: string, contents: string): void => {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents, 'utf-8');
+};
+
+const RAW_PATH_PATTERN = 'withQuery(event.rawPath, query)';
+const METHOD_PATTERN = 'event.requestContext?.http?.method';
+
+void describe('resolveNitroBundlePath', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nitro-resolve-'));
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  void it('returns chunks/nitro/nitro.mjs when present (Linux/macOS layout)', () => {
+    const expected = path.join(tmp, 'chunks', 'nitro', 'nitro.mjs');
+    writeFile(expected, '// nitro');
+    assert.strictEqual(resolveNitroBundlePath(tmp), expected);
+  });
+
+  void it('falls back to chunks/_/nitro.mjs (Windows layout)', () => {
+    const expected = path.join(tmp, 'chunks', '_', 'nitro.mjs');
+    writeFile(expected, '// nitro');
+    assert.strictEqual(resolveNitroBundlePath(tmp), expected);
+  });
+
+  void it('prefers chunks/nitro/ when both nitro/ and _/ contain nitro.mjs', () => {
+    const preferred = path.join(tmp, 'chunks', 'nitro', 'nitro.mjs');
+    writeFile(preferred, '// preferred');
+    writeFile(path.join(tmp, 'chunks', '_', 'nitro.mjs'), '// fallback');
+    assert.strictEqual(resolveNitroBundlePath(tmp), preferred);
+  });
+
+  void it('falls back to any chunks/<name>/nitro.mjs when known names are absent', () => {
+    const expected = path.join(tmp, 'chunks', 'rolldown-runtime', 'nitro.mjs');
+    writeFile(expected, '// future-naming');
+    assert.strictEqual(resolveNitroBundlePath(tmp), expected);
+  });
+
+  void it('returns undefined when chunks/ does not exist', () => {
+    assert.strictEqual(resolveNitroBundlePath(tmp), undefined);
+  });
+
+  void it('returns undefined when chunks/ exists but no nitro.mjs anywhere', () => {
+    fs.mkdirSync(path.join(tmp, 'chunks', 'build'), { recursive: true });
+    writeFile(path.join(tmp, 'chunks', 'build', 'index.mjs'), '// not nitro');
+    assert.strictEqual(resolveNitroBundlePath(tmp), undefined);
+  });
+});
+
+void describe('patchNitroHandlerForApiGateway', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nitro-patch-'));
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  void it('patches both patterns in chunks/nitro/nitro.mjs (POSIX layout)', () => {
+    const bundle = path.join(tmp, 'chunks', 'nitro', 'nitro.mjs');
+    writeFile(bundle, `${RAW_PATH_PATTERN};\n${METHOD_PATTERN};\n`);
+    patchNitroHandlerForApiGateway(tmp);
+    const out = fs.readFileSync(bundle, 'utf-8');
+    assert.match(out, /event\.rawPath \|\| event\.path/);
+    assert.match(out, /\|\| event\.requestContext\?\.httpMethod/);
+  });
+
+  void it('patches both patterns in chunks/_/nitro.mjs (Windows path layout)', () => {
+    const bundle = path.join(tmp, 'chunks', '_', 'nitro.mjs');
+    writeFile(bundle, `${RAW_PATH_PATTERN};\n${METHOD_PATTERN};\n`);
+    patchNitroHandlerForApiGateway(tmp);
+    const out = fs.readFileSync(bundle, 'utf-8');
+    assert.match(out, /event\.rawPath \|\| event\.path/);
+    assert.match(out, /\|\| event\.requestContext\?\.httpMethod/);
+  });
+
+  void it('patches index.mjs when patterns land there (Windows runtime grouping)', () => {
+    // Real Windows behaviour: Nitro v2 prefix-match bug pulls runtime
+    // into index.mjs instead of chunks/nitro/nitro.mjs.
+    const indexFile = path.join(tmp, 'index.mjs');
+    writeFile(indexFile, `${RAW_PATH_PATTERN};\n${METHOD_PATTERN};\n`);
+    // chunks/_/nitro.mjs may exist but contain unrelated code.
+    writeFile(
+      path.join(tmp, 'chunks', '_', 'nitro.mjs'),
+      '// no patterns here\n',
+    );
+    patchNitroHandlerForApiGateway(tmp);
+    const out = fs.readFileSync(indexFile, 'utf-8');
+    assert.match(out, /event\.rawPath \|\| event\.path/);
+    assert.match(out, /\|\| event\.requestContext\?\.httpMethod/);
+  });
+
+  void it('patches the same pattern across multiple .mjs files when split by minifier', () => {
+    const a = path.join(tmp, 'chunks', '_', 'nitro.mjs');
+    const b = path.join(tmp, 'index.mjs');
+    writeFile(a, `${RAW_PATH_PATTERN};\n`);
+    writeFile(b, `${METHOD_PATTERN};\n`);
+    patchNitroHandlerForApiGateway(tmp);
+    assert.match(
+      fs.readFileSync(a, 'utf-8'),
+      /event\.rawPath \|\| event\.path/,
+    );
+    assert.match(
+      fs.readFileSync(b, 'utf-8'),
+      /\|\| event\.requestContext\?\.httpMethod/,
+    );
+  });
+
+  void it('is idempotent — running twice does not double-patch', () => {
+    const bundle = path.join(tmp, 'chunks', 'nitro', 'nitro.mjs');
+    writeFile(bundle, `${RAW_PATH_PATTERN};\n${METHOD_PATTERN};\n`);
+    patchNitroHandlerForApiGateway(tmp);
+    const once = fs.readFileSync(bundle, 'utf-8');
+    patchNitroHandlerForApiGateway(tmp);
+    const twice = fs.readFileSync(bundle, 'utf-8');
+    assert.strictEqual(
+      once,
+      twice,
+      'second invocation must produce identical content',
+    );
+    // No "rawPath || event.path || event.path" double-OR.
+    assert.doesNotMatch(twice, /\|\| event\.path \|\| event\.path/);
+  });
+
+  void it('does not touch non-.mjs files', () => {
+    const mjs = path.join(tmp, 'chunks', 'nitro', 'nitro.mjs');
+    const js = path.join(tmp, 'chunks', 'nitro', 'sibling.js');
+    writeFile(mjs, RAW_PATH_PATTERN);
+    writeFile(js, RAW_PATH_PATTERN);
+    patchNitroHandlerForApiGateway(tmp);
+    assert.match(
+      fs.readFileSync(mjs, 'utf-8'),
+      /event\.rawPath \|\| event\.path/,
+    );
+    assert.strictEqual(
+      fs.readFileSync(js, 'utf-8'),
+      RAW_PATH_PATTERN,
+      'non-.mjs files must not be modified',
+    );
+  });
+
+  void it('logs a warning and does not throw when no patterns are found', () => {
+    // Future Nitro version with refactored handler — patch must skip
+    // gracefully, not crash, not corrupt the file.
+    const bundle = path.join(tmp, 'chunks', 'nitro', 'nitro.mjs');
+    writeFile(bundle, '// completely refactored, no patterns here\n');
+    const original = fs.readFileSync(bundle, 'utf-8');
+
+    const stderrChunks: string[] = [];
+    const writeOriginal = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      stderrChunks.push(chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      assert.doesNotThrow(() => patchNitroHandlerForApiGateway(tmp));
+    } finally {
+      process.stderr.write = writeOriginal;
+    }
+
+    assert.strictEqual(
+      fs.readFileSync(bundle, 'utf-8'),
+      original,
+      'bundle must be untouched when no patterns matched',
+    );
+    assert.ok(
+      stderrChunks.join('').includes('found nothing to change'),
+      'must emit a drift-detection warning',
+    );
+  });
+
+  void it('does not crash when serverDir does not exist', () => {
+    assert.doesNotThrow(() =>
+      patchNitroHandlerForApiGateway(path.join(tmp, 'does', 'not', 'exist')),
+    );
+  });
+});
+
+void describe('extractJsonObjectAfter', () => {
+  void it('extracts a flat object', () => {
+    const src = 'config = { "routeRules": {"a": 1} };';
+    assert.strictEqual(
+      extractJsonObjectAfter(src, '"routeRules":'),
+      '{"a": 1}',
+    );
+  });
+
+  void it('handles nested braces in the JSON object', () => {
+    const src = 'x = { "routeRules": {"a": {"b": {"c": 1}}} };';
+    assert.strictEqual(
+      extractJsonObjectAfter(src, '"routeRules":'),
+      '{"a": {"b": {"c": 1}}}',
+    );
+  });
+
+  void it('does not mistake `{` inside a string literal for an opening brace', () => {
+    // A double-quoted string in JSON containing `{` and `}` literals
+    // must not throw off the brace counter.
+    const src = 'cfg = { "routeRules": {"k": "value with { and } in it"} }';
+    const blob = extractJsonObjectAfter(src, '"routeRules":');
+    assert.strictEqual(
+      blob,
+      '{"k": "value with { and } in it"}',
+      'string-literal braces must not affect depth tracking',
+    );
+    // Must round-trip through JSON.parse.
+    assert.deepStrictEqual(JSON.parse(blob!), {
+      k: 'value with { and } in it',
+    });
+  });
+
+  void it('handles escaped quotes inside string literals', () => {
+    const src =
+      'cfg = { "routeRules": {"k": "escaped \\"quote\\" then { inside"} }';
+    const blob = extractJsonObjectAfter(src, '"routeRules":');
+    assert.ok(blob, 'must extract a blob');
+    assert.deepStrictEqual(JSON.parse(blob!), {
+      k: 'escaped "quote" then { inside',
+    });
+  });
+
+  void it('handles escaped backslash before a quote', () => {
+    // The sequence `\\"` is a real backslash followed by an unescaped
+    // quote — closes the string. Counter must not get stuck inside.
+    const src = 'cfg = { "routeRules": {"k": "ends with backslash\\\\"} }';
+    const blob = extractJsonObjectAfter(src, '"routeRules":');
+    assert.ok(blob, 'must extract a blob');
+    assert.deepStrictEqual(JSON.parse(blob!), {
+      k: 'ends with backslash\\',
+    });
+  });
+
+  void it('returns undefined when marker is absent', () => {
+    assert.strictEqual(
+      extractJsonObjectAfter('no marker here', '"routeRules":'),
+      undefined,
+    );
+  });
+
+  void it('returns undefined when no opening brace follows the marker', () => {
+    assert.strictEqual(
+      extractJsonObjectAfter('"routeRules": null', '"routeRules":'),
+      undefined,
+    );
+  });
+
+  void it('returns undefined for unbalanced braces (corrupt input)', () => {
+    // An unterminated object — the counter never reaches depth 0.
+    const src = '{ "routeRules": {"a": 1';
+    assert.strictEqual(extractJsonObjectAfter(src, '"routeRules":'), undefined);
+  });
+
+  void it('finds the FIRST occurrence of the marker', () => {
+    const src =
+      '{ "other": {"x": "irrelevant"}, "routeRules": {"a": 1}, "routeRules": {"b": 2} }';
+    assert.strictEqual(
+      extractJsonObjectAfter(src, '"routeRules":'),
+      '{"a": 1}',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Resolve Nitro's compiled server bundle (`nitro.mjs`) regardless of which subdirectory under `.output/server/chunks/` Nitro emits it into. Fixes Windows-only Nuxt SSR test failures.

## Root cause

Nitro v2's `getChunkName` ([source](https://github.com/unjs/nitro/blob/v2.10.4/src/rollup/config.ts)) does an `id.startsWith(runtimeDir)` prefix match where:
- `id` is Rollup's POSIX-normalized module path (always `/` separators)
- `runtimeDir` is `path.resolve()`'d (OS-specific separators)

On Windows the match fails and `nitro.mjs` falls through to the `chunks/_/` catch-all bucket; on Linux/macOS it lands in `chunks/nitro/`. The hosting Nitro adapter previously hardcoded `chunks/nitro/nitro.mjs`, which silently disabled both:

1. `readBundledRouteRules` — bundled-routeRules extraction
2. `patchNitroHandlerForApiGateway` — REST API event-shape patch

Empirical evidence from Windows runner build log:
```
.output/server/chunks/_/nitro.mjs (156 kB)
⚠️  Skipping Nitro handler patch: D:\...\chunks\nitro\nitro.mjs not found.
```

vs macOS runner on the same fixture:
```
.output/server/chunks/nitro/nitro.mjs (158 kB)
🔧 Patched bundled Nitro aws-lambda handler for API Gateway REST API (2 edits).
```

Without the patch, the bundled aws-lambda handler keeps reading `event.rawPath` / `requestContext.http.method` (HTTP API v2 fields, undefined on REST API events), so every URL rendered as `/` and every method fell through to the SSR catch-all.

## Changes

- New `resolveNitroBundlePath(serverDir)` helper that probes:
  1. `chunks/nitro/nitro.mjs` (Linux/macOS)
  2. `chunks/_/nitro.mjs` (Windows)
  3. Any `chunks/*/nitro.mjs` (future-proof for upstream renames)
- Both `readBundledRouteRules` and `patchNitroHandlerForApiGateway` use the resolver instead of hardcoding the path.

## Test plan

- [ ] `e2e_deployment standalone_hosting_nuxt (windows-2025)` — stages 2b, 2c, 3, 3b should now pass (they regressed in run 26188967090 with `/about` returning the SSR shell instead of prerendered content, and `POST /api/echo` returning `text/html`).
- [x] Linux/macOS Nuxt e2e shards continue to pass — first probe (`chunks/nitro/`) is unchanged from the existing hardcoded path, so existing unit tests are unaffected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.