### PR TITLE
fix(integration-tests): prevent hosting e2e stack collision on overlapping runs

### DIFF
--- a/.changeset/hosting-e2e-stack-collision-fix.md
+++ b/.changeset/hosting-e2e-stack-collision-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(integration-tests): serialize hosting e2e and wait for shared stack deletion to avoid CloudFormation DELETE_IN_PROGRESS collisions

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -51,6 +51,7 @@
   "declarator",
   "decrypt",
   "dependabot",
+  "deployable",
   "deployer",
   "deprecations",
   "deprecator",

--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -422,6 +422,16 @@ jobs:
     if: needs.do_include_e2e.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    # The hosting e2e test intentionally deploys into a fixed, manually pre-connected
+    # Amplify app ('hosting-test-app') on a fixed branch, so it cannot use the random
+    # per-run app/branch naming the other e2e tests use. That means every run reuses the
+    # same CloudFormation stack (amplify-<appId>-<branch>-<hash>). When two runs overlap,
+    # the newer run's pipeline-deploy hits a stack the previous run is still asynchronously
+    # deleting, failing with `CloudFormationDeploymentError ... DELETE_IN_PROGRESS`.
+    # Serialize this job (queue, don't cancel) so runs never overlap on the shared app.
+    concurrency:
+      group: e2e-hosting-shared-app
+      cancel-in-progress: false
     needs:
       - do_include_e2e
       - build

--- a/packages/integration-tests/src/test-e2e/hosting.test.ts
+++ b/packages/integration-tests/src/test-e2e/hosting.test.ts
@@ -20,10 +20,21 @@ import {
   UpdateAppCommand,
   UpdateBranchCommand,
 } from '@aws-sdk/client-amplify';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  DescribeStacksCommandOutput,
+  waitUntilStackDeleteComplete,
+} from '@aws-sdk/client-cloudformation';
 import { e2eToolingClientConfig } from '../e2e_tooling_client_config.js';
 import { runWithRetry } from '../retry.js';
 
 const amplifyClient = new AmplifyClient({
+  ...e2eToolingClientConfig,
+  maxAttempts: 5,
+});
+
+const cloudFormationClient = new CloudFormationClient({
   ...e2eToolingClientConfig,
   maxAttempts: 5,
 });
@@ -126,6 +137,13 @@ void describe('hosting', () => {
   });
 
   void it('can deploy backend', async () => {
+    // The pipeline-deploy triggered by this job (see buildSpec) deploys into a fixed,
+    // shared CloudFormation stack (amplify-<appId>-<branchName>-<hash>) because this test
+    // reuses a manually pre-connected app/branch and cannot randomize its name like the
+    // other e2e tests. If a previous run's stack is still asynchronously deleting, the new
+    // deployment fails with `CloudFormationDeploymentError ... DELETE_IN_PROGRESS`. Wait for
+    // any in-progress deletion of the shared stack to reach a terminal state before deploying.
+    await waitForSharedStackToBeDeployable(appId, branchName);
     const deploymentJob = await startOrGetDeploymentJob(
       appId,
       branchName,
@@ -242,6 +260,74 @@ const startOrGetDeploymentJob = async (
     5, // maxAttempts
     60 * 1000, // delayMs
   );
+};
+
+/**
+ * Waits until the shared CloudFormation stack backing this app/branch is deployable, i.e. it
+ * is not currently being deleted.
+ *
+ * Unlike the other e2e tests, the hosting test intentionally reuses a fixed, manually
+ * pre-connected app and branch, so its stack name (amplify-<appId>-<branchName>-<hash>) is the
+ * same on every run rather than randomized. Overlapping runs can therefore race: a new
+ * deployment starts while the previous run's stack is still in DELETE_IN_PROGRESS, producing
+ * `CloudFormationDeploymentError ... DELETE_IN_PROGRESS`. This guard blocks until any such
+ * in-progress deletion completes before we kick off a new deployment.
+ *
+ * It is defensive: if no matching stack exists (nothing to delete), it returns immediately.
+ */
+const waitForSharedStackToBeDeployable = async (
+  appId: string,
+  branchName: string,
+) => {
+  const stackNamePrefix = `amplify-${appId}-${branchName}-`;
+  const deletingStack = await findStack(
+    stackNamePrefix,
+    (status) => status === 'DELETE_IN_PROGRESS',
+  );
+  if (!deletingStack?.StackName) {
+    return;
+  }
+  console.log(
+    `Stack ${deletingStack.StackName} is in ${deletingStack.StackStatus}. Waiting for deletion to complete before deploying.`,
+  );
+  const maxWaitSeconds = 10 * 60; // 10 minutes
+  const result = await waitUntilStackDeleteComplete(
+    { client: cloudFormationClient, maxWaitTime: maxWaitSeconds },
+    { StackName: deletingStack.StackName },
+  );
+  assert.ok(
+    result.state === 'SUCCESS',
+    `Stack ${deletingStack.StackName} did not finish deleting within ${maxWaitSeconds}s (waiter state: ${result.state}). Aborting to avoid deploying into a stack that is being deleted.`,
+  );
+  console.log(`Stack ${deletingStack.StackName} finished deleting.`);
+};
+
+/**
+ * Finds the first stack whose name starts with the given prefix and whose status matches the
+ * predicate. Returns undefined when there is no match.
+ */
+const findStack = async (
+  stackNamePrefix: string,
+  statusPredicate: (status: string) => boolean,
+) => {
+  let describeStacksResult: DescribeStacksCommandOutput | undefined;
+  do {
+    describeStacksResult = await cloudFormationClient.send(
+      new DescribeStacksCommand({
+        NextToken: describeStacksResult?.NextToken,
+      }),
+    );
+    const match = describeStacksResult.Stacks?.find(
+      (stack) =>
+        stack.StackName?.startsWith(stackNamePrefix) &&
+        !!stack.StackStatus &&
+        statusPredicate(stack.StackStatus),
+    );
+    if (match) {
+      return match;
+    }
+  } while (describeStacksResult.NextToken);
+  return undefined;
 };
 
 const listJobs = async (


### PR DESCRIPTION
## Problem

The scheduled `hosting` e2e test (`e2e_hosting` job in `health_checks.yml`) intermittently fails with:

```
CloudFormationDeploymentError: The CloudFormation deployment failed due to
amplify-<appId>-main-branch-<hash> being in DELETE_IN_PROGRESS state.
```

Unlike the other e2e tests, `hosting.test.ts` cannot randomize its app/branch name: it deploys into a **fixed, manually pre-connected** Amplify app (`hosting-test-app`) on a fixed branch. The other e2e tests use the shared `amplifyAppPool`, which appends a random `shortUuid()` suffix to every app/branch, so each run gets a unique CloudFormation stack. The hosting test instead reuses the **same** stack (`amplify-<appId>-<branch>-<hash>`) on every run.

Because branch deletion (and the resulting stack deletion) happens **asynchronously**, when two scheduled runs overlap the newer run's `pipeline-deploy` can start while the previous run's stack is still `DELETE_IN_PROGRESS`, causing the failure above.

## Fix (defense in depth)

1. **Serialize the `e2e_hosting` job** with a job-level `concurrency` group (`cancel-in-progress: false`) so overlapping runs **queue** instead of racing on the shared app. This is scoped to the single job so other jobs still run in parallel.

2. **Pre-deploy guard in `hosting.test.ts`**: before deploying, look up the shared stack by its `amplify-<appId>-<branch>-` name prefix and, if it is `DELETE_IN_PROGRESS`, wait (bounded 10 min, via the `waitUntilStackDeleteComplete` SDK waiter) for the deletion to complete. If no matching stack exists it proceeds immediately; on timeout it fails with a clear message.

The fixed-name design of this test is intentional (the app requires a manual repo-connection step), so the fix serializes + waits rather than randomizing the name. Comments in both files explain the why.

## Validation

- `tsc --build` of `@aws-amplify/integration-tests` compiles cleanly (no errors in the changed files).
- No changeset: `@aws-amplify/integration-tests` is a private package and the workflow change is CI-only.
- Live e2e not run here (requires AWS credentials).
