### PR TITLE
feat(sandbox): support CloudFormation/CDK Express mode via `ampx sandbox --express`

### DIFF
--- a/.changeset/sandbox-express-mode.md
+++ b/.changeset/sandbox-express-mode.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/backend-cli': minor
+'@aws-amplify/sandbox': minor
+'@aws-amplify/backend-deployer': minor
+---
+
+Add opt-in `ampx sandbox --express` flag that enables CloudFormation/CDK Express mode for faster sandbox deployments. Bumps `@aws-cdk/toolkit-lib` to `1.32.0`.

--- a/.changeset/sandbox-express-mode.md
+++ b/.changeset/sandbox-express-mode.md
@@ -3,6 +3,7 @@
 '@aws-amplify/sandbox': minor
 '@aws-amplify/backend-deployer': minor
 '@aws-amplify/cli-core': patch
+'@aws-amplify/plugin-types': patch
 ---
 
 Add opt-in `ampx sandbox --express` flag that enables CloudFormation/CDK Express mode for faster sandbox deployments. When a deployment completes with resources still stabilizing, the Express Mode warning (e.g. `Stack deployed using Express Mode. Resources still stabilizing: ...`) is surfaced in the sandbox output. Bumps `@aws-cdk/toolkit-lib` to `1.32.0` and `@aws-sdk/client-cloudformation` to `^3.1078.0` (the version that adds the `DeploymentConfig` Express mode field to the CloudFormation request; older SDK versions silently drop it).

--- a/.changeset/sandbox-express-mode.md
+++ b/.changeset/sandbox-express-mode.md
@@ -5,4 +5,4 @@
 '@aws-amplify/cli-core': patch
 ---
 
-Add opt-in `ampx sandbox --express` flag that enables CloudFormation/CDK Express mode for faster sandbox deployments. Bumps `@aws-cdk/toolkit-lib` to `1.32.0` and `@aws-sdk/client-cloudformation` to `^3.1078.0` (the version that adds the `DeploymentConfig` Express mode field to the CloudFormation request; older SDK versions silently drop it).
+Add opt-in `ampx sandbox --express` flag that enables CloudFormation/CDK Express mode for faster sandbox deployments. When a deployment completes with resources still stabilizing, the Express Mode warning (e.g. `Stack deployed using Express Mode. Resources still stabilizing: ...`) is surfaced in the sandbox output. Bumps `@aws-cdk/toolkit-lib` to `1.32.0` and `@aws-sdk/client-cloudformation` to `^3.1078.0` (the version that adds the `DeploymentConfig` Express mode field to the CloudFormation request; older SDK versions silently drop it).

--- a/.changeset/sandbox-express-mode.md
+++ b/.changeset/sandbox-express-mode.md
@@ -2,6 +2,7 @@
 '@aws-amplify/backend-cli': minor
 '@aws-amplify/sandbox': minor
 '@aws-amplify/backend-deployer': minor
+'@aws-amplify/cli-core': patch
 ---
 
-Add opt-in `ampx sandbox --express` flag that enables CloudFormation/CDK Express mode for faster sandbox deployments. Bumps `@aws-cdk/toolkit-lib` to `1.32.0`.
+Add opt-in `ampx sandbox --express` flag that enables CloudFormation/CDK Express mode for faster sandbox deployments. Bumps `@aws-cdk/toolkit-lib` to `1.32.0` and `@aws-sdk/client-cloudformation` to `^3.1078.0` (the version that adds the `DeploymentConfig` Express mode field to the CloudFormation request; older SDK versions silently drop it).

--- a/package-lock.json
+++ b/package-lock.json
@@ -17840,68 +17840,22 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.1017.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1017.0.tgz",
-      "integrity": "sha512-GIOy/y2UdTXApjfnILkl56fpxKA5KIpE57BkzxpL3u7HGP4NWPlOGCCZC3jdRZBDfX+iMO8H1tkXzv7llVSQkQ==",
+      "version": "3.1078.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1078.0.tgz",
+      "integrity": "sha512-k+G2ZWbb+EjcJHN4Tg8kys8vwRbBJwUoJ1+jHPAW2bLuy8Np/yROeCjXi6xHaOALFT4gmqqXqjAHhqaa2Bs/1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/credential-provider-node": "^3.972.25",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.25",
-        "@aws-sdk/region-config-resolver": "^3.972.9",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.11",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
-        "@smithy/middleware-retry": "^4.4.44",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.43",
-        "@smithy/util-defaults-mode-node": "^4.2.47",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cloudtrail": {
@@ -24202,41 +24156,22 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
-      "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
+      "version": "3.974.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.26.tgz",
+      "integrity": "sha512-wRj7Pthvjk3anees97pUWlxlTa0DUjeGrEQU5fKDZVdWZV0ekaprbof0df2uaE9g8u67t035v2j+ne2AW2UMkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.15",
-        "@smithy/core": "^3.23.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
@@ -24269,15 +24204,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.22.tgz",
-      "integrity": "sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.52.tgz",
+      "integrity": "sha512-sxuaHZGHqOgKB8OdL3doXa1NJjqmO60FPfyTnYVKGjX9taRsIEGS9pd+2yALmo06hijZ8L94uSK0kfXZsRmVyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24285,20 +24220,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.24.tgz",
-      "integrity": "sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.54.tgz",
+      "integrity": "sha512-e6yz52nq3SpR1oPLcvfsDM7H7k2gIYk/NSn/rwsFqzGXEwr3g0mRMlPbLaKCPCGNZJMU/gZg6/64B3eSam+gBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24306,24 +24238,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.24.tgz",
-      "integrity": "sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.59.tgz",
+      "integrity": "sha512-9Um/UpruN76AdpiLnvwChVkJJwJ9Vx9ykk/2AeLxxSCM/YYRD8Kkq2towUk9fZQLV7dd9ATlsi87U7hKs0z/iQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/credential-provider-env": "^3.972.22",
-        "@aws-sdk/credential-provider-http": "^3.972.24",
-        "@aws-sdk/credential-provider-login": "^3.972.24",
-        "@aws-sdk/credential-provider-process": "^3.972.22",
-        "@aws-sdk/credential-provider-sso": "^3.972.24",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-env": "^3.972.52",
+        "@aws-sdk/credential-provider-http": "^3.972.54",
+        "@aws-sdk/credential-provider-login": "^3.972.58",
+        "@aws-sdk/credential-provider-process": "^3.972.52",
+        "@aws-sdk/credential-provider-sso": "^3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24331,18 +24262,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.24.tgz",
-      "integrity": "sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.58.tgz",
+      "integrity": "sha512-H3q96qF8/DJsPsXMVtMRqSWOc85K5O4zos32untdw+vE5vw0f3a6qJo1YqbND4BsEIKd4iZmzzVUq9kV4LjbHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24350,22 +24279,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.25.tgz",
-      "integrity": "sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.61.tgz",
+      "integrity": "sha512-2U2KHMRCt1dlZoLU3KZR5g5EL4b0h2HHw96SkaUBK7qvEXPZj5rGRO/3ZTeJmh37dIYQuCnA2273rZOQvmsiHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.22",
-        "@aws-sdk/credential-provider-http": "^3.972.24",
-        "@aws-sdk/credential-provider-ini": "^3.972.24",
-        "@aws-sdk/credential-provider-process": "^3.972.22",
-        "@aws-sdk/credential-provider-sso": "^3.972.24",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.52",
+        "@aws-sdk/credential-provider-http": "^3.972.54",
+        "@aws-sdk/credential-provider-ini": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.52",
+        "@aws-sdk/credential-provider-sso": "^3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24373,16 +24301,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.22.tgz",
-      "integrity": "sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.52.tgz",
+      "integrity": "sha512-Aff9Ebs42lz+Ep1wkS+Nlwh5S0eahakpyskPsuKGjiBJ6ExOjNtxbfKJTKovQtQNgJ7oG1BH6esJwGrbs7qgSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24390,18 +24317,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.24.tgz",
-      "integrity": "sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.58.tgz",
+      "integrity": "sha512-syloC58mXOacUqM2toPNfwd7X3jT+tWj0F/cN7qdW1FQyI0q41J0tPf6DIZ56BF0x82iS9j3ALP45MoBz79YuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/token-providers": "3.1015.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/token-providers": "3.1078.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24409,17 +24335,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.24.tgz",
-      "integrity": "sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.58.tgz",
+      "integrity": "sha512-pTBImKzcGK+pcMKjL0fAJbnYzzYd1c0UDc7BSIOGNQhF9Nuk66vWlIXfYTYyzNSs+w8Q/vfbbNDDU8zdrouwLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24885,66 +24810,22 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
-      "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+      "version": "3.997.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.26.tgz",
+      "integrity": "sha512-Lwe3F6K7bs+jEubp1LbrvzeMBYb5fMazJ1IxV9TtKWPF8CSh67Fmwyq9fLz3NL/k55Dfpuph5Dimw76JFgr+SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.25",
-        "@aws-sdk/region-config-resolver": "^3.972.9",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.11",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
-        "@smithy/middleware-retry": "^4.4.44",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.43",
-        "@smithy/util-defaults-mode-node": "^4.2.47",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
@@ -24964,16 +24845,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.13.tgz",
-      "integrity": "sha512-7j8rOFHHq4e9McCSuWBmBSADriW5CjPUem4inckRh/cyQGaijBwDbkNbVTgDVDWqFo29SoVVUfI6HCOnck6HZw==",
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.25",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24981,17 +24860,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1015.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1015.0.tgz",
-      "integrity": "sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==",
+      "version": "3.1078.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1078.0.tgz",
+      "integrity": "sha512-/uyXLBGu3Lw1GbBA2X66hcOMnKtMcqAIF+3/eHfxBQmUeXF2sdqozDPrTfEr/TnSd0D6deZar+eVyhEqqWu29w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -24999,12 +24877,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -25142,13 +25020,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
-      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -29704,34 +29581,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.12",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
-      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.0.tgz",
+      "integrity": "sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/core/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -29739,15 +29594,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
-      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.5.tgz",
+      "integrity": "sha512-LnjUTNG0GgQlKIq7IioeOrPaEmC5xOd1WtAz24TLSiYQnWX2uHr53GrFuQhkrJBktPYCMga/NbUOW7hFbSA2Cg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -29825,29 +29678,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.2.tgz",
+      "integrity": "sha512-q96PSDOAGw+X+nuELd7Cjebps0SYr+YlPbviEX9sLVw+VM4M7VV8hn1nL1mGS6urDu33eQ5A7WhlphaDO6kUyQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -30034,15 +29871,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
-      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.2.tgz",
+      "integrity": "sha512-s0yAIRj6TVfHgl+QzVyqal1KMGZ9B5512IrxKc6+dOpw8fUmFL3CvuAhjv0J+aNjUPfVZ2IhqPEDvkB5Ncx9oA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -30128,18 +29963,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.1.tgz",
+      "integrity": "sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -30165,9 +29995,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -36814,41 +36644,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -41056,21 +40851,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -43391,6 +43171,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
       "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -45974,7 +45755,7 @@
         "@aws-amplify/sandbox": "^2.2.1",
         "@aws-amplify/schema-generator": "^1.4.0",
         "@aws-sdk/client-amplify": "^3.936.0",
-        "@aws-sdk/client-cloudformation": "^3.936.0",
+        "@aws-sdk/client-cloudformation": "^3.1078.0",
         "@aws-sdk/client-s3": "^3.936.0",
         "@aws-sdk/client-sts": "^3.936.0",
         "@aws-sdk/credential-provider-ini": "^3.936.0",
@@ -46015,7 +45796,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-sdk/client-cloudformation": "^3.936.0",
+        "@aws-sdk/client-cloudformation": "^3.1078.0",
         "@inquirer/prompts": "^7.3.2",
         "@opentelemetry/api": "^1.9.0",
         "execa": "^9.5.1",
@@ -46305,7 +46086,7 @@
         "@aws-sdk/client-accessanalyzer": "^3.936.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-bedrock-runtime": "3.936.0",
-        "@aws-sdk/client-cloudformation": "^3.936.0",
+        "@aws-sdk/client-cloudformation": "^3.1078.0",
         "@aws-sdk/client-cloudtrail": "^3.937.0",
         "@aws-sdk/client-cognito-identity": "^3.936.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37185,7 +37185,6 @@
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
       "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -39064,7 +39063,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
       "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -45277,6 +45275,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -45398,17 +45405,17 @@
     },
     "packages/ai-constructs": {
       "name": "@aws-amplify/ai-constructs",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-bedrock-runtime": "^3.936.0",
         "@smithy/types": "^4.9.0",
         "json-schema-to-ts": "^3.1.1"
       },
       "devDependencies": {
-        "@aws-amplify/backend-output-storage": "^1.3.3",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
         "@types/lodash.transform": "^4.6.9",
         "lodash.transform": "^4.6.0",
         "typescript": "^5.0.0"
@@ -45440,20 +45447,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-auth": "^1.9.3",
-        "@aws-amplify/backend-data": "^1.6.4",
-        "@aws-amplify/backend-function": "^1.18.0",
+        "@aws-amplify/backend-auth": "^1.9.4",
+        "@aws-amplify/backend-data": "^1.7.0",
+        "@aws-amplify/backend-function": "^1.18.1",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.4",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/backend-storage": "^1.4.3",
-        "@aws-amplify/client-config": "^1.10.1",
+        "@aws-amplify/backend-storage": "^1.5.0",
+        "@aws-amplify/client-config": "^1.10.2",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-amplify": "^3.936.0"
       },
       "devDependencies": {
@@ -45467,15 +45474,15 @@
     },
     "packages/backend-ai": {
       "name": "@aws-amplify/backend-ai",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.5.6",
+        "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/data-schema-types": "^1.2.0",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2"
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
@@ -45484,17 +45491,17 @@
     },
     "packages/backend-auth": {
       "name": "@aws-amplify/backend-auth",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/auth-construct": "^1.11.1",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
-        "@aws-amplify/plugin-types": "^1.11.2"
+        "@aws-amplify/backend-output-storage": "^1.3.5",
+        "@aws-amplify/plugin-types": "^1.12.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
-        "@aws-amplify/platform-core": "^1.10.4",
+        "@aws-amplify/platform-core": "^1.11.1",
         "@aws-sdk/client-cognito-identity": "^3.936.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
         "@types/aws-lambda": "^8.10.119"
@@ -45506,21 +45513,21 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.6.4",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/data-construct": "^1.15.1",
         "@aws-amplify/data-schema-types": "^1.2.0",
         "@aws-amplify/graphql-generator": "^0.5.1",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "graphql": "^15.8.0"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/platform-core": "^1.10.4"
+        "@aws-amplify/platform-core": "^1.11.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
@@ -45529,12 +45536,12 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0",
-        "@aws-cdk/toolkit-lib": "1.19.0",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-cdk/toolkit-lib": "1.32.0",
         "execa": "^9.5.1",
         "minimatch": "10.2.3",
         "strip-ansi": "^7.1.0",
@@ -45545,6 +45552,117 @@
         "typescript": "^5.0.0"
       }
     },
+    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.6.tgz",
+      "integrity": "sha512-lw+Z5JT4e5rAMMR8tvj2yKSIQTvlxpBeYMUjfSgpJ4RN9d94vF6CpnvPqq6LsfO37n6jw0ufQrDNrR8ZHWKkuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.8.0.tgz",
+      "integrity": "sha512-f891G+Uv4x0/PWTYkA7psEoxHj4//uXEYklB853uFZVHq2zwoH5Eko+uL07wUXZsUiXpZZl8c72KJVnEidR+zg==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/backend-deployer/node_modules/@aws-cdk/toolkit-lib": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.32.0.tgz",
+      "integrity": "sha512-gZ/gWngRa3ZKwPOcw4zw2+NkJe73mG5XK1/FOEiz6yERJqI+s0QpXCnnOnsDr6l9o6w3Uexpfhd7wueho33hww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/cdk-assets-lib": "^1",
+        "@aws-cdk/cloud-assembly-api": "2.2.6",
+        "@aws-cdk/cloud-assembly-schema": ">=54.7.0",
+        "@aws-cdk/cloudformation-diff": "^2",
+        "@aws-cdk/cx-api": "^2",
+        "@aws-sdk/client-appsync": "^3",
+        "@aws-sdk/client-bedrock-agentcore-control": "^3",
+        "@aws-sdk/client-cloudcontrol": "^3",
+        "@aws-sdk/client-cloudformation": "^3",
+        "@aws-sdk/client-cloudwatch-logs": "^3",
+        "@aws-sdk/client-codebuild": "^3",
+        "@aws-sdk/client-ec2": "^3",
+        "@aws-sdk/client-ecr": "^3",
+        "@aws-sdk/client-ecs": "^3",
+        "@aws-sdk/client-elastic-load-balancing-v2": "^3",
+        "@aws-sdk/client-iam": "^3",
+        "@aws-sdk/client-kms": "^3",
+        "@aws-sdk/client-lambda": "^3",
+        "@aws-sdk/client-route-53": "^3",
+        "@aws-sdk/client-s3": "^3",
+        "@aws-sdk/client-secrets-manager": "^3",
+        "@aws-sdk/client-sfn": "^3",
+        "@aws-sdk/client-ssm": "^3",
+        "@aws-sdk/client-sts": "^3",
+        "@aws-sdk/credential-providers": "^3",
+        "@aws-sdk/ec2-metadata-service": "^3",
+        "@aws-sdk/lib-storage": "^3",
+        "@smithy/middleware-endpoint": "^4",
+        "@smithy/property-provider": "^4",
+        "@smithy/shared-ini-file-loader": "^4",
+        "@smithy/util-retry": "^4",
+        "@smithy/util-waiter": "^4",
+        "cdk-from-cfn": "^0.304.0",
+        "chalk": "^4",
+        "chokidar": "^4",
+        "fast-deep-equal": "^3.1.3",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11",
+        "p-limit": "^3",
+        "picomatch": "^4",
+        "semver": "^7.8.4",
+        "split2": "^4.2.0",
+        "wrap-ansi": "^7",
+        "yaml": "^1",
+        "yazl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cli-plugin-contract": "^2"
+      }
+    },
     "packages/backend-deployer/node_modules/ansi-regex": {
       "version": "6.2.2",
       "license": "MIT",
@@ -45553,6 +45671,117 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/backend-deployer/node_modules/cdk-from-cfn": {
+      "version": "0.304.0",
+      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.304.0.tgz",
+      "integrity": "sha512-OLw/T42SqnlU3DERX0R1e9R/VaLVDuMwKAFONm9nzIineHANqnXRg9u83FAyEzaf9sOvN4qCCDlsjAp29WnTHw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "packages/backend-deployer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/backend-deployer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "packages/backend-deployer/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/backend-deployer/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/backend-deployer/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/backend-deployer/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/backend-deployer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/backend-deployer/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/backend-deployer/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/backend-deployer/node_modules/strip-ansi": {
@@ -45568,20 +45797,79 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "packages/backend-deployer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/backend-deployer/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "packages/backend-deployer/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/backend-deployer/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/backend-deployer/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/backend-output-storage": "^1.3.5",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-s3": "^3.936.0",
         "execa": "^9.5.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
-        "@aws-amplify/platform-core": "^1.10.4",
+        "@aws-amplify/platform-core": "^1.11.1",
         "@aws-sdk/client-s3": "^3.936.0",
         "@aws-sdk/client-ssm": "^3.936.0",
         "uuid": "^11.1.0"
@@ -45616,12 +45904,12 @@
     },
     "packages/backend-output-storage": {
       "name": "@aws-amplify/backend-output-storage",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0"
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1"
@@ -45652,16 +45940,16 @@
     },
     "packages/backend-storage": {
       "name": "@aws-amplify/backend-storage",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/backend-output-storage": "^1.3.3",
-        "@aws-amplify/plugin-types": "^1.11.2"
+        "@aws-amplify/backend-output-storage": "^1.3.5",
+        "@aws-amplify/plugin-types": "^1.12.1"
       },
       "devDependencies": {
         "@aws-amplify/backend-platform-test-stubs": "^0.3.10",
-        "@aws-amplify/platform-core": "^1.10.4"
+        "@aws-amplify/platform-core": "^1.11.1"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
@@ -45670,20 +45958,20 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.5",
+        "@aws-amplify/backend-deployer": "^2.1.7",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.3",
-        "@aws-amplify/client-config": "^1.10.0",
-        "@aws-amplify/deployed-backend-client": "^1.8.0",
-        "@aws-amplify/form-generator": "^1.2.6",
-        "@aws-amplify/model-generator": "^1.2.2",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
-        "@aws-amplify/sandbox": "^2.1.4",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
+        "@aws-amplify/form-generator": "^1.2.7",
+        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/sandbox": "^2.2.1",
         "@aws-amplify/schema-generator": "^1.4.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-cloudformation": "^3.936.0",
@@ -45723,10 +46011,10 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/platform-core": "^1.11.0",
+        "@aws-amplify/platform-core": "^1.11.1",
         "@aws-sdk/client-cloudformation": "^3.936.0",
         "@inquirer/prompts": "^7.3.2",
         "@opentelemetry/api": "^1.9.0",
@@ -45837,14 +46125,14 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/deployed-backend-client": "^1.8.1",
-        "@aws-amplify/model-generator": "^1.2.2",
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
+        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "zod": "3.25.17"
       },
       "devDependencies": {
@@ -45859,12 +46147,12 @@
       }
     },
     "packages/create-amplify": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/cli-core": "^2.2.2",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "execa": "^9.5.1",
         "kleur": "^4.1.5",
         "yargs": "^17.7.2"
@@ -45951,12 +46239,12 @@
     },
     "packages/deployed-backend-client": {
       "name": "@aws-amplify/deployed-backend-client",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.7.1",
-        "@aws-amplify/platform-core": "^1.10.1",
-        "@aws-amplify/plugin-types": "^1.11.1",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "zod": "3.25.17"
       },
       "peerDependencies": {
@@ -45979,7 +46267,7 @@
     },
     "packages/form-generator": {
       "name": "@aws-amplify/form-generator",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.11.0",
@@ -45998,22 +46286,22 @@
     },
     "packages/integration-tests": {
       "name": "@aws-amplify/integration-tests",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@apollo/client": "^3.10.1",
-        "@aws-amplify/ai-constructs": "^1.6.1",
+        "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/auth-construct": "^1.11.1",
-        "@aws-amplify/backend": "^1.21.0",
-        "@aws-amplify/backend-ai": "^1.5.3",
+        "@aws-amplify/backend": "^1.23.0",
+        "@aws-amplify/backend-ai": "^1.5.4",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.3",
-        "@aws-amplify/client-config": "^1.10.0",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/client-config": "^1.10.2",
         "@aws-amplify/data-schema": "^1.13.4",
-        "@aws-amplify/deployed-backend-client": "^1.8.1",
-        "@aws-amplify/platform-core": "^1.10.4",
-        "@aws-amplify/plugin-types": "^1.11.2",
-        "@aws-amplify/seed": "^1.1.1",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/seed": "^1.1.3",
         "@aws-sdk/client-accessanalyzer": "^3.936.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-bedrock-runtime": "3.936.0",
@@ -46674,15 +46962,15 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.7.1",
-        "@aws-amplify/deployed-backend-client": "^1.8.1",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
-        "@aws-amplify/platform-core": "^1.10.3",
-        "@aws-amplify/plugin-types": "^1.11.1",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-appsync": "^3.936.0",
         "@aws-sdk/client-s3": "^3.937.0",
         "@aws-sdk/credential-providers": "^3.936.0",
@@ -46696,10 +46984,10 @@
     },
     "packages/platform-core": {
       "name": "@aws-amplify/platform-core",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-sts": "^3.936.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.0.0",
@@ -46739,10 +47027,10 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/toolkit-lib": "1.19.0"
+        "@aws-cdk/toolkit-lib": "1.32.0"
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
@@ -46750,18 +47038,257 @@
         "constructs": "^10.0.0"
       }
     },
-    "packages/sandbox": {
-      "name": "@aws-amplify/sandbox",
-      "version": "2.2.0",
+    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.6.tgz",
+      "integrity": "sha512-lw+Z5JT4e5rAMMR8tvj2yKSIQTvlxpBeYMUjfSgpJ4RN9d94vF6CpnvPqq6LsfO37n6jw0ufQrDNrR8ZHWKkuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.4",
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.8.0.tgz",
+      "integrity": "sha512-f891G+Uv4x0/PWTYkA7psEoxHj4//uXEYklB853uFZVHq2zwoH5Eko+uL07wUXZsUiXpZZl8c72KJVnEidR+zg==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/plugin-types/node_modules/@aws-cdk/toolkit-lib": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.32.0.tgz",
+      "integrity": "sha512-gZ/gWngRa3ZKwPOcw4zw2+NkJe73mG5XK1/FOEiz6yERJqI+s0QpXCnnOnsDr6l9o6w3Uexpfhd7wueho33hww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/cdk-assets-lib": "^1",
+        "@aws-cdk/cloud-assembly-api": "2.2.6",
+        "@aws-cdk/cloud-assembly-schema": ">=54.7.0",
+        "@aws-cdk/cloudformation-diff": "^2",
+        "@aws-cdk/cx-api": "^2",
+        "@aws-sdk/client-appsync": "^3",
+        "@aws-sdk/client-bedrock-agentcore-control": "^3",
+        "@aws-sdk/client-cloudcontrol": "^3",
+        "@aws-sdk/client-cloudformation": "^3",
+        "@aws-sdk/client-cloudwatch-logs": "^3",
+        "@aws-sdk/client-codebuild": "^3",
+        "@aws-sdk/client-ec2": "^3",
+        "@aws-sdk/client-ecr": "^3",
+        "@aws-sdk/client-ecs": "^3",
+        "@aws-sdk/client-elastic-load-balancing-v2": "^3",
+        "@aws-sdk/client-iam": "^3",
+        "@aws-sdk/client-kms": "^3",
+        "@aws-sdk/client-lambda": "^3",
+        "@aws-sdk/client-route-53": "^3",
+        "@aws-sdk/client-s3": "^3",
+        "@aws-sdk/client-secrets-manager": "^3",
+        "@aws-sdk/client-sfn": "^3",
+        "@aws-sdk/client-ssm": "^3",
+        "@aws-sdk/client-sts": "^3",
+        "@aws-sdk/credential-providers": "^3",
+        "@aws-sdk/ec2-metadata-service": "^3",
+        "@aws-sdk/lib-storage": "^3",
+        "@smithy/middleware-endpoint": "^4",
+        "@smithy/property-provider": "^4",
+        "@smithy/shared-ini-file-loader": "^4",
+        "@smithy/util-retry": "^4",
+        "@smithy/util-waiter": "^4",
+        "cdk-from-cfn": "^0.304.0",
+        "chalk": "^4",
+        "chokidar": "^4",
+        "fast-deep-equal": "^3.1.3",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11",
+        "p-limit": "^3",
+        "picomatch": "^4",
+        "semver": "^7.8.4",
+        "split2": "^4.2.0",
+        "wrap-ansi": "^7",
+        "yaml": "^1",
+        "yazl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cli-plugin-contract": "^2"
+      }
+    },
+    "packages/plugin-types/node_modules/cdk-from-cfn": {
+      "version": "0.304.0",
+      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.304.0.tgz",
+      "integrity": "sha512-OLw/T42SqnlU3DERX0R1e9R/VaLVDuMwKAFONm9nzIineHANqnXRg9u83FAyEzaf9sOvN4qCCDlsjAp29WnTHw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "packages/plugin-types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/plugin-types/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "packages/plugin-types/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/plugin-types/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/plugin-types/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/plugin-types/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/plugin-types/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/plugin-types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/plugin-types/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "packages/plugin-types/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "packages/sandbox": {
+      "name": "@aws-amplify/sandbox",
+      "version": "2.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/backend-deployer": "^2.1.7",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.3",
-        "@aws-amplify/client-config": "^1.9.1",
-        "@aws-amplify/deployed-backend-client": "^1.8.1",
-        "@aws-amplify/platform-core": "^1.10.3",
-        "@aws-amplify/plugin-types": "^1.11.1",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/deployed-backend-client": "^1.8.2",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
         "@aws-sdk/client-lambda": "^3.936.0",
         "@aws-sdk/client-ssm": "^3.936.0",
@@ -46790,14 +47317,14 @@
     },
     "packages/seed": {
       "name": "@aws-amplify/seed",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.4",
-        "@aws-amplify/client-config": "^1.10.1",
-        "@aws-amplify/platform-core": "^1.11.0",
-        "@aws-amplify/plugin-types": "^1.12.0",
+        "@aws-amplify/cli-core": "^2.2.5",
+        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/platform-core": "^1.11.1",
+        "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
         "aws-amplify": "6.14.4"
       }

--- a/packages/backend-deployer/API.md
+++ b/packages/backend-deployer/API.md
@@ -36,6 +36,7 @@ export type DeploymentTimes = {
 export type DeployProps = {
     secretLastUpdated?: Date;
     validateAppSources?: boolean;
+    express?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/backend-deployer/package.json
+++ b/packages/backend-deployer/package.json
@@ -28,7 +28,7 @@
     "execa": "^9.5.1",
     "tsx": "4.19.4",
     "strip-ansi": "^7.1.0",
-    "@aws-cdk/toolkit-lib": "1.19.0",
+    "@aws-cdk/toolkit-lib": "1.32.0",
     "minimatch": "10.2.3"
   },
   "peerDependencies": {

--- a/packages/backend-deployer/src/cdk_deployer.test.ts
+++ b/packages/backend-deployer/src/cdk_deployer.test.ts
@@ -135,6 +135,28 @@ void describe('invokeCDKCommand', () => {
     } as AssemblySourceProps);
   });
 
+  void it('enables Express mode for sandbox deployments when requested', async () => {
+    await invoker.deploy(sandboxBackendId, {
+      ...sandboxDeployProps,
+      express: true,
+    });
+    assert.strictEqual(deployMock.mock.callCount(), 1);
+    assert.deepStrictEqual(deployMock.mock.calls[0].arguments[1], {
+      deploymentMethod: { method: 'hotswap', fallback: { method: 'direct' } },
+      stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+      express: true,
+    } as DeployOptions);
+  });
+
+  void it('does not enable Express mode for branch deployments', async () => {
+    await invoker.deploy(branchBackendId, { express: true });
+    assert.strictEqual(deployMock.mock.callCount(), 1);
+    assert.deepStrictEqual(deployMock.mock.calls[0].arguments[1], {
+      deploymentMethod: { method: 'direct' },
+      stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+    } as DeployOptions);
+  });
+
   void it('handles destroy for sandbox', async () => {
     await invoker.destroy(sandboxBackendId);
     assert.strictEqual(fromAssemblyBuilderMock.mock.callCount(), 1);

--- a/packages/backend-deployer/src/cdk_deployer.ts
+++ b/packages/backend-deployer/src/cdk_deployer.ts
@@ -143,15 +143,17 @@ export class CDKDeployer implements BackendDeployer {
 
     // Perform actual deployment. CFN or hotswap
     const deployStartTime = Date.now();
+    const isSandbox = backendId.type === 'sandbox';
     try {
       await this.cdkToolkit.deploy(synthAssembly!, {
         stacks: {
           strategy: StackSelectionStrategy.ALL_STACKS,
         },
-        deploymentMethod:
-          backendId.type === 'sandbox'
-            ? { method: 'hotswap', fallback: { method: 'direct' } }
-            : { method: 'direct' },
+        deploymentMethod: isSandbox
+          ? { method: 'hotswap', fallback: { method: 'direct' } }
+          : { method: 'direct' },
+        // Opt-in Express mode is only wired for sandbox deployments.
+        ...(isSandbox && deployProps?.express ? { express: true } : {}),
       });
     } catch (error) {
       await this.ioHost.notify({

--- a/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
+++ b/packages/backend-deployer/src/cdk_deployer_singleton_factory.ts
@@ -13,6 +13,7 @@ import { BaseCredentials, Toolkit } from '@aws-cdk/toolkit-lib';
 export type DeployProps = {
   secretLastUpdated?: Date;
   validateAppSources?: boolean;
+  express?: boolean;
 };
 
 export type DeployResult = {

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-amplify/platform-core": "^1.11.1",
-    "@aws-sdk/client-cloudformation": "^3.936.0",
+    "@aws-sdk/client-cloudformation": "^3.1078.0",
     "@inquirer/prompts": "^7.3.2",
     "@opentelemetry/api": "^1.9.0",
     "execa": "^9.5.1",

--- a/packages/cli-core/src/loggers/amplify_event_logger_for_sandbox.test.ts
+++ b/packages/cli-core/src/loggers/amplify_event_logger_for_sandbox.test.ts
@@ -39,6 +39,24 @@ void describe('amplify sandbox event logging', () => {
     printerStopSpinnerMock.mock.resetCalls();
   });
 
+  void it('prints the Express Mode stabilization warning emitted on --express deployments', async () => {
+    const expressWarning =
+      '⚠️  Stack deployed using Express Mode. Resources still stabilizing: Worker11F36D0F\n';
+    await classUnderTest.notify({
+      code: 'CDK_TOOLKIT_W5902',
+      action: 'cdk',
+      level: 'warn',
+      message: expressWarning,
+      time: new Date(),
+      data: undefined,
+    } as unknown as AmplifyIoHostEventMessage<unknown>);
+
+    assert.deepStrictEqual(
+      printerLogMock.mock.calls.map((call) => call.arguments[0]),
+      [expressWarning.trim()],
+    );
+  });
+
   void it('generates correct events when customer updated amplify outputs and nothing else', async () => {
     for (const event of updateAmplifyOutputsCdkEvents) {
       await classUnderTest.notify(

--- a/packages/cli-core/src/loggers/amplify_event_loggers.ts
+++ b/packages/cli-core/src/loggers/amplify_event_loggers.ts
@@ -175,6 +175,20 @@ export class AmplifyEventLogger {
       }
     }
 
+    // Express Mode stabilization warning. Emitted by @aws-cdk/toolkit-lib when a
+    // `--express` deployment completes while some resources are still stabilizing.
+    // The message is already formatted by the toolkit (e.g. "Stack deployed using
+    // Express Mode. Resources still stabilizing: ...").
+    if (msg.code === 'CDK_TOOLKIT_W5902') {
+      if (this.printer.isSpinnerRunning()) {
+        this.printer.stopSpinner();
+        this.printer.log(msg.message.trim());
+        this.printer.startSpinner('Deployment in progress...');
+      } else {
+        this.printer.log(msg.message.trim());
+      }
+    }
+
     // CFN Outputs we care about. CDK_TOOLKIT_I5900 code represents outputs message.
     // We save it so we can display at the end of the deployment.
     if (msg.code === 'CDK_TOOLKIT_I5900') {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
     "@aws-amplify/sandbox": "^2.2.1",
     "@aws-amplify/schema-generator": "^1.4.0",
     "@aws-sdk/client-amplify": "^3.936.0",
-    "@aws-sdk/client-cloudformation": "^3.936.0",
+    "@aws-sdk/client-cloudformation": "^3.1078.0",
     "@aws-sdk/client-s3": "^3.936.0",
     "@aws-sdk/client-sts": "^3.936.0",
     "@aws-sdk/credential-provider-ini": "^3.936.0",

--- a/packages/cli/src/commands/sandbox/sandbox_command.test.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.test.ts
@@ -124,6 +124,21 @@ void describe('sandbox command', () => {
     );
   });
 
+  void it('starts sandbox with express mode when --express is provided', async () => {
+    await commandRunner.runCommand('sandbox --express');
+    assert.equal(sandboxStartMock.mock.callCount(), 1);
+    assert.strictEqual(
+      sandboxStartMock.mock.calls[0].arguments[0].express,
+      true,
+    );
+  });
+
+  void it('does not enable express mode by default', async () => {
+    await commandRunner.runCommand('sandbox');
+    assert.equal(sandboxStartMock.mock.callCount(), 1);
+    assert.ok(!sandboxStartMock.mock.calls[0].arguments[0].express);
+  });
+
   void it('throws AmplifyUserError if invalid identifier is provided', async () => {
     const invalidIdentifier = 'invalid@';
     await assert.rejects(
@@ -150,6 +165,7 @@ void describe('sandbox command', () => {
     assert.match(output, /--outputs-format/);
     assert.match(output, /--outputs-out-dir/);
     assert.match(output, /--once/);
+    assert.match(output, /--express/);
     assert.match(output, /--stream-function-logs/);
     assert.match(output, /--logs-filter/);
     assert.match(output, /--logs-out-file/);

--- a/packages/cli/src/commands/sandbox/sandbox_command.ts
+++ b/packages/cli/src/commands/sandbox/sandbox_command.ts
@@ -34,6 +34,7 @@ export type SandboxCommandOptionsKebabCase = ArgumentsKebabCase<
     streamFunctionLogs: boolean | undefined;
     logsFilter: string[] | undefined;
     logsOutFile: string | undefined;
+    express: boolean | undefined;
   } & SandboxCommandGlobalOptions
 >;
 
@@ -156,6 +157,7 @@ export class SandboxCommand implements CommandModule<
       identifier: args.identifier,
       watchForChanges: !args.once,
       functionStreamingOptions,
+      express: args.express,
     });
     process.once('SIGINT', () => void this.sigIntHandler());
   };
@@ -229,6 +231,12 @@ export class SandboxCommand implements CommandModule<
             'logs-filter',
             'logs-out-file',
           ],
+        })
+        .option('express', {
+          describe:
+            'Deploy using CloudFormation/CDK Express mode for faster sandbox deployments',
+          boolean: true,
+          global: false,
         })
         .option('stream-function-logs', {
           describe:

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/client-accessanalyzer": "^3.936.0",
     "@aws-sdk/client-amplify": "^3.936.0",
     "@aws-sdk/client-bedrock-runtime": "3.936.0",
-    "@aws-sdk/client-cloudformation": "^3.936.0",
+    "@aws-sdk/client-cloudformation": "^3.1078.0",
     "@aws-sdk/client-cloudtrail": "^3.937.0",
     "@aws-sdk/client-cognito-identity": "^3.936.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.936.0",

--- a/packages/integration-tests/src/test-in-memory/express_mode_deployment_config.test.ts
+++ b/packages/integration-tests/src/test-in-memory/express_mode_deployment_config.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable spellcheck/spell-checker */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  CloudFormationClient,
+  CreateStackCommand,
+  UpdateStackCommand,
+} from '@aws-sdk/client-cloudformation';
+
+/**
+ * The unit tests mock `Toolkit.deploy`, so they only assert we *ask* for Express
+ * mode, not that it reaches CloudFormation. This exercises the real resolved
+ * `@aws-sdk/client-cloudformation` and asserts `DeploymentConfig.Mode=EXPRESS` is
+ * serialized onto the request. Older SDKs (< 3.1077.0) drop the field, silently
+ * turning `--express` into a STANDARD deployment; this test catches that.
+ */
+void describe('Express mode reaches the CloudFormation request', () => {
+  /**
+   * Sends a command through a real CloudFormationClient whose request handler
+   * captures the serialized HTTP request body and short-circuits before any
+   * network call is made.
+   */
+  const captureSerializedRequest = async (
+    command: unknown,
+  ): Promise<string> => {
+    let capturedBody = '';
+    const client = new CloudFormationClient({
+      region: 'us-east-1',
+      credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+      requestHandler: {
+        handle: async (request: { body?: string }) => {
+          capturedBody = typeof request.body === 'string' ? request.body : '';
+          throw new Error('__request_captured__');
+        },
+      } as never,
+    });
+
+    try {
+      await client.send(command as never);
+    } catch (error) {
+      if (!String(error).includes('__request_captured__')) {
+        throw error;
+      }
+    }
+
+    return capturedBody;
+  };
+
+  // The sandbox `--express` path performs a direct CloudFormation deployment,
+  // which issues CreateStack (new stack) or UpdateStack (existing stack).
+  const commands = [
+    {
+      name: 'CreateStack',
+      command: new CreateStackCommand({
+        StackName: 'test-express-stack',
+        DeploymentConfig: { Mode: 'EXPRESS' },
+      }),
+    },
+    {
+      name: 'UpdateStack',
+      command: new UpdateStackCommand({
+        StackName: 'test-express-stack',
+        DeploymentConfig: { Mode: 'EXPRESS' },
+      }),
+    },
+  ];
+
+  commands.forEach(({ name, command }) => {
+    void it(`serializes DeploymentConfig.Mode=EXPRESS on ${name}`, async () => {
+      const body = await captureSerializedRequest(command);
+      assert.match(
+        body,
+        /DeploymentConfig\.Mode=EXPRESS/,
+        `Express mode was not serialized onto the ${name} request. The resolved ` +
+          '@aws-sdk/client-cloudformation likely predates DeploymentConfig support (>= 3.1077.0).',
+      );
+    });
+  });
+});

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/types": "^3.734.0"
   },
   "dependencies": {
-    "@aws-cdk/toolkit-lib": "1.19.0"
+    "@aws-cdk/toolkit-lib": "1.32.0"
   },
   "imports": {
     "#package.json": "./package.json"

--- a/packages/sandbox/API.md
+++ b/packages/sandbox/API.md
@@ -44,6 +44,7 @@ export type SandboxOptions = {
     format?: ClientConfigFormat;
     watchForChanges?: boolean;
     functionStreamingOptions?: SandboxFunctionStreamingOptions;
+    express?: boolean;
 };
 
 // @public

--- a/packages/sandbox/src/file_watching_sandbox.test.ts
+++ b/packages/sandbox/src/file_watching_sandbox.test.ts
@@ -424,6 +424,33 @@ void describe('Sandbox using local project name resolver', () => {
     ]);
   });
 
+  void it('forwards express option to the deployer when set', async () => {
+    ({ sandboxInstance, fileChangeEventCallback } = await setupAndStartSandbox(
+      {
+        executor: sandboxExecutor,
+        ssmClient: ssmClientMock,
+        functionsLogStreamer:
+          functionsLogStreamerMock as unknown as LambdaFunctionLogStreamer,
+      },
+      {
+        dir: 'testDir',
+        exclude: ['exclude1', 'exclude2'],
+        express: true,
+      },
+      false,
+    ));
+
+    assert.strictEqual(backendDeployerDeployMock.mock.callCount(), 1);
+    assert.deepEqual(backendDeployerDeployMock.mock.calls[0].arguments, [
+      testSandboxBackendId,
+      {
+        secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
+        validateAppSources: false,
+        express: true,
+      },
+    ]);
+  });
+
   void it('makes initial deployment with type checking at start if some typescript file is present', async () => {
     // using this file's dir, mocking a glob search appears to be impossible
     const testDir = path.dirname(fileURLToPath(new URL(import.meta.url)));

--- a/packages/sandbox/src/file_watching_sandbox.ts
+++ b/packages/sandbox/src/file_watching_sandbox.ts
@@ -301,6 +301,7 @@ export class FileWatchingSandbox extends EventEmitter implements Sandbox {
           // It's important to pass this as callback so that debounce does
           // not reset tracker prematurely
           this.shouldValidateAppSources,
+          options.express,
         );
         const data: DeepPartial<TelemetryPayload> = {
           latency: {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -37,6 +37,7 @@ export type SandboxOptions = {
   format?: ClientConfigFormat;
   watchForChanges?: boolean;
   functionStreamingOptions?: SandboxFunctionStreamingOptions;
+  express?: boolean;
 };
 
 export type SandboxFunctionStreamingOptions = {

--- a/packages/sandbox/src/sandbox_executor.test.ts
+++ b/packages/sandbox/src/sandbox_executor.test.ts
@@ -140,4 +140,26 @@ void describe('Sandbox executor', () => {
       );
     });
   });
+
+  void it('forwards express flag to the deployer', async () => {
+    await sandboxExecutor.deploy(
+      {
+        namespace: 'testSandboxId',
+        name: 'testSandboxName',
+        type: 'sandbox',
+      },
+      validateAppSourcesProvider,
+      true,
+    );
+
+    assert.strictEqual(backendDeployerDeployMock.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      backendDeployerDeployMock.mock.calls[0].arguments[1],
+      {
+        secretLastUpdated: newlyUpdatedSecretItem.lastUpdated,
+        validateAppSources: true,
+        express: true,
+      },
+    );
+  });
 });

--- a/packages/sandbox/src/sandbox_executor.ts
+++ b/packages/sandbox/src/sandbox_executor.ts
@@ -38,6 +38,7 @@ export class AmplifySandboxExecutor {
   deploy = async (
     backendId: BackendIdentifier,
     validateAppSourcesProvider: () => boolean,
+    express?: boolean,
   ): Promise<DeployResult> => {
     this.printer.log('[Sandbox] Executing command `deploy`', LogLevel.DEBUG);
     const secretLastUpdated = await this.getSecretLastUpdated(backendId);
@@ -49,6 +50,7 @@ export class AmplifySandboxExecutor {
       return this.backendDeployer.deploy(backendId, {
         secretLastUpdated,
         validateAppSources,
+        ...(express !== undefined ? { express } : {}),
       });
     });
   };


### PR DESCRIPTION
## Problem

`ampx sandbox` has no way to opt into the newly released CloudFormation/CDK Express mode, which lets stack operations complete once resource configuration is applied instead of waiting for extended stabilization. For the sandbox edit -> deploy -> verify loop (used by both humans and AI coding agents), this is a meaningful speedup.

**Issue number, if available:** 

Close #3261

## Changes

- Add an opt-in `ampx sandbox --express` flag. The flag threads `express: true` through `SandboxOptions` -> the sandbox executor -> `BackendDeployer` -> `Toolkit.deploy()`. Express is only applied to sandbox deployments; the
  existing `hotswap` + `direct` fallback deployment method is preserved.
- Bump `@aws-cdk/toolkit-lib` `1.19.0` -> `1.32.0`, the version that exposes the `express` deploy option and sets `DeploymentConfig.Mode = 'EXPRESS'` on the CloudFormation request.
- Raise `@aws-sdk/client-cloudformation` to `^3.1078.0`. `toolkit-lib` only requires `^3`, so the tree resolved an older SDK (3.1017.0) that does not model the `DeploymentConfig` field and silently dropped it, leaving deployments in `STANDARD` mode. Support was added in `3.1077.0`.
- Surface the Express Mode stabilization warning (`CDK_TOOLKIT_W5902`) in the sandbox output, e.g. `Stack deployed using Express Mode. Resources still stabilizing: ...`.

**Corresponding docs PR, if applicable:** 

_None yet — the `--express` flag help text is included; longer-form docs can follow._

## Validation

- Unit tests added/updated:
  - `backend-deployer`: asserts `express: true` is passed to `Toolkit.deploy()` only for sandbox deployments, and never for branch deployments.
  - `sandbox`: asserts `express` is forwarded through the executor and `file_watching_sandbox` to `BackendDeployer`.
  - `backend-cli`: asserts `--express` parses and reaches `sandbox.start`.
  - `cli-core`: asserts the `CDK_TOOLKIT_W5902` Express warning is printed.
- Manual verification: created a test project with `npm run setup:test-project <name>` and ran `ampx sandbox --express` against it, confirming the deployment runs in Express mode and the Express Mode stabilization warning is shown.
- Verified at the dependency-resolution level that `@aws-cdk/toolkit-lib@1.32.0` resolves `@aws-sdk/client-cloudformation@3.1078.0` (which serializes the `DeploymentConfig` Express field).
- Note: Express mode applies only to full CloudFormation deployments; changes handled by hotswap bypass CloudFormation and do not emit the Express warning.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the Project Architecture README, I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
