### PR TITLE
fix(backend-notifications): add explicit string types to route-path properties

### DIFF
--- a/.changeset/notifications-route-path-string-types.md
+++ b/.changeset/notifications-route-path-string-types.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-notifications': patch
+---
+
+Annotate notifications route-path properties with explicit string types.

--- a/packages/backend-notifications/API.md
+++ b/packages/backend-notifications/API.md
@@ -29,10 +29,10 @@ export class AmplifyNotifications extends Construct implements ResourceProvider<
     readonly connectInstanceId?: string;
     readonly createsResources: boolean;
     readonly domainName: string;
-    readonly identifyUserPath = "/identify-user";
+    readonly identifyUserPath: string;
     readonly pushFunctionArn: string;
-    readonly registerDevicePath = "/register-device";
-    readonly removeDevicePath = "/remove-device";
+    readonly registerDevicePath: string;
+    readonly removeDevicePath: string;
     readonly resources: NotificationsResources;
     readonly routeInvokeArns: string[];
     readonly stack: Stack;

--- a/packages/backend-notifications/src/construct.ts
+++ b/packages/backend-notifications/src/construct.ts
@@ -291,11 +291,11 @@ export class AmplifyNotifications
   /** Base invoke URL. Clients call `POST {apiEndpoint}/{route}`. */
   public readonly apiEndpoint: string;
   /** The identify-user route path appended to {@link apiEndpoint}. */
-  public readonly identifyUserPath = '/identify-user';
+  public readonly identifyUserPath: string = '/identify-user';
   /** The register-device route path appended to {@link apiEndpoint}. */
-  public readonly registerDevicePath = '/register-device';
+  public readonly registerDevicePath: string = '/register-device';
   /** The remove-device route path appended to {@link apiEndpoint}. */
-  public readonly removeDevicePath = '/remove-device';
+  public readonly removeDevicePath: string = '/remove-device';
   /**
    * The `execute-api:Invoke` ARNs of the three SigV4 write routes, to grant to
    * the app's Cognito Identity Pool authenticated AND unauthenticated roles (a


### PR DESCRIPTION
## Problem

`scripts/check_api_changes` fails repo-wide with:

```
index.ts(46,25): error TS1110: Type expected
index.ts(52,25): error TS1110: Type expected
index.ts(55,25): error TS1110: Type expected
```

Three public fields on `AmplifyNotifications` were declared with a literal initializer and no type annotation, so API.md recorded them as `readonly identifyUserPath = "/identify-user";`. The API-usage generator (`api_usage_statements_generators.ts`) reads `propertyDeclaration.type` and emits `const propertyValue:  = obj.identifyUserPath;` — an empty type, hence TS1110.

## Fix

Annotate the three route-path properties with explicit `: string` types (values unchanged) and regenerate API.md, which now records them as public `string` properties.

## Verification

Ran the repo's own usage generator against both API.md revisions:

- old: `const propertyValue:  = ...identifyUserPath;` (TS1110)
- new: `const propertyValue: string = ...identifyUserPath;` (valid)

Plus `tsc --build packages/backend-notifications` (exit 0), api-extractor clean, eslint/prettier clean, changeset completeness check passes.