### PR TITLE
fix(hosting): upgrade @aws-blocks/hosting to ^0.1.5 (CloudFront S3-origin policy fix)

### DIFF
--- a/.changeset/upgrade-aws-blocks-hosting-0-1-5.md
+++ b/.changeset/upgrade-aws-blocks-hosting-0-1-5.md
@@ -1,0 +1,16 @@
+---
+'@aws-amplify/hosting': patch
+---
+
+fix(hosting): upgrade `@aws-blocks/hosting` to `^0.1.5`
+
+Bumps the vendored `@aws-blocks/hosting` construct from `0.1.4` to `0.1.5`, which
+fixes the CloudFront `InvalidRequest` failure on compute/SSR deployments. `0.1.4`
+attached the AWS-managed `ALL_VIEWER_EXCEPT_HOST_HEADER` origin request policy to
+CloudFront behaviors whose origin is S3 (the default behavior and edge-route
+behaviors), which CloudFront rejects — "S3 Origins can only use the following
+managed request policies: CORS-CustomOrigin, CORS-S3Origin,
+UserAgentRefererHeaders" — rolling back Nuxt/Astro/vanilla-CDK SSR distributions
+at create time. `0.1.5` replaces it with a synthesized custom origin request
+policy (all viewer data except `Host`) on both S3-origin behaviors; the sentinel
+behaviors (custom/function-URL origins) keep the managed policy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16473,6 +16473,33 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@aws-blocks/hosting": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-blocks/hosting/-/hosting-0.1.5.tgz",
+      "integrity": "sha512-dET+NiQdbCPQezAKddQzD/2jEtXpwRJoQgPZtS/KgooVLPa0lK4G/dLjDu40HBE4+JluuCoTqeuDKZjidQ99IA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1075.0",
+        "@aws-sdk/signature-v4a": "^3.1069.0",
+        "cross-spawn": "^7.0.6",
+        "fast-glob": "^3.3.2",
+        "jiti": "^2.4.0",
+        "local-pkg": "^0.5.0",
+        "parse-cache-control": "^1.0.1",
+        "semver": "^7.6.0",
+        "zod": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opennextjs/aws": ">=3.10.0",
+        "aws-cdk-lib": "^2.257.0",
+        "constructs": "^10.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@opennextjs/aws": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aws-blocks/pipeline": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@aws-blocks/pipeline/-/pipeline-0.1.1.tgz",
@@ -44520,35 +44547,8 @@
         "@aws-amplify/backend-output-storage": "^1.3.4",
         "@aws-amplify/platform-core": "^1.11.0",
         "@aws-amplify/plugin-types": "^1.12.0",
-        "@aws-blocks/hosting": "^0.1.4",
+        "@aws-blocks/hosting": "^0.1.5",
         "@aws-blocks/pipeline": "^0.1.1"
-      },
-      "peerDependencies": {
-        "@opennextjs/aws": ">=3.10.0",
-        "aws-cdk-lib": "^2.257.0",
-        "constructs": "^10.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@opennextjs/aws": {
-          "optional": true
-        }
-      }
-    },
-    "packages/hosting/node_modules/@aws-blocks/hosting": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@aws-blocks/hosting/-/hosting-0.1.4.tgz",
-      "integrity": "sha512-xkrI4X0bQGH41UyVOlFyu/uL9qmphULNNyi1UAMLhxsJROc90ckNytqwoKOD6eyHxgyuTS+J6yPJtUP2miT8kw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1075.0",
-        "@aws-sdk/signature-v4a": "^3.1069.0",
-        "cross-spawn": "^7.0.6",
-        "fast-glob": "^3.3.2",
-        "jiti": "^2.4.0",
-        "local-pkg": "^0.5.0",
-        "parse-cache-control": "^1.0.1",
-        "semver": "^7.6.0",
-        "zod": "^3.25.0"
       },
       "peerDependencies": {
         "@opennextjs/aws": ">=3.10.0",

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -43,7 +43,7 @@
     "@aws-amplify/backend-output-storage": "^1.3.4",
     "@aws-amplify/platform-core": "^1.11.0",
     "@aws-amplify/plugin-types": "^1.12.0",
-    "@aws-blocks/hosting": "^0.1.4",
+    "@aws-blocks/hosting": "^0.1.5",
     "@aws-blocks/pipeline": "^0.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Purpose

Upgrade the vendored `@aws-blocks/hosting` construct from `0.1.4` → `^0.1.5` to fix the CloudFront `InvalidRequest` failure that is rolling back all compute/SSR hosting deployments (and their E2E tests) on this branch.

## Root cause (fixed by 0.1.5)

`0.1.4` attached the AWS-managed origin request policy `ALL_VIEWER_EXCEPT_HOST_HEADER` to CloudFront behaviors whose origin is **S3**. CloudFront rejects that at distribution create:

> `AWS::CloudFront::Distribution: The parameter Origin S3 Origins can only use the following managed request policies: CORS-CustomOrigin, CORS-S3Origin, UserAgentRefererHeaders` — `400 InvalidRequest`

`0.1.5` replaces it with a synthesized **custom** origin request policy (all viewer data except `Host`) on **both** S3-origin behaviors — the default behavior **and** the edge-route behavior. The sentinel behaviors (custom / Lambda function-URL origins) correctly keep the managed policy.

I verified in the published `0.1.5` tarball that both S3-origin sites now use the custom policy (`cdn_construct.js` — default behavior + the edge-route `additionalBehaviors[pattern]` block), so this closes the full bug class, not just the default behavior.

## Changes
- `packages/hosting/package.json`: `@aws-blocks/hosting` `^0.1.4` → `^0.1.5`
- `package-lock.json`: resolved to `0.1.5` from the **public** `registry.npmjs.org` (integrity matches the public registry; no internal-mirror URLs leaked)
- Added a `patch` changeset for `@aws-amplify/hosting`

## Verification
- ✅ `tsc --build packages/hosting` — clean (no API breakage on the 0.1.4→0.1.5 bump)
- ✅ `packages/hosting` unit tests — **74 pass / 0 fail**, including `shim_parity` (validates our shim matches the upstream `@aws-blocks/hosting` API) and the `./error` re-export tests
- ✅ lockfile stable + integrity verified against the public registry

## Expected E2E impact
The compute/SSR hosting deployment jobs that were failing with the CloudFront S3-origin error — `vanilla_cdk_hosting_ssr`, `standalone_hosting_nuxt`, `standalone_hosting_astro` / `astro_basepath`, `standalone_hosting_ssr` / `ssr_monorepo` — should now deploy and pass. Static SPA fixtures were already passing and are unaffected.

## Notes
- The public npm registry version line for this package is `0.1.x` (latest `0.1.5`, published 2026-07-15); it is **not** the `0.23.x` line that exists only on an internal mirror. This PR intentionally targets the public `0.1.5`, which is what CI resolves.
- Targets `snapshot/iac-hosting` (the hosting feature branch), not `main`.
