### PR TITLE
fix(ci): raise canary live_dependency_health_checks timeouts (outer job 20→45, inner per-attempt default 25→40) for slow construct install

### DIFF
--- a/.github/actions/run_with_e2e_account/action.yml
+++ b/.github/actions/run_with_e2e_account/action.yml
@@ -30,7 +30,7 @@ inputs:
   attempt_timeout_minutes:
     description: Timeout for each attempt in minutes
     required: false
-    default: '25'
+    default: '40'
   retry_attempts:
     description: Number of retry attempts for the main script
     required: false

--- a/.github/workflows/canary_checks.yml
+++ b/.github/workflows/canary_checks.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         region: [us-west-2, us-east-1, ca-central-1, eu-central-1]
-    timeout-minutes: 20
+    timeout-minutes: 45
     permissions:
       # these permissions are required for the configure-aws-credentials action to get a JWT from GitHub
       id-token: write


### PR DESCRIPTION
## Summary

Fixes the canary `live_dependency_health_checks` job timing out. The job's real work (attempt 1) now takes ~33 min due to a heavier construct install, which was exceeding both the outer job cap and the inner per-attempt cap.

Two canary-scoped timeout changes:

1. **Outer job timeout 20 → 45 min** (`.github/workflows/canary_checks.yml`): the overall `live_dependency_health_checks` job `timeout-minutes` was too low for the slower construct install.
2. **Inner per-attempt cap default 25 → 40 min** (`.github/actions/run_with_e2e_account/action.yml`): the `attempt_timeout_minutes` input default was tripping on attempt 1 (~33 min), terminating it and orphaning processes before it could finish. Raising the default lets attempt 1 complete before the inner cap fires. 40 (inner) < 45 (outer) is preserved.

## Scope

The `attempt_timeout_minutes` default change only affects the canary. All 7 `live_dependency_health_checks` callers pass `attempt_timeout_minutes` explicitly, so they are unaffected by the changed default — the canary is the only path relying on the default value.
