### PR TITLE
fix(pipeline): use "npx cdk synth --app" for correct synth without cdk.json

### DIFF
--- a/packages/hosting/src/pipeline/pipeline_construct.test.ts
+++ b/packages/hosting/src/pipeline/pipeline_construct.test.ts
@@ -117,7 +117,7 @@ void describe('AmplifyPipelineConstruct', () => {
                 build: Match.objectLike({
                   commands: Match.arrayWith([
                     'npm ci',
-                    'npx tsx amplify/pipeline.ts',
+                    'npx cdk synth --app "npx tsx amplify/pipeline.ts"',
                   ]),
                 }),
               }),

--- a/packages/hosting/src/pipeline/pipeline_construct.ts
+++ b/packages/hosting/src/pipeline/pipeline_construct.ts
@@ -20,7 +20,10 @@ import type {
 const VALID_ARN_PATTERN =
   /^arn:(aws|aws-us-gov|aws-cn):codeconnections:[a-z0-9-]+:\d{12}:connection\/[a-zA-Z0-9-]+$/;
 
-const DEFAULT_SYNTH_COMMANDS = ['npm ci', 'npx tsx amplify/pipeline.ts'];
+const DEFAULT_SYNTH_COMMANDS = [
+  'npm ci',
+  'npx cdk synth --app "npx tsx amplify/pipeline.ts"',
+];
 
 /**
  * CDK Pipelines-based CI/CD pipeline construct (L3).


### PR DESCRIPTION
Fixes the pipeline synth step to use CDK CLI with explicit --app flag.

**Problem:** PR #3219 changed the default to `npx tsx amplify/pipeline.ts` which bypasses CDK CLI. This broke `CDK_OUTDIR` handling (output went to /tmp/ instead of ./cdk.out).

**Fix:** `['npm ci', 'npx cdk synth --app "npx tsx amplify/pipeline.ts"']`

This gives us:
- ✅ No cdk.json needed (--app flag is explicit)
- ✅ CDK CLI sets CDK_OUTDIR properly
- ✅ No outdir hacks needed
- ✅ Standard CDK Pipelines pattern