### PR TITLE
chore: pin human-id

### DIFF
--- a/scripts/components/release_lifecycle.test.ts
+++ b/scripts/components/release_lifecycle.test.ts
@@ -92,6 +92,10 @@ void describe('release lifecycle', async () => {
     await gitClient.switchToBranch('main');
     await npmClient.init();
 
+    // Pin human-id@4.1.3 to fix ESM/CJS breakage with @changesets/cli
+    // human-id@4.2.0 switched to ESM-only, breaking @changesets/cli which requires it
+    await npmClient.install(['human-id@4.1.3']);
+
     await npmClient.initWorkspacePackage(cantaloupePackageName);
     await setPackageToPublic(
       path.join(testWorkingDir, 'packages', cantaloupePackageName),


### PR DESCRIPTION
## Description

human-id@4.2.0 switched to ESM-only, breaking @changesets/cli which uses require(). This installs the last CJS-compatible version explicitly.

Fixes test_scripts CI failures on main since June 4.

<!--
Thank you for your Pull Request! Please describe the problem this PR fixes and a summary of the changes made.
Link to any relevant issues, code snippets, or other PRs.

For trivial changes, this template can be ignored in favor of a short description of the changes.
-->

## Problem

<!--
Describe the issue this PR is solving
-->

**Issue number, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. This is a good place to call out critical or potentially problematic parts of the change.
-->

**Corresponding docs PR, if applicable:**

## Validation

<!--
Describe how changes in this PR have been validated. This may include added or updated unit, integration and/or E2E tests, test workflow runs, or manual verification. If manual verification is the only way changes in this PR have been validated, you will need to write some automated tests before this PR is ready to merge.

For changes to test infra, or non-functional changes, tests are not always required. Instead, you should call out _why_ you think tests are not required here.

If changes affect a GitHub workflow that is not included in the PR checks, include a link to a passing test run of the modified workflow.
--->

## Checklist

<!--
These items must be completed before a PR is ready to be merged.
Feel free to publish a draft PR before these items are complete.
-->

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
