### PR TITLE
feat(backend-data): add minimizeRdsVpcEndpoints support to defineData for SQL data sources

### DIFF
--- a/.changeset/minimize-rds-vpc-endpoints.md
+++ b/.changeset/minimize-rds-vpc-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-data': minor
+---
+
+Map `minimizeRdsVpcEndpoints` from `DataSourceConfiguration` onto the generated SQL `ModelDataSourceStrategy` so the customer setting is forwarded to the SQL strategy.

--- a/.changeset/minimize-rds-vpc-endpoints.md
+++ b/.changeset/minimize-rds-vpc-endpoints.md
@@ -1,5 +1,6 @@
 ---
 '@aws-amplify/backend-data': minor
+'@aws-amplify/backend': minor
 ---
 
 Map `minimizeRdsVpcEndpoints` from `DataSourceConfiguration` onto the generated SQL `ModelDataSourceStrategy` so the customer setting is forwarded to the SQL strategy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.17.1.tgz",
-      "integrity": "sha512-DuwRm2n2iRnIAKuvv760KII+P2V/i1hrnMRXexIeftKWf/fv6azVqEyHNb/PPR2u8+jfdJlzg6FFBwDGQt2qbA==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.17.7.tgz",
+      "integrity": "sha512-SLRKbgItEX0JHhHnx1L5mR291fC19YetyZFsljxXyeM/Juuqb69WRtGfmcxs/7YO7+4dgU9JmYdzdUBG3iExFw==",
       "bundleDependencies": [
         "@aws-amplify/ai-constructs",
         "@aws-amplify/backend-output-schemas",
@@ -772,12 +772,15 @@
         "@aws-amplify/graphql-validate-transformer",
         "@aws-amplify/platform-core",
         "@aws-amplify/plugin-types",
+        "@babel/runtime",
         "@aws-crypto/crc32",
         "@aws-crypto/sha256-browser",
         "@aws-crypto/sha256-js",
         "@aws-crypto/supports-web-crypto",
         "@aws-crypto/util",
         "@aws-sdk/client-bedrock-runtime",
+        "@aws-sdk/eventstream-handler-node",
+        "@aws-sdk/middleware-eventstream",
         "@aws-sdk/client-sso",
         "@aws-sdk/client-sso-oidc",
         "@aws-sdk/client-sts",
@@ -793,12 +796,17 @@
         "@aws-sdk/middleware-host-header",
         "@aws-sdk/middleware-logger",
         "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-sdk-s3",
         "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/middleware-websocket",
         "@aws-sdk/nested-clients",
         "@aws-sdk/region-config-resolver",
+        "@aws-sdk/signature-v4-multi-region",
         "@aws-sdk/token-providers",
         "@aws-sdk/types",
+        "@aws-sdk/util-arn-parser",
         "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-format-url",
         "@aws-sdk/util-locate-window",
         "@aws-sdk/util-user-agent-browser",
         "@aws-sdk/util-user-agent-node",
@@ -859,8 +867,6 @@
         "charenc",
         "ci-info",
         "crypt",
-        "fast-xml-builder",
-        "fast-xml-parser",
         "fs-extra",
         "graceful-fs",
         "graphql",
@@ -870,6 +876,7 @@
         "immer",
         "is-buffer",
         "is-ci",
+        "json-schema-to-ts",
         "jsonfile",
         "libphonenumber-js",
         "lodash",
@@ -877,40 +884,39 @@
         "lodash.snakecase",
         "md5",
         "object-hash",
-        "path-expression-matcher",
         "pluralize",
+        "regenerator-runtime",
         "semver",
-        "strnum",
+        "ts-algebra",
         "ts-dedent",
         "tslib",
         "universalify",
         "uuid",
         "zod"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.6.1",
+        "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/backend-output-schemas": "^1.0.0",
         "@aws-amplify/backend-output-storage": "^1.0.0",
-        "@aws-amplify/graphql-api-construct": "1.21.1",
-        "@aws-amplify/graphql-auth-transformer": "4.2.6",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.14",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.16",
+        "@aws-amplify/graphql-api-construct": "1.22.2",
+        "@aws-amplify/graphql-auth-transformer": "4.2.9",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.16",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.18",
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-function-transformer": "3.1.18",
-        "@aws-amplify/graphql-generation-transformer": "1.2.6",
-        "@aws-amplify/graphql-http-transformer": "3.0.21",
-        "@aws-amplify/graphql-index-transformer": "3.1.1",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.21",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.21",
-        "@aws-amplify/graphql-relational-transformer": "3.1.13",
-        "@aws-amplify/graphql-searchable-transformer": "3.1.1",
-        "@aws-amplify/graphql-sql-transformer": "0.4.21",
-        "@aws-amplify/graphql-transformer": "2.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
-        "@aws-amplify/graphql-validate-transformer": "1.1.6",
+        "@aws-amplify/graphql-function-transformer": "3.1.20",
+        "@aws-amplify/graphql-generation-transformer": "1.2.8",
+        "@aws-amplify/graphql-http-transformer": "3.0.23",
+        "@aws-amplify/graphql-index-transformer": "3.1.3",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.24",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.23",
+        "@aws-amplify/graphql-relational-transformer": "3.1.15",
+        "@aws-amplify/graphql-searchable-transformer": "3.1.4",
+        "@aws-amplify/graphql-sql-transformer": "0.4.23",
+        "@aws-amplify/graphql-transformer": "2.5.1",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
+        "@aws-amplify/graphql-validate-transformer": "1.1.8",
         "@aws-amplify/platform-core": "^1.0.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "@aws-crypto/crc32": "5.2.0",
@@ -918,90 +924,96 @@
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
         "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.622.0",
-        "@aws-sdk/client-sso": "3.637.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "^3.624.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-ini": "3.637.0",
-        "@aws-sdk/credential-provider-login": "3.955.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/nested-clients": "^3.777.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/token-providers": "3.614.0",
-        "@aws-sdk/types": "^3.734.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@aws-sdk/xml-builder": "3.804.0",
+        "@aws-sdk/client-bedrock-runtime": "3.1078.0",
+        "@aws-sdk/client-sso": "3.1078.0",
+        "@aws-sdk/client-sso-oidc": "3.1078.0",
+        "@aws-sdk/client-sts": "3.1078.0",
+        "@aws-sdk/core": "3.974.26",
+        "@aws-sdk/credential-provider-env": "3.972.52",
+        "@aws-sdk/credential-provider-http": "3.972.54",
+        "@aws-sdk/credential-provider-ini": "3.972.59",
+        "@aws-sdk/credential-provider-login": "3.972.58",
+        "@aws-sdk/credential-provider-node": "3.972.61",
+        "@aws-sdk/credential-provider-process": "3.972.52",
+        "@aws-sdk/credential-provider-sso": "3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "3.972.58",
+        "@aws-sdk/eventstream-handler-node": "3.972.25",
+        "@aws-sdk/middleware-eventstream": "3.972.21",
+        "@aws-sdk/middleware-host-header": "3.972.27",
+        "@aws-sdk/middleware-logger": "3.972.26",
+        "@aws-sdk/middleware-recursion-detection": "3.972.28",
+        "@aws-sdk/middleware-sdk-s3": "3.972.57",
+        "@aws-sdk/middleware-user-agent": "3.972.56",
+        "@aws-sdk/middleware-websocket": "3.972.34",
+        "@aws-sdk/nested-clients": "3.997.26",
+        "@aws-sdk/region-config-resolver": "3.972.30",
+        "@aws-sdk/signature-v4-multi-region": "3.996.38",
+        "@aws-sdk/token-providers": "3.1078.0",
+        "@aws-sdk/types": "3.973.15",
+        "@aws-sdk/util-arn-parser": "3.972.21",
+        "@aws-sdk/util-endpoints": "3.996.25",
+        "@aws-sdk/util-format-url": "3.972.28",
+        "@aws-sdk/util-locate-window": "3.965.8",
+        "@aws-sdk/util-user-agent-browser": "3.972.27",
+        "@aws-sdk/util-user-agent-node": "3.973.42",
+        "@aws-sdk/xml-builder": "3.972.33",
         "@aws/lambda-invoke-store": "^0.2.2",
+        "@babel/runtime": "^7.18.3",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/resources": "2.0.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/eventstream-codec": "^3.1.2",
-        "@smithy/eventstream-serde-browser": "^3.0.6",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.5",
-        "@smithy/eventstream-serde-universal": "^3.0.5",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/querystring-parser": "^3.0.3",
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.3",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/abort-controller": "4.2.12",
+        "@smithy/config-resolver": "4.4.17",
+        "@smithy/core": "3.29.0",
+        "@smithy/credential-provider-imds": "4.4.5",
+        "@smithy/eventstream-codec": "4.2.14",
+        "@smithy/eventstream-serde-browser": "4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "4.3.14",
+        "@smithy/eventstream-serde-node": "4.2.14",
+        "@smithy/eventstream-serde-universal": "4.2.14",
+        "@smithy/fetch-http-handler": "5.6.2",
+        "@smithy/hash-node": "4.2.14",
+        "@smithy/invalid-dependency": "4.2.14",
+        "@smithy/is-array-buffer": "4.2.2",
+        "@smithy/middleware-content-length": "4.2.14",
+        "@smithy/middleware-endpoint": "4.4.32",
+        "@smithy/middleware-retry": "4.5.7",
+        "@smithy/middleware-serde": "4.2.20",
+        "@smithy/middleware-stack": "4.2.14",
+        "@smithy/node-config-provider": "4.3.14",
+        "@smithy/node-http-handler": "4.9.2",
+        "@smithy/property-provider": "4.2.14",
+        "@smithy/protocol-http": "5.3.14",
+        "@smithy/querystring-builder": "4.2.14",
+        "@smithy/querystring-parser": "4.2.14",
+        "@smithy/service-error-classification": "4.3.1",
+        "@smithy/shared-ini-file-loader": "4.4.9",
+        "@smithy/signature-v4": "5.6.1",
+        "@smithy/smithy-client": "4.12.13",
+        "@smithy/types": "4.15.1",
+        "@smithy/url-parser": "4.2.14",
+        "@smithy/util-base64": "4.3.2",
+        "@smithy/util-body-length-browser": "4.2.2",
+        "@smithy/util-body-length-node": "4.2.3",
+        "@smithy/util-buffer-from": "4.2.2",
+        "@smithy/util-config-provider": "4.2.2",
+        "@smithy/util-defaults-mode-browser": "4.3.49",
+        "@smithy/util-defaults-mode-node": "4.2.54",
+        "@smithy/util-endpoints": "3.4.2",
+        "@smithy/util-hex-encoding": "4.2.2",
+        "@smithy/util-middleware": "4.2.14",
+        "@smithy/util-retry": "4.3.8",
+        "@smithy/util-stream": "4.5.25",
+        "@smithy/util-uri-escape": "4.2.2",
+        "@smithy/util-utf8": "4.2.2",
+        "@smithy/uuid": "1.1.2",
         "@types/uuid": "^9.0.8",
         "bowser": "^2.11.0",
         "charenc": "^0.0.2",
         "ci-info": "^3.2.0",
         "crypt": "^0.0.2",
-        "fast-xml-builder": "1.1.1",
-        "fast-xml-parser": "5.5.2",
         "fs-extra": "^8.1.0",
         "graceful-fs": "^4.2.0",
         "graphql": "^15.5.0",
@@ -1011,6 +1023,7 @@
         "immer": "^9.0.12",
         "is-buffer": "~1.1.6",
         "is-ci": "^3.0.1",
+        "json-schema-to-ts": "^3.1.1",
         "jsonfile": "^4.0.0",
         "libphonenumber-js": "1.9.47",
         "lodash": "^4.17.23",
@@ -1018,29 +1031,29 @@
         "lodash.snakecase": "^4.1.1",
         "md5": "^2.2.1",
         "object-hash": "^3.0.0",
-        "path-expression-matcher": "1.1.3",
         "pluralize": "8.0.0",
+        "regenerator-runtime": "^0.14.0",
         "semver": "^7.6.3",
-        "strnum": "^1.0.5",
+        "ts-algebra": "^2.0.0",
         "ts-dedent": "^2.0.0",
         "tslib": "^2.6.2",
         "universalify": "^0.1.0",
-        "uuid": "^9.0.1",
+        "uuid": "^11.1.1",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.224.0",
-        "constructs": "^10.3.0"
+        "constructs": "^10.5.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs": {
-      "version": "1.6.1",
+      "version": "1.6.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/plugin-types": "^1.11.2",
-        "@aws-sdk/client-bedrock-runtime": "3.622.0",
+        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.936.0",
         "@smithy/types": "^4.9.0",
         "json-schema-to-ts": "^3.1.1"
       },
@@ -1050,493 +1063,290 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.622.0",
+      "version": "3.1058.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.622.0",
-        "@aws-sdk/client-sts": "3.622.0",
-        "@aws-sdk/core": "3.622.0",
-        "@aws-sdk/credential-provider-node": "3.622.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/eventstream-serde-browser": "^3.0.5",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.3",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.48",
+        "@aws-sdk/eventstream-handler-node": "^3.972.18",
+        "@aws-sdk/middleware-eventstream": "^3.972.14",
+        "@aws-sdk/middleware-websocket": "^3.972.23",
+        "@aws-sdk/token-providers": "3.1058.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.41",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sso": {
-      "version": "3.622.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.622.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.622.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.622.0",
-        "@aws-sdk/credential-provider-node": "3.622.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.622.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sts": {
-      "version": "3.622.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.622.0",
-        "@aws-sdk/core": "3.622.0",
-        "@aws-sdk/credential-provider-node": "3.622.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/core": {
-      "version": "3.622.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^2.3.2",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/core/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.622.0",
+      "version": "3.972.43",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.622.0",
+      "version": "3.972.46",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.622.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.622.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-login": "^3.972.45",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.622.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.45",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.622.0",
+      "version": "3.972.48",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.622.0",
-        "@aws-sdk/credential-provider-ini": "3.622.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.622.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-ini": "^3.972.46",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.41",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.622.0",
+      "version": "3.972.45",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.622.0",
-        "@aws-sdk/token-providers": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/token-providers": "3.1056.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1056.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.620.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.45",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.18",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.14",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.23",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.13",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.30",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1058.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+      "version": "3.973.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.614.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-schemas": {
@@ -1570,15 +1380,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "4.2.6",
+      "version": "4.2.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-relational-transformer": "3.1.13",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-relational-transformer": "3.1.15",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
@@ -1591,17 +1401,17 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
-      "version": "1.1.14",
+      "version": "1.1.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.6.1",
+        "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-index-transformer": "3.1.1",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-relational-transformer": "3.1.13",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-index-transformer": "3.1.3",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-relational-transformer": "3.1.15",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1615,13 +1425,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "3.1.16",
+      "version": "3.1.18",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
@@ -1634,13 +1444,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "3.1.18",
+      "version": "3.1.20",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1651,13 +1461,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
-      "version": "1.2.6",
+      "version": "1.2.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
@@ -1669,13 +1479,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "3.0.21",
+      "version": "3.0.23",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1686,14 +1496,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "3.1.1",
+      "version": "3.1.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1704,13 +1514,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "4.0.21",
+      "version": "4.0.24",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
       },
@@ -1720,13 +1530,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "3.4.1",
+      "version": "3.5.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1737,13 +1547,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "3.0.21",
+      "version": "3.0.23",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1754,15 +1564,15 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "3.1.13",
+      "version": "3.1.15",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-index-transformer": "3.1.1",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-index-transformer": "3.1.3",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
@@ -1774,14 +1584,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "3.1.1",
+      "version": "3.1.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1792,14 +1602,14 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.4.21",
+      "version": "0.4.23",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1810,26 +1620,26 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "2.4.1",
+      "version": "2.5.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "4.2.6",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.14",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.16",
-        "@aws-amplify/graphql-function-transformer": "3.1.18",
-        "@aws-amplify/graphql-generation-transformer": "1.2.6",
-        "@aws-amplify/graphql-http-transformer": "3.0.21",
-        "@aws-amplify/graphql-index-transformer": "3.1.1",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.21",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.21",
-        "@aws-amplify/graphql-relational-transformer": "3.1.13",
-        "@aws-amplify/graphql-searchable-transformer": "3.1.1",
-        "@aws-amplify/graphql-sql-transformer": "0.4.21",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
-        "@aws-amplify/graphql-validate-transformer": "1.1.6",
+        "@aws-amplify/graphql-auth-transformer": "4.2.9",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.16",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.18",
+        "@aws-amplify/graphql-function-transformer": "3.1.20",
+        "@aws-amplify/graphql-generation-transformer": "1.2.8",
+        "@aws-amplify/graphql-http-transformer": "3.0.23",
+        "@aws-amplify/graphql-index-transformer": "3.1.3",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.24",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.23",
+        "@aws-amplify/graphql-relational-transformer": "3.1.15",
+        "@aws-amplify/graphql-searchable-transformer": "3.1.4",
+        "@aws-amplify/graphql-sql-transformer": "0.4.23",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
+        "@aws-amplify/graphql-validate-transformer": "1.1.8",
         "@aws-amplify/plugin-types": "^1.0.0"
       },
       "peerDependencies": {
@@ -1838,12 +1648,12 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "3.5.1",
+      "version": "3.6.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -1860,7 +1670,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "4.3.0",
+      "version": "4.4.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1872,13 +1682,13 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-validate-transformer": {
-      "version": "1.1.6",
+      "version": "1.1.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -1948,29 +1758,6 @@
         "@smithy/util-endpoints": "^3.3.3",
         "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/core": {
-      "version": "3.973.20",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -2330,560 +2117,6 @@
         }
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.11",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/abort-controller": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/config-resolver": {
-      "version": "4.4.11",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/core": {
-      "version": "3.23.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/hash-node": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.26",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-middleware": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-retry": {
-      "version": "4.4.43",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-serde": {
-      "version": "4.2.15",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-stack": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/node-config-provider": {
-      "version": "4.3.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/node-http-handler": {
-      "version": "4.5.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/property-provider": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/querystring-parser": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/service-error-classification": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/smithy-client": {
-      "version": "4.12.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-endpoint": "^4.4.26",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/url-parser": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-config-provider": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.42",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.45",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-endpoints": {
-      "version": "3.3.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-middleware": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-retry": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-stream": {
-      "version": "4.5.20",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/uuid": {
-      "version": "1.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/ci-info": {
       "version": "4.2.0",
       "funding": [
@@ -2915,18 +2148,6 @@
         "is-ci": "bin.js"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/uuid": {
-      "version": "11.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core/node_modules/zod": {
       "version": "3.25.17",
       "inBundle": true,
@@ -2936,11 +2157,11 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/plugin-types": {
-      "version": "1.12.0",
+      "version": "1.12.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/toolkit-lib": "1.16.0"
+        "@aws-cdk/toolkit-lib": "1.19.0"
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
@@ -2961,6 +2182,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "inBundle": true,
@@ -2973,6 +2206,29 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
@@ -3023,6 +2279,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/supports-web-crypto": {
       "version": "5.2.0",
       "inBundle": true,
@@ -3039,6 +2307,18 @@
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
@@ -3077,4132 +2357,499 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.828.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.828.0",
-        "@aws-sdk/eventstream-handler-node": "3.821.0",
-        "@aws-sdk/middleware-eventstream": "3.821.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/eventstream-serde-browser": "^4.0.4",
-        "@smithy/eventstream-serde-config-resolver": "^4.1.2",
-        "@smithy/eventstream-serde-node": "^4.0.4",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/eventstream-handler-node": "^3.972.25",
+        "@aws-sdk/middleware-eventstream": "^3.972.21",
+        "@aws-sdk/middleware-websocket": "^3.972.34",
+        "@aws-sdk/token-providers": "3.1078.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
-      "version": "3.826.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.826.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.826.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.828.0",
-        "@aws-sdk/credential-provider-web-identity": "3.828.0",
-        "@aws-sdk/nested-clients": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.828.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.828.0",
-        "@aws-sdk/credential-provider-web-identity": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.826.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.828.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/token-providers": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-endpoints": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/abort-controller": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/config-resolver": {
-      "version": "4.1.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/core": {
-      "version": "3.5.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-codec": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/hash-node": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.11",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.5.3",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-middleware": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-retry": {
-      "version": "4.1.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-serde": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-stack": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-config-provider": {
-      "version": "4.1.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/property-provider": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/protocol-http": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/querystring-builder": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/querystring-parser": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/service-error-classification": {
-      "version": "4.0.5",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/signature-v4": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/smithy-client": {
-      "version": "4.4.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.5.3",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/url-parser": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.19",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.19",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-endpoints": {
-      "version": "3.0.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-middleware": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-retry": {
-      "version": "4.0.5",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-stream": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sso": {
-      "version": "3.637.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.637.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.637.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts": {
-      "version": "3.777.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-node": "3.777.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.777.0",
-        "@aws-sdk/credential-provider-web-identity": "3.777.0",
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-ini": "3.777.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.777.0",
-        "@aws-sdk/credential-provider-web-identity": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.777.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/token-providers": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/abort-controller": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/config-resolver": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/core": {
-      "version": "3.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-retry": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-serde": {
-      "version": "4.0.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-stack": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-config-provider": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/property-provider": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/protocol-http": {
-      "version": "5.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-builder": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-parser": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/signature-v4": {
-      "version": "5.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/smithy-client": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/url-parser": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-endpoints": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-middleware": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-retry": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-stream": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/core": {
-      "version": "3.635.0",
+      "version": "3.974.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.4.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "fast-xml-parser": "4.4.1",
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.620.1",
+      "version": "3.972.52",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.635.0",
+      "version": "3.972.54",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.3",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.637.0",
+      "version": "3.972.59",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-env": "^3.972.52",
+        "@aws-sdk/credential-provider-http": "^3.972.54",
+        "@aws-sdk/credential-provider-login": "^3.972.58",
+        "@aws-sdk/credential-provider-process": "^3.972.52",
+        "@aws-sdk/credential-provider-sso": "^3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.637.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.955.0",
+      "version": "3.972.58",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.954.0",
-        "@aws-sdk/nested-clients": "3.955.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
-      "version": "3.954.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.954.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.954.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.955.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.954.0",
-        "@aws-sdk/middleware-host-header": "3.953.0",
-        "@aws-sdk/middleware-logger": "3.953.0",
-        "@aws-sdk/middleware-recursion-detection": "3.953.0",
-        "@aws-sdk/middleware-user-agent": "3.954.0",
-        "@aws-sdk/region-config-resolver": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@aws-sdk/util-user-agent-browser": "3.953.0",
-        "@aws-sdk/util-user-agent-node": "3.954.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/core": "^3.19.0",
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/hash-node": "^4.2.6",
-        "@smithy/invalid-dependency": "^4.2.6",
-        "@smithy/middleware-content-length": "^4.2.6",
-        "@smithy/middleware-endpoint": "^4.4.0",
-        "@smithy/middleware-retry": "^4.4.16",
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/middleware-stack": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.15",
-        "@smithy/util-defaults-mode-node": "^4.2.18",
-        "@smithy/util-endpoints": "^3.2.6",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-retry": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-endpoints": "^3.2.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.954.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.954.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "fast-xml-parser": "5.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/abort-controller": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/config-resolver": {
-      "version": "4.4.5",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/core": {
-      "version": "3.20.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-stream": "^4.5.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/hash-node": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.20.0",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-retry": {
-      "version": "4.4.17",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-serde": {
-      "version": "4.2.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-stack": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/node-config-provider": {
-      "version": "4.3.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/property-provider": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/protocol-http": {
-      "version": "5.3.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/querystring-parser": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/service-error-classification": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/signature-v4": {
-      "version": "5.3.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/smithy-client": {
-      "version": "4.10.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.20.0",
-        "@smithy/middleware-endpoint": "^4.4.1",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-stream": "^4.5.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/types": {
-      "version": "4.11.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/url-parser": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.16",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.19",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-endpoints": {
-      "version": "3.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-middleware": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-retry": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-stream": {
-      "version": "4.5.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.637.0",
+      "version": "3.972.61",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-ini": "3.637.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/credential-provider-env": "^3.972.52",
+        "@aws-sdk/credential-provider-http": "^3.972.54",
+        "@aws-sdk/credential-provider-ini": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.52",
+        "@aws-sdk/credential-provider-sso": "^3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.620.1",
+      "version": "3.972.52",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.637.0",
+      "version": "3.972.58",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.637.0",
-        "@aws-sdk/token-providers": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/token-providers": "3.1078.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.621.0",
+      "version": "3.972.58",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.621.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.25",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.21",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.620.0",
+      "version": "3.972.27",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.609.0",
+      "version": "3.972.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.620.0",
+      "version": "3.972.28",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.57",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.637.0",
+      "version": "3.972.56",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.34",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.777.0",
+      "version": "3.997.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
-      "version": "3.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
-      "version": "4.0.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
-      "version": "5.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
-      "version": "5.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.614.0",
+      "version": "3.972.30",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/region-config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/token-providers": {
-      "version": "3.614.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.614.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
+      "version": "3.973.15",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-      "version": "4.3.1",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.637.0",
+      "version": "3.996.25",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.5",
+        "@aws-sdk/core": "^3.974.26",
+        "@smithy/core": "^3.29.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.28",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.804.0",
+      "version": "3.965.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.609.0",
+      "version": "3.972.27",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.614.0",
+      "version": "3.973.42",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.804.0",
+      "version": "3.972.33",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws/lambda-invoke-store": {
@@ -7211,6 +2858,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/api": {
@@ -7222,7 +2880,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
+      "version": "2.8.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7275,595 +2933,584 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/abort-controller": {
-      "version": "3.1.9",
+      "version": "4.2.12",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/config-resolver": {
-      "version": "3.0.13",
+      "version": "4.4.17",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/core": {
-      "version": "2.5.7",
+      "version": "3.29.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.11",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.11",
-        "@smithy/util-stream": "^3.3.4",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/credential-provider-imds": {
-      "version": "3.2.8",
+      "version": "4.4.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/property-provider": "^3.1.11",
-        "@smithy/types": "^3.7.2",
-        "@smithy/url-parser": "^3.0.11",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-codec": {
-      "version": "3.1.10",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.14",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.13",
-        "@smithy/types": "^3.7.2",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.11",
+      "version": "4.3.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.13",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.13",
-        "@smithy/types": "^3.7.2",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.13",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.1.10",
-        "@smithy/types": "^3.7.2",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.9",
+      "version": "5.6.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/querystring-builder": "^3.0.7",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-base64": "^3.0.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/hash-node": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.13",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/types": "^3.7.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-endpoint": {
-      "version": "3.2.8",
+      "version": "4.4.32",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.5.7",
-        "@smithy/middleware-serde": "^3.0.11",
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/shared-ini-file-loader": "^3.1.12",
-        "@smithy/types": "^3.7.2",
-        "@smithy/url-parser": "^3.0.11",
-        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-retry": {
-      "version": "3.0.34",
+      "version": "4.5.7",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/service-error-classification": "^3.0.11",
-        "@smithy/smithy-client": "^3.7.0",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-middleware": "^3.0.11",
-        "@smithy/util-retry": "^3.0.11",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-serde": {
-      "version": "3.0.11",
+      "version": "4.2.20",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-stack": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.12",
+      "version": "4.3.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.11",
-        "@smithy/shared-ini-file-loader": "^3.1.12",
-        "@smithy/types": "^3.7.2",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/node-http-handler": {
-      "version": "3.3.3",
+      "version": "4.9.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.9",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/querystring-builder": "^3.0.11",
-        "@smithy/types": "^3.7.2",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/property-provider": {
-      "version": "3.1.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/protocol-http": {
-      "version": "4.1.8",
+      "version": "5.3.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/querystring-builder": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/querystring-parser": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.11",
+      "version": "4.3.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.12",
+      "version": "4.4.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/signature-v4": {
-      "version": "4.2.4",
+      "version": "5.6.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.11",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/smithy-client": {
-      "version": "3.7.0",
+      "version": "4.12.13",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.5.7",
-        "@smithy/middleware-endpoint": "^3.2.8",
-        "@smithy/middleware-stack": "^3.0.11",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-stream": "^3.3.4",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/types": {
-      "version": "3.7.2",
+      "version": "4.15.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/url-parser": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.11",
-        "@smithy/types": "^3.7.2",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-base64": {
-      "version": "3.0.0",
+      "version": "4.3.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-body-length-browser": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-body-length-node": {
-      "version": "3.0.0",
+      "version": "4.2.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-config-provider": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.34",
+      "version": "4.3.49",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.11",
-        "@smithy/smithy-client": "^3.7.0",
-        "@smithy/types": "^3.7.2",
-        "bowser": "^2.11.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.34",
+      "version": "4.2.54",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.13",
-        "@smithy/credential-provider-imds": "^3.2.8",
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/property-provider": "^3.1.11",
-        "@smithy/smithy-client": "^3.7.0",
-        "@smithy/types": "^3.7.2",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-endpoints": {
-      "version": "2.1.7",
+      "version": "3.4.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/types": "^3.7.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-hex-encoding": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-middleware": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-retry": {
-      "version": "3.0.11",
+      "version": "4.3.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.11",
-        "@smithy/types": "^3.7.2",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-stream": {
-      "version": "3.3.4",
+      "version": "4.5.25",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^4.1.3",
-        "@smithy/node-http-handler": "^3.3.3",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
-      "version": "4.1.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/querystring-builder": "^3.0.11",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-base64": "^3.0.0",
-        "tslib": "^2.6.2"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-uri-escape": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@smithy/uuid": {
-      "version": "1.1.0",
+      "version": "1.1.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7912,50 +3559,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/fast-xml-builder": {
-      "version": "1.1.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/fast-xml-parser": {
-      "version": "5.5.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.1",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/fast-xml-parser/node_modules/strnum": {
-      "version": "2.1.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -8032,6 +3635,18 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/jsonfile": {
       "version": "4.0.0",
       "inBundle": true,
@@ -8046,7 +3661,7 @@
       "license": "MIT"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
       "inBundle": true,
       "license": "MIT"
     },
@@ -8078,20 +3693,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-amplify/data-construct/node_modules/pluralize": {
       "version": "8.0.0",
       "inBundle": true,
@@ -8099,6 +3700,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/semver": {
       "version": "7.7.1",
@@ -8111,14 +3717,8 @@
         "node": ">=10"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/strnum": {
-      "version": "1.1.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
+    "node_modules/@aws-amplify/data-construct/node_modules/ts-algebra": {
+      "version": "2.0.0",
       "inBundle": true,
       "license": "MIT"
     },
@@ -8144,7 +3744,7 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/uuid": {
-      "version": "9.0.1",
+      "version": "11.1.1",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -8152,7 +3752,7 @@
       "inBundle": true,
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/zod": {
@@ -8177,10 +3777,9 @@
       }
     },
     "node_modules/@aws-amplify/data-schema-types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.2.1.tgz",
-      "integrity": "sha512-SuYVcy9Hg8Ox9P0QCXEPwqHxX5zVPgVo2YvNBOm5TpkZr4UK6ir3USame7dELZsk5/9f6KoP70QAYhTvp/j1Og==",
-      "license": "Apache-2.0",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.3.0.tgz",
+      "integrity": "sha512-A9vuOwhdrRFCXIXaL48JtpJjSoAdhpI4CPFRPm7F+i4hF1nQO3+bGdiSHY6iKRrEoBoXCAcwozIjvAImhxz2sg==",
       "dependencies": {
         "graphql": "15.8.0",
         "rxjs": "^7.8.1"
@@ -8243,9 +3842,9 @@
       "link": true
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.21.1.tgz",
-      "integrity": "sha512-W1hwVUFodaDOIX4yOHCJ4CWa/2Wb5vW9OUQXbwXadrsKdVvGsaVi5shT2F+ZVuHLbgbfNG6hM02n9DxqZzKS0g==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.22.2.tgz",
+      "integrity": "sha512-Loc7fjgdh7P1wiq6vnJ81Q1kLSZnF911rde7bK3eOiwHXyzJVahOsnTMwB6yL+XLfXA8Pnd6MhDeeGCkqB/mqw==",
       "bundleDependencies": [
         "@aws-amplify/ai-constructs",
         "@aws-amplify/backend-output-schemas",
@@ -8270,12 +3869,15 @@
         "@aws-amplify/graphql-validate-transformer",
         "@aws-amplify/platform-core",
         "@aws-amplify/plugin-types",
+        "@babel/runtime",
         "@aws-crypto/crc32",
         "@aws-crypto/sha256-browser",
         "@aws-crypto/sha256-js",
         "@aws-crypto/supports-web-crypto",
         "@aws-crypto/util",
         "@aws-sdk/client-bedrock-runtime",
+        "@aws-sdk/eventstream-handler-node",
+        "@aws-sdk/middleware-eventstream",
         "@aws-sdk/client-sso",
         "@aws-sdk/client-sso-oidc",
         "@aws-sdk/client-sts",
@@ -8291,12 +3893,17 @@
         "@aws-sdk/middleware-host-header",
         "@aws-sdk/middleware-logger",
         "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-sdk-s3",
         "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/middleware-websocket",
         "@aws-sdk/nested-clients",
         "@aws-sdk/region-config-resolver",
+        "@aws-sdk/signature-v4-multi-region",
         "@aws-sdk/token-providers",
         "@aws-sdk/types",
+        "@aws-sdk/util-arn-parser",
         "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-format-url",
         "@aws-sdk/util-locate-window",
         "@aws-sdk/util-user-agent-browser",
         "@aws-sdk/util-user-agent-node",
@@ -8357,8 +3964,6 @@
         "charenc",
         "ci-info",
         "crypt",
-        "fast-xml-builder",
-        "fast-xml-parser",
         "fs-extra",
         "graceful-fs",
         "graphql",
@@ -8368,6 +3973,7 @@
         "immer",
         "is-buffer",
         "is-ci",
+        "json-schema-to-ts",
         "jsonfile",
         "libphonenumber-js",
         "lodash",
@@ -8375,39 +3981,38 @@
         "lodash.snakecase",
         "md5",
         "object-hash",
-        "path-expression-matcher",
         "pluralize",
+        "regenerator-runtime",
         "semver",
-        "strnum",
+        "ts-algebra",
         "ts-dedent",
         "tslib",
         "universalify",
         "uuid",
         "zod"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.6.1",
+        "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/backend-output-schemas": "^1.0.0",
         "@aws-amplify/backend-output-storage": "^1.0.0",
-        "@aws-amplify/graphql-auth-transformer": "4.2.6",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.14",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.16",
+        "@aws-amplify/graphql-auth-transformer": "4.2.9",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.16",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.18",
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-function-transformer": "3.1.18",
-        "@aws-amplify/graphql-generation-transformer": "1.2.6",
-        "@aws-amplify/graphql-http-transformer": "3.0.21",
-        "@aws-amplify/graphql-index-transformer": "3.1.1",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.21",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.21",
-        "@aws-amplify/graphql-relational-transformer": "3.1.13",
-        "@aws-amplify/graphql-searchable-transformer": "3.1.1",
-        "@aws-amplify/graphql-sql-transformer": "0.4.21",
-        "@aws-amplify/graphql-transformer": "2.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
-        "@aws-amplify/graphql-validate-transformer": "1.1.6",
+        "@aws-amplify/graphql-function-transformer": "3.1.20",
+        "@aws-amplify/graphql-generation-transformer": "1.2.8",
+        "@aws-amplify/graphql-http-transformer": "3.0.23",
+        "@aws-amplify/graphql-index-transformer": "3.1.3",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.24",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.23",
+        "@aws-amplify/graphql-relational-transformer": "3.1.15",
+        "@aws-amplify/graphql-searchable-transformer": "3.1.4",
+        "@aws-amplify/graphql-sql-transformer": "0.4.23",
+        "@aws-amplify/graphql-transformer": "2.5.1",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
+        "@aws-amplify/graphql-validate-transformer": "1.1.8",
         "@aws-amplify/platform-core": "^1.0.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "@aws-crypto/crc32": "5.2.0",
@@ -8415,90 +4020,96 @@
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
         "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.622.0",
-        "@aws-sdk/client-sso": "3.637.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "^3.624.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-ini": "3.637.0",
-        "@aws-sdk/credential-provider-login": "3.955.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/nested-clients": "^3.777.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/token-providers": "3.614.0",
-        "@aws-sdk/types": "^3.734.0",
-        "@aws-sdk/util-endpoints": "3.734.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@aws-sdk/xml-builder": "3.804.0",
+        "@aws-sdk/client-bedrock-runtime": "3.1078.0",
+        "@aws-sdk/client-sso": "3.1078.0",
+        "@aws-sdk/client-sso-oidc": "3.1078.0",
+        "@aws-sdk/client-sts": "3.1078.0",
+        "@aws-sdk/core": "3.974.26",
+        "@aws-sdk/credential-provider-env": "3.972.52",
+        "@aws-sdk/credential-provider-http": "3.972.54",
+        "@aws-sdk/credential-provider-ini": "3.972.59",
+        "@aws-sdk/credential-provider-login": "3.972.58",
+        "@aws-sdk/credential-provider-node": "3.972.61",
+        "@aws-sdk/credential-provider-process": "3.972.52",
+        "@aws-sdk/credential-provider-sso": "3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "3.972.58",
+        "@aws-sdk/eventstream-handler-node": "3.972.25",
+        "@aws-sdk/middleware-eventstream": "3.972.21",
+        "@aws-sdk/middleware-host-header": "3.972.27",
+        "@aws-sdk/middleware-logger": "3.972.26",
+        "@aws-sdk/middleware-recursion-detection": "3.972.28",
+        "@aws-sdk/middleware-sdk-s3": "3.972.57",
+        "@aws-sdk/middleware-user-agent": "3.972.56",
+        "@aws-sdk/middleware-websocket": "3.972.34",
+        "@aws-sdk/nested-clients": "3.997.26",
+        "@aws-sdk/region-config-resolver": "3.972.30",
+        "@aws-sdk/signature-v4-multi-region": "3.996.38",
+        "@aws-sdk/token-providers": "3.1078.0",
+        "@aws-sdk/types": "3.973.15",
+        "@aws-sdk/util-arn-parser": "3.972.21",
+        "@aws-sdk/util-endpoints": "3.996.25",
+        "@aws-sdk/util-format-url": "3.972.28",
+        "@aws-sdk/util-locate-window": "3.965.8",
+        "@aws-sdk/util-user-agent-browser": "3.972.27",
+        "@aws-sdk/util-user-agent-node": "3.973.42",
+        "@aws-sdk/xml-builder": "3.972.33",
         "@aws/lambda-invoke-store": "^0.2.2",
+        "@babel/runtime": "^7.18.3",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/resources": "2.0.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/eventstream-codec": "^3.1.2",
-        "@smithy/eventstream-serde-browser": "^3.0.6",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.5",
-        "@smithy/eventstream-serde-universal": "^3.0.5",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/querystring-parser": "^3.0.3",
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.3",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/abort-controller": "4.2.12",
+        "@smithy/config-resolver": "4.4.17",
+        "@smithy/core": "3.29.0",
+        "@smithy/credential-provider-imds": "4.4.5",
+        "@smithy/eventstream-codec": "4.2.14",
+        "@smithy/eventstream-serde-browser": "4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "4.3.14",
+        "@smithy/eventstream-serde-node": "4.2.14",
+        "@smithy/eventstream-serde-universal": "4.2.14",
+        "@smithy/fetch-http-handler": "5.6.2",
+        "@smithy/hash-node": "4.2.14",
+        "@smithy/invalid-dependency": "4.2.14",
+        "@smithy/is-array-buffer": "4.2.2",
+        "@smithy/middleware-content-length": "4.2.14",
+        "@smithy/middleware-endpoint": "4.4.32",
+        "@smithy/middleware-retry": "4.5.7",
+        "@smithy/middleware-serde": "4.2.20",
+        "@smithy/middleware-stack": "4.2.14",
+        "@smithy/node-config-provider": "4.3.14",
+        "@smithy/node-http-handler": "4.9.2",
+        "@smithy/property-provider": "4.2.14",
+        "@smithy/protocol-http": "5.3.14",
+        "@smithy/querystring-builder": "4.2.14",
+        "@smithy/querystring-parser": "4.2.14",
+        "@smithy/service-error-classification": "4.3.1",
+        "@smithy/shared-ini-file-loader": "4.4.9",
+        "@smithy/signature-v4": "5.6.1",
+        "@smithy/smithy-client": "4.12.13",
+        "@smithy/types": "4.15.1",
+        "@smithy/url-parser": "4.2.14",
+        "@smithy/util-base64": "4.3.2",
+        "@smithy/util-body-length-browser": "4.2.2",
+        "@smithy/util-body-length-node": "4.2.3",
+        "@smithy/util-buffer-from": "4.2.2",
+        "@smithy/util-config-provider": "4.2.2",
+        "@smithy/util-defaults-mode-browser": "4.3.49",
+        "@smithy/util-defaults-mode-node": "4.2.54",
+        "@smithy/util-endpoints": "3.4.2",
+        "@smithy/util-hex-encoding": "4.2.2",
+        "@smithy/util-middleware": "4.2.14",
+        "@smithy/util-retry": "4.3.8",
+        "@smithy/util-stream": "4.5.25",
+        "@smithy/util-uri-escape": "4.2.2",
+        "@smithy/util-utf8": "4.2.2",
+        "@smithy/uuid": "1.1.2",
         "@types/uuid": "^9.0.8",
         "bowser": "^2.11.0",
         "charenc": "^0.0.2",
         "ci-info": "^3.2.0",
         "crypt": "^0.0.2",
-        "fast-xml-builder": "1.1.1",
-        "fast-xml-parser": "5.5.2",
         "fs-extra": "^8.1.0",
         "graceful-fs": "^4.2.0",
         "graphql": "^15.5.0",
@@ -8508,6 +4119,7 @@
         "immer": "^9.0.12",
         "is-buffer": "~1.1.6",
         "is-ci": "^3.0.1",
+        "json-schema-to-ts": "^3.1.1",
         "jsonfile": "^4.0.0",
         "libphonenumber-js": "1.9.47",
         "lodash": "^4.17.23",
@@ -8515,29 +4127,29 @@
         "lodash.snakecase": "^4.1.1",
         "md5": "^2.2.1",
         "object-hash": "^3.0.0",
-        "path-expression-matcher": "1.1.3",
         "pluralize": "8.0.0",
+        "regenerator-runtime": "^0.14.0",
         "semver": "^7.6.3",
-        "strnum": "^1.0.5",
+        "ts-algebra": "^2.0.0",
         "ts-dedent": "^2.0.0",
         "tslib": "^2.6.2",
         "universalify": "^0.1.0",
-        "uuid": "^9.0.1",
+        "uuid": "^11.1.1",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.224.0",
-        "constructs": "^10.3.0"
+        "constructs": "^10.5.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs": {
-      "version": "1.6.1",
+      "version": "1.6.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
-        "@aws-amplify/plugin-types": "^1.11.2",
-        "@aws-sdk/client-bedrock-runtime": "3.622.0",
+        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.936.0",
         "@smithy/types": "^4.9.0",
         "json-schema-to-ts": "^3.1.1"
       },
@@ -8547,493 +4159,290 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.622.0",
+      "version": "3.1058.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.622.0",
-        "@aws-sdk/client-sts": "3.622.0",
-        "@aws-sdk/core": "3.622.0",
-        "@aws-sdk/credential-provider-node": "3.622.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/eventstream-serde-browser": "^3.0.5",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.3",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.48",
+        "@aws-sdk/eventstream-handler-node": "^3.972.18",
+        "@aws-sdk/middleware-eventstream": "^3.972.14",
+        "@aws-sdk/middleware-websocket": "^3.972.23",
+        "@aws-sdk/token-providers": "3.1058.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.41",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sso": {
-      "version": "3.622.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.622.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.622.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.622.0",
-        "@aws-sdk/credential-provider-node": "3.622.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.622.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sts": {
-      "version": "3.622.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.622.0",
-        "@aws-sdk/core": "3.622.0",
-        "@aws-sdk/credential-provider-node": "3.622.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/core": {
-      "version": "3.622.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^2.3.2",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/core/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.622.0",
+      "version": "3.972.43",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.3",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.622.0",
+      "version": "3.972.46",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.622.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.622.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-login": "^3.972.45",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.622.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.45",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.622.0",
+      "version": "3.972.48",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.622.0",
-        "@aws-sdk/credential-provider-ini": "3.622.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.622.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-ini": "^3.972.46",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.41",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.622.0",
+      "version": "3.972.45",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.622.0",
-        "@aws-sdk/token-providers": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/token-providers": "3.1056.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1056.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.620.0",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.45",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
-      "version": "3.7.2",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.18",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.14",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.23",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.13",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.30",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1058.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+      "version": "3.973.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.614.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs/node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-schemas": {
@@ -9067,15 +4476,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "4.2.6",
+      "version": "4.2.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-relational-transformer": "3.1.13",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-relational-transformer": "3.1.15",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
@@ -9088,17 +4497,17 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
-      "version": "1.1.14",
+      "version": "1.1.16",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ai-constructs": "^1.6.1",
+        "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-index-transformer": "3.1.1",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-relational-transformer": "3.1.13",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-index-transformer": "3.1.3",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-relational-transformer": "3.1.15",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "@aws-amplify/plugin-types": "^1.0.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -9112,13 +4521,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "3.1.16",
+      "version": "3.1.18",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
@@ -9131,13 +4540,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "3.1.18",
+      "version": "3.1.20",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -9148,13 +4557,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
-      "version": "1.2.6",
+      "version": "1.2.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
@@ -9166,13 +4575,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "3.0.21",
+      "version": "3.0.23",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -9183,14 +4592,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "3.1.1",
+      "version": "3.1.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -9201,13 +4610,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "4.0.21",
+      "version": "4.0.24",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
       },
@@ -9217,13 +4626,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "3.4.1",
+      "version": "3.5.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -9234,13 +4643,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "3.0.21",
+      "version": "3.0.23",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -9251,15 +4660,15 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "3.1.13",
+      "version": "3.1.15",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-index-transformer": "3.1.1",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-index-transformer": "3.1.3",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4",
@@ -9271,14 +4680,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "3.1.1",
+      "version": "3.1.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -9289,14 +4698,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.4.21",
+      "version": "0.4.23",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -9307,26 +4716,26 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "2.4.1",
+      "version": "2.5.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "4.2.6",
-        "@aws-amplify/graphql-conversation-transformer": "1.1.14",
-        "@aws-amplify/graphql-default-value-transformer": "3.1.16",
-        "@aws-amplify/graphql-function-transformer": "3.1.18",
-        "@aws-amplify/graphql-generation-transformer": "1.2.6",
-        "@aws-amplify/graphql-http-transformer": "3.0.21",
-        "@aws-amplify/graphql-index-transformer": "3.1.1",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.21",
-        "@aws-amplify/graphql-model-transformer": "3.4.1",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.21",
-        "@aws-amplify/graphql-relational-transformer": "3.1.13",
-        "@aws-amplify/graphql-searchable-transformer": "3.1.1",
-        "@aws-amplify/graphql-sql-transformer": "0.4.21",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
-        "@aws-amplify/graphql-validate-transformer": "1.1.6",
+        "@aws-amplify/graphql-auth-transformer": "4.2.9",
+        "@aws-amplify/graphql-conversation-transformer": "1.1.16",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.18",
+        "@aws-amplify/graphql-function-transformer": "3.1.20",
+        "@aws-amplify/graphql-generation-transformer": "1.2.8",
+        "@aws-amplify/graphql-http-transformer": "3.0.23",
+        "@aws-amplify/graphql-index-transformer": "3.1.3",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.24",
+        "@aws-amplify/graphql-model-transformer": "3.5.0",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.23",
+        "@aws-amplify/graphql-relational-transformer": "3.1.15",
+        "@aws-amplify/graphql-searchable-transformer": "3.1.4",
+        "@aws-amplify/graphql-sql-transformer": "0.4.23",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
+        "@aws-amplify/graphql-validate-transformer": "1.1.8",
         "@aws-amplify/plugin-types": "^1.0.0"
       },
       "peerDependencies": {
@@ -9335,12 +4744,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "3.5.1",
+      "version": "3.6.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
@@ -9357,7 +4766,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "4.3.0",
+      "version": "4.4.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9369,13 +4778,13 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-validate-transformer": {
-      "version": "1.1.6",
+      "version": "1.1.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-directives": "2.8.0",
-        "@aws-amplify/graphql-transformer-core": "3.5.1",
-        "@aws-amplify/graphql-transformer-interfaces": "4.3.0",
+        "@aws-amplify/graphql-transformer-core": "3.6.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.4.0",
         "graphql": "^15.5.0",
         "graphql-mapping-template": "5.0.2",
         "graphql-transformer-common": "5.1.4"
@@ -9445,29 +4854,6 @@
         "@smithy/util-endpoints": "^3.3.3",
         "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/core": {
-      "version": "3.973.20",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -9827,560 +5213,6 @@
         }
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.11",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/abort-controller": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/config-resolver": {
-      "version": "4.4.11",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/core": {
-      "version": "3.23.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/hash-node": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.26",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-middleware": "^4.2.12",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-retry": {
-      "version": "4.4.43",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-serde": {
-      "version": "4.2.15",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/middleware-stack": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/node-config-provider": {
-      "version": "4.3.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/node-http-handler": {
-      "version": "4.5.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/property-provider": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/querystring-parser": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/service-error-classification": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/smithy-client": {
-      "version": "4.12.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-endpoint": "^4.4.26",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/url-parser": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-config-provider": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.42",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.45",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-endpoints": {
-      "version": "3.3.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-middleware": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-retry": {
-      "version": "4.2.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-stream": {
-      "version": "4.5.20",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/@smithy/uuid": {
-      "version": "1.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/ci-info": {
       "version": "4.2.0",
       "funding": [
@@ -10412,18 +5244,6 @@
         "is-ci": "bin.js"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/uuid": {
-      "version": "11.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core/node_modules/zod": {
       "version": "3.25.17",
       "inBundle": true,
@@ -10433,11 +5253,11 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/plugin-types": {
-      "version": "1.12.0",
+      "version": "1.12.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/toolkit-lib": "1.16.0"
+        "@aws-cdk/toolkit-lib": "1.19.0"
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
@@ -10458,6 +5278,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "inBundle": true,
@@ -10470,6 +5302,29 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
@@ -10520,6 +5375,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/supports-web-crypto": {
       "version": "5.2.0",
       "inBundle": true,
@@ -10536,6 +5403,18 @@
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
@@ -10574,4236 +5453,499 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.828.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.828.0",
-        "@aws-sdk/eventstream-handler-node": "3.821.0",
-        "@aws-sdk/middleware-eventstream": "3.821.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/eventstream-serde-browser": "^4.0.4",
-        "@smithy/eventstream-serde-config-resolver": "^4.1.2",
-        "@smithy/eventstream-serde-node": "^4.0.4",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/eventstream-handler-node": "^3.972.25",
+        "@aws-sdk/middleware-eventstream": "^3.972.21",
+        "@aws-sdk/middleware-websocket": "^3.972.34",
+        "@aws-sdk/token-providers": "3.1078.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
-      "version": "3.826.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.826.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.826.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.828.0",
-        "@aws-sdk/credential-provider-web-identity": "3.828.0",
-        "@aws-sdk/nested-clients": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.828.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.828.0",
-        "@aws-sdk/credential-provider-web-identity": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.826.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.828.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/token-providers": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-endpoints": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.828.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.821.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/abort-controller": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/config-resolver": {
-      "version": "4.1.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/core": {
-      "version": "3.5.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-codec": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/hash-node": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.11",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.5.3",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-middleware": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-retry": {
-      "version": "4.1.12",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-serde": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-stack": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-config-provider": {
-      "version": "4.1.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/property-provider": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/protocol-http": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/querystring-builder": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/querystring-parser": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/service-error-classification": {
-      "version": "4.0.5",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/signature-v4": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/smithy-client": {
-      "version": "4.4.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.5.3",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/url-parser": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.19",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.19",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-endpoints": {
-      "version": "3.0.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-middleware": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-retry": {
-      "version": "4.0.5",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-stream": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso": {
-      "version": "3.637.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.637.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.637.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.637.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.637.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts": {
-      "version": "3.777.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-node": "3.777.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.777.0",
-        "@aws-sdk/credential-provider-web-identity": "3.777.0",
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-ini": "3.777.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.777.0",
-        "@aws-sdk/credential-provider-web-identity": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.777.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/token-providers": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
-      "version": "3.777.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/abort-controller": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/config-resolver": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/core": {
-      "version": "3.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-retry": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-serde": {
-      "version": "4.0.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-stack": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-config-provider": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/property-provider": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/protocol-http": {
-      "version": "5.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-builder": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-parser": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/signature-v4": {
-      "version": "5.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/smithy-client": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/url-parser": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-endpoints": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-middleware": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-retry": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-stream": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/core": {
-      "version": "3.635.0",
+      "version": "3.974.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.4.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "fast-xml-parser": "4.4.1",
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.620.1",
+      "version": "3.972.52",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.635.0",
+      "version": "3.972.54",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.3",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.637.0",
+      "version": "3.972.59",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-env": "^3.972.52",
+        "@aws-sdk/credential-provider-http": "^3.972.54",
+        "@aws-sdk/credential-provider-login": "^3.972.58",
+        "@aws-sdk/credential-provider-process": "^3.972.52",
+        "@aws-sdk/credential-provider-sso": "^3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.637.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.955.0",
+      "version": "3.972.58",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.954.0",
-        "@aws-sdk/nested-clients": "3.955.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
-      "version": "3.954.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.954.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.954.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.955.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.954.0",
-        "@aws-sdk/middleware-host-header": "3.953.0",
-        "@aws-sdk/middleware-logger": "3.953.0",
-        "@aws-sdk/middleware-recursion-detection": "3.953.0",
-        "@aws-sdk/middleware-user-agent": "3.954.0",
-        "@aws-sdk/region-config-resolver": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@aws-sdk/util-user-agent-browser": "3.953.0",
-        "@aws-sdk/util-user-agent-node": "3.954.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/core": "^3.19.0",
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/hash-node": "^4.2.6",
-        "@smithy/invalid-dependency": "^4.2.6",
-        "@smithy/middleware-content-length": "^4.2.6",
-        "@smithy/middleware-endpoint": "^4.4.0",
-        "@smithy/middleware-retry": "^4.4.16",
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/middleware-stack": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.15",
-        "@smithy/util-defaults-mode-node": "^4.2.18",
-        "@smithy/util-endpoints": "^3.2.6",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-retry": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-endpoints": "^3.2.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.954.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.954.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.953.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "fast-xml-parser": "5.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/abort-controller": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/config-resolver": {
-      "version": "4.4.5",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/core": {
-      "version": "3.20.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-stream": "^4.5.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/hash-node": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.20.0",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-retry": {
-      "version": "4.4.17",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-serde": {
-      "version": "4.2.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/middleware-stack": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/node-config-provider": {
-      "version": "4.3.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/property-provider": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/protocol-http": {
-      "version": "5.3.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/querystring-parser": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/service-error-classification": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/signature-v4": {
-      "version": "5.3.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/smithy-client": {
-      "version": "4.10.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.20.0",
-        "@smithy/middleware-endpoint": "^4.4.1",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-stream": "^4.5.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/types": {
-      "version": "4.11.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/url-parser": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.16",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.19",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-endpoints": {
-      "version": "3.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-middleware": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-retry": {
-      "version": "4.2.7",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-stream": {
-      "version": "4.5.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.637.0",
+      "version": "3.972.61",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-ini": "3.637.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/credential-provider-env": "^3.972.52",
+        "@aws-sdk/credential-provider-http": "^3.972.54",
+        "@aws-sdk/credential-provider-ini": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.52",
+        "@aws-sdk/credential-provider-sso": "^3.972.58",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.620.1",
+      "version": "3.972.52",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.637.0",
+      "version": "3.972.58",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.637.0",
-        "@aws-sdk/token-providers": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/token-providers": "3.1078.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.621.0",
+      "version": "3.972.58",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.621.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.25",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.21",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.620.0",
+      "version": "3.972.27",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.609.0",
+      "version": "3.972.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.620.0",
+      "version": "3.972.28",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.57",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.637.0",
+      "version": "3.972.56",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.34",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.637.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.777.0",
+      "version": "3.997.26",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.775.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
-      "version": "3.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
-      "version": "4.0.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
-      "version": "5.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
-      "version": "5.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.614.0",
+      "version": "3.972.30",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/region-config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/token-providers": {
-      "version": "3.614.0",
+      "version": "3.1078.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/nested-clients": "^3.997.26",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.614.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
+      "version": "3.973.15",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-      "version": "4.3.1",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.21",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.734.0",
+      "version": "3.996.25",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-endpoints": "^3.0.1",
+        "@aws-sdk/core": "^3.974.26",
+        "@smithy/core": "^3.29.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-      "version": "3.734.0",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.28",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/node-config-provider": {
-      "version": "4.1.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/property-provider": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/util-endpoints": {
-      "version": "3.0.6",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.804.0",
+      "version": "3.965.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.609.0",
+      "version": "3.972.27",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.614.0",
+      "version": "3.973.42",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "^3.974.26",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.804.0",
+      "version": "3.972.33",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws/lambda-invoke-store": {
@@ -14812,6 +5954,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/api": {
@@ -14823,7 +5976,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
+      "version": "2.8.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14876,595 +6029,584 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/abort-controller": {
-      "version": "3.1.9",
+      "version": "4.2.12",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/config-resolver": {
-      "version": "3.0.13",
+      "version": "4.4.17",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/core": {
-      "version": "2.5.7",
+      "version": "3.29.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.11",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.11",
-        "@smithy/util-stream": "^3.3.4",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/credential-provider-imds": {
-      "version": "3.2.8",
+      "version": "4.4.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/property-provider": "^3.1.11",
-        "@smithy/types": "^3.7.2",
-        "@smithy/url-parser": "^3.0.11",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-codec": {
-      "version": "3.1.10",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.14",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.13",
-        "@smithy/types": "^3.7.2",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.11",
+      "version": "4.3.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.13",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.13",
-        "@smithy/types": "^3.7.2",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.13",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.1.10",
-        "@smithy/types": "^3.7.2",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.9",
+      "version": "5.6.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/querystring-builder": "^3.0.7",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-base64": "^3.0.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/hash-node": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.13",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/types": "^3.7.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-endpoint": {
-      "version": "3.2.8",
+      "version": "4.4.32",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.5.7",
-        "@smithy/middleware-serde": "^3.0.11",
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/shared-ini-file-loader": "^3.1.12",
-        "@smithy/types": "^3.7.2",
-        "@smithy/url-parser": "^3.0.11",
-        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-retry": {
-      "version": "3.0.34",
+      "version": "4.5.7",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/service-error-classification": "^3.0.11",
-        "@smithy/smithy-client": "^3.7.0",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-middleware": "^3.0.11",
-        "@smithy/util-retry": "^3.0.11",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-serde": {
-      "version": "3.0.11",
+      "version": "4.2.20",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-stack": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.12",
+      "version": "4.3.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.11",
-        "@smithy/shared-ini-file-loader": "^3.1.12",
-        "@smithy/types": "^3.7.2",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/node-http-handler": {
-      "version": "3.3.3",
+      "version": "4.9.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.9",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/querystring-builder": "^3.0.11",
-        "@smithy/types": "^3.7.2",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/property-provider": {
-      "version": "3.1.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/protocol-http": {
-      "version": "4.1.8",
+      "version": "5.3.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/querystring-builder": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/querystring-parser": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.11",
+      "version": "4.3.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.12",
+      "version": "4.4.9",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/signature-v4": {
-      "version": "4.2.4",
+      "version": "5.6.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.11",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/smithy-client": {
-      "version": "3.7.0",
+      "version": "4.12.13",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.5.7",
-        "@smithy/middleware-endpoint": "^3.2.8",
-        "@smithy/middleware-stack": "^3.0.11",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-stream": "^3.3.4",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/types": {
-      "version": "3.7.2",
+      "version": "4.15.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/url-parser": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.11",
-        "@smithy/types": "^3.7.2",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-base64": {
-      "version": "3.0.0",
+      "version": "4.3.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-body-length-browser": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-body-length-node": {
-      "version": "3.0.0",
+      "version": "4.2.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-config-provider": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.34",
+      "version": "4.3.49",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.11",
-        "@smithy/smithy-client": "^3.7.0",
-        "@smithy/types": "^3.7.2",
-        "bowser": "^2.11.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.34",
+      "version": "4.2.54",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.13",
-        "@smithy/credential-provider-imds": "^3.2.8",
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/property-provider": "^3.1.11",
-        "@smithy/smithy-client": "^3.7.0",
-        "@smithy/types": "^3.7.2",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-endpoints": {
-      "version": "2.1.7",
+      "version": "3.4.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.12",
-        "@smithy/types": "^3.7.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-hex-encoding": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-middleware": {
-      "version": "3.0.11",
+      "version": "4.2.14",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-retry": {
-      "version": "3.0.11",
+      "version": "4.3.8",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.11",
-        "@smithy/types": "^3.7.2",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-stream": {
-      "version": "3.3.4",
+      "version": "4.5.25",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^4.1.3",
-        "@smithy/node-http-handler": "^3.3.3",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
-      "version": "4.1.3",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/querystring-builder": "^3.0.11",
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-base64": "^3.0.0",
-        "tslib": "^2.6.2"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-uri-escape": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/uuid": {
-      "version": "1.1.0",
+      "version": "1.1.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15513,50 +6655,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-builder": {
-      "version": "1.1.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-parser": {
-      "version": "5.5.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.1",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-parser/node_modules/strnum": {
-      "version": "2.1.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -15633,6 +6731,18 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/jsonfile": {
       "version": "4.0.0",
       "inBundle": true,
@@ -15647,7 +6757,7 @@
       "license": "MIT"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
       "inBundle": true,
       "license": "MIT"
     },
@@ -15679,20 +6789,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/pluralize": {
       "version": "8.0.0",
       "inBundle": true,
@@ -15700,6 +6796,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/semver": {
       "version": "7.7.1",
@@ -15712,14 +6813,8 @@
         "node": ">=10"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/strnum": {
-      "version": "1.1.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/ts-algebra": {
+      "version": "2.0.0",
       "inBundle": true,
       "license": "MIT"
     },
@@ -15745,7 +6840,7 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/uuid": {
-      "version": "9.0.1",
+      "version": "11.1.1",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -15753,7 +6848,7 @@
       "inBundle": true,
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/zod": {
@@ -33937,7 +25032,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -44238,7 +35332,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -45114,8 +36207,8 @@
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.5",
-        "@aws-amplify/data-construct": "^1.15.1",
-        "@aws-amplify/data-schema-types": "^1.2.0",
+        "@aws-amplify/data-construct": "^1.17.7",
+        "@aws-amplify/data-schema-types": "^1.3.0",
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/plugin-types": "^1.12.1",
         "graphql": "^15.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -894,6 +894,7 @@
         "uuid",
         "zod"
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/backend-output-schemas": "^1.0.0",
@@ -3780,6 +3781,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.3.0.tgz",
       "integrity": "sha512-A9vuOwhdrRFCXIXaL48JtpJjSoAdhpI4CPFRPm7F+i4hF1nQO3+bGdiSHY6iKRrEoBoXCAcwozIjvAImhxz2sg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "graphql": "15.8.0",
         "rxjs": "^7.8.1"
@@ -3991,6 +3993,7 @@
         "uuid",
         "zod"
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/ai-constructs": "^1.6.2",
         "@aws-amplify/backend-output-schemas": "^1.0.0",
@@ -25032,6 +25035,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -35332,6 +35336,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "@aws-amplify/backend-output-storage": "^1.3.5",
     "@aws-amplify/backend-output-schemas": "^1.8.0",
-    "@aws-amplify/data-construct": "^1.15.1",
-    "@aws-amplify/data-schema-types": "^1.2.0",
+    "@aws-amplify/data-construct": "^1.17.7",
+    "@aws-amplify/data-schema-types": "^1.3.0",
     "@aws-amplify/graphql-generator": "^0.5.1",
     "@aws-amplify/plugin-types": "^1.12.1",
     "graphql": "^15.8.0"

--- a/packages/backend-data/src/convert_schema.test.ts
+++ b/packages/backend-data/src/convert_schema.test.ts
@@ -225,6 +225,7 @@ void describe('convertSchemaToCDK', () => {
             'SELECT * from post where id % 2 = 1;',
         },
         vpcConfiguration: undefined,
+        minimizeRdsVpcEndpoints: undefined,
       },
     );
   });
@@ -277,6 +278,7 @@ void describe('convertSchemaToCDK', () => {
         },
         customSqlStatements: {},
         vpcConfiguration: undefined,
+        minimizeRdsVpcEndpoints: undefined,
       },
     );
   });
@@ -390,6 +392,7 @@ void describe('convertSchemaToCDK', () => {
             },
           ],
         },
+        minimizeRdsVpcEndpoints: undefined,
         /* eslint-enable spellcheck/spell-checker */
       },
     );
@@ -450,6 +453,7 @@ void describe('convertSchemaToCDK', () => {
         dbType: 'MYSQL',
         name: '00034dcf3444861c3ca5mysql',
         vpcConfiguration: undefined,
+        minimizeRdsVpcEndpoints: undefined,
         /* eslint-enable spellcheck/spell-checker */
       },
     );
@@ -510,8 +514,58 @@ void describe('convertSchemaToCDK', () => {
         dbType: 'POSTGRES',
         name: '00034dcf3444861c3ca5postgresql',
         vpcConfiguration: undefined,
+        minimizeRdsVpcEndpoints: undefined,
         /* eslint-enable spellcheck/spell-checker */
       },
+    );
+  });
+
+  void it('maps minimizeRdsVpcEndpoints onto the SQL model data source strategy', () => {
+    const schema = configure({
+      database: {
+        engine: 'mysql',
+        connectionUri: new TestBackendSecret('MYSQL_CONNECTION_STRING'),
+        /* eslint-disable spellcheck/spell-checker */
+        vpcConfig: {
+          vpcId: 'vpc-a1aa11a1',
+          securityGroupIds: ['sg-11111a11'],
+          subnetAvailabilityZones: [
+            {
+              subnetId: 'subnet-1aa1aa11',
+              availabilityZone: 'us-east-1a',
+            },
+          ],
+          /* eslint-enable spellcheck/spell-checker */
+        },
+        minimizeRdsVpcEndpoints: true,
+      },
+    }).schema({
+      post: a
+        .model({
+          id: a.integer().required(),
+          title: a.string(),
+        })
+        .identifier(['id'])
+        .authorization((allow) => allow.publicApiKey()),
+    });
+
+    const convertedDefinition = convertSchemaToCDK(
+      schema,
+      secretResolver,
+      stableBackendIdentifiers,
+    );
+
+    assert.equal(
+      Object.values(convertedDefinition.dataSourceStrategies).length,
+      1,
+    );
+    assert.equal(
+      (
+        Object.values(convertedDefinition.dataSourceStrategies)[0] as {
+          minimizeRdsVpcEndpoints?: boolean;
+        }
+      ).minimizeRdsVpcEndpoints,
+      true,
     );
   });
 });

--- a/packages/backend-data/src/convert_schema.ts
+++ b/packages/backend-data/src/convert_schema.ts
@@ -225,6 +225,7 @@ const convertDatabaseConfigurationToDataSourceStrategy = (
     },
     vpcConfiguration,
     customSqlStatements,
+    minimizeRdsVpcEndpoints: configuration.minimizeRdsVpcEndpoints,
   };
 
   return strategy;

--- a/packages/backend-data/src/factory.test.ts
+++ b/packages/backend-data/src/factory.test.ts
@@ -1,23 +1,26 @@
 import { beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { DataFactory, defineData } from './factory.js';
-import { App, Stack } from 'aws-cdk-lib';
+import { App, SecretValue, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import {
   AmplifyFunction,
   AuthResources,
   BackendOutputEntry,
   BackendOutputStorageStrategy,
+  BackendSecret,
   ConstructContainer,
   ConstructFactory,
   ConstructFactoryGetInstanceProps,
   FunctionResources,
   ImportPathVerifier,
+  ResolvePathResult,
   ResourceAccessAcceptorFactory,
   ResourceNameValidator,
   ResourceProvider,
   SsmEnvironmentEntry,
 } from '@aws-amplify/plugin-types';
+import { configure } from '@aws-amplify/data-schema/internals';
 import { Policy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import {
   CfnIdentityPool,
@@ -1494,6 +1497,76 @@ void describe('DataFactory stackMappings', () => {
     orderDefaultTemplate.hasResourceProperties('AWS::AppSync::Resolver', {
       FieldName: 'deleteOrder',
       TypeName: 'Mutation',
+    });
+  });
+});
+
+class TestBackendSecret implements BackendSecret {
+  constructor(private readonly secretName: string) {}
+  resolve = (): SecretValue => SecretValue.unsafePlainText(this.secretName);
+  resolvePath = (): ResolvePathResult => ({
+    branchSecretPath: `/amplify/branch/${this.secretName}`,
+    sharedSecretPath: `/amplify/shared/${this.secretName}`,
+  });
+}
+
+void describe('DataFactory minimizeRdsVpcEndpoints', () => {
+  beforeEach(() => {
+    resetFactoryCount();
+  });
+
+  void it('synthesizes a single ssm VPC endpoint when minimizeRdsVpcEndpoints is true', () => {
+    const schema = configure({
+      database: {
+        engine: 'mysql',
+        connectionUri: new TestBackendSecret('MYSQL_CONNECTION_STRING'),
+        /* eslint-disable spellcheck/spell-checker */
+        vpcConfig: {
+          vpcId: 'vpc-a1aa11a1',
+          securityGroupIds: ['sg-11111a11'],
+          subnetAvailabilityZones: [
+            {
+              subnetId: 'subnet-1aa1aa11',
+              availabilityZone: 'us-east-1a',
+            },
+          ],
+        },
+        /* eslint-enable spellcheck/spell-checker */
+        minimizeRdsVpcEndpoints: true,
+      },
+    }).schema({
+      post: a
+        .model({
+          id: a.integer().required(),
+          title: a.string(),
+        })
+        .identifier(['id'])
+        .authorization((allow) => allow.publicApiKey()),
+    });
+
+    const dataFactory = defineData({
+      schema,
+      authorizationModes: {
+        defaultAuthorizationMode: 'apiKey',
+        apiKeyAuthorizationMode: { expiresInDays: 7 },
+      },
+    });
+    const getInstanceProps = createInstancePropsBySetupCDKApp({
+      isSandboxMode: false,
+    });
+    const dataConstruct = dataFactory.getInstance(getInstanceProps);
+
+    const sqlStack = Object.values(dataConstruct.resources.nestedStacks).find(
+      (nestedStack) => nestedStack.node.id.startsWith('SQLApiStack'),
+    );
+    assert(sqlStack, 'Expected a SQLApiStack nested stack to be created');
+
+    const template = Template.fromStack(sqlStack);
+    template.resourceCountIs('AWS::EC2::VPCEndpoint', 1);
+    template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
+      ServiceName: {
+        'Fn::Join': ['', Match.arrayWith(['.ssm'])],
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `minimizeRdsVpcEndpoints` support to the Gen2 `defineData` experience by mapping the SQL `DataSourceConfiguration.minimizeRdsVpcEndpoints` customer option onto the underlying `SQLLambdaModelDataSourceStrategy`.

When set to `true`, an RDS-in-VPC SQL Lambda provisions only the `ssm` interface VPC endpoint instead of the default 5 (`ssm`, `ssmmessages`, `ec2`, `ec2messages`, `kms`), reducing per-hour interface-endpoint cost. The default (`false`) preserves the existing behavior. This option is SQL-only and has no effect on DynamoDB-backed models.

## Changes

- **`packages/backend-data/src/convert_schema.ts`** — map `configuration.minimizeRdsVpcEndpoints` onto the `SQLLambdaModelDataSourceStrategy` when constructing the SQL strategy.
- **Dependency bumps** (to pick up the new strategy + customer config types):
  - `@aws-amplify/data-construct` `^1.15.1` → `^1.17.7` (provides the `minimizeRdsVpcEndpoints` field on the strategy type)
  - `@aws-amplify/data-schema-types` `^1.2.0` → `^1.3.0` (provides the `minimizeRdsVpcEndpoints` customer config type)
  - `package-lock.json` updated accordingly
- **Tests**:
  - `packages/backend-data/src/convert_schema.test.ts` — asserts the config → strategy mapping for both the set (`true`) and omitted cases.
  - `packages/backend-data/src/factory.test.ts` — construct-synth test asserting exactly 1 `AWS::EC2::VPCEndpoint` is synthesized and that its `ServiceName` resolves to the `.ssm` endpoint.
- **Changeset** — minor bump for `@aws-amplify/backend-data`.

## Note on package-lock.json size

The large deletion in `package-lock.json` is legitimate and expected. The `@aws-amplify/data-construct` and `@aws-amplify/graphql-api-construct` packages ship `bundleDependencies`, so their nested dependency trees are represented inline in the lockfile. After the version bumps, npm dedupes those bundled subtrees (~479/487 → ~196 entries each).

- `lockfileVersion` is unchanged (still `3`).
- Top-level dependency counts are identical.
- All churn is confined to those two construct subtrees — this is not a tooling/format rewrite.

## Coordinated change

This is the final PR of a 3-repo coordinated change that plumbs `minimizeRdsVpcEndpoints` from the customer-facing schema type down to CDK synthesis:

1. **amplify-category-api #3449** (released) — adds `SQLLambdaModelDataSourceStrategy.minimizeRdsVpcEndpoints` and the transformer consumer that reduces the provisioned VPC endpoints. https://github.com/aws-amplify/amplify-category-api/pull/3449
2. **amplify-data #754** (released as `data-schema-types@1.3.0`) — adds `DataSourceConfiguration.minimizeRdsVpcEndpoints` to the customer-facing SQL config type. https://github.com/aws-amplify/amplify-data/pull/754
3. **This PR** — the integration layer that maps the customer config onto the strategy, making the feature reachable from `defineData`.

Issue: https://github.com/aws-amplify/amplify-category-api/issues/3409

## Testing

- `convert_schema.test.ts` unit tests pass (config → strategy mapping, set + omitted cases).
- `factory.test.ts` construct-synth test passes (asserts 1 `AWS::EC2::VPCEndpoint` with the `.ssm` ServiceName).
- No e2e test added: the provisioned endpoint count is synth-deterministic and the amplify-category-api synth test is the authoritative coverage for the endpoint-minimization behavior.
