### PR TITLE
fix(hosting): default primaryOutputDirectory to 'cdk.out' in pipeline construct

### DIFF
--- a/.changeset/fix-pipeline-primary-output-directory.md
+++ b/.changeset/fix-pipeline-primary-output-directory.md
@@ -1,0 +1,14 @@
+---
+'@aws-amplify/hosting': patch
+---
+
+fix(hosting): default primaryOutputDirectory to 'cdk.out' in pipeline construct
+
+When users call `definePipeline()` without specifying `synth.primaryOutputDirectory`,
+the ShellStep's `primaryOutputDirectory` was `undefined`. This caused the CDK Pipelines
+synth step to fail to find the cloud assembly output because `npx tsx amplify/pipeline.ts`
+writes to `cdk.out/` by default but the ShellStep didn't know to look there.
+
+Also sets explicit `outdir: 'cdk.out'` in the App constructor within `definePipeline()` to
+ensure synthesis output goes to a deterministic location when invoked directly (not via
+`cdk` CLI which sets `CDK_OUTDIR` automatically).

--- a/packages/hosting/src/pipeline/pipeline_construct.test.ts
+++ b/packages/hosting/src/pipeline/pipeline_construct.test.ts
@@ -127,6 +127,60 @@ void describe('AmplifyPipelineConstruct', () => {
       });
     });
 
+    void it('defaults primaryOutputDirectory to cdk.out when synth config is omitted', () => {
+      const app = new App();
+      const stack = new Stack(app, 'DefaultOutputDirStack');
+
+      new AmplifyPipelineConstruct(
+        stack,
+        'Pipeline',
+        defaultPipelineProps({
+          synth: undefined,
+        }),
+      );
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::CodeBuild::Project', {
+        Source: Match.objectLike({
+          BuildSpec: Match.serializedJson(
+            Match.objectLike({
+              artifacts: Match.objectLike({
+                'base-directory': 'cdk.out',
+              }),
+            }),
+          ),
+        }),
+      });
+    });
+
+    void it('defaults primaryOutputDirectory to cdk.out when synth is provided without primaryOutputDirectory', () => {
+      const app = new App();
+      const stack = new Stack(app, 'SynthNoPrimaryOutputStack');
+
+      new AmplifyPipelineConstruct(
+        stack,
+        'Pipeline',
+        defaultPipelineProps({
+          synth: {
+            commands: ['npm ci', 'npx tsx amplify/pipeline.ts'],
+          },
+        }),
+      );
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::CodeBuild::Project', {
+        Source: Match.objectLike({
+          BuildSpec: Match.serializedJson(
+            Match.objectLike({
+              artifacts: Match.objectLike({
+                'base-directory': 'cdk.out',
+              }),
+            }),
+          ),
+        }),
+      });
+    });
+
     void it('uses custom synth commands when provided', () => {
       const app = new App();
       const stack = new Stack(app, 'CustomCommandsStack');

--- a/packages/hosting/src/pipeline/pipeline_construct.ts
+++ b/packages/hosting/src/pipeline/pipeline_construct.ts
@@ -294,7 +294,7 @@ const buildCodePipeline = <TConfig>(
     installCommands: props.synth?.installCommands,
     commands: synthCommands,
     env: props.synth?.env,
-    primaryOutputDirectory: props.synth?.primaryOutputDirectory,
+    primaryOutputDirectory: props.synth?.primaryOutputDirectory ?? 'cdk.out',
   });
 
   const codePipeline = new CodePipeline(construct, branchId, {

--- a/packages/hosting/src/pipeline/pipeline_factory.ts
+++ b/packages/hosting/src/pipeline/pipeline_factory.ts
@@ -86,7 +86,7 @@ const DISCOVERABLE_EXTENSIONS = ['.ts', '.js', '.cjs'];
  * ```
  */
 export const definePipeline = (props: DefinePipelineProps): void => {
-  const app = new cdk.App();
+  const app = new cdk.App({ outdir: 'cdk.out' });
   const repoSuffix = props.source.repo.replace(/[^a-zA-Z0-9]/g, '-');
   const stackName = props.stackName ?? `amplify-pipeline-${repoSuffix}`;
   const rootStack = new cdk.Stack(app, stackName, {


### PR DESCRIPTION
## Problem

When users call `definePipeline()` without specifying `synth.primaryOutputDirectory`, the ShellStep's `primaryOutputDirectory` was `undefined`.

Combined with the `DEFAULT_SYNTH_COMMANDS` change to `'npx tsx amplify/pipeline.ts'` (PR #3219), which runs directly without the CDK CLI setting `CDK_OUTDIR`, this caused:

1. **Synth output goes to a temp dir**: `new cdk.App()` without `outdir` uses `CDK_OUTDIR` env var, which is only set by the `cdk` CLI. Running `npx tsx amplify/pipeline.ts` directly means no `CDK_OUTDIR`, so output goes to `/tmp/cdk.out*`.
2. **Artifact collection fails**: The ShellStep's buildspec has `base-directory: undefined` instead of `cdk.out`, causing CodeBuild to fail with "no matching base directory path found".

## Root Cause

The e2e test was **not catching this** because it explicitly sets:
```typescript
synth: {
  commands: ['echo "Using pre-built cloud assembly"'],
  primaryOutputDirectory: 'cdk.out',  // <-- masks the bug
},
```

A real user who just calls `definePipeline({ source: {...}, branches: [...] })` without any `synth` config would hit this bug.

## Fix

1. **`pipeline_construct.ts`**: Default `primaryOutputDirectory` to `'cdk.out'`:
   ```typescript
   primaryOutputDirectory: props.synth?.primaryOutputDirectory ?? 'cdk.out',
   ```

2. **`pipeline_factory.ts`**: Set explicit `outdir` on the App constructor:
   ```typescript
   const app = new cdk.App({ outdir: 'cdk.out' });
   ```

## Testing

- Added 2 new unit tests verifying the default `base-directory: 'cdk.out'` is set when:
  - `synth` is undefined (omitted entirely)
  - `synth` is provided without `primaryOutputDirectory`
- All 73 tests pass (47 construct + 26 factory)
- Verified end-to-end in a real pipeline deployment (all stages succeeded)