### PR TITLE
chore: derive snapshot dist-tag from branch name

### DIFF
--- a/scripts/publish_runner.ts
+++ b/scripts/publish_runner.ts
@@ -29,7 +29,10 @@ const publishDefaults: PublishOptions = {
   snapshotRelease: false,
 };
 
-const snapshotTag = 'test';
+const refName = process.env.GITHUB_REF_NAME || '';
+const snapshotTag = refName.startsWith('snapshot/')
+  ? refName.replace('snapshot/', '')
+  : 'test';
 
 /**
  * Wrapper around `changeset publish` that exposes a few config options


### PR DESCRIPTION
## Summary

Changes the snapshot publish script to derive the npm dist-tag from the branch name instead of using a hardcoded `'test'` tag.

### Before
All `snapshot/*` branches publish under the `@test` dist-tag, causing collisions.

### After
Each `snapshot/*` branch publishes under its own dist-tag derived from the branch name:
- `snapshot/iac-hosting` → `@iac-hosting`
- `snapshot/some-feature` → `@some-feature`
- Fallback (non-snapshot branch) → `@test` (backward compatible)

### Why
We need customers and internal projects to be able to install specific snapshot builds from `snapshot/iac-hosting` via:
```bash
npm install @aws-amplify/hosting@iac-hosting
```

### Change
One file: `scripts/publish_runner.ts` — 3 lines replacing 1.