### PR TITLE
fix(backend-function): avoid serializing full env in malformed data-env error

### DIFF
--- a/.changeset/redact-data-env-error-message.md
+++ b/.changeset/redact-data-env-error-message.md
@@ -1,0 +1,8 @@
+---
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend': patch
+---
+
+fix(backend-function): avoid serializing the full environment in the malformed data-env error
+
+When the data environment variables are missing or malformed, `getAmplifyDataClientConfig` no longer serializes the entire runtime environment into the thrown error. The message now lists only the names of the missing/malformed variables, which keeps it debuggable without including unrelated environment values.

--- a/packages/backend-function/src/runtime/get_amplify_clients_configuration.test.ts
+++ b/packages/backend-function/src/runtime/get_amplify_clients_configuration.test.ts
@@ -138,15 +138,6 @@ void describe('getAmplifyDataClientConfig', () => {
   });
 
   void describe('when the data environment variables are malformed', () => {
-    // The malformed-env error should name the missing/malformed variables
-    // without echoing the values of unrelated environment entries.
-    const unrelatedEnvValues = [
-      'TEST_VALUE for AWS_ACCESS_KEY_ID',
-      'TEST_VALUE for AWS_SECRET_ACCESS_KEY',
-      'TEST_VALUE for AWS_SESSION_TOKEN',
-      'TEST_VALUE for MY_OTHER_ENV_VAR',
-    ];
-
     const malformedEnv = {
       AWS_ACCESS_KEY_ID: 'TEST_VALUE for AWS_ACCESS_KEY_ID',
       AWS_SECRET_ACCESS_KEY: 'TEST_VALUE for AWS_SECRET_ACCESS_KEY',
@@ -157,6 +148,11 @@ void describe('getAmplifyDataClientConfig', () => {
       // The derived data env vars (bucket/key/endpoint) are intentionally
       // absent, which triggers the malformed-env validation.
     };
+
+    // None of the entries present in the fixture are the missing data
+    // variables, so none of their values should appear in the error. Deriving
+    // the list from the fixture keeps the two in sync if the fixture changes.
+    const unrelatedEnvValues = Object.values(malformedEnv);
 
     void it('names the missing variables without echoing unrelated env values', async () => {
       await assert.rejects(
@@ -180,6 +176,43 @@ void describe('getAmplifyDataClientConfig', () => {
               `error message must not contain the value "${value}"`,
             );
           }
+          return true;
+        },
+      );
+    });
+
+    void it('lists only the invalid variable names, not the ones present', async () => {
+      // Only the GraphQL endpoint is missing; the bucket and key are present
+      // as valid strings, so the error must name the endpoint alone.
+      const envMissingOnlyEndpoint = {
+        ...malformedEnv,
+        AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_BUCKET_NAME:
+          'TEST_VALUE for AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_BUCKET_NAME',
+        AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_KEY:
+          'TEST_VALUE for AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_KEY',
+        // AMPLIFY_DATA_GRAPHQL_ENDPOINT is still absent.
+      };
+
+      await assert.rejects(
+        async () =>
+          await getAmplifyDataClientConfig(
+            envMissingOnlyEndpoint,
+            mockS3Client,
+          ),
+        (error: Error) => {
+          assert.match(error.message, /AMPLIFY_DATA_GRAPHQL_ENDPOINT/);
+          assert.ok(
+            !error.message.includes(
+              'AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_BUCKET_NAME',
+            ),
+            'present bucket variable must not be listed as malformed',
+          );
+          assert.ok(
+            !error.message.includes(
+              'AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_KEY',
+            ),
+            'present key variable must not be listed as malformed',
+          );
           return true;
         },
       );

--- a/packages/backend-function/src/runtime/get_amplify_clients_configuration.test.ts
+++ b/packages/backend-function/src/runtime/get_amplify_clients_configuration.test.ts
@@ -136,4 +136,53 @@ void describe('getAmplifyDataClientConfig', () => {
       });
     });
   });
+
+  void describe('when the data environment variables are malformed', () => {
+    // The malformed-env error should name the missing/malformed variables
+    // without echoing the values of unrelated environment entries.
+    const unrelatedEnvValues = [
+      'TEST_VALUE for AWS_ACCESS_KEY_ID',
+      'TEST_VALUE for AWS_SECRET_ACCESS_KEY',
+      'TEST_VALUE for AWS_SESSION_TOKEN',
+      'TEST_VALUE for MY_OTHER_ENV_VAR',
+    ];
+
+    const malformedEnv = {
+      AWS_ACCESS_KEY_ID: 'TEST_VALUE for AWS_ACCESS_KEY_ID',
+      AWS_SECRET_ACCESS_KEY: 'TEST_VALUE for AWS_SECRET_ACCESS_KEY',
+      AWS_SESSION_TOKEN: 'TEST_VALUE for AWS_SESSION_TOKEN',
+      AWS_REGION: 'TEST_VALUE for AWS_REGION',
+      AMPLIFY_DATA_DEFAULT_NAME: 'AmplifyData',
+      MY_OTHER_ENV_VAR: 'TEST_VALUE for MY_OTHER_ENV_VAR',
+      // The derived data env vars (bucket/key/endpoint) are intentionally
+      // absent, which triggers the malformed-env validation.
+    };
+
+    void it('names the missing variables without echoing unrelated env values', async () => {
+      await assert.rejects(
+        async () =>
+          await getAmplifyDataClientConfig(malformedEnv, mockS3Client),
+        (error: Error) => {
+          // The message pinpoints the three expected data variables by name.
+          assert.match(
+            error.message,
+            /AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_BUCKET_NAME/,
+          );
+          assert.match(
+            error.message,
+            /AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_KEY/,
+          );
+          assert.match(error.message, /AMPLIFY_DATA_GRAPHQL_ENDPOINT/);
+          // Unrelated environment values do not appear in the message.
+          for (const value of unrelatedEnvValues) {
+            assert.ok(
+              !error.message.includes(value),
+              `error message must not contain the value "${value}"`,
+            );
+          }
+          return true;
+        },
+      );
+    });
+  });
 });

--- a/packages/backend-function/src/runtime/get_amplify_clients_configuration.ts
+++ b/packages/backend-function/src/runtime/get_amplify_clients_configuration.ts
@@ -107,18 +107,15 @@ const extendEnv = (
   const bucketName = `${dataName}${dataBucketNameContent}`;
   const keyName = `${dataName}${dataKeyNameContent}`;
   const endpointName = `${dataName}${dataEndpointNameContent}`;
-  if (
-    !(
-      bucketName in env &&
-      keyName in env &&
-      endpointName in env &&
-      typeof env[bucketName] === 'string' &&
-      typeof env[keyName] === 'string' &&
-      typeof env[endpointName] === 'string'
-    )
-  ) {
+  const requiredNames = [bucketName, keyName, endpointName];
+  const invalidNames = requiredNames.filter(
+    (name) => !(name in env) || typeof env[name] !== 'string',
+  );
+  if (invalidNames.length > 0) {
     throw new Error(
-      `The data environment variables are malformed. env=${JSON.stringify(env)}`,
+      `The data environment variables are malformed. Expected string values for: ${invalidNames.join(
+        ', ',
+      )}.`,
     );
   }
 


### PR DESCRIPTION
## Problem

When the data environment variables consumed by `getAmplifyDataClientConfig` are missing or malformed, the internal `extendEnv` validation throws an error that serializes the **entire** runtime environment into the message:

```ts
throw new Error(
  `The data environment variables are malformed. env=${JSON.stringify(env)}`,
);
```

In a Lambda runtime, `env` includes values unrelated to the data configuration — for example the standard `AWS_*` variables and any additional environment values configured on the function. Embedding the whole environment in an error message is more than is needed to diagnose the problem, and that message can be surfaced in logs. The error only needs to identify which of the expected data variables is missing or malformed.

**Issue number, if available:** N/A

## Changes

- `extendEnv` now computes which of the three expected data variables (`..._MODEL_INTROSPECTION_SCHEMA_BUCKET_NAME`, `..._MODEL_INTROSPECTION_SCHEMA_KEY`, `..._GRAPHQL_ENDPOINT`) are missing or not strings, and throws an error that lists only those **variable names** — it no longer serializes `env` values into the message.
- The new message stays actionable: it names exactly which variables need to be provided as strings.

Before:
```
The data environment variables are malformed. env={ ...entire environment serialized... }
```
After:
```
The data environment variables are malformed. Expected string values for: AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_BUCKET_NAME, AMPLIFY_DATA_MODEL_INTROSPECTION_SCHEMA_KEY, AMPLIFY_DATA_GRAPHQL_ENDPOINT.
```

**Corresponding docs PR, if applicable:** N/A

## Validation

Added a unit test to `packages/backend-function/src/runtime/get_amplify_clients_configuration.test.ts` that calls `getAmplifyDataClientConfig` with a malformed data environment and asserts that:
- the thrown message names the three expected data variables, and
- none of the surrounding environment values (e.g. `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and an additional configured env value) appear in the message.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
