### PR TITLE
feat(pipeline): two-phase deployment with amplify_outputs.json injection

### DIFF
--- a/packages/backend/src/backend_factory.ts
+++ b/packages/backend/src/backend_factory.ts
@@ -3,7 +3,7 @@ import {
   DeepPartialAmplifyGeneratedConfigs,
   ResourceProvider,
 } from '@aws-amplify/plugin-types';
-import { Stack, Stage } from 'aws-cdk-lib';
+import { CfnOutput, Stack, Stage } from 'aws-cdk-lib';
 import {
   NestedStackResolver,
   StackResolver,
@@ -169,6 +169,20 @@ const createPipelineStack = (pipelineScope: Stage): Stack => {
   stack.node.setContext(CDKContextKey.BACKEND_NAMESPACE, 'pipeline');
   stack.node.setContext(CDKContextKey.BACKEND_NAME, stageName);
   stack.node.setContext(CDKContextKey.DEPLOYMENT_TYPE, 'standalone');
+
+  // Expose stack name as CfnOutput so the pipeline post-deploy step can
+  // run `ampx generate outputs --stack <name>` after deployment.
+  const stackNameOutput = new CfnOutput(stack, 'BackendStackName', {
+    value: stack.stackName,
+    description: 'Backend stack name for amplify_outputs.json generation',
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any)['__AMPLIFY_BACKEND_PIPELINE_OUTPUTS__'] = {
+    stackNameOutput,
+    backendStack: stack,
+  };
+
   return stack;
 };
 

--- a/packages/hosting/src/pipeline/pipeline_construct.ts
+++ b/packages/hosting/src/pipeline/pipeline_construct.ts
@@ -259,7 +259,7 @@ const buildCodePipeline = <TConfig>(
   branchId: string,
   branchConfig: BranchConfig<TConfig>,
   props: PipelineProps<TConfig>,
-): CodePipeline => {
+): { codePipeline: CodePipeline; source: CodePipelineSource } => {
   const hasTriggerFilters =
     props.source.triggerFilters && props.source.triggerFilters.length > 0;
   if (branchConfig.triggerOnPush === true && hasTriggerFilters) {
@@ -290,7 +290,7 @@ const buildCodePipeline = <TConfig>(
     primaryOutputDirectory: props.synth?.primaryOutputDirectory,
   });
 
-  return new CodePipeline(construct, branchId, {
+  const codePipeline = new CodePipeline(construct, branchId, {
     synth: synthStep,
     selfMutation: props.selfMutation ?? true,
     crossAccountKeys: props.crossAccountKeys ?? false,
@@ -305,12 +305,15 @@ const buildCodePipeline = <TConfig>(
       },
     },
   });
+
+  return { codePipeline, source };
 };
 
 const addStageToCodePipeline = <TConfig>(
   codePipeline: CodePipeline,
   stageConfig: PipelineStageConfig<TConfig>,
   deployStage: DeployStage<TConfig>,
+  additionalPostSteps?: Array<ShellStep | CodeBuildStep>,
 ): void => {
   const pre: Array<ManualApprovalStep | ShellStep> = [];
   const post: Array<ShellStep | CodeBuildStep> = [];
@@ -334,6 +337,10 @@ const addStageToCodePipeline = <TConfig>(
         timeout: cdk.Duration.minutes(timeoutMinutes),
       }),
     );
+  }
+
+  if (additionalPostSteps) {
+    post.push(...additionalPostSteps);
   }
 
   codePipeline.addStage(deployStage, { pre, post });
@@ -374,7 +381,7 @@ const createBranchPipelineSync = <TConfig>(
   const safeBranch = branchConfig.branch.replace(/[^a-zA-Z0-9-]/g, '-');
   const branchId = `${id}-${safeBranch}`;
 
-  const codePipeline = buildCodePipeline(
+  const { codePipeline, source } = buildCodePipeline(
     construct,
     branchId,
     branchConfig,
@@ -422,7 +429,16 @@ const createBranchPipelineSync = <TConfig>(
     }
 
     validateStageStacks(stage, stageConfig.name);
-    addStageToCodePipeline(codePipeline, stageConfig, stage);
+
+    const additionalPostSteps = props._postStageHook
+      ? props._postStageHook({ source, stage, stageConfig })
+      : undefined;
+    addStageToCodePipeline(
+      codePipeline,
+      stageConfig,
+      stage,
+      additionalPostSteps,
+    );
   }
 
   addTriggerFilters(codePipeline, branchConfig, props);
@@ -441,7 +457,7 @@ const createBranchPipelineAsync = async <TConfig>(
   const safeBranch = branchConfig.branch.replace(/[^a-zA-Z0-9-]/g, '-');
   const branchId = `${id}-${safeBranch}`;
 
-  const codePipeline = buildCodePipeline(
+  const { codePipeline, source } = buildCodePipeline(
     construct,
     branchId,
     branchConfig,
@@ -481,7 +497,16 @@ const createBranchPipelineAsync = async <TConfig>(
     }
 
     validateStageStacks(stage, stageConfig.name);
-    addStageToCodePipeline(codePipeline, stageConfig, stage);
+
+    const additionalPostSteps = props._postStageHook
+      ? props._postStageHook({ source, stage, stageConfig })
+      : undefined;
+    addStageToCodePipeline(
+      codePipeline,
+      stageConfig,
+      stage,
+      additionalPostSteps,
+    );
   }
 
   addTriggerFilters(codePipeline, branchConfig, props);

--- a/packages/hosting/src/pipeline/pipeline_factory.test.ts
+++ b/packages/hosting/src/pipeline/pipeline_factory.test.ts
@@ -66,17 +66,26 @@ if (scope) {
     );
   });
 
-  void it('auto-discovers and invokes backend.ts before hosting.ts', () => {
-    // Write backend.js that records invocation
+  void it('auto-discovers and invokes backend.ts (hosting deployed via post-step)', () => {
+    // Write backend.js that creates a stack using the ambient scope
     const backendCode = `
 const cdk = require('aws-cdk-lib');
 const scope = globalThis.__AMPLIFY_PIPELINE_SCOPE__;
 if (scope) {
-  new cdk.Stack(scope, 'BackendStack');
+  const stack = new cdk.Stack(scope, 'BackendStack');
+  // Simulate CfnOutput for backend stack name (as defineBackend does)
+  new cdk.CfnOutput(stack, 'BackendStackName', { value: stack.stackName });
+  globalThis.__AMPLIFY_BACKEND_PIPELINE_OUTPUTS__ = {
+    stackNameOutput: new cdk.CfnOutput(stack, 'BackendStackNameForPipeline', { value: stack.stackName }),
+    backendStack: stack,
+  };
 }
 `;
-    // Write hosting.js that records invocation
+    // Write hosting.js — should NOT be imported when backend.ts exists
     const hostingCode = `
+const fs = require('fs');
+const path = require('path');
+fs.writeFileSync(path.join(process.cwd(), 'hosting-was-imported.txt'), 'yes');
 const cdk = require('aws-cdk-lib');
 const scope = globalThis.__AMPLIFY_PIPELINE_SCOPE__;
 if (scope) {
@@ -87,7 +96,7 @@ if (scope) {
     fs.writeFileSync(path.join(tmpDir, 'amplify', 'hosting.js'), hostingCode);
     process.chdir(tmpDir);
 
-    // Both backend and hosting stacks created without error
+    // Both backend and hosting files exist — two-phase deployment is used
     assert.doesNotThrow(() =>
       definePipeline({
         source: {
@@ -101,6 +110,12 @@ if (scope) {
           },
         ],
       }),
+    );
+
+    // Hosting.js should NOT have been imported during stageFactory
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, 'hosting-was-imported.txt')),
+      'hosting.js should NOT be imported when backend.ts exists (two-phase deployment)',
     );
   });
 
@@ -259,6 +274,296 @@ if (scope) {
       branches: [{ branch: 'main', stages: [{ name: 'x' }] }],
     };
     assert.ok(props, 'DefinePipelineProps should not include stageFactory');
+  });
+
+  void it('imports backend.ts fresh for each stage with full cache busting', () => {
+    // Write backend.js that increments a counter to prove fresh import per stage
+    // eslint-disable-next-line spellcheck/spell-checker
+    const backendCode = `
+const cdk = require('aws-cdk-lib');
+const fs = require('fs');
+const path = require('path');
+const scope = globalThis.__AMPLIFY_PIPELINE_SCOPE__;
+if (scope) {
+  const counterFile = path.join(process.cwd(), 'backend-invoke-count.txt');
+  const count = fs.existsSync(counterFile) ? parseInt(fs.readFileSync(counterFile, 'utf-8'), 10) : 0;
+  fs.writeFileSync(counterFile, String(count + 1));
+  const stack = new cdk.Stack(scope, 'BackendStack-' + (count + 1));
+  new cdk.CfnOutput(stack, 'BackendStackName', { value: stack.stackName });
+  globalThis.__AMPLIFY_BACKEND_PIPELINE_OUTPUTS__ = {
+    stackNameOutput: new cdk.CfnOutput(stack, 'PipelineBackendName', { value: stack.stackName }),
+    backendStack: stack,
+  };
+}
+`;
+    fs.writeFileSync(path.join(tmpDir, 'amplify', 'backend.js'), backendCode);
+    process.chdir(tmpDir);
+
+    definePipeline({
+      source: {
+        repo: 'my-org/my-app',
+        connectionArn: VALID_CONNECTION_ARN,
+      },
+      branches: [
+        {
+          branch: 'main',
+          stages: [{ name: 'alpha' }, { name: 'beta' }],
+        },
+      ],
+    });
+
+    const counterFile = path.join(tmpDir, 'backend-invoke-count.txt');
+    assert.ok(fs.existsSync(counterFile), 'counter file should exist');
+    const count = parseInt(fs.readFileSync(counterFile, 'utf-8'), 10);
+    assert.strictEqual(
+      count,
+      2,
+      'backend.js should be invoked once per stage (2 stages)',
+    );
+  });
+
+  void it('cache-busts @aws-amplify/* transitive deps (singleton pattern)', () => {
+    // Simulate the real @aws-amplify/backend-auth singleton problem:
+    // A module at a path matching /@aws-amplify\// has a static counter
+    // (like AmplifyAuthFactory.factoryCount). Without cache-busting,
+    // the second stage import would see factoryCount=1 and fail.
+    //
+    // This test creates a fake @aws-amplify/backend-auth module in the
+    // tmp dir's node_modules and a backend.js that requires it.
+    // If cache-busting works, the module is re-executed for each stage,
+    // giving factoryCount=0 each time.
+
+    // Remove the symlinked node_modules (from beforeEach) and create a real directory
+    const realNodeModules = fs.readlinkSync(path.join(tmpDir, 'node_modules'));
+    fs.unlinkSync(path.join(tmpDir, 'node_modules'));
+    fs.mkdirSync(path.join(tmpDir, 'node_modules'), { recursive: true });
+
+    // Symlink aws-cdk-lib and constructs from real node_modules
+    fs.symlinkSync(
+      path.join(realNodeModules, 'aws-cdk-lib'),
+      path.join(tmpDir, 'node_modules', 'aws-cdk-lib'),
+    );
+    fs.symlinkSync(
+      path.join(realNodeModules, 'constructs'),
+      path.join(tmpDir, 'node_modules', 'constructs'),
+    );
+
+    // Create fake @aws-amplify/backend-auth with a singleton counter
+    const fakeAuthDir = path.join(
+      tmpDir,
+      'node_modules',
+      '@aws-amplify',
+      'backend-auth',
+    );
+    fs.mkdirSync(fakeAuthDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeAuthDir, 'index.js'),
+      `
+// Simulates AmplifyAuthFactory.factoryCount singleton pattern
+let factoryCount = 0;
+class AmplifyAuthFactory {
+  static get factoryCount() { return factoryCount; }
+  constructor() {
+    factoryCount++;
+    if (factoryCount > 1) {
+      throw new Error('AmplifyAuthFactory already defined — singleton violation!');
+    }
+  }
+}
+module.exports = { AmplifyAuthFactory };
+`,
+    );
+    fs.writeFileSync(
+      path.join(fakeAuthDir, 'package.json'),
+      JSON.stringify({ name: '@aws-amplify/backend-auth', main: 'index.js' }),
+    );
+
+    // Create fake @aws-amplify/data-schema with a cached schema singleton
+    const fakeDataDir = path.join(
+      tmpDir,
+      'node_modules',
+      '@aws-amplify',
+      'data-schema',
+    );
+    fs.mkdirSync(fakeDataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeDataDir, 'index.js'),
+      `
+let schemaInstance = null;
+const a = (modelDef) => {
+  if (schemaInstance) throw new Error('Schema already created — singleton violation!');
+  schemaInstance = { models: modelDef };
+  return schemaInstance;
+};
+module.exports = { a };
+`,
+    );
+    fs.writeFileSync(
+      path.join(fakeDataDir, 'package.json'),
+      JSON.stringify({ name: '@aws-amplify/data-schema', main: 'index.js' }),
+    );
+
+    // backend.js imports and uses the singletons — would fail on 2nd stage
+    // without cache-busting
+    const backendCode = `
+const cdk = require('aws-cdk-lib');
+const { AmplifyAuthFactory } = require('@aws-amplify/backend-auth');
+const { a } = require('@aws-amplify/data-schema');
+const fs = require('fs');
+const path = require('path');
+
+const scope = globalThis.__AMPLIFY_PIPELINE_SCOPE__;
+if (scope) {
+  // Instantiate singletons (would throw on 2nd call without cache-busting)
+  new AmplifyAuthFactory();
+  a({ Todo: {} });
+
+  const counterFile = path.join(process.cwd(), 'singleton-invoke-count.txt');
+  const count = fs.existsSync(counterFile) ? parseInt(fs.readFileSync(counterFile, 'utf-8'), 10) : 0;
+  fs.writeFileSync(counterFile, String(count + 1));
+
+  const stack = new cdk.Stack(scope, 'BackendStack-' + (count + 1));
+  new cdk.CfnOutput(stack, 'BackendStackName', { value: stack.stackName });
+  globalThis.__AMPLIFY_BACKEND_PIPELINE_OUTPUTS__ = {
+    stackNameOutput: new cdk.CfnOutput(stack, 'PipelineBackendName', { value: stack.stackName }),
+    backendStack: stack,
+  };
+}
+`;
+    fs.writeFileSync(path.join(tmpDir, 'amplify', 'backend.js'), backendCode);
+    process.chdir(tmpDir);
+
+    // TWO stages — without cache-busting, the 2nd stage would throw
+    // "AmplifyAuthFactory already defined" or "Schema already created"
+    assert.doesNotThrow(() =>
+      definePipeline({
+        source: {
+          repo: 'my-org/my-app',
+          connectionArn: VALID_CONNECTION_ARN,
+        },
+        branches: [
+          {
+            branch: 'main',
+            stages: [{ name: 'staging' }, { name: 'prod' }],
+          },
+        ],
+      }),
+    );
+
+    // Verify BOTH stages were executed (singletons didn't block 2nd stage)
+    const counterFile = path.join(tmpDir, 'singleton-invoke-count.txt');
+    assert.ok(fs.existsSync(counterFile), 'counter file should exist');
+    const count = parseInt(fs.readFileSync(counterFile, 'utf-8'), 10);
+    assert.strictEqual(
+      count,
+      2,
+      'Both stages must complete — singletons reset between stages via cache-busting',
+    );
+  });
+
+  void it('verifies require.cache entries matching @aws-amplify are removed', () => {
+    // Directly verify that importFresh clears @aws-amplify entries from cache.
+    // We seed require.cache with fake entries and verify they're gone after import.
+    const backendCode = `
+const cdk = require('aws-cdk-lib');
+const scope = globalThis.__AMPLIFY_PIPELINE_SCOPE__;
+if (scope) {
+  const stack = new cdk.Stack(scope, 'BackendStack');
+  new cdk.CfnOutput(stack, 'BackendStackName', { value: stack.stackName });
+  globalThis.__AMPLIFY_BACKEND_PIPELINE_OUTPUTS__ = {
+    stackNameOutput: new cdk.CfnOutput(stack, 'PipelineBackendName', { value: stack.stackName }),
+    backendStack: stack,
+  };
+}
+`;
+    fs.writeFileSync(path.join(tmpDir, 'amplify', 'backend.js'), backendCode);
+    process.chdir(tmpDir);
+
+    // Seed require.cache with fake entries that match CACHE_BUST_PATTERNS
+    const fakeKeys = [
+      '/node_modules/@aws-amplify/backend-auth/lib/index.js',
+      '/node_modules/@aws-amplify/backend-data/lib/factory.js',
+      '/node_modules/@aws-amplify/data-schema/lib/schema.js',
+      '/node_modules/@aws-amplify/auth-construct/lib/construct.js',
+      '/some/path/packages/backend/lib/backend_factory.js',
+      '/some/path/packages/hosting/lib/factory.js',
+      '/user/project/amplify/auth/resource.js',
+      '/user/project/amplify/data/resource.js',
+    ];
+    for (const key of fakeKeys) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (require as any).cache[key] = { id: key, exports: {} };
+    }
+
+    // Run definePipeline — importFresh should clear all matching entries
+    definePipeline({
+      source: {
+        repo: 'my-org/my-app',
+        connectionArn: VALID_CONNECTION_ARN,
+      },
+      branches: [
+        {
+          branch: 'main',
+          stages: [{ name: 'beta' }],
+        },
+      ],
+    });
+
+    // Verify ALL fake entries matching CACHE_BUST_PATTERNS are gone
+    for (const key of fakeKeys) {
+      assert.strictEqual(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (require as any).cache[key],
+        undefined,
+        `require.cache entry "${key}" should have been cleared by importFresh`,
+      );
+    }
+  });
+
+  void it('creates post-deploy hosting step when both backend and hosting exist', () => {
+    // Backend creates a stack + CfnOutput (mimics defineBackend pipeline mode)
+    const backendCode = `
+const cdk = require('aws-cdk-lib');
+const scope = globalThis.__AMPLIFY_PIPELINE_SCOPE__;
+if (scope) {
+  const stack = new cdk.Stack(scope, 'BackendStack');
+  globalThis.__AMPLIFY_BACKEND_PIPELINE_OUTPUTS__ = {
+    stackNameOutput: new cdk.CfnOutput(stack, 'BackendStackName', { value: stack.stackName }),
+    backendStack: stack,
+  };
+}
+`;
+    // Hosting file exists but should NOT be imported during synth
+    const hostingCode = `
+const fs = require('fs');
+const path = require('path');
+fs.writeFileSync(path.join(process.cwd(), 'hosting-imported-during-synth.txt'), 'yes');
+`;
+    fs.writeFileSync(path.join(tmpDir, 'amplify', 'backend.js'), backendCode);
+    fs.writeFileSync(path.join(tmpDir, 'amplify', 'hosting.js'), hostingCode);
+    process.chdir(tmpDir);
+
+    // Should not throw — the post-deploy step is added for hosting
+    assert.doesNotThrow(() =>
+      definePipeline({
+        source: {
+          repo: 'my-org/my-app',
+          connectionArn: VALID_CONNECTION_ARN,
+        },
+        branches: [
+          {
+            branch: 'main',
+            stages: [{ name: 'prod' }],
+          },
+        ],
+      }),
+    );
+
+    // Hosting should NOT have been imported during synth (two-phase mode)
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, 'hosting-imported-during-synth.txt')),
+      'hosting.js must not be imported during synth when backend exists',
+    );
   });
 });
 

--- a/packages/hosting/src/pipeline/pipeline_factory.ts
+++ b/packages/hosting/src/pipeline/pipeline_factory.ts
@@ -1,18 +1,31 @@
 import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import * as path from 'path';
 import * as fs from 'fs';
 import { createRequire } from 'node:module';
+import {
+  CodeBuildStep,
+  IFileSetProducer,
+  ShellStep,
+} from 'aws-cdk-lib/pipelines';
 import { AmplifyPipelineConstruct } from './pipeline_construct.js';
 import type { DefinePipelineProps, PipelineStageConfig } from './types.js';
 
 const require = createRequire(import.meta.url);
 
 /**
- * Global key used to pass the pipeline stage scope to `defineHosting`/`defineBackend`
- * during pipeline synthesis. When set, these functions attach their constructs
- * to the pipeline stage rather than creating their own App.
+ * Global key used to pass the pipeline stage scope to `defineBackend`
+ * during pipeline synthesis. When set, `defineBackend()` attaches its constructs
+ * to the pipeline stage rather than creating its own App.
  */
 const AMPLIFY_PIPELINE_SCOPE_KEY = '__AMPLIFY_PIPELINE_SCOPE__';
+
+/**
+ * Global key used by `defineBackend()` to publish CfnOutput references
+ * back to the pipeline factory after creating the BackendStack.
+ */
+const BACKEND_PIPELINE_OUTPUTS_KEY = '__AMPLIFY_BACKEND_PIPELINE_OUTPUTS__';
 
 /**
  * File extensions to search when discovering hosting.ts/backend.ts.
@@ -26,10 +39,16 @@ const DISCOVERABLE_EXTENSIONS = ['.ts', '.js', '.cjs'];
  * Creates a self-mutating CodePipeline V2 that deploys through the configured
  * stages. Each branch gets its own independent pipeline.
  *
- * Unlike the underlying {@link AmplifyPipelineConstruct}, this user-facing factory
- * does NOT accept a `stageFactory`. Instead, it automatically discovers and imports
- * `amplify/hosting.ts` and `amplify/backend.ts` for each stage, using the ambient
- * scope pattern (`globalThis.__AMPLIFY_PIPELINE_SCOPE__`).
+ * The pipeline uses a two-phase deployment per stage:
+ * 1. **Backend deploy** — CloudFormation stacks (Cognito, AppSync, DynamoDB, etc.)
+ *    deployed via CDK Pipelines' native stage mechanism.
+ * 2. **Hosting deploy** — A post-deploy CodeBuild step that mirrors `ampx deploy`:
+ *    generates `amplify_outputs.json` from the deployed backend, builds the frontend
+ *    (so `amplify_outputs.json` is baked into Lambda bundles for SSR), then deploys
+ *    hosting via `cdk deploy`.
+ *
+ * This two-phase approach ensures `amplify_outputs.json` is available during the
+ * frontend build — the same ordering that `ampx deploy` provides locally.
  *
  * Use `getStageConfig()` inside `hosting.ts`/`backend.ts` to read per-stage
  * configuration during synthesis.
@@ -88,10 +107,22 @@ export const definePipeline = (props: DefinePipelineProps): void => {
     );
   }
 
+  // Two-phase deployment is only needed when BOTH backend and hosting exist.
+  // When both exist: backend deploys first, then a post-deploy CodeBuild step
+  // generates amplify_outputs.json and deploys hosting (so the frontend build
+  // has access to backend outputs — required for SSR/Next.js Lambda bundles).
+  //
+  // When only one exists, it's imported directly in the stageFactory.
+  const useTwoPhaseDeployment = !!(backendFile && hostingFile);
+
   const internalStageFactory = (
     scope: cdk.Stage,
     stageConfig: PipelineStageConfig,
   ): void => {
+    // Clear backend outputs from previous stage iteration
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any)[BACKEND_PIPELINE_OUTPUTS_KEY];
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any)[AMPLIFY_PIPELINE_SCOPE_KEY] = scope;
     scope.node.setContext('AMPLIFY_STAGE_CONFIG', JSON.stringify(stageConfig));
@@ -101,21 +132,148 @@ export const definePipeline = (props: DefinePipelineProps): void => {
       if (backendFile) {
         importFresh(backendFile);
       }
-      if (hostingFile) {
+      if (hostingFile && !useTwoPhaseDeployment) {
+        // Hosting-only project (no backend) — import directly since there's
+        // no backend stack to wait for before building.
         importFresh(hostingFile);
       }
+      // When useTwoPhaseDeployment is true, hosting.ts is NOT imported here.
+      // It is deployed by the post-deploy CodeBuild step, which runs AFTER
+      // the backend CloudFormation stack is live. This ensures
+      // amplify_outputs.json is available during the frontend build.
     } finally {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (globalThis as any)[AMPLIFY_PIPELINE_SCOPE_KEY];
     }
   };
 
+  // Post-stage hook: creates a CodeBuild step that deploys hosting after backend
+  const postStageHook =
+    useTwoPhaseDeployment && hostingFile
+      ? createHostingDeployHook(hostingFile)
+      : undefined;
+
   new AmplifyPipelineConstruct(rootStack, 'Pipeline', {
     ...props,
     stageFactory: internalStageFactory,
+    _postStageHook: postStageHook,
   });
 
   app.synth();
+};
+
+/**
+ * Create the _postStageHook that produces hosting deploy steps.
+ *
+ * The returned hook reads the backend CfnOutput from globalThis (set by
+ * `defineBackend()` during the stageFactory call) and creates a CodeBuildStep
+ * that deploys hosting after the backend stack is live.
+ */
+const createHostingDeployHook = (
+  hostingFile: string,
+): ((params: {
+  source: IFileSetProducer;
+  stage: cdk.Stage;
+  stageConfig: PipelineStageConfig;
+}) => Array<ShellStep | CodeBuildStep>) => {
+  // Determine the hosting entry point relative to the project root
+  const projectDir = process.cwd();
+  const relativeHostingPath = path.relative(projectDir, hostingFile);
+
+  return ({ source, stageConfig }) => {
+    // Read backend CfnOutput from globalThis (set by defineBackend in pipeline mode)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const backendOutputs = (globalThis as any)[BACKEND_PIPELINE_OUTPUTS_KEY] as
+      | { stackNameOutput: cdk.CfnOutput; backendStack: cdk.Stack }
+      | undefined;
+
+    if (!backendOutputs?.stackNameOutput) {
+      // No backend stack — skip hosting deploy step.
+      // This happens when there's no backend.ts or defineBackend() wasn't called.
+      return [];
+    }
+
+    const deployStep = new CodeBuildStep(`DeployHosting-${stageConfig.name}`, {
+      input: source,
+      envFromCfnOutputs: {
+        BACKEND_STACK_NAME: backendOutputs.stackNameOutput,
+      },
+      env: {
+        STAGE_NAME: stageConfig.name,
+        HOSTING_ENTRY_POINT: relativeHostingPath,
+      },
+      commands: [
+        // Install project dependencies
+        'npm ci',
+
+        // Install the Amplify CLI for `ampx generate outputs`.
+        // The CLI package may not be in the project's dependencies
+        // since it's typically a global/dev tool.
+        'npm install --no-save @aws-amplify/backend-cli',
+
+        // Generate amplify_outputs.json from the deployed backend stack.
+        // This queries CloudFormation stack outputs — same as `ampx generate outputs`.
+        'npx ampx generate outputs --stack $BACKEND_STACK_NAME --out-dir .',
+
+        // Build the frontend. For SSR (Next.js), this produces Lambda bundles
+        // that include amplify_outputs.json (via the adapter's
+        // copyAmplifyOutputsToServerBundles).
+        'npm run build',
+
+        // Deploy hosting stack using CDK. Context flags provide the backend
+        // identifier that defineHosting() reads via getBackendIdentifier().
+        // This mirrors the same flow as `ampx deploy`.
+        'npx cdk deploy --all --app "npx tsx $HOSTING_ENTRY_POINT" --require-approval never -c amplify-backend-namespace=pipeline -c amplify-backend-name=$STAGE_NAME -c amplify-backend-type=standalone',
+      ],
+      buildEnvironment: {
+        buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2023_5,
+        computeType: codebuild.ComputeType.MEDIUM,
+      },
+      rolePolicyStatements: [
+        // Allow assuming CDK bootstrap roles (deploy, file-publishing, lookup)
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['sts:AssumeRole'],
+          resources: ['arn:aws:iam::*:role/cdk-*'],
+        }),
+        // Broad read/write permissions for `ampx generate outputs` and `cdk deploy`.
+        // Mirrors the scope of AWS managed policy AdministratorAccess-Amplify
+        // which covers all services Amplify backends use (CloudFormation, S3,
+        // Cognito, AppSync, DynamoDB, Lambda, IAM, SSM, etc.).
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: [
+            'cloudformation:*',
+            's3:*',
+            'amplify:*',
+            'appsync:*',
+            'cognito-idp:*',
+            'cognito-identity:*',
+            'dynamodb:*',
+            'lambda:*',
+            'iam:PassRole',
+            'iam:CreateRole',
+            'iam:AttachRolePolicy',
+            'iam:PutRolePolicy',
+            'iam:GetRole',
+            'iam:GetRolePolicy',
+            'iam:DeleteRole',
+            'iam:DeleteRolePolicy',
+            'iam:DetachRolePolicy',
+            'ssm:GetParameter*',
+            'ssm:PutParameter',
+            'logs:*',
+            'cloudfront:*',
+            'route53:*',
+            'acm:*',
+          ],
+          resources: ['*'],
+        }),
+      ],
+    });
+
+    return [deployStep];
+  };
 };
 
 /**
@@ -193,19 +351,49 @@ export function findFile(dir: string, baseName: string): string | undefined {
 }
 
 /**
- * Import a module with cache-busting for CJS.
+ * Patterns of module paths to bust from the require cache before each stage.
  *
- * Clears the require cache for the resolved module path before requiring,
- * ensuring each pipeline stage gets a fresh execution of hosting.ts/backend.ts.
+ * These cover all `@aws-amplify/*` packages that hold static singleton state
+ * (e.g., AmplifyAuthFactory.factoryCount, cached generators, schema singletons)
+ * which would prevent re-instantiation across pipeline stages.
  *
- * Note: Only the target module's cache entry is busted. Transitive dependencies
- * (modules required by hosting.ts/backend.ts) are NOT cache-busted and will
- * retain state across stages. If per-stage isolation of transitive deps is needed,
- * consider using worker_threads or forked processes.
+ * Also covers the user's own `amplify/` directory files (auth/resource, data/resource, etc.)
+ * which may import and configure those singletons.
+ */
+const CACHE_BUST_PATTERNS = [
+  /@aws-amplify\//,
+  /packages\/backend/,
+  /packages\/hosting/,
+  /packages\/auth-construct/,
+  /packages\/data-schema/,
+  /\/amplify\//,
+];
+
+/**
+ * Import a module with aggressive cache-busting for multi-stage pipelines.
+ *
+ * Before importing the target file, clears ALL `@aws-amplify/*` packages and
+ * user amplify directory modules from the require cache. This ensures each
+ * pipeline stage gets completely fresh singleton state — no static counters,
+ * no cached generators, no stale schema instances.
+ *
+ * Without this, packages like `@aws-amplify/backend-auth` retain
+ * `AmplifyAuthFactory.factoryCount` across stages, causing "already defined"
+ * errors on the second stage. Users should NOT need any cache-busting
+ * workarounds in their own code — the pipeline handles it here.
  */
 // eslint-disable-next-line no-restricted-syntax
 function importFresh(filePath: string): void {
+  // Bust all Amplify-related modules from cache
+  for (const key of Object.keys(require.cache)) {
+    if (CACHE_BUST_PATTERNS.some((pattern) => pattern.test(key))) {
+      delete require.cache[key];
+    }
+  }
+
+  // Also bust the target file itself
   const resolved = require.resolve(filePath);
   delete require.cache[resolved];
+
   require(resolved);
 }

--- a/packages/hosting/src/pipeline/types.ts
+++ b/packages/hosting/src/pipeline/types.ts
@@ -1,6 +1,11 @@
 import * as cdk from 'aws-cdk-lib';
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
-import { CodePipelineSource } from 'aws-cdk-lib/pipelines';
+import {
+  CodeBuildStep,
+  CodePipelineSource,
+  IFileSetProducer,
+  ShellStep,
+} from 'aws-cdk-lib/pipelines';
 
 /**
  * Configuration for the pipeline source (GitHub/CodeConnections).
@@ -351,4 +356,18 @@ export type PipelineProps<TConfig = Record<string, unknown>> = {
    * @internal
    */
   readonly _sourceOverride?: CodePipelineSource;
+
+  /**
+   * Internal hook called after each stage's stageFactory runs.
+   *
+   * Returns additional post-deploy steps to append to the stage.
+   * Used by `definePipeline()` to add the hosting deployment CodeBuild step
+   * after the backend stage deploys.
+   * @internal
+   */
+  readonly _postStageHook?: (params: {
+    source: IFileSetProducer;
+    stage: cdk.Stage;
+    stageConfig: PipelineStageConfig<TConfig>;
+  }) => Array<ShellStep | CodeBuildStep>;
 };

--- a/packages/integration-tests/src/test-projects/standalone-hosting-ssr/amplify/pipeline.ts
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-ssr/amplify/pipeline.ts
@@ -1,0 +1,15 @@
+import { definePipeline } from '@aws-amplify/hosting/pipeline';
+
+definePipeline({
+  source: {
+    repo: 'adrianjoshua-strutt/amplify-gen2-pipeline-demo',
+    connectionArn:
+      'arn:aws:codeconnections:us-east-1:028064247663:connection/70f8c66a-3d3e-4a87-98af-2f44f9e54d97',
+  },
+  branches: [
+    {
+      branch: 'main',
+      stages: [{ name: 'prod' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Implements **two-phase deployment** in `definePipeline()` to correctly inject `amplify_outputs.json` into frontend builds. This mirrors the `ampx deploy` sequence: backend deploys → generate outputs → build frontend → deploy hosting.

## Problem

When using `definePipeline()` with both `amplify/backend.ts` and `amplify/hosting.ts`, the frontend build needs `amplify_outputs.json` (containing Cognito User Pool IDs, AppSync endpoints, etc.) to properly configure `Amplify.configure()` in the client. However, these values are only available AFTER the backend CloudFormation stack deploys.

## Solution

**Two-phase deployment:**
1. **Phase 1 (CDK Pipelines stage):** Only `BackendStack` deploys (Cognito, AppSync, DynamoDB)
2. **Phase 2 (`DeployHosting` CodeBuild step):** Post-deploy step that:
   - Runs `ampx generate outputs --stack $BACKEND_STACK_NAME` to create `amplify_outputs.json`
   - Runs `npm run build` (Next.js + OpenNext adapter bundles the outputs into Lambda)
   - Runs `cdk deploy` to deploy the hosting stack (CloudFront + Lambda + S3)

**Cache-busting (`importFresh`):** Aggressively clears `require.cache` for all `@aws-amplify/*` transitive deps so each stage gets fresh module instances (singletons, factory counters, etc.)

## Changes

| File | Description |
|------|-------------|
| `packages/backend/src/backend_factory.ts` | Adds `CfnOutput` for backend stack name + stores on `globalThis` for cross-package communication |
| `packages/hosting/src/pipeline/pipeline_factory.ts` | Two-phase deployment logic, `importFresh()` cache-busting, `createHostingDeployHook()` CodeBuild step |
| `packages/hosting/src/pipeline/pipeline_construct.ts` | `_postStageHook` support in `addStageToCodePipeline()` |
| `packages/hosting/src/pipeline/types.ts` | `_postStageHook` type on `PipelineProps` |
| `packages/hosting/src/pipeline/pipeline_factory.test.ts` | 21 tests covering two-phase deployment, cache-busting, backward compatibility |
| `packages/integration-tests/.../amplify/pipeline.ts` | Test project pipeline config |

## Verified Working

End-to-end deployed demo at CloudFront:
- ✅ Server renders "Backend: connected (Cognito + AppSync + DynamoDB)"
- ✅ Client-side CRUD (Create, Read, Update, Delete) against AppSync/DynamoDB
- ✅ Guest access via IAM auth (Cognito Identity Pool unauthenticated role)
- ✅ `amplify_outputs.json` generated and bundled into Lambda at build time
- ✅ No `amplify_outputs.json` committed to git

## Test Results
- `pipeline_factory.test.ts`: 21/21 pass
- `pipeline_construct.test.ts`: 43/43 pass
- `backend_factory.test.ts`: 18/18 pass

## User DX (unchanged)

```typescript
// amplify/backend.ts — CLEAN, no cache-busting
import { defineBackend } from "@aws-amplify/backend";
import { auth } from "./auth/resource.js";
import { data } from "./data/resource.js";
defineBackend({ auth, data });

// amplify/hosting.ts
import { defineHosting } from "@aws-amplify/hosting";
defineHosting({ framework: "nextjs" });

// amplify/pipeline.ts
import { definePipeline } from "@aws-amplify/hosting/pipeline";
definePipeline({
  source: { repo: "org/repo", connectionArn: "..." },
  branches: [{ branch: "main", stages: [{ name: "prod" }] }],
});
```
