### PR TITLE
fix(hosting): pin pipeline CodeBuild steps to Node.js 22

### DIFF
--- a/.changeset/fix-pipeline-node22.md
+++ b/.changeset/fix-pipeline-node22.md
@@ -1,0 +1,11 @@
+---
+'@aws-amplify/hosting': minor
+---
+
+fix(hosting): pin pipeline CodeBuild steps to Node.js 22 runtime
+
+The pipeline synth and hosting deploy steps now explicitly specify
+Node.js 22 (current LTS) via `partialBuildSpec` runtime-versions.
+Previously, CodeBuild defaulted to Node 18 which is EOL.
+
+Users can override via `synth.partialBuildSpec` if needed.

--- a/packages/hosting/src/pipeline/pipeline_construct.test.ts
+++ b/packages/hosting/src/pipeline/pipeline_construct.test.ts
@@ -222,6 +222,70 @@ void describe('AmplifyPipelineConstruct', () => {
         }),
       });
     });
+
+    void it('includes Node.js 22 runtime version in synth step by default', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Node22DefaultStack');
+
+      new AmplifyPipelineConstruct(stack, 'Pipeline', defaultPipelineProps());
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::CodeBuild::Project', {
+        Source: Match.objectLike({
+          BuildSpec: Match.serializedJson(
+            Match.objectLike({
+              phases: Match.objectLike({
+                install: Match.objectLike({
+                  'runtime-versions': {
+                    nodejs: 22,
+                  },
+                }),
+              }),
+            }),
+          ),
+        }),
+      });
+    });
+
+    void it('allows overriding partialBuildSpec via synth config', () => {
+      const app = new App();
+      const stack = new Stack(app, 'CustomBuildSpecStack');
+
+      new AmplifyPipelineConstruct(
+        stack,
+        'Pipeline',
+        defaultPipelineProps({
+          synth: {
+            partialBuildSpec: codebuild.BuildSpec.fromObject({
+              phases: {
+                install: {
+                  'runtime-versions': {
+                    nodejs: 20,
+                  },
+                },
+              },
+            }),
+          },
+        }),
+      );
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::CodeBuild::Project', {
+        Source: Match.objectLike({
+          BuildSpec: Match.serializedJson(
+            Match.objectLike({
+              phases: Match.objectLike({
+                install: Match.objectLike({
+                  'runtime-versions': {
+                    nodejs: 20,
+                  },
+                }),
+              }),
+            }),
+          ),
+        }),
+      });
+    });
   });
 
   void describe('multi-branch pipelines', () => {

--- a/packages/hosting/src/pipeline/pipeline_construct.ts
+++ b/packages/hosting/src/pipeline/pipeline_construct.ts
@@ -310,6 +310,17 @@ const buildCodePipeline = <TConfig>(
           codebuild.LinuxBuildImage.AMAZON_LINUX_2023_5,
         computeType: props.synth?.computeType ?? codebuild.ComputeType.MEDIUM,
       },
+      partialBuildSpec:
+        props.synth?.partialBuildSpec ??
+        codebuild.BuildSpec.fromObject({
+          phases: {
+            install: {
+              'runtime-versions': {
+                nodejs: 22,
+              },
+            },
+          },
+        }),
     },
   });
 

--- a/packages/hosting/src/pipeline/pipeline_factory.test.ts
+++ b/packages/hosting/src/pipeline/pipeline_factory.test.ts
@@ -761,6 +761,15 @@ const createPipelineWithHostingHook = (
             'npm run build',
             'npx cdk deploy --all --app "npx tsx $HOSTING_ENTRY_POINT" --require-approval never -c amplify-backend-namespace=pipeline -c amplify-backend-name=$STAGE_NAME -c amplify-backend-type=standalone',
           ],
+          partialBuildSpec: codebuild.BuildSpec.fromObject({
+            phases: {
+              install: {
+                'runtime-versions': {
+                  nodejs: 22,
+                },
+              },
+            },
+          }),
           buildEnvironment: {
             buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2023_5,
             computeType: codebuild.ComputeType.MEDIUM,
@@ -823,6 +832,26 @@ void describe('CDK template assertions for hosting deploy step', () => {
           ]),
         }),
       ]),
+    });
+  });
+
+  void it('hosting deploy step includes Node.js 22 runtime version', () => {
+    const { template } = createPipelineWithHostingHook();
+
+    template.hasResourceProperties('AWS::CodeBuild::Project', {
+      Source: Match.objectLike({
+        BuildSpec: Match.serializedJson(
+          Match.objectLike({
+            phases: Match.objectLike({
+              install: Match.objectLike({
+                'runtime-versions': {
+                  nodejs: 22,
+                },
+              }),
+            }),
+          }),
+        ),
+      }),
     });
   });
 

--- a/packages/hosting/src/pipeline/pipeline_factory.ts
+++ b/packages/hosting/src/pipeline/pipeline_factory.ts
@@ -225,6 +225,15 @@ const createHostingDeployHook = (
         // This mirrors the same flow as `ampx deploy`.
         'npx cdk deploy --all --app "npx tsx $HOSTING_ENTRY_POINT" --require-approval never -c amplify-backend-namespace=pipeline -c amplify-backend-name=$STAGE_NAME -c amplify-backend-type=standalone',
       ],
+      partialBuildSpec: codebuild.BuildSpec.fromObject({
+        phases: {
+          install: {
+            'runtime-versions': {
+              nodejs: 22,
+            },
+          },
+        },
+      }),
       buildEnvironment: {
         buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2023_5,
         computeType: codebuild.ComputeType.MEDIUM,

--- a/packages/hosting/src/pipeline/types.ts
+++ b/packages/hosting/src/pipeline/types.ts
@@ -126,6 +126,21 @@ export type PipelineSynthConfig = {
    * Lambda bundling + frontend builds. Use SMALL for trivial apps or LARGE for monorepos.
    */
   readonly computeType?: codebuild.ComputeType;
+
+  /**
+   * Partial BuildSpec merged into the synth step's CodeBuild project.
+   *
+   * Use this to override runtime versions or add custom build phases.
+   * When omitted, defaults to Node.js 22 runtime (current LTS).
+   * @default BuildSpec with `phases.install.runtime-versions.nodejs: 22`
+   * @example
+   * ```ts
+   * partialBuildSpec: codebuild.BuildSpec.fromObject({
+   *   phases: { install: { 'runtime-versions': { nodejs: 20 } } },
+   * })
+   * ```
+   */
+  readonly partialBuildSpec?: codebuild.BuildSpec;
 };
 
 /**


### PR DESCRIPTION
## Summary

Pin the pipeline's CodeBuild steps (synth + hosting deploy) to Node.js 22 via `partialBuildSpec` with `runtime-versions`.

### Problem

The pipeline uses `AMAZON_LINUX_2023_5` but doesn't specify a Node.js runtime version, defaulting to Node 18. Both Node 18 (EOL April 2025) and Node 20 (EOL April 2026) are end-of-life.

### Solution

- Added `partialBuildSpec` with `runtime-versions: { nodejs: 22 }` to the synth step defaults in `pipeline_construct.ts`
- Added the same to the hosting deploy `CodeBuildStep` in `pipeline_factory.ts`
- Added `partialBuildSpec` to `PipelineSynthConfig` type so users can override if needed
- Added unit tests verifying the default and override behavior

### Changes

- `packages/hosting/src/pipeline/types.ts` — Added optional `partialBuildSpec` to synth config
- `packages/hosting/src/pipeline/pipeline_construct.ts` — Default Node 22 in synth step
- `packages/hosting/src/pipeline/pipeline_factory.ts` — Default Node 22 in deploy step
- `packages/hosting/src/pipeline/pipeline_construct.test.ts` — 2 new tests
- `packages/hosting/src/pipeline/pipeline_factory.test.ts` — 1 new test
- `.changeset/fix-pipeline-node22.md` — Minor changeset

### Testing

All 74 tests passing (47 construct + 27 factory).