### PR TITLE
feat(hosting): custom environment variables + error pages (M4 + M5)

### DIFF
--- a/.changeset/fix-env-vars-error-pages.md
+++ b/.changeset/fix-env-vars-error-pages.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/hosting': patch
+---
+
+feat(hosting): add custom environment variables and error pages support

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -107,6 +107,7 @@
   "dirent",
   "disambiguator",
   "dockerfile",
+  "doctype",
   "docx",
   "dotfiles",
   "downlevel",

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -1,5 +1,6 @@
 [
   "Aaaa",
+  "SKey",
   "aaaaaaaa",
   "abc",
   "abc123",
@@ -265,6 +266,7 @@
   "patchers",
   "pathname",
   "pipelined",
+  "plaintext",
   "pnpm",
   "positionals",
   "posix",
@@ -318,7 +320,6 @@
   "signout",
   "signup",
   "sigv4",
-  "SKey",
   "sms",
   "solidjs",
   "stderr",

--- a/packages/backend-function/src/function_env_type_generator.test.ts
+++ b/packages/backend-function/src/function_env_type_generator.test.ts
@@ -5,6 +5,7 @@ import { FunctionEnvironmentTypeGenerator } from './function_env_type_generator.
 import assert from 'assert';
 import { pathToFileURL } from 'url';
 import path from 'path';
+import os from 'os';
 
 void describe('FunctionEnvironmentTypeGenerator', () => {
   after(async () => {
@@ -67,14 +68,24 @@ void describe('FunctionEnvironmentTypeGenerator', () => {
   });
 
   void it('generated type definition file has valid syntax', async () => {
-    const functionEnvironmentTypeGenerator =
-      new FunctionEnvironmentTypeGenerator('testFunction');
-    const filePath = `${process.cwd()}/.amplify/generated/env/testFunction.ts`;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'env-gen-test-'));
+    const originalCwd = process.cwd;
+    process.cwd = () => tmpDir;
+    try {
+      const functionEnvironmentTypeGenerator =
+        new FunctionEnvironmentTypeGenerator('testFunction');
+      const filePath = `${tmpDir}/.amplify/generated/env/testFunction.ts`;
 
-    functionEnvironmentTypeGenerator.generateTypedProcessEnvShim(['TEST_ENV']);
+      functionEnvironmentTypeGenerator.generateTypedProcessEnvShim([
+        'TEST_ENV',
+      ]);
 
-    // import to validate syntax of type definition file
-    await import(pathToFileURL(filePath).toString());
+      // import to validate syntax of type definition file
+      await import(pathToFileURL(filePath).toString());
+    } finally {
+      process.cwd = originalCwd;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   void it('does not generate duplicate environment variables', () => {

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -960,6 +960,26 @@ export class CdnConstruct extends Construct {
       }
     }
 
+    // ---- Error-page behavior (B22) ----
+    // CloudFront custom error responses fetch the configured
+    // responsePagePath from the behavior matching that path. Error pages
+    // live at /builds/<buildId>/404.html (or _error.html) in S3. Without
+    // an explicit behavior, the path falls to the default (compute)
+    // behavior and the Lambda can't serve the file — causing CloudFront
+    // to fall back to the original error. Add a direct-to-S3 behavior
+    // for /builds/* so error page fetches resolve correctly.
+    if (errorResponses.length > 0 && hasCompute) {
+      additionalBehaviors['/builds/*'] = {
+        origin: s3Origin,
+        viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        allowedMethods: AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+        cachedMethods: CachedMethods.CACHE_GET_HEAD_OPTIONS,
+        cachePolicy: CachePolicy.CACHING_OPTIMIZED,
+        compress: true,
+        responseHeadersPolicy: props.securityHeadersPolicy,
+      };
+    }
+
     // ---- Distribution ----
     this.distribution = new Distribution(this, 'HostingDistribution', {
       defaultBehavior,

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -947,9 +947,7 @@ export class CdnConstruct extends Construct {
       // For compute (SSR) stacks, the default 502/503/504 error pages are
       // already wired above; only add 500 with the custom page.
       // For static/SPA stacks, add all server error statuses.
-      const serverErrorStatuses = hasCompute
-        ? [403, 500]
-        : [403, 500, 502, 503, 504];
+      const serverErrorStatuses = hasCompute ? [500] : [500, 502, 503, 504];
       for (const status of serverErrorStatuses) {
         errorResponses.push({
           httpStatus: status,

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -136,6 +136,11 @@ export type CdnConstructProps = {
   };
   /** Custom error page HTML. */
   errorPageHtml?: string;
+  /** Custom error pages configuration for CloudFront error responses. */
+  customErrorPages?: {
+    notFound?: boolean;
+    serverError?: boolean;
+  };
   /** Lambda@Edge function version for middleware (viewer-request). */
   middlewareEdgeFunction?: IVersion;
   /**
@@ -928,6 +933,30 @@ export class CdnConstruct extends Construct {
           ]
         : []),
     ];
+
+    // ---- Custom error pages (user-provided) ----
+    if (props.customErrorPages?.notFound) {
+      errorResponses.push({
+        httpStatus: 404,
+        responseHttpStatus: 404,
+        responsePagePath: `/builds/${buildId}/404.html`,
+        ttl: Duration.seconds(0),
+      });
+    }
+    if (props.customErrorPages?.serverError) {
+      // For compute (SSR) stacks, the default 502/503/504 error pages are
+      // already wired above; only add 500 with the custom page.
+      // For static/SPA stacks, add all server error statuses.
+      const serverErrorStatuses = hasCompute ? [500] : [500, 502, 503, 504];
+      for (const status of serverErrorStatuses) {
+        errorResponses.push({
+          httpStatus: status,
+          responseHttpStatus: status,
+          responsePagePath: `/builds/${buildId}/500.html`,
+          ttl: Duration.seconds(10),
+        });
+      }
+    }
 
     // ---- Distribution ----
     this.distribution = new Distribution(this, 'HostingDistribution', {

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -947,7 +947,9 @@ export class CdnConstruct extends Construct {
       // For compute (SSR) stacks, the default 502/503/504 error pages are
       // already wired above; only add 500 with the custom page.
       // For static/SPA stacks, add all server error statuses.
-      const serverErrorStatuses = hasCompute ? [500] : [500, 502, 503, 504];
+      const serverErrorStatuses = hasCompute
+        ? [403, 500]
+        : [403, 500, 502, 503, 504];
       for (const status of serverErrorStatuses) {
         errorResponses.push({
           httpStatus: status,

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -1757,7 +1757,7 @@ void describe('AmplifyHostingConstruct — custom environment variables (M4)', (
     }
   });
 
-  void it('adds env vars to multiple compute functions (SSR + image opt)', () => {
+  void it('adds env vars to ALL compute functions including image opt', () => {
     const staticDir = createStaticDir();
     const bundleDir = createBundleDir();
     const stack = createStack();
@@ -1802,10 +1802,49 @@ void describe('AmplifyHostingConstruct — custom environment variables (M4)', (
       const vars = env?.Variables as Record<string, unknown> | undefined;
       return vars?.MY_FEATURE_FLAG === 'enabled';
     });
-    // At least the default compute function should have it
-    assert.ok(
-      lambdasWithEnvVar.length >= 1,
-      `Expected at least 1 Lambda with MY_FEATURE_FLAG, got ${lambdasWithEnvVar.length}`,
+    // Both the default compute and image-optimization Lambda should have it (2 total)
+    assert.strictEqual(
+      lambdasWithEnvVar.length,
+      2,
+      `Expected exactly 2 Lambdas with MY_FEATURE_FLAG (default + image-opt), got ${lambdasWithEnvVar.length}`,
+    );
+  });
+
+  void it('throws InvalidEnvironmentKeyError for invalid key characters', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          environment: { 'invalid-key': 'value' },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'InvalidEnvironmentKeyError');
+        assert.ok(err.message.includes('invalid-key'));
+        return true;
+      },
+    );
+  });
+
+  void it('throws ReservedEnvironmentKeyError for reserved prefix', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          environment: { AWS_SECRET: 'forbidden' },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'ReservedEnvironmentKeyError');
+        assert.ok(err.message.includes('AWS_SECRET'));
+        return true;
+      },
     );
   });
 });
@@ -1999,6 +2038,75 @@ void describe('AmplifyHostingConstruct — custom error pages (M5)', () => {
             ErrorCode: 500,
             ResponseCode: 500,
             ResponsePagePath: Match.stringLikeRegexp('/builds/.*/500\\.html'),
+          }),
+        ]),
+      },
+    });
+  });
+
+  void it('throws CustomErrorPageNotFoundError for invalid file path', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          errorPages: { notFound: '/nonexistent/path/404.html' },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'CustomErrorPageNotFoundError');
+        assert.ok(err.message.includes('/nonexistent/path/404.html'));
+        return true;
+      },
+    );
+  });
+
+  void it('throws InvalidErrorPageContentError for non-HTML file', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const notHtmlPath = path.join(tmpDir, 'not-html.txt');
+    fs.writeFileSync(notHtmlPath, 'This is just plain text, not HTML');
+
+    const stack = createStack();
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          errorPages: { notFound: notHtmlPath },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'InvalidErrorPageContentError');
+        assert.ok(err.message.includes('does not appear to be valid HTML'));
+        return true;
+      },
+    );
+  });
+
+  void it('configures custom error pages for SPA mode with CloudFront error responses', () => {
+    const staticDir = createStaticDir();
+    const custom404Path = path.join(tmpDir, '404.html');
+    fs.writeFileSync(
+      custom404Path,
+      '<!DOCTYPE html><html><body>Custom SPA 404</body></html>',
+    );
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: spaManifest(staticDir),
+      errorPages: { notFound: custom404Path },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: {
+        CustomErrorResponses: Match.arrayWith([
+          Match.objectLike({
+            ErrorCode: 404,
+            ResponseCode: 404,
+            ResponsePagePath: Match.stringLikeRegexp('/builds/.*/404\\.html'),
           }),
         ]),
       },

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -1847,6 +1847,103 @@ void describe('AmplifyHostingConstruct — custom environment variables (M4)', (
       },
     );
   });
+
+  void it('throws ReservedEnvironmentKeyError for NODE_ prefix', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          environment: { NODE_OPTIONS: '--require=/tmp/evil.js' },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'ReservedEnvironmentKeyError');
+        assert.ok(err.message.includes('NODE_OPTIONS'));
+        return true;
+      },
+    );
+  });
+
+  void it('throws ReservedEnvironmentKeyError for LAMBDA_ prefix', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          environment: { LAMBDA_TASK_ROOT: '/tmp' },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'ReservedEnvironmentKeyError');
+        assert.ok(err.message.includes('LAMBDA_TASK_ROOT'));
+        return true;
+      },
+    );
+  });
+
+  void it('throws ReservedEnvironmentKeyError for exact reserved keys', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          environment: { _HANDLER: 'override' },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'ReservedEnvironmentKeyError');
+        assert.ok(err.message.includes('_HANDLER'));
+        return true;
+      },
+    );
+  });
+
+  void it('throws EnvironmentKeyTooLongError for keys exceeding 256 chars', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    const longKey = 'A'.repeat(257);
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          environment: { [longKey]: 'value' },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'EnvironmentKeyTooLongError');
+        assert.ok(err.message.includes('exceeds 256 character limit'));
+        return true;
+      },
+    );
+  });
+
+  void it('throws EnvironmentValueTooLongError for values exceeding 8KB', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    const longValue = 'x'.repeat(8193);
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          environment: { MY_VAR: longValue },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'EnvironmentValueTooLongError');
+        assert.ok(err.message.includes('exceeds 8KB limit'));
+        return true;
+      },
+    );
+  });
 });
 
 // ================================================================
@@ -2111,5 +2208,128 @@ void describe('AmplifyHostingConstruct — custom error pages (M5)', () => {
         ]),
       },
     });
+  });
+
+  void it('adds /builds/* behavior routing to S3 when error pages are configured in SSR mode', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const custom404Path = path.join(tmpDir, '404.html');
+    fs.writeFileSync(custom404Path, '<html><body>Custom 404</body></html>');
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+      errorPages: { notFound: custom404Path },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: {
+        CacheBehaviors: Match.arrayWith([
+          Match.objectLike({
+            PathPattern: '/builds/*',
+            ViewerProtocolPolicy: 'redirect-to-https',
+          }),
+        ]),
+      },
+    });
+  });
+
+  void it('/builds/* behavior routes to S3 origin (not Lambda)', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const custom500Path = path.join(tmpDir, '500.html');
+    fs.writeFileSync(custom500Path, '<html><body>Server Error</body></html>');
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+      errorPages: { serverError: custom500Path },
+    });
+
+    const template = Template.fromStack(stack);
+    const distributions = template.findResources(
+      'AWS::CloudFront::Distribution',
+    );
+    const distConfig = Object.values(distributions)[0] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const distProperties = distConfig.Properties?.DistributionConfig as
+      | Record<string, unknown>
+      | undefined;
+    const cacheBehaviors = (distProperties?.CacheBehaviors ?? []) as Array<
+      Record<string, unknown>
+    >;
+    const buildsBehavior = cacheBehaviors.find(
+      (b) => b.PathPattern === '/builds/*',
+    );
+    assert.ok(buildsBehavior, '/builds/* behavior should exist');
+    // The origin should be S3 (not Lambda@Edge). Verify by checking
+    // that AllowedMethods does not include POST/PUT/DELETE (Lambda behaviors allow all)
+    const allowed = buildsBehavior.AllowedMethods as string[] | undefined;
+    assert.ok(
+      allowed,
+      'AllowedMethods should be present on /builds/* behavior',
+    );
+    assert.ok(
+      !allowed.includes('PUT'),
+      '/builds/* behavior should not allow PUT (S3 read-only)',
+    );
+  });
+
+  void it('does not add /builds/* behavior in SPA mode without custom error pages', () => {
+    const staticDir = createStaticDir();
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: spaManifest(staticDir),
+    });
+
+    const template = Template.fromStack(stack);
+    const distributions = template.findResources(
+      'AWS::CloudFront::Distribution',
+    );
+    const distConfig = Object.values(distributions)[0] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const distProperties = distConfig.Properties?.DistributionConfig as
+      | Record<string, unknown>
+      | undefined;
+    const cacheBehaviors = (distProperties?.CacheBehaviors ?? []) as Array<
+      Record<string, unknown>
+    >;
+    const buildsBehavior = cacheBehaviors.find(
+      (b) => b.PathPattern === '/builds/*',
+    );
+    assert.strictEqual(
+      buildsBehavior,
+      undefined,
+      '/builds/* behavior should not exist in SPA mode without custom error pages',
+    );
+  });
+
+  void it('throws ErrorPageTooLargeError for oversized error pages', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const largePath = path.join(tmpDir, 'large-404.html');
+    const largeContent = '<html>' + 'x'.repeat(51 * 1024) + '</html>';
+    fs.writeFileSync(largePath, largeContent);
+
+    const stack = createStack();
+    assert.throws(
+      () => {
+        new AmplifyHostingConstruct(stack, 'Hosting', {
+          manifest: ssrManifest(staticDir, bundleDir),
+          errorPages: { notFound: largePath },
+        });
+      },
+      (err: HostingError) => {
+        assert.strictEqual(err.name, 'ErrorPageTooLargeError');
+        assert.ok(err.message.includes('Maximum is 50KB'));
+        return true;
+      },
+    );
   });
 });

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -1701,3 +1701,307 @@ void describe('AmplifyHostingConstruct — KMS Key Policy', () => {
     });
   });
 });
+
+// ================================================================
+// M4: Custom environment variables
+// ================================================================
+
+void describe('AmplifyHostingConstruct — custom environment variables (M4)', () => {
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('adds custom environment variables to all compute Lambda functions', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+      environment: {
+        DATABASE_URL: 'postgres://localhost:5432/app',
+        API_KEY: 'sk-test-123',
+      },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Environment: {
+        Variables: Match.objectLike({
+          DATABASE_URL: 'postgres://localhost:5432/app',
+          API_KEY: 'sk-test-123',
+        }),
+      },
+    });
+  });
+
+  void it('does not add extra env vars when environment is not provided', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+    });
+
+    const template = Template.fromStack(stack);
+    const lambdas = template.findResources('AWS::Lambda::Function');
+    for (const [, resource] of Object.entries(lambdas)) {
+      const props = (resource as Record<string, Record<string, unknown>>)
+        .Properties;
+      const env = props?.Environment as Record<string, unknown> | undefined;
+      const vars = env?.Variables as Record<string, unknown> | undefined;
+      assert.strictEqual(
+        vars !== undefined && 'DATABASE_URL' in vars,
+        false,
+        'Should not have DATABASE_URL when environment is not provided',
+      );
+    }
+  });
+
+  void it('adds env vars to multiple compute functions (SSR + image opt)', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    const manifest: DeployManifest = {
+      version: 1,
+      compute: {
+        default: {
+          type: 'handler',
+          bundle: bundleDir,
+          handler: 'index.handler',
+          placement: 'regional',
+          streaming: true,
+          runtime: 'nodejs20.x',
+        },
+      },
+      staticAssets: { directory: staticDir },
+      routes: [
+        { pattern: '/_next/static/*', target: 'static' },
+        { pattern: '/*', target: 'default' },
+      ],
+      buildId: 'multi-compute-test',
+      imageOptimization: {
+        bundle: bundleDir,
+        handler: 'index.handler',
+        formats: ['webp'],
+        sizes: [640, 1920],
+      },
+    };
+
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest,
+      environment: { MY_FEATURE_FLAG: 'enabled' },
+    });
+
+    const template = Template.fromStack(stack);
+    // All user Lambda functions should have the env var
+    const lambdas = template.findResources('AWS::Lambda::Function');
+    const lambdasWithEnvVar = Object.entries(lambdas).filter(([, resource]) => {
+      const props = (resource as Record<string, Record<string, unknown>>)
+        .Properties;
+      const env = props?.Environment as Record<string, unknown> | undefined;
+      const vars = env?.Variables as Record<string, unknown> | undefined;
+      return vars?.MY_FEATURE_FLAG === 'enabled';
+    });
+    // At least the default compute function should have it
+    assert.ok(
+      lambdasWithEnvVar.length >= 1,
+      `Expected at least 1 Lambda with MY_FEATURE_FLAG, got ${lambdasWithEnvVar.length}`,
+    );
+  });
+});
+
+// ================================================================
+// M5: Custom error pages
+// ================================================================
+
+void describe('AmplifyHostingConstruct — custom error pages (M5)', () => {
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('creates Custom404Deployment when notFound error page is provided', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    // Create a custom 404 HTML file
+    const custom404Path = path.join(tmpDir, '404.html');
+    fs.writeFileSync(custom404Path, '<html><body>Custom 404</body></html>');
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+      errorPages: { notFound: custom404Path },
+    });
+
+    const template = Template.fromStack(stack);
+    // Should have BucketDeployment resources (at least the built-in error page + custom 404 + asset)
+    const deployments = template.findResources('Custom::CDKBucketDeployment');
+    assert.ok(
+      Object.keys(deployments).length >= 3,
+      `Expected at least 3 BucketDeployments (error + custom404 + assets), got ${Object.keys(deployments).length}`,
+    );
+  });
+
+  void it('creates Custom500Deployment when serverError page is provided', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    // Create a custom 500 HTML file
+    const custom500Path = path.join(tmpDir, '500.html');
+    fs.writeFileSync(custom500Path, '<html><body>Custom 500</body></html>');
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+      errorPages: { serverError: custom500Path },
+    });
+
+    const template = Template.fromStack(stack);
+    const deployments = template.findResources('Custom::CDKBucketDeployment');
+    assert.ok(
+      Object.keys(deployments).length >= 3,
+      `Expected at least 3 BucketDeployments (error + custom500 + assets), got ${Object.keys(deployments).length}`,
+    );
+  });
+
+  void it('adds CloudFront custom 404 error response when notFound is provided', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const custom404Path = path.join(tmpDir, '404.html');
+    fs.writeFileSync(custom404Path, '<html><body>Custom 404</body></html>');
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+      errorPages: { notFound: custom404Path },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: {
+        CustomErrorResponses: Match.arrayWith([
+          Match.objectLike({
+            ErrorCode: 404,
+            ResponseCode: 404,
+            ResponsePagePath: Match.stringLikeRegexp('/builds/.*/404\\.html'),
+          }),
+        ]),
+      },
+    });
+  });
+
+  void it('adds CloudFront custom 500 error response when serverError is provided', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const custom500Path = path.join(tmpDir, '500.html');
+    fs.writeFileSync(custom500Path, '<html><body>Custom 500</body></html>');
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+      errorPages: { serverError: custom500Path },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: {
+        CustomErrorResponses: Match.arrayWith([
+          Match.objectLike({
+            ErrorCode: 500,
+            ResponseCode: 500,
+            ResponsePagePath: Match.stringLikeRegexp('/builds/.*/500\\.html'),
+          }),
+        ]),
+      },
+    });
+  });
+
+  void it('preserves default error behavior when errorPages is not provided', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+    });
+
+    const template = Template.fromStack(stack);
+    // Default SSR behavior: 502/503/504 error responses pointing to _error.html
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: {
+        CustomErrorResponses: Match.arrayWith([
+          Match.objectLike({
+            ErrorCode: 502,
+            ResponsePagePath: Match.stringLikeRegexp(
+              '/builds/.*/_error\\.html',
+            ),
+          }),
+          Match.objectLike({
+            ErrorCode: 503,
+            ResponsePagePath: Match.stringLikeRegexp(
+              '/builds/.*/_error\\.html',
+            ),
+          }),
+          Match.objectLike({
+            ErrorCode: 504,
+            ResponsePagePath: Match.stringLikeRegexp(
+              '/builds/.*/_error\\.html',
+            ),
+          }),
+        ]),
+      },
+    });
+    // Should NOT have custom 404/500 responses
+    const distributions = template.findResources(
+      'AWS::CloudFront::Distribution',
+    );
+    const distConfig = Object.values(distributions)[0] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const distProperties = distConfig.Properties?.DistributionConfig as
+      | Record<string, unknown>
+      | undefined;
+    const errorResponses = (distProperties?.CustomErrorResponses ??
+      []) as Array<Record<string, unknown>>;
+    const has404 = errorResponses.some((r) => r.ErrorCode === 404);
+    assert.strictEqual(
+      has404,
+      false,
+      'Should not have 404 error response by default in SSR mode',
+    );
+  });
+
+  void it('supports both notFound and serverError together', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const custom404Path = path.join(tmpDir, '404.html');
+    const custom500Path = path.join(tmpDir, '500.html');
+    fs.writeFileSync(custom404Path, '<html><body>Not Found</body></html>');
+    fs.writeFileSync(custom500Path, '<html><body>Server Error</body></html>');
+
+    const stack = createStack();
+    new AmplifyHostingConstruct(stack, 'Hosting', {
+      manifest: ssrManifest(staticDir, bundleDir),
+      errorPages: {
+        notFound: custom404Path,
+        serverError: custom500Path,
+      },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: {
+        CustomErrorResponses: Match.arrayWith([
+          Match.objectLike({
+            ErrorCode: 404,
+            ResponseCode: 404,
+            ResponsePagePath: Match.stringLikeRegexp('/builds/.*/404\\.html'),
+          }),
+          Match.objectLike({
+            ErrorCode: 500,
+            ResponseCode: 500,
+            ResponsePagePath: Match.stringLikeRegexp('/builds/.*/500\\.html'),
+          }),
+        ]),
+      },
+    });
+  });
+});

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -1,7 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Construct } from 'constructs';
-import * as fs from 'fs';
 import { CfnOutput, Duration, Fn, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import {
   Distribution,
@@ -334,17 +333,6 @@ export class AmplifyHostingConstruct extends Construct {
       }
     }
 
-    // ---- 2a. User-provided environment variables ----
-    if (props.environment) {
-      for (const [, fn] of this.computeFunctions.entries()) {
-        if (fn instanceof LambdaFunction) {
-          for (const [key, value] of Object.entries(props.environment)) {
-            fn.addEnvironment(key, value);
-          }
-        }
-      }
-    }
-
     // ---- 3. Cache infrastructure (ISR) ----
     if (manifest.cache && manifest.cache.driver === 'nitro-s3') {
       // Nitro path: a single S3 bucket fronts Nitro's `useStorage('cache')`
@@ -620,6 +608,42 @@ export class AmplifyHostingConstruct extends Construct {
       middlewareEdgeVersion = middlewareConstruct.function.currentVersion;
     }
 
+    // ---- 5a. User-provided environment variables (applied to ALL compute functions) ----
+    const RESERVED_PREFIXES = [
+      'AWS_',
+      'AMPLIFY_',
+      'OPEN_NEXT_',
+      'CACHE_',
+      'REVALIDATION_',
+    ];
+    const KEY_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+    if (props.environment) {
+      for (const key of Object.keys(props.environment)) {
+        if (!KEY_PATTERN.test(key)) {
+          throw new HostingError('InvalidEnvironmentKeyError', {
+            message: `Environment variable key '${key}' contains invalid characters.`,
+            resolution:
+              'Keys must match [a-zA-Z_][a-zA-Z0-9_]* (letters, numbers, underscores only, cannot start with a number).',
+          });
+        }
+        if (RESERVED_PREFIXES.some((p) => key.startsWith(p))) {
+          throw new HostingError('ReservedEnvironmentKeyError', {
+            message: `Environment variable key '${key}' uses a reserved prefix.`,
+            resolution: `Keys starting with ${RESERVED_PREFIXES.join(', ')} are reserved for internal use.`,
+          });
+        }
+      }
+
+      for (const [, fn] of this.computeFunctions.entries()) {
+        if (fn instanceof LambdaFunction) {
+          for (const [key, value] of Object.entries(props.environment)) {
+            fn.addEnvironment(key, value);
+          }
+        }
+      }
+    }
+
     // ---- 6. WAF (conditional) ----
     // Only create the built-in WAF construct if user didn't provide their own ARN
     if (!props.cdn?.webAclArn) {
@@ -811,10 +835,27 @@ export class AmplifyHostingConstruct extends Construct {
 
     // ---- 11a. Custom error pages ----
     if (props.errorPages?.notFound) {
+      if (!fs.existsSync(props.errorPages.notFound)) {
+        throw new HostingError('CustomErrorPageNotFoundError', {
+          message: `Custom 404 error page not found at path: ${props.errorPages.notFound}`,
+          resolution:
+            'Ensure the notFound path points to an existing HTML file relative to your project root.',
+        });
+      }
       const notFoundContent = fs.readFileSync(
         props.errorPages.notFound,
         'utf-8',
       );
+      if (
+        !notFoundContent.trim().toLowerCase().includes('<html') &&
+        !notFoundContent.trim().toLowerCase().includes('<!doctype')
+      ) {
+        throw new HostingError('InvalidErrorPageContentError', {
+          message: `Custom error page at ${props.errorPages.notFound} does not appear to be valid HTML.`,
+          resolution:
+            'Ensure the file contains valid HTML (should include <html> or <!DOCTYPE> tag).',
+        });
+      }
       new BucketDeployment(this, 'Custom404Deployment', {
         sources: [Source.data('404.html', notFoundContent)],
         destinationBucket: this.bucket,
@@ -823,10 +864,27 @@ export class AmplifyHostingConstruct extends Construct {
       });
     }
     if (props.errorPages?.serverError) {
+      if (!fs.existsSync(props.errorPages.serverError)) {
+        throw new HostingError('CustomErrorPageNotFoundError', {
+          message: `Custom 500 error page not found at path: ${props.errorPages.serverError}`,
+          resolution:
+            'Ensure the serverError path points to an existing HTML file relative to your project root.',
+        });
+      }
       const serverErrorContent = fs.readFileSync(
         props.errorPages.serverError,
         'utf-8',
       );
+      if (
+        !serverErrorContent.trim().toLowerCase().includes('<html') &&
+        !serverErrorContent.trim().toLowerCase().includes('<!doctype')
+      ) {
+        throw new HostingError('InvalidErrorPageContentError', {
+          message: `Custom error page at ${props.errorPages.serverError} does not appear to be valid HTML.`,
+          resolution:
+            'Ensure the file contains valid HTML (should include <html> or <!DOCTYPE> tag).',
+        });
+      }
       new BucketDeployment(this, 'Custom500Deployment', {
         sources: [Source.data('500.html', serverErrorContent)],
         destinationBucket: this.bucket,

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Construct } from 'constructs';
+import * as fs from 'fs';
 import { CfnOutput, Duration, Fn, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import {
   Distribution,
@@ -168,6 +169,18 @@ export type AmplifyHostingConstructProps = {
     enabled: boolean;
     retentionDays?: number;
   };
+  /** Custom environment variables for all compute functions. */
+  environment?: Record<string, string>;
+  /**
+   * Custom error page configuration.
+   * Provide paths to HTML files for custom 404 and 500 error responses.
+   */
+  errorPages?: {
+    /** Path to a custom 404 HTML file (relative to project root). */
+    notFound?: string;
+    /** Path to a custom 500 HTML file (relative to project root). */
+    serverError?: string;
+  };
   /**
    * Cookie-based skew protection.
    * When enabled, users mid-session keep receiving assets from their original
@@ -318,6 +331,17 @@ export class AmplifyHostingConstruct extends Construct {
       this.computeFunctions.set(name, computeConstruct.function);
       if (computeConstruct.functionUrl) {
         this.computeFunctionUrls.set(name, computeConstruct.functionUrl);
+      }
+    }
+
+    // ---- 2a. User-provided environment variables ----
+    if (props.environment) {
+      for (const [, fn] of this.computeFunctions.entries()) {
+        if (fn instanceof LambdaFunction) {
+          for (const [key, value] of Object.entries(props.environment)) {
+            fn.addEnvironment(key, value);
+          }
+        }
       }
     }
 
@@ -681,6 +705,12 @@ export class AmplifyHostingConstruct extends Construct {
       skewProtection: props.skewProtection ?? { enabled: true },
       ssrDefaultTtl: props.cdn?.ssrDefaultTtl,
       webAclArn: props.cdn?.webAclArn,
+      customErrorPages: props.errorPages
+        ? {
+            notFound: !!props.errorPages.notFound,
+            serverError: !!props.errorPages.serverError,
+          }
+        : undefined,
     });
 
     this.distribution = cdn.distribution;
@@ -773,6 +803,32 @@ export class AmplifyHostingConstruct extends Construct {
     if (hasCompute) {
       new BucketDeployment(this, 'ErrorPageDeployment', {
         sources: [Source.data(ERROR_PAGE_KEY, cdn.errorPageHtml)],
+        destinationBucket: this.bucket,
+        destinationKeyPrefix: `builds/${buildId}/`,
+        prune: false,
+      });
+    }
+
+    // ---- 11a. Custom error pages ----
+    if (props.errorPages?.notFound) {
+      const notFoundContent = fs.readFileSync(
+        props.errorPages.notFound,
+        'utf-8',
+      );
+      new BucketDeployment(this, 'Custom404Deployment', {
+        sources: [Source.data('404.html', notFoundContent)],
+        destinationBucket: this.bucket,
+        destinationKeyPrefix: `builds/${buildId}/`,
+        prune: false,
+      });
+    }
+    if (props.errorPages?.serverError) {
+      const serverErrorContent = fs.readFileSync(
+        props.errorPages.serverError,
+        'utf-8',
+      );
+      new BucketDeployment(this, 'Custom500Deployment', {
+        sources: [Source.data('500.html', serverErrorContent)],
         destinationBucket: this.bucket,
         destinationKeyPrefix: `builds/${buildId}/`,
         prune: false,

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -615,7 +615,14 @@ export class AmplifyHostingConstruct extends Construct {
       'OPEN_NEXT_',
       'CACHE_',
       'REVALIDATION_',
+      'NODE_',
+      'LAMBDA_',
     ];
+    const RESERVED_EXACT_KEYS = new Set([
+      '_HANDLER',
+      'LD_PRELOAD',
+      '_X_AMZN_TRACE_ID',
+    ]);
     const KEY_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
     if (props.environment) {
@@ -631,6 +638,27 @@ export class AmplifyHostingConstruct extends Construct {
           throw new HostingError('ReservedEnvironmentKeyError', {
             message: `Environment variable key '${key}' uses a reserved prefix.`,
             resolution: `Keys starting with ${RESERVED_PREFIXES.join(', ')} are reserved for internal use.`,
+          });
+        }
+        if (RESERVED_EXACT_KEYS.has(key)) {
+          throw new HostingError('ReservedEnvironmentKeyError', {
+            message: `Environment variable key '${key}' is a reserved runtime key.`,
+            resolution: `The key '${key}' is reserved by the Lambda runtime and cannot be overridden.`,
+          });
+        }
+        if (key.length > 256) {
+          throw new HostingError('EnvironmentKeyTooLongError', {
+            message: `Environment variable key '${key}' exceeds 256 character limit.`,
+            resolution:
+              'Lambda environment variable keys must be 256 characters or fewer.',
+          });
+        }
+        const value = props.environment[key];
+        if (value.length > 8192) {
+          throw new HostingError('EnvironmentValueTooLongError', {
+            message: `Environment variable value for '${key}' exceeds 8KB limit.`,
+            resolution:
+              'Lambda environment variable values must be 8192 characters or fewer.',
           });
         }
       }
@@ -846,6 +874,12 @@ export class AmplifyHostingConstruct extends Construct {
         props.errorPages.notFound,
         'utf-8',
       );
+      if (notFoundContent.length > 50 * 1024) {
+        throw new HostingError('ErrorPageTooLargeError', {
+          message: `Custom error page at ${props.errorPages.notFound} is ${Math.round(notFoundContent.length / 1024)}KB. Maximum is 50KB.`,
+          resolution: 'Reduce the size of your custom error page HTML file.',
+        });
+      }
       if (
         !notFoundContent.trim().toLowerCase().includes('<html') &&
         !notFoundContent.trim().toLowerCase().includes('<!doctype')
@@ -875,6 +909,12 @@ export class AmplifyHostingConstruct extends Construct {
         props.errorPages.serverError,
         'utf-8',
       );
+      if (serverErrorContent.length > 50 * 1024) {
+        throw new HostingError('ErrorPageTooLargeError', {
+          message: `Custom error page at ${props.errorPages.serverError} is ${Math.round(serverErrorContent.length / 1024)}KB. Maximum is 50KB.`,
+          resolution: 'Reduce the size of your custom error page HTML file.',
+        });
+      }
       if (
         !serverErrorContent.trim().toLowerCase().includes('<html') &&
         !serverErrorContent.trim().toLowerCase().includes('<!doctype')

--- a/packages/hosting/src/factory.ts
+++ b/packages/hosting/src/factory.ts
@@ -326,6 +326,8 @@ const doBuildHostingConstruct = (
     cdn: props.cdn,
     storage: props.storage,
     logging: props.logging,
+    environment: props.environment,
+    errorPages: props.errorPages,
   };
 
   const hostingConstruct = new AmplifyHostingConstruct(

--- a/packages/hosting/src/types.ts
+++ b/packages/hosting/src/types.ts
@@ -87,9 +87,13 @@ export type HostingProps = {
   };
 
   /**
-   * Custom environment variables injected into all SSR Lambda functions at runtime.
-   * Use for database URLs, API keys, feature flags, etc.
-   * These are runtime env vars — NOT build-time `NEXT_PUBLIC_*` variables.
+   * Custom environment variables injected into all compute Lambda functions at runtime.
+   *
+   * Values appear in plaintext in the CloudFormation template. For sensitive values
+   * (database passwords, API secrets), use AWS Systems Manager Parameter Store or
+   * Secrets Manager and read them at runtime instead.
+   *
+   * Safe for: feature flags, non-secret URLs, region config, service names.
    * @example
    * ```typescript
    * defineHosting({

--- a/packages/hosting/src/types.ts
+++ b/packages/hosting/src/types.ts
@@ -87,6 +87,42 @@ export type HostingProps = {
   };
 
   /**
+   * Custom environment variables injected into all SSR Lambda functions at runtime.
+   * Use for database URLs, API keys, feature flags, etc.
+   * These are runtime env vars — NOT build-time `NEXT_PUBLIC_*` variables.
+   * @example
+   * ```typescript
+   * defineHosting({
+   *   environment: {
+   *     DATABASE_URL: process.env.DATABASE_URL,
+   *     FEATURE_FLAGS_API_KEY: process.env.FF_KEY,
+   *   },
+   * });
+   * ```
+   */
+  environment?: Record<string, string>;
+
+  /**
+   * Custom error page configuration.
+   * Provide paths to HTML files for custom 404 and 500 error responses.
+   * @example
+   * ```typescript
+   * defineHosting({
+   *   errorPages: {
+   *     notFound: './public/404.html',
+   *     serverError: './public/500.html',
+   *   },
+   * });
+   * ```
+   */
+  errorPages?: {
+    /** Path to a custom 404 HTML file (relative to project root). */
+    notFound?: string;
+    /** Path to a custom 500 HTML file (relative to project root). */
+    serverError?: string;
+  };
+
+  /**
    * CDN (CloudFront) configuration.
    */
   cdn?: {

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_spa.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_spa.deployment.test.ts
@@ -309,6 +309,30 @@ void describe(
           );
         });
 
+        void it('stage 2c: custom 404 page — verifies custom error page is served for non-existent paths', async () => {
+          // With errorPages.notFound configured, CloudFront should serve the custom 404 page
+          // when the origin returns a 404. For S3-backed SPAs, non-existent paths trigger 403
+          // which still falls back to index.html. But a direct request to a path that returns
+          // a genuine 404 (if any) would use the custom page.
+          // Verify the custom 404 page was deployed by fetching it directly:
+          const custom404Response = await fetchWithRetry(
+            `${distributionUrl}/404.html`,
+            {
+              expectedStatus: 200,
+              maxRetries: 3,
+              intervalMs: 5000,
+            },
+          );
+          const custom404Body = await custom404Response.text();
+          assert.ok(
+            custom404Body.includes('Custom 404 - Page Not Found'),
+            `Custom 404 page should be deployed and accessible, got: ${custom404Body.substring(0, 200)}`,
+          );
+          process.stderr.write(
+            `Custom 404 page deployed and accessible at ${distributionUrl}/404.html\n`,
+          );
+        });
+
         void it('stage 3: applies v2 changes and full deploys — validates v2 content, outputs, and infra change', async () => {
           // Apply combined v2 update (content change + access logging)
           const updates = await testProject.getUpdates();

--- a/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_ssr.deployment.test.ts
+++ b/packages/integration-tests/src/test-e2e/deployment/standalone_hosting_ssr.deployment.test.ts
@@ -490,6 +490,52 @@ void describe(
           );
         });
 
+        void it('stage 2j: custom environment variables — SSR Lambda receives user-defined env vars (M4)', async () => {
+          const envRes = await fetchWithRetry(`${distributionUrl}/api/env`, {
+            expectedStatus: 200,
+            maxRetries: 5,
+            intervalMs: 10000,
+          });
+          assert.strictEqual(
+            envRes.status,
+            200,
+            `API env route should return 200, got ${envRes.status}`,
+          );
+          const envBody = (await envRes.json()) as Record<string, string>;
+          assert.strictEqual(
+            envBody['CUSTOM_TEST_VAR'],
+            'e2e-test-value-12345',
+            `CUSTOM_TEST_VAR should be 'e2e-test-value-12345' (injected via defineHosting environment), got: ${JSON.stringify(envBody)}`,
+          );
+          process.stderr.write(
+            `Custom environment variable verified: CUSTOM_TEST_VAR=${envBody['CUSTOM_TEST_VAR']}\n`,
+          );
+        });
+
+        void it('stage 2k: custom error pages — 404 returns custom HTML content (M5)', async () => {
+          const notFoundRes = await fetchWithRetry(
+            `${distributionUrl}/this-page-does-not-exist-e2e-custom-404`,
+            {
+              expectedStatus: 404,
+              maxRetries: 8,
+              intervalMs: 15000,
+            },
+          );
+          assert.strictEqual(
+            notFoundRes.status,
+            404,
+            `Non-existent route should return 404, got ${notFoundRes.status}`,
+          );
+          const notFoundBody = await notFoundRes.text();
+          assert.ok(
+            notFoundBody.includes('Custom 404 Page - E2E Test'),
+            `404 response body should contain custom error page content "Custom 404 Page - E2E Test", got: ${notFoundBody.substring(0, 500)}`,
+          );
+          process.stderr.write(
+            `Custom 404 error page verified: response contains expected custom content\n`,
+          );
+        });
+
         void it('stage 2c: SSR origin accepts every HTTP verb with body and preserves multi-Set-Cookie + streaming', async () => {
           // Regression coverage for the OAC + Function URL body-hash bug:
           // pre-fix, any non-empty POST/PUT/PATCH returned 403 SignatureDoesNotMatch.

--- a/packages/integration-tests/src/test-project-setup/standalone_hosting_spa.ts
+++ b/packages/integration-tests/src/test-project-setup/standalone_hosting_spa.ts
@@ -62,6 +62,14 @@ export class StandaloneHostingSpaTestProjectCreator implements TestProjectCreato
     const destDistDir = path.join(projectRoot, 'dist');
     await fs.cp(sourceDistDir, destDistDir, { recursive: true });
 
+    // Copy the custom-404.html file
+    const sourceCustom404 = new URL(
+      `${project.sourceProjectDirPath}/custom-404.html`,
+      import.meta.url,
+    );
+    const destCustom404 = path.join(projectRoot, 'custom-404.html');
+    await fs.cp(sourceCustom404, destCustom404);
+
     return project;
   };
 }

--- a/packages/integration-tests/src/test-project-setup/standalone_hosting_ssr.ts
+++ b/packages/integration-tests/src/test-project-setup/standalone_hosting_ssr.ts
@@ -80,6 +80,10 @@ export class StandaloneHostingSsrTestProjectCreator implements TestProjectCreato
       path.join(sourceDir, 'middleware.ts'),
       path.join(projectRoot, 'middleware.ts'),
     );
+    await fs.cp(
+      path.join(sourceDir, 'custom-404.html'),
+      path.join(projectRoot, 'custom-404.html'),
+    );
 
     // Write the project package.json with Next.js dependencies
     // (overwrite the one created by createEmptyAmplifyProject)

--- a/packages/integration-tests/src/test-projects/standalone-hosting-spa/amplify/hosting.ts
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-spa/amplify/hosting.ts
@@ -2,4 +2,5 @@ import { defineHosting } from '@aws-amplify/hosting';
 
 defineHosting({
   framework: 'spa',
+  errorPages: { notFound: './custom-404.html' },
 });

--- a/packages/integration-tests/src/test-projects/standalone-hosting-spa/custom-404.html
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-spa/custom-404.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Page Not Found</title>
-</head>
-<body>
-  <h1>Custom 404 - Page Not Found</h1>
-  <p>The page you are looking for does not exist.</p>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page Not Found</title>
+  </head>
+  <body>
+    <h1>Custom 404 - Page Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+  </body>
 </html>

--- a/packages/integration-tests/src/test-projects/standalone-hosting-spa/custom-404.html
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-spa/custom-404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page Not Found</title>
+</head>
+<body>
+  <h1>Custom 404 - Page Not Found</h1>
+  <p>The page you are looking for does not exist.</p>
+</body>
+</html>

--- a/packages/integration-tests/src/test-projects/standalone-hosting-ssr/amplify/hosting.js
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-ssr/amplify/hosting.js
@@ -1,6 +1,10 @@
 import { defineHosting } from '@aws-amplify/hosting';
 defineHosting({
     framework: 'nextjs',
-    buildOutputDir: '.next',
+    environment: {
+        CUSTOM_TEST_VAR: 'e2e-test-value-12345',
+    },
+    errorPages: {
+        notFound: './custom-404.html',
+    },
 });
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaG9zdGluZy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImhvc3RpbmcudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxFQUFFLGFBQWEsRUFBRSxNQUFNLHNCQUFzQixDQUFDO0FBRXJELGFBQWEsQ0FBQztJQUNaLFNBQVMsRUFBRSxRQUFRO0lBQ25CLGNBQWMsRUFBRSxPQUFPO0NBQ3hCLENBQUMsQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGRlZmluZUhvc3RpbmcgfSBmcm9tICdAYXdzLWFtcGxpZnkvaG9zdGluZyc7XG5cbmRlZmluZUhvc3Rpbmcoe1xuICBmcmFtZXdvcms6ICduZXh0anMnLFxuICBidWlsZE91dHB1dERpcjogJy5uZXh0Jyxcbn0pO1xuIl19

--- a/packages/integration-tests/src/test-projects/standalone-hosting-ssr/amplify/hosting.ts
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-ssr/amplify/hosting.ts
@@ -2,4 +2,10 @@ import { defineHosting } from '@aws-amplify/hosting';
 
 defineHosting({
   framework: 'nextjs',
+  environment: {
+    CUSTOM_TEST_VAR: 'e2e-test-value-12345',
+  },
+  errorPages: {
+    notFound: './custom-404.html',
+  },
 });

--- a/packages/integration-tests/src/test-projects/standalone-hosting-ssr/app/api/env/route.ts
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-ssr/app/api/env/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json(
+    {
+      CUSTOM_TEST_VAR: process.env.CUSTOM_TEST_VAR ?? 'NOT_SET',
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    },
+  );
+}

--- a/packages/integration-tests/src/test-projects/standalone-hosting-ssr/custom-404.html
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-ssr/custom-404.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>404 - Not Found</title></head>
+<body>Custom 404 Page - E2E Test</body>
+</html>

--- a/packages/integration-tests/src/test-projects/standalone-hosting-ssr/custom-404.html
+++ b/packages/integration-tests/src/test-projects/standalone-hosting-ssr/custom-404.html
@@ -1,5 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head><title>404 - Not Found</title></head>
-<body>Custom 404 Page - E2E Test</body>
+  <head>
+    <title>404 - Not Found</title>
+  </head>
+  <body>
+    Custom 404 Page - E2E Test
+  </body>
 </html>

--- a/scripts/components/dependabot_version_update_handler.test.ts
+++ b/scripts/components/dependabot_version_update_handler.test.ts
@@ -84,6 +84,7 @@ void describe('dependabot version update handler', async () => {
     await setPackageToPublic(platypusPackagePath);
 
     await npmClient.install(['@changesets/cli']);
+    await npmClient.install(['human-id@4.1.3']);
     await setPackageDependencies(cantaloupePackagePath, { testDep: '^1.0.0' });
     await setPackageDependencies(platypusPackagePath, { testDep: '^1.0.0' });
 

--- a/scripts/components/release_lifecycle.test.ts
+++ b/scripts/components/release_lifecycle.test.ts
@@ -103,6 +103,7 @@ void describe('release lifecycle', async () => {
     );
 
     await npmClient.install(['@changesets/cli']);
+    await npmClient.install(['human-id@4.1.3']);
 
     await $`npx --package @changesets/cli -- changeset init`;
     await gitClient.commitAllChanges('Version Packages (baseline release)');


### PR DESCRIPTION
## Summary

Adds two production-ready features to the hosting construct:

### M4: Custom environment variables for SSR Lambda

Customers can now pass arbitrary environment variables to their SSR Lambda functions:

```typescript
defineHosting({
  environment: {
    DATABASE_URL: process.env.DATABASE_URL,
    FEATURE_FLAGS_API_KEY: process.env.FF_KEY,
  },
});
```

These are runtime env vars (not build-time NEXT_PUBLIC_*). Applied to all compute functions (SSR, image optimization, revalidation worker).

### M5: Custom error pages

Customers can provide their own branded 404 and 500 error pages:

```typescript
defineHosting({
  errorPages: {
    notFound: './public/404.html',
    serverError: './public/500.html',
  },
});
```

Pages are uploaded to S3 and wired into CloudFront error responses.

## Testing

- Unit tests for environment variable propagation to all compute functions
- Unit tests for custom error page upload and CloudFront wiring
- Tests for default behavior when props are not provided