### PR TITLE
fix(ci): restore node 24 for publish_snapshot + forward registry-url

### DIFF
--- a/.github/actions/setup_node/action.yml
+++ b/.github/actions/setup_node/action.yml
@@ -5,6 +5,10 @@ inputs:
   node-version:
     description: node version used to configure environment with
     required: true
+  registry-url:
+    description: npm registry URL (needed for trusted publishing)
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -22,6 +26,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
+        registry-url: ${{ inputs.registry-url }}
     - name: Hydrate npx cache
       # This step hydrates npx cache with packages that we use in builds and tests upfront.
       # Otherwise, concurrent attempt to use these tools with cache miss results in race conditions between

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
       - uses: ./.github/actions/restore_build_cache
         with:


### PR DESCRIPTION
## Symptom
The conditional snapshot release (`publish_snapshot` job in `snapshot_release.yml`) fails at `npm run publish:snapshot` with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@aws-amplify%2fbackend
npm error 404  '@aws-amplify/backend@0.0.0-...' is not in this registry.
```

## Root cause
This is an npm **authorization** failure that npm surfaces as an E404 for scoped packages. The publish uses **OIDC trusted publishing** (`NPM_TRUSTED_PUBLISHER: 'true'`, `id-token: write`), which requires **npm >= 11.5.1** (shipped with Node 24).

PR #3283 ("Node version modernization") did a blanket node-version remap across `snapshot_release.yml` and **inadvertently downgraded the `publish_snapshot` step from `node-version: 24` to `node-version: 22`**. Node 22 ships npm 10.x, which cannot perform the OIDC token exchange — so npm publishes unauthenticated and gets E404. The break went unnoticed because snapshot releases only run on `snapshot/*` branch pushes.

The `registry-url` was already passed by the caller and is not the actual cause — Node 24's npm does OIDC against the default `registry.npmjs.org` automatically.

## Fix
1. **`snapshot_release.yml`** — restore `node-version: 24` on the `publish_snapshot` setup_node step, matching the working `publish_package_versions` job in `health_checks.yml`. **(the actual fix)**
2. **`actions/setup_node/action.yml`** — accept and forward an optional `registry-url` input to `actions/setup-node` (it was previously declared-but-dropped). Hygiene / makes the caller's existing `registry-url:` argument actually take effect. Pinned `actions/setup-node` SHA unchanged.

## Testing
Branch uses the `snapshot/` prefix so `run_snapshot_release` (`if: startsWith(github.ref_name, 'snapshot/')`) can be dispatched to validate the trusted-publishing flow end-to-end.

https://github.com/aws-amplify/amplify-backend/actions/runs/29831364525/job/88637823769