### PR TITLE
feat(backend): add ambient scope detection to defineBackend() for pipeline support

### DIFF
--- a/.changeset/feat-define-backend-pipeline-scope.md
+++ b/.changeset/feat-define-backend-pipeline-scope.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': minor
+---
+
+feat(backend): add ambient scope detection to defineBackend() for pipeline support

--- a/packages/backend/src/backend_factory.test.ts
+++ b/packages/backend/src/backend_factory.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   ConstructFactory,
   DeepPartialAmplifyGeneratedConfigs,
@@ -6,8 +6,8 @@ import {
   ResourceProvider,
 } from '@aws-amplify/plugin-types';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { BackendFactory } from './backend_factory.js';
-import { App, Stack } from 'aws-cdk-lib';
+import { BackendFactory, defineBackend } from './backend_factory.js';
+import { App, Stack, Stage } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import assert from 'node:assert';
 import { ClientConfig } from '@aws-amplify/client-config';
@@ -230,3 +230,115 @@ void describe('Backend', () => {
 });
 
 type TestResourceProvider = ResourceProvider<{ bucket: Bucket }>;
+
+void describe('defineBackend with pipeline ambient scope', () => {
+  const PIPELINE_SCOPE_KEY = '__AMPLIFY_PIPELINE_SCOPE__';
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any)[PIPELINE_SCOPE_KEY];
+  });
+
+  void it('attaches to pipeline stage when ambient scope is set', () => {
+    const app = new App();
+    const stage = new Stage(app, 'TestStage');
+    stage.node.setContext('AMPLIFY_STAGE_NAME', 'beta');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any)[PIPELINE_SCOPE_KEY] = stage;
+
+    const testFactory: ConstructFactory<TestResourceProvider> = {
+      getInstance: ({ constructContainer }) => {
+        return constructContainer.getOrCompute({
+          resourceGroupName: 'test',
+          generateContainerEntry: ({ scope }) => {
+            return {
+              resources: {
+                bucket: new Bucket(scope, 'test-bucket'),
+              },
+            };
+          },
+        }) as TestResourceProvider;
+      },
+    };
+
+    const backend = defineBackend({ testFactory });
+
+    assert.ok(backend.stack);
+    assert.equal(Stack.of(backend.stack).node.scope, stage);
+    const template = Template.fromStack(backend.stack);
+    template.resourceCountIs('AWS::CloudFormation::Stack', 1);
+  });
+
+  void it('does not create branch linker in pipeline mode (standalone type)', () => {
+    const app = new App();
+    const stage = new Stage(app, 'TestStage');
+    stage.node.setContext('AMPLIFY_STAGE_NAME', 'prod');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any)[PIPELINE_SCOPE_KEY] = stage;
+
+    const backend = defineBackend({});
+
+    const template = Template.fromStack(backend.stack);
+    template.resourceCountIs('Custom::AmplifyBranchLinkerResource', 0);
+  });
+
+  void it('sets standalone deployment type in platform output', () => {
+    const app = new App();
+    const stage = new Stage(app, 'TestStage');
+    stage.node.setContext('AMPLIFY_STAGE_NAME', 'gamma');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any)[PIPELINE_SCOPE_KEY] = stage;
+
+    const backend = defineBackend({});
+
+    const template = Template.fromStack(backend.stack);
+    template.hasOutput('deploymentType', { Value: 'standalone' });
+  });
+
+  void it('uses stage name as backend name', () => {
+    const app = new App();
+    const stage = new Stage(app, 'TestStage');
+    stage.node.setContext('AMPLIFY_STAGE_NAME', 'staging');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any)[PIPELINE_SCOPE_KEY] = stage;
+
+    const backend = defineBackend({});
+
+    const template = Template.fromStack(backend.stack);
+    template.hasOutput('deploymentType', { Value: 'standalone' });
+    assert.ok(backend.stack.stackName.includes('BackendStack'));
+  });
+
+  void it('falls back to default stage name when not provided', () => {
+    const app = new App();
+    const stage = new Stage(app, 'TestStage');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any)[PIPELINE_SCOPE_KEY] = stage;
+
+    const backend = defineBackend({});
+
+    assert.ok(backend.stack);
+    const template = Template.fromStack(backend.stack);
+    template.hasOutput('deploymentType', { Value: 'standalone' });
+  });
+
+  void it('follows normal path when ambient scope is not set', () => {
+    // Ensure no ambient scope
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any)[PIPELINE_SCOPE_KEY];
+
+    const app = new App();
+    app.node.setContext('amplify-backend-type', 'sandbox');
+    app.node.setContext('amplify-backend-namespace', 'testProject');
+    app.node.setContext('amplify-backend-name', 'testUser');
+
+    const stack = new Stack(app);
+    const backend = new BackendFactory({}, stack);
+    assert.equal(backend.stack, stack);
+  });
+});

--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -3,7 +3,7 @@ import {
   DeepPartialAmplifyGeneratedConfigs,
   ResourceProvider,
 } from '@aws-amplify/plugin-types';
-import { Stack } from 'aws-cdk-lib';
+import { Stack, Stage } from 'aws-cdk-lib';
 import {
   NestedStackResolver,
   StackResolver,
@@ -25,7 +25,7 @@ import {
   ClientConfigVersionOption,
 } from '@aws-amplify/client-config';
 import { CustomOutputsAccumulator } from './engine/custom_outputs_accumulator.js';
-import { ObjectAccumulator } from '@aws-amplify/platform-core';
+import { CDKContextKey, ObjectAccumulator } from '@aws-amplify/platform-core';
 import { DefaultResourceNameValidator } from './engine/validations/default_resource_name_validator.js';
 
 // Be very careful editing this value. It is the value used in the BI metrics to attribute stacks as Amplify root stacks
@@ -148,13 +148,44 @@ export class BackendFactory<
 }
 
 /**
+ * Global key used by `definePipeline()` to pass the pipeline stage scope.
+ * When set, `defineBackend()` creates its stack inside the pipeline stage
+ * rather than creating a standalone CDK App.
+ */
+const AMPLIFY_PIPELINE_SCOPE_KEY = '__AMPLIFY_PIPELINE_SCOPE__';
+
+/**
+ * Creates a stack inside the pipeline stage scope with required context values
+ * for the BackendFactory to operate correctly.
+ *
+ * Uses deployment type 'standalone' because pipeline-managed backends are
+ * independent of Amplify Console — no branch linker is needed.
+ */
+const createPipelineStack = (pipelineScope: Stage): Stack => {
+  const stageName =
+    pipelineScope.node.tryGetContext('AMPLIFY_STAGE_NAME') || 'default';
+
+  const stack = new Stack(pipelineScope, 'BackendStack');
+  stack.node.setContext(CDKContextKey.BACKEND_NAMESPACE, 'pipeline');
+  stack.node.setContext(CDKContextKey.BACKEND_NAME, stageName);
+  stack.node.setContext(CDKContextKey.DEPLOYMENT_TYPE, 'standalone');
+  return stack;
+};
+
+/**
  * Creates a new Amplify backend instance and returns it
  * @param constructFactories - list of backend factories such as those created by `defineAuth` or `defineData`
  */
 export const defineBackend = <T extends DefineBackendProps>(
   constructFactories: T,
 ): Backend<T> => {
-  const backend = new BackendFactory(constructFactories);
+  // Check for pipeline ambient scope
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pipelineScope = (globalThis as any)[AMPLIFY_PIPELINE_SCOPE_KEY] as
+    | Stage
+    | undefined;
+  const stack = pipelineScope ? createPipelineStack(pipelineScope) : undefined;
+  const backend = new BackendFactory(constructFactories, stack);
   return {
     ...backend.resources,
     createStack: backend.createStack,


### PR DESCRIPTION
Adds pipeline ambient scope detection to defineBackend(), following the same pattern as defineHosting().

When running inside a pipeline stage, defineBackend() attaches to the pipeline stage instead of creating a standalone App. This enables definePipeline() to auto-invoke backend.ts per stage.

- 6 new tests
- TypeScript compiles clean
- Tested end-to-end with demo project