### PR TITLE
fix(scripts): pin human-id@4.1.3 (4.2.0 is ESM-only, breaks @changesets/write)

### DIFF
--- a/.changeset/fix-human-id-esm.md
+++ b/.changeset/fix-human-id-esm.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(scripts): pin human-id@4.1.3 to avoid ESM-only 4.2.0 breaking @changesets/write in test scripts

--- a/scripts/components/dependabot_version_update_handler.test.ts
+++ b/scripts/components/dependabot_version_update_handler.test.ts
@@ -84,6 +84,7 @@ void describe('dependabot version update handler', async () => {
     await setPackageToPublic(platypusPackagePath);
 
     await npmClient.install(['@changesets/cli']);
+    await npmClient.install(['human-id@4.1.3']);
     await setPackageDependencies(cantaloupePackagePath, { testDep: '^1.0.0' });
     await setPackageDependencies(platypusPackagePath, { testDep: '^1.0.0' });
 

--- a/scripts/components/release_lifecycle.test.ts
+++ b/scripts/components/release_lifecycle.test.ts
@@ -103,6 +103,7 @@ void describe('release lifecycle', async () => {
     );
 
     await npmClient.install(['@changesets/cli']);
+    await npmClient.install(['human-id@4.1.3']);
 
     await $`npx --package @changesets/cli -- changeset init`;
     await gitClient.commitAllChanges('Version Packages (baseline release)');


### PR DESCRIPTION
## Problem

`human-id@4.2.0` (published recently) is ESM-only (`"type": "module"`). `@changesets/write` uses `require('human-id')` (CJS), causing `ERR_REQUIRE_ESM` when tests install fresh `@changesets/cli` which resolves to the latest `human-id`.

## Fix

Pin `human-id@4.1.3` (last CJS-compatible version) after `@changesets/cli` install in both affected test files.

## Affected tests
- `scripts/components/release_lifecycle.test.ts`
- `scripts/components/dependabot_version_update_handler.test.ts`

## Verified
Both tests pass locally with the pin.