### PR TITLE
docs(backend-notifications): update README to reflect the shipped Customer Profiles push API

### DIFF
--- a/.changeset/lucky-pugs-write.md
+++ b/.changeset/lucky-pugs-write.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-notifications': patch
+---
+
+Document the shipped `defineNotifications` surface in the package README: attach and create modes, `apns` / `fcm` channel props supplied with `secret()`, the three IAM/SigV4 write routes, and the `notifications.amazon_connect` client-config output.

--- a/packages/backend-notifications/README.md
+++ b/packages/backend-notifications/README.md
@@ -3,12 +3,10 @@
 > **Preview:** this package is in preview / prerelease. Its API and generated
 > resources may change in a future release.
 
-An Amplify Gen2 backend factory (`defineNotifications`) that adds an
-Amazon Connect Customer Profiles–backed **write API** (identify-user,
-register-device, remove-device — for both authenticated and guest users, all
-authorized with IAM/SigV4) and a **push-delivery** Lambda to your app. It
-replaces the deprecated Pinpoint `identifyUser` / `UpdateEndpoint` flow with
-per-user Customer Profiles storage plus device registration.
+`defineNotifications` is an Amplify Gen2 backend factory that gives your app an
+Amazon Connect Customer Profiles–backed write API for user identification and
+mobile-device registration, plus a push-delivery Lambda that Amazon Connect
+journeys invoke to send mobile push notifications.
 
 ## Installation
 
@@ -23,70 +21,84 @@ It has peer dependencies on `aws-cdk-lib` (`^2.234.1`) and `constructs`
 ## Prerequisites
 
 - An Amplify Gen2 backend defined with `defineBackend`.
-- An **`auth` resource** (Cognito) in that backend. `defineNotifications`
-  throws a `NotificationsMissingAuthError` if no auth resource is present — the
-  write routes are authorized with IAM/SigV4, so callers sign requests with
-  their Cognito Identity Pool credentials.
-- For **guest** (unauthenticated) identification, your auth resource must allow
-  unauthenticated (guest) access on its Cognito Identity Pool (see
-  [guest support](#guest-unauthenticated-support) below).
+- An **`auth` resource** (`defineAuth`) in that backend, so a Cognito Identity
+  Pool is available: the write routes are authorized with IAM/SigV4 and callers
+  sign requests with their Identity Pool credentials. `defineNotifications`
+  throws a `NotificationsMissingAuthError` when the backend has no auth
+  resource.
+- To identify **guest** callers, enable unauthenticated (guest) access on the
+  auth resource's Identity Pool.
+- To enable push channels, store the platform credentials as Amplify secrets
+  (`npx ampx sandbox secret set ...`) and reference them with `secret()` — an
+  APNs `.p8` token signing key for Apple, an FCM service-account JSON for
+  Android.
 
 ## What it provisions
 
-- A single `AmplifyProfile` Customer Profiles object type, keyed on the
-  server-derived `principalId` (the Cognito Identity Pool `cognitoIdentityId`,
-  populated for **both** authenticated and guest callers). There is no separate
-  guest object type and no `MergeProfiles` — one principal maps to one profile.
-- A dedicated **DynamoDB Devices table** as the authoritative device store (PK
-  `deviceId`, GSI on `principalId`, native TTL). Devices live here, **not** in
-  Customer Profiles.
-- An HTTP API + write Lambda that find-or-creates the caller's profile and
-  manages their devices, exposing three routes — all authorized with
-  **IAM/SigV4** (`AWS_IAM`), no JWT authorizer:
+- An `AmplifyProfile` Customer Profiles object type, keyed on the
+  server-derived `principalId` — the Cognito Identity Pool `identityId`, which
+  is populated for both authenticated and guest callers.
+- A **DynamoDB devices table** as the device store: partition key `deviceId`, a
+  global secondary index on `principalId`, and native TTL expiry.
+- An HTTP API and write Lambda exposing three routes, all authorized with
+  **IAM/SigV4** and callable with authenticated or guest Identity Pool
+  credentials:
   - `POST /identify-user` — find-or-create the caller's profile.
-  - `POST /register-device` — register / re-home a device to the caller.
+  - `POST /register-device` — register a device to the caller.
   - `POST /remove-device` — remove a device the caller owns.
+- A **push-delivery Lambda** that serves as the target of an Amazon Connect
+  journey custom action, together with an AWS End User Messaging (Pinpoint)
+  application through which push messages are delivered.
+- Optional APNs and GCM/FCM channel configuration on that application, when
+  `apns` / `fcm` are supplied.
 
-  All three are callable with authenticated **or** unauthenticated (guest)
-  Cognito Identity Pool credentials; the SigV4-verified `cognitoIdentityId`
-  identifies the caller, so a guest is just an unauthenticated caller on the
-  same routes.
-
-- A push-delivery Lambda (a Connect **Journey Custom-action** target) plus a
-  minimal **AWS End User Messaging (Pinpoint)** application, so Connect can
-  deliver mobile push through `SendMessages`.
+The factory grants `execute-api:Invoke` on the three routes to the Identity
+Pool's authenticated and unauthenticated roles, so identify, register and
+remove work for signed-in and guest callers with no extra IAM wiring. The
+construct also exposes those route ARNs as `routeInvokeArns`.
 
 ## Modes
 
-`defineNotifications` operates in one of two modes, chosen by whether you pass
-`domainName`:
+`defineNotifications` accepts a discriminated union of props, selected by
+whether you pass `domainName`.
 
-### Create-from-scratch (default — no `domainName`)
+### Create mode (`domainName` omitted)
 
-Calling `defineNotifications()` with no `domainName` is the zero-config default.
-It provisions, from scratch and with generated stable names:
+`defineNotifications()` is the zero-config default. It provisions, with
+generated stable names:
 
 - a new Amazon Connect instance (`CONNECT_MANAGED`) and a new Customer Profiles
-  domain, with the object types registered into it;
-- an automatic **Outbound Campaigns v2** association of the new domain with the
-  new instance (via a Lambda-backed CDK custom resource at deploy time), so
-  Connect Journeys can target these profiles;
-- a **message-templates knowledge base** associated with the instance, so push
+  domain, with the object type registered into it;
+- an Outbound Campaigns v2 association between the new domain and the new
+  instance (via a Lambda-backed CDK custom resource at deploy time), so Connect
+  journeys can target these profiles;
+- a message-templates knowledge base associated with the instance, so push
   templates are authorable in the Amazon Connect console.
 
-No pre-existing Connect setup is required.
+Create mode accepts two extra props:
 
-### Attach (`domainName` provided)
+- `instanceAlias?: string` — override the generated Connect instance alias.
+- `expirationDays?: number` — object-type record expiration in days
+  (default `366`).
 
-Passing an existing `domainName` **attaches** to that Customer Profiles domain:
-it registers the object types into the domain additively and never creates a
-Connect instance or a domain. It does not touch the domain's other integrations
-(CTR, Outbound Campaigns) or its Identity Resolution setting. Associating a
-pre-existing domain with Outbound Campaigns remains your responsibility.
+Create-mode resources use the default `RemovalPolicy.DESTROY`, so deleting the
+stack deletes the Connect instance, the Customer Profiles domain, and the
+profile data stored in it.
+
+### Attach mode (`domainName` provided)
+
+Passing `domainName` attaches to that existing Customer Profiles domain — for
+example the `amazon-connect-<instance>` domain Amazon Connect creates when
+Customer Profiles is enabled on your instance. The object type is registered
+into the domain additively; the domain's own integrations (CTR, Outbound
+Campaigns) and Identity Resolution setting are left as they are, and
+associating a pre-existing domain with Outbound Campaigns stays under your
+control. `instanceAlias` and `expirationDays` apply to create mode, so they are
+not part of attach-mode props.
 
 ## Usage
 
-### Zero-config (create from scratch)
+### Zero-config
 
 ```ts
 import { defineBackend } from '@aws-amplify/backend';
@@ -95,9 +107,33 @@ import { auth } from './auth/resource';
 
 defineBackend({
   auth,
-  // Creates a new Connect instance + Customer Profiles domain and wires
-  // everything up — no pre-existing Connect setup required.
   notifications: defineNotifications(),
+});
+```
+
+### Create mode with push channels
+
+```ts
+import { defineBackend, secret } from '@aws-amplify/backend';
+import { defineNotifications } from '@aws-amplify/backend-notifications';
+import { auth } from './auth/resource';
+
+defineBackend({
+  auth,
+  notifications: defineNotifications({
+    instanceAlias: 'my-app-connect',
+    expirationDays: 366,
+    apns: {
+      tokenKey: secret('APNS_SIGNING_KEY'), // contents of AuthKey_XXXX.p8
+      tokenKeyId: 'ABC123DEFG',
+      teamId: 'DEF456GHIJ',
+      bundleId: 'com.example.app',
+      sandbox: false,
+    },
+    fcm: {
+      serviceJson: secret('FCM_SERVICE_ACCOUNT_JSON'),
+    },
+  }),
 });
 ```
 
@@ -111,45 +147,16 @@ import { auth } from './auth/resource';
 defineBackend({
   auth,
   notifications: defineNotifications({
-    // OPTIONAL: attach to an EXISTING Customer Profiles domain — e.g. the
-    // domain Amazon Connect auto-creates for your instance. Omit to create
-    // from scratch (the default above).
     domainName: 'amazon-connect-amplify',
-    // OPTIONAL: object-type record expiration in days (default 366).
-    // expirationDays: 366,
   }),
 });
 ```
 
-`domainName` is **optional**: omit it for the create-from-scratch default, or
-provide it to attach to an existing domain. All properties of
-`defineNotifications` are optional; an `auth` resource, however, is required.
-
-### Guest (unauthenticated) support
-
-Guests use the **same** IAM/SigV4 routes as authenticated users — there is no
-separate guest route. An unauthenticated caller SigV4-signs `POST
-/identify-user` (and `/register-device` / `/remove-device`) with its
-unauthenticated Cognito Identity Pool credentials; API Gateway verifies the
-signature and surfaces the `cognitoIdentityId`, which the Lambda uses as the
-`principalId`. A guest therefore gets an ordinary `AmplifyProfile` keyed by that
-principal — the same object type an authenticated caller gets.
-
-Device ownership is authoritative in the DynamoDB Devices table: registering a
-device is a last-writer-wins `UpdateItem` on the `deviceId`, so when the same
-physical device is later registered under a different principal (e.g. after
-sign-in) it is re-homed atomically and a campaign can never leak to a device now
-owned by another principal.
-
-The construct exposes the three routes' `execute-api:Invoke` ARNs as
-`routeInvokeArns` (and as a stack output) so the app can grant them to the
-Cognito Identity Pool **authenticated and unauthenticated** roles.
-
 ## Client configuration output
 
-The API invoke endpoint and region are surfaced under the canonical
-`notifications` section of `amplify_outputs.json`, at the fixed key
-`amazon_connect` (the path amplify-js reads):
+The API endpoint and region are surfaced under the `notifications` section of
+`amplify_outputs.json` at the `amazon_connect` key (client-config schema
+v1.5), which amplify-js reads:
 
 ```json
 {
@@ -163,104 +170,58 @@ The API invoke endpoint and region are surfaced under the canonical
 ```
 
 Clients reach the routes by convention — `POST {endpoint}/identify-user`,
-`POST {endpoint}/register-device`, and `POST {endpoint}/remove-device` — signing
-each request with SigV4 (authenticated or guest Identity Pool credentials).
+`POST {endpoint}/register-device` and `POST {endpoint}/remove-device` — signing
+each request with SigV4 using authenticated or guest Identity Pool credentials.
 
-## Enabling push channels (APNS / GCM)
+## Push channels
 
-The APNS (Apple) and GCM/FCM (Android) channels require **platform credentials
-that are secrets** (an APNS `.p8` token signing key, or an FCM service-account
-JSON). There are two ways to enable them.
+APNs uses token authentication: supply the `.p8` signing key through
+`secret()` as `apns.tokenKey`, along with the plain `tokenKeyId`, `teamId` and
+`bundleId` identifiers. Set `apns.sandbox: true` to configure the APNs sandbox
+channel for development builds; flipping this value on a deployed stack
+replaces the channel resource, since production and sandbox APNs channels are
+distinct CloudFormation resource types.
 
-### Option A — declarative, via Amplify `secret()` (recommended)
+FCM uses HTTP v1 authentication: supply the Google service-account JSON through
+`secret()` as `fcm.serviceJson`, and the GCM channel is configured with
+`DefaultAuthenticationMethod = TOKEN`.
 
-Pass an optional `apns` and/or `fcm` config to `defineNotifications`. The secret
-key material is supplied with Amplify's `secret()` and resolved at deploy time —
-it is never written into the CloudFormation template as plain text (it flows
-through the same secret custom-resource token Amplify uses for external-auth
-provider secrets in `defineAuth`). Non-secret identifiers are plain props.
+Secret values are resolved at deploy time and are not written into the
+CloudFormation template as plain text. When `apns` or `fcm` is omitted, that
+channel is left unset and the End User Messaging application is still created,
+so you can enable the channel yourself afterwards with your own credentials:
 
-First store the secrets:
-
-```bash
-npx ampx sandbox secret set APNS_SIGNING_KEY      # paste the AuthKey_XXXX.p8 contents
-npx ampx sandbox secret set FCM_SERVICE_ACCOUNT_JSON  # paste the service-account JSON
-```
-
-Then wire them into the resource:
-
-```ts
-import { defineBackend, secret } from '@aws-amplify/backend';
-import { defineNotifications } from '@aws-amplify/backend-notifications';
-import { auth } from './auth/resource';
-
-defineBackend({
-  auth,
-  notifications: defineNotifications({
-    domainName: 'amazon-connect-amplify',
-    // APNs token (.p8) auth. Set `sandbox: true` for development builds.
-    apns: {
-      keySecret: secret('APNS_SIGNING_KEY'),
-      keyId: 'ABC123DEFG',
-      teamId: 'DEF456GHIJ',
-      bundleId: 'com.example.app',
-    },
-    // FCM HTTP v1 (Google deprecated the legacy server key). The credential is
-    // the service-account JSON; the construct sets DefaultAuthenticationMethod=TOKEN.
-    fcm: {
-      credentialsSecret: secret('FCM_SERVICE_ACCOUNT_JSON'),
-    },
-  }),
-});
-```
-
-When `apns`/`fcm` are omitted the channels are left unset (the End User
-Messaging application is still created, but no channel is enabled) — unchanged
-behavior.
-
-> Note: `SendMessages` will only deliver once a channel is enabled **and** the
-> credentials are valid for a real Apple/Google project. A placeholder/dummy
-> secret enables the channel-configuration path but will not deliver to a device.
-
-### Option B — enable the channels yourself after deploy
-
-If you prefer to keep credentials entirely out of the backend definition, omit
-`apns`/`fcm` and enable the channels on the created application with **your own
-credentials**, via the console or CLI:
-
-- **Console:** AWS End User Messaging → your application → **Push notifications**
-  → enable APNS and/or FCM and upload your credentials.
-- **CLI (FCM/GCM):**
+- **Console:** AWS End User Messaging → your application → **Push
+  notifications** → enable APNs and/or FCM and upload your credentials.
+- **CLI:**
 
   ```bash
   aws pinpoint update-gcm-channel \
     --application-id <APP_ID> \
     --gcm-channel-request 'Enabled=true,DefaultAuthenticationMethod=TOKEN,ServiceJson=<FCM_SERVICE_ACCOUNT_JSON>'
-  ```
 
-- **CLI (APNS):**
-
-  ```bash
   aws pinpoint update-apns-channel \
     --application-id <APP_ID> \
     --apns-channel-request 'Enabled=true,TokenKey=<KEY>,TokenKeyId=<KEY_ID>,TeamId=<TEAM_ID>,BundleId=<BUNDLE_ID>'
   ```
 
-The application id is exported by the construct as `eumApplicationId` (and via
-the `PushHandlerFunctionArn` / stack outputs for wiring the Journey
-Custom-action).
+Push delivery reaches a device once a channel is enabled with credentials valid
+for a real Apple or Google project.
+
+## Construct resources
+
+`AmplifyNotifications` exposes the underlying CDK resources through
+`resources` — `apiFunction`, `httpApi`, `profileObjectType`, `devicesTable`,
+`pushFunction`, `pushApplication`, plus `apnsChannel` / `gcmChannel` when a
+channel is configured and `connectInstance` / `profilesDomain` in create mode.
+It also exposes `apiEndpoint`, `domainName`, `pushFunctionArn`,
+`routeInvokeArns`, `createsResources`, the three route paths, and
+`connectInstanceId` / `connectInstanceArn` in create mode.
 
 ## Known limitations
 
-- **At-least-once push delivery (no dedup yet).** The push-delivery Lambda
-  reports a per-profile `retryable` flag so Amazon Connect can retry a transient
-  failure. Those retries are **not** de-duplicated: the per-item
-  `IdempotencyToken` that Connect sends on each batch entry is captured (and
-  surfaced for logging) but is not yet used to suppress a duplicate send, so a
+- **At-least-once push delivery.** The push-delivery Lambda reports a
+  per-profile `retryable` flag so Amazon Connect can retry a transient failure.
+  The per-item `IdempotencyToken` Connect sends on each batch entry is captured
+  for logging, and de-duplication of retried sends is a planned follow-up, so a
   retried profile may receive the same push notification more than once.
-  Idempotent de-duplication is a planned follow-up.
-- **Create-from-scratch resources are destroyed on stack deletion.** In
-  create-from-scratch mode the Connect instance and Customer Profiles domain are
-  provisioned with the default `RemovalPolicy.DESTROY`, so deleting the stack
-  destroys them and **all stored profile data is lost**. Use attach mode with a
-  pre-existing domain if you need the data to outlive the stack.

--- a/packages/backend-notifications/README.md
+++ b/packages/backend-notifications/README.md
@@ -1,8 +1,5 @@
 # @aws-amplify/backend-notifications
 
-> **Preview:** this package is in preview / prerelease. Its API and generated
-> resources may change in a future release.
-
 `defineNotifications` is an Amplify Gen2 backend factory that gives your app an
 Amazon Connect Customer Profiles–backed write API for user identification and
 mobile-device registration, plus a push-delivery Lambda that Amazon Connect
@@ -207,6 +204,65 @@ so you can enable the channel yourself afterwards with your own credentials:
 
 Push delivery reaches a device once a channel is enabled with credentials valid
 for a real Apple or Google project.
+
+## Creating message templates
+
+Push copy is authored as **Amazon Q in Connect message templates** with
+`channelSubtype = PUSH`. In create mode the resource provisions an empty
+`MESSAGE_TEMPLATES` knowledge base and associates it with the Connect instance
+(`Q_MESSAGE_TEMPLATES` integration), and the templates inside it are authored by
+you.
+
+At send time the push-delivery Lambda resolves the template for a journey run:
+
+1. `connectcampaignsv2:DescribeCampaign` on the campaign id from the event gives
+   the Connect instance id.
+2. `connect:ListIntegrationAssociations` filtered to `Q_MESSAGE_TEMPLATES` gives
+   the knowledge base id.
+3. `wisdom:ListMessageTemplates` on that knowledge base selects the template
+   whose `channelSubtype` is `PUSH` **and** whose **name equals the journey
+   custom-action block name** (`ActionId`) that invoked the Lambda.
+4. `wisdom:RenderMessageTemplate` renders `<templateId>:$ACTIVE_VERSION` per
+   profile, so only the published version is delivered.
+
+So the template name is the wiring: name the template exactly as the journey's
+custom-action block. Authoring is a manual step performed with the `qconnect`
+API/CLI against the knowledge base:
+
+```bash
+aws qconnect create-message-template \
+  --knowledge-base-id <KB_ID> \
+  --name 'Push Notification' \
+  --channel-subtype PUSH \
+  --content '{"push":{"apns":{"title":"Hello {{Attributes.firstName}}","body":{"content":"Your order shipped."}},"fcm":{"title":"Hello {{Attributes.firstName}}","body":{"content":"Your order shipped."}}}}'
+
+aws qconnect create-message-template-version \
+  --knowledge-base-id <KB_ID> \
+  --message-template-id <TEMPLATE_ID>
+```
+
+Notes on authoring:
+
+- Publishing a version is required: rendering targets `$ACTIVE_VERSION`, so a
+  saved draft alone is not delivered and a new version is published for each
+  copy change.
+- Per-platform content maps to channels as `push.apns` → `APNS` (and
+  `APNS_SANDBOX`) and `push.fcm` → `GCM`; a platform entry needs both a title
+  and a body to be used.
+- Personalization uses `{{Attributes.<key>}}` variables, resolved from the
+  profile's data: the profile's top-level fields (such as `firstName`) and each
+  entry of its `attributes` map are passed as flat custom attributes.
+- A variable with no matching profile value stays literal in the rendered copy,
+  and the Lambda delivers its default copy for that profile rather than the
+  unresolved text. The same default-copy path applies when no campaign metadata,
+  knowledge base association, or matching template is found.
+- Find the knowledge base id with
+  `aws connect list-integration-associations --instance-id <INSTANCE_ID> --integration-type Q_MESSAGE_TEMPLATES`
+  (the `IntegrationArn` ends in `knowledge-base/<KB_ID>`). In attach mode,
+  associate a `MESSAGE_TEMPLATES` knowledge base with your Connect instance so
+  this lookup resolves.
+
+See the [Amazon Q in Connect message template API reference](https://docs.aws.amazon.com/amazon-q-connect/latest/APIReference/API_CreateMessageTemplate.html).
 
 ## Construct resources
 


### PR DESCRIPTION
Updates `packages/backend-notifications/README.md` so it matches the shipped `defineNotifications` surface.

- Documents the two prop modes of the discriminated union: attach (`domainName`) and create (`instanceAlias`, `expirationDays`).
- Corrects the channel prop names to the shipped types: `apns: { tokenKey, tokenKeyId, teamId, bundleId, sandbox? }` and `fcm: { serviceJson }`, supplied with `secret()`.
- Fixes the usage examples so they type-check (create-mode-only props are no longer shown alongside `domainName`) and shows `defineBackend({ auth, notifications })`.
- Describes the `AmplifyProfile` object type keyed on the server-derived `principalId`, the DynamoDB device store, the three IAM/SigV4 routes, the push-delivery Lambda, the `notifications.amazon_connect` client-config output, and the exposed construct resources.

Docs-only change; a `patch` changeset is included because `check_changeset_completeness` covers every non-test file under `packages/`.