### PR TITLE
ci: drop EOL Node 18/20, run CI on supported Node 22/24/26

### DIFF
--- a/.github/workflows/deprecate_release.yml
+++ b/.github/workflows/deprecate_release.yml
@@ -35,10 +35,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/install_with_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
   deprecate_release:
     needs:
@@ -60,10 +60,10 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
       - name: Deprecate release versions
         run: npx tsx scripts/deprecate_release.ts

--- a/.github/workflows/e2e_resource_cleanup.yml
+++ b/.github/workflows/e2e_resource_cleanup.yml
@@ -25,10 +25,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/install_with_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -43,7 +43,7 @@ on:
         description: 'Node versions list (as JSON array).'
         required: false
         type: string
-        default: '["20", "22"]'
+        default: '["22", "24", "26"]'
   workflow_call:
     inputs:
       desired-cdk-lib-version:
@@ -74,7 +74,7 @@ on:
         description: 'Node versions list (as JSON array).'
         required: false
         type: string
-        default: '["20", "22"]'
+        default: '["22", "24", "26"]'
 
 env:
   # Health checks can run on un-released code. Often work in progress.
@@ -118,7 +118,7 @@ jobs:
           echo "os=$os" >> "$GITHUB_OUTPUT"
           echo "os_for_e2e=$os_for_e2e" >> "$GITHUB_OUTPUT"
           if [ -z "${{ inputs.node }}" ]; then
-            echo 'node=["20", "22"]' >> "$GITHUB_OUTPUT"
+            echo 'node=["22", "24", "26"]' >> "$GITHUB_OUTPUT"
           else
             echo 'node=${{ inputs.node }}' >> "$GITHUB_OUTPUT"
           fi
@@ -136,10 +136,11 @@ jobs:
         # Changing between standard and custom workers requires full install cache invalidation
         os: ${{ fromJSON(needs.resolve_inputs.outputs.os) }}
         node: ${{ fromJSON(needs.resolve_inputs.outputs.node) }}
-        # Always include Node 18 and Ubuntu. Non-testing jobs depend on it.
+        # Always include Node 24 and Ubuntu. Non-testing jobs depend on it
+        # (they restore the Node-24-keyed install/build cache produced here).
         include:
           - os: ubuntu-latest
-            node: 18
+            node: 24
     runs-on: ${{ matrix.os }}
     needs:
       - resolve_inputs
@@ -157,9 +158,10 @@ jobs:
     strategy:
       matrix:
         node: ${{ fromJSON(needs.resolve_inputs.outputs.node) }}
-        # Always include Node 18. Non-testing jobs depend on it.
+        # Always include Node 24. Non-testing jobs depend on it
+        # (they restore the Node-24-keyed build cache produced here).
         include:
-          - node: 18
+          - node: 24
     runs-on: ubuntu-latest
     needs:
       - install
@@ -202,10 +204,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: |
           npm run set-script-shell
@@ -219,10 +221,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - name: Pin some dependencies to nearest patch and rebuild
         run: |
@@ -249,10 +251,10 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       # Warm the shared verdaccio proxy cache so the ~27 per-package installs
       # below are served from disk instead of each cold-proxying the full
@@ -260,7 +262,7 @@ jobs:
       - name: Warm verdaccio cache
         uses: ./.github/actions/warm_verdaccio_cache
         with:
-          node-version: 18
+          node-version: 24
       - name: Publish packages locally
         timeout-minutes: 5
         env:
@@ -316,10 +318,10 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - name: Handle Dependabot version update pull request
         run: |
@@ -349,10 +351,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - name: Check if any E2E tests should run
         id: check
@@ -405,7 +407,7 @@ jobs:
         uses: ./.github/actions/setup_baseline_version
         id: setup_baseline_version
         with:
-          node_version: 18
+          node_version: 24
       - name: Checkout current version
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       # Warm the shared verdaccio proxy cache so the first create-amplify install
@@ -414,12 +416,12 @@ jobs:
       - name: Warm verdaccio cache
         uses: ./.github/actions/warm_verdaccio_cache
         with:
-          node-version: 18
+          node-version: 24
       - name: Run e2e iam access drift test
         uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-          node_version: 18
+          node_version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
           # This test does two create-amplify installs + two live deploys per
           # attempt; a single PASSING attempt currently measures ~47 min (heavy
@@ -459,7 +461,7 @@ jobs:
         uses: ./.github/actions/setup_baseline_version
         id: setup_baseline_version
         with:
-          node_version: 18
+          node_version: 24
       - name: Checkout current version
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       # Warm the shared verdaccio proxy cache so the first create-amplify install
@@ -468,12 +470,12 @@ jobs:
       - name: Warm verdaccio cache
         uses: ./.github/actions/warm_verdaccio_cache
         with:
-          node-version: 18
+          node-version: 24
       - name: Run e2e amplify outputs backwards compatibility test
         uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-          node_version: 18
+          node_version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
           # MEASURED: one full attempt needs ~60-65 min (3 full installs that
           # each re-unpack the ~450 MB bundled data/graphql constructs, + 2
@@ -509,7 +511,7 @@ jobs:
         uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-          node_version: 18
+          node_version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
           attempt_timeout_minutes: 120
           run: npm run test:dir packages/integration-tests/lib/test-e2e/hosting.test.js
@@ -530,7 +532,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: echo "$(npx tsx scripts/generate_sparse_test_matrix.ts 'packages/integration-tests/lib/test-e2e/deployment/*.deployment.test.js' '${{ needs.resolve_inputs.outputs.node }}' '${{ needs.resolve_inputs.outputs.os_for_e2e }}')"
       - name: Generate matrix with retry
@@ -597,7 +599,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: echo "$(npx tsx scripts/generate_sparse_test_matrix.ts 'packages/integration-tests/lib/test-e2e/sandbox/*.sandbox.test.js' '${{ needs.resolve_inputs.outputs.node }}' '${{ needs.resolve_inputs.outputs.os_for_e2e }}')"
       - name: Generate matrix with retry
@@ -666,10 +668,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 20
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 20
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: cd packages/cli && npm link
       - name: Run e2e notices tests
@@ -697,7 +699,7 @@ jobs:
         uses: ./.github/actions/run_with_e2e_account
         with:
           e2e_test_accounts: ${{ vars.E2E_TEST_ACCOUNTS }}
-          node_version: 18
+          node_version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
           link_cli: true
           attempt_timeout_minutes: 25
@@ -713,9 +715,9 @@ jobs:
         # skip multiple node version test on other os
         exclude:
           - os: macos-14
-            node-version: 20
+            node-version: 26
           - os: windows-2025
-            node-version: 18
+            node-version: 24
           - os: macos-14
             node-version: 22
           - os: windows-2025
@@ -807,10 +809,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: npm run lint
         env:
@@ -826,10 +828,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       # - run: npm run check:dependencies
   check_tsconfig_refs:
@@ -841,10 +843,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: npm run check:tsconfig-refs
   check_api_extract:
@@ -856,10 +858,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: npm run check:api
         env:
@@ -876,10 +878,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: npm run check:create-amplify-deps
   docs_build_and_publish:
@@ -894,10 +896,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: npm run docs
       - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # version 4.0.0
@@ -915,10 +917,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: git fetch origin
       - run: npm run diff:check "$BASE_SHA"
@@ -937,10 +939,10 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - name: Validate that PR has changeset
         run: npx --package @changesets/cli -- changeset status --since origin/"$BASE_REF"
@@ -966,10 +968,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - run: npx --verbose --package @changesets/cli -- changeset version
       - run: npm run check:package-versions
@@ -988,10 +990,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - id: is_version_packages_commit
         run: echo "is_version_packages_commit=$(npx tsx scripts/is_version_packages_commit.ts)" >> "$GITHUB_OUTPUT"
@@ -1027,10 +1029,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: ${{ needs.resolve_inputs.outputs.cdk_lib_version }}
       - id: is_version_packages_commit
         run: echo "is_version_packages_commit=$(npx tsx scripts/is_version_packages_commit.ts)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/restore_release.yml
+++ b/.github/workflows/restore_release.yml
@@ -31,10 +31,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/install_with_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
   restore_release:
     needs:
@@ -55,10 +55,10 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_install_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
       - name: Restore release versions
         run: npx tsx scripts/restore_release.ts

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/install_with_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
   build:
     runs-on: ubuntu-latest
@@ -23,10 +23,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/build_with_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
   test:
     needs:
@@ -36,10 +36,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 18
+          node-version: 24
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
       - run: npm run set-script-shell
       - run: npm run test
@@ -59,7 +59,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - uses: ./.github/actions/restore_build_cache
         with:
-          node-version: 18
+          node-version: 24
           cdk-lib-version: FROM_PACKAGE_LOCK
       - name: Publish snapshot to npm
         run: |

--- a/.github/workflows/validate_cdk_release.yml
+++ b/.github/workflows/validate_cdk_release.yml
@@ -29,7 +29,7 @@ jobs:
       # They don't bring much value, but may bring instability and extra latency.
       include-macos: false
       include-windows: false
-      node: '["18"]'
+      node: '["24"]'
       # Exclude package manager and create-amplify tests.
       # They don't bring functional coverage for CDK usage patterns.
       include-package-manager-e2e-tests: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/semver": "^7.7.0",
         "@typescript-eslint/eslint-plugin": "^8.23.0",
         "@typescript-eslint/parser": "^8.23.0",
-        "c8": "^10.1.3",
+        "c8": "^12.0.0",
         "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-config-xo-typescript": "^0.57.0",
@@ -28183,9 +28183,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -33485,9 +33485,9 @@
       }
     },
     "node_modules/c8": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
-      "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-12.0.0.tgz",
+      "integrity": "sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -33498,16 +33498,16 @@
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.1.6",
-        "test-exclude": "^7.0.1",
+        "test-exclude": "^8.0.0",
         "v8-to-istanbul": "^9.0.0",
-        "yargs": "^17.7.2",
+        "yargs": "^18.0.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
         "c8": "bin/c8.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       },
       "peerDependencies": {
         "monocart-coverage-reports": "^2"
@@ -33518,27 +33518,33 @@
         }
       }
     },
+    "node_modules/c8/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/c8/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
-    },
-    "node_modules/c8/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/c8/node_modules/find-up": {
       "version": "5.0.0",
@@ -33555,16 +33561,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/c8/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/c8/node_modules/locate-path": {
@@ -33615,37 +33611,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/c8/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+    "node_modules/c8/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/c8/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/c8/node_modules/y18n": {
@@ -33659,22 +33638,31 @@
       }
     },
     "node_modules/c8/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^7.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^22.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/c8/node_modules/yargs/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -43381,209 +43369,36 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
-      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^10.4.1",
+        "glob": "^13.0.6",
         "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/test-exclude/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/test-exclude/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
+        "node": "20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/test-exclude/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/test-exclude/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/test-exclude/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/text-decoder": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/semver": "^7.7.0",
     "@typescript-eslint/eslint-plugin": "^8.23.0",
     "@typescript-eslint/parser": "^8.23.0",
-    "c8": "^10.1.3",
+    "c8": "^12.0.0",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-config-xo-typescript": "^0.57.0",


### PR DESCRIPTION
> **Stacked on #3283.** Base is `chore/e2e-ci-hardening` (PR #3283), not `main`: the e2e reliability fixes there (credential lifetime, install speed, runner OOM) are required for these jobs to pass. Merge #3283 first, then this retargets to `main` automatically. Diff below is Node-version-only.

## Purpose

CI was still running **Node 18** (EOL 2025-04-30) and **Node 20** (EOL 2026-04-30), which triggers `NodeVersionSupportWarning` in job output and tests versions Node/AWS SDK no longer support. Replace the EOL versions with currently-supported majors.

## Change (1:1 replacement — no new checks)

- Node matrix `["18", "20", "22"]` → **`["22", "24", "26"]`** (drop the two EOL versions, add the two newest supported; keep 22).
  - **22** & **24** — Active LTS. **26** — released 2026-05-05, becomes LTS 2026-10-28. **25 skipped** (odd-numbered, non-LTS, EOL 2026-06-01).
- Retarget the pinned single-node jobs and the always-include install/build cache node **18 → 24** (the many literal `node-version: 18` test jobs restore the Node-keyed build cache, so the pinned cache node must match the retargeted jobs).
- Preserve the `e2e_create_amplify` OS-trim (`exclude`) mapping: ubuntu runs all 3, macos runs 1, windows runs 1 → **still 5 jobs**, unchanged from before.
- Bump the release/cleanup workflows off Node 18: `deprecate_release`, `restore_release`, `snapshot_release`, `e2e_resource_cleanup`, `validate_cdk_release`.

## Explicitly NOT changed

- **`engines.node`** in `package.json` / `cli` / `create-amplify` is left as-is. That field is the **customer-facing supported-runtime contract** and changing it is a support-policy decision (needs a changeset + owner sign-off), out of scope for a CI fix.

## Verification

- All 6 changed workflows parse as valid YAML.
- Repo-wide sweep: **0** remaining `node-version: 18/20` (or matrix `"18"/"20"`) references in `.github/`.
- Matrix math confirmed: create_amplify → ubuntu`[22,24,26]`, macos`[24]`, windows`[26]` = 5 jobs (same as the prior 18/20/22 layout).
- Diff contains only Node-version numbers + their explanatory comments.

## Note on the failing `notices` e2e test that prompted this

The `notices.test.ts` failure in the referenced run is a **DNS/network error** (`getaddrinfo ENOTFOUND beta.notices.cli.amplify.aws`), not a Node-version failure — the `NodeVersionSupportWarning` was only a warning in that output. This PR removes the warning and the EOL versions, but the notices test failure is a separate infra/endpoint issue tracked independently.

