### PR TITLE
test(backend-notifications): derive user-agent version assertion from package.json

### DIFF
--- a/.changeset/notifications-ua-assertion-test-only.md
+++ b/.changeset/notifications-ua-assertion-test-only.md
@@ -1,0 +1,4 @@
+---
+---
+
+Adjust the backend-notifications user-agent unit assertion to derive the expected package version at test time, so it stays correct across version bumps.

--- a/packages/backend-notifications/src/lambda/api/handler.test.ts
+++ b/packages/backend-notifications/src/lambda/api/handler.test.ts
@@ -5,6 +5,7 @@
 
 import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
 import { Readable } from 'node:stream';
 import { CustomerProfilesClient } from '@aws-sdk/client-customer-profiles';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
@@ -14,6 +15,17 @@ import { awsClientConfig } from '../shared/client_config.js';
 import { ENV_DEVICES_TABLE_NAME, ENV_DOMAIN_NAME } from '../../constants.js';
 
 const EXPECTED_USER_AGENT = awsClientConfig().customUserAgent;
+
+/**
+ * Read the version straight from package.json so the assertions below track the
+ * real published version and never pin a major (a pinned major breaks the
+ * changesets release PR, which bumps the package before CI runs).
+ */
+const PACKAGE_VERSION: string = JSON.parse(
+  readFileSync(new URL('../../../package.json', import.meta.url), 'utf-8'),
+).version;
+
+const OWN_USER_AGENT_TOKEN = `amplify-backend-notifications/${PACKAGE_VERSION}`;
 
 const PRINCIPAL = 'us-east-1:principal-1';
 
@@ -552,7 +564,10 @@ void describe('inbound user agent propagation', () => {
     for (const ua of userAgents()) {
       assert.match(ua, /aws-amplify\/6\.15\.4/);
       assert.match(ua, /analytics\/2/);
-      assert.match(ua, /amplify-backend-notifications\/0\.\d+\.\d+/);
+      assert.ok(
+        ua.includes(OWN_USER_AGENT_TOKEN),
+        `expected "${ua}" to contain ${OWN_USER_AGENT_TOKEN}`,
+      );
     }
   });
 
@@ -565,7 +580,10 @@ void describe('inbound user agent propagation', () => {
     assert.strictEqual(res.statusCode, 200);
     assert.ok(userAgents().length > 0, 'a DynamoDB call was made');
     for (const ua of userAgents()) {
-      assert.match(ua, /amplify-backend-notifications\/0\.\d+\.\d+/);
+      assert.ok(
+        ua.includes(OWN_USER_AGENT_TOKEN),
+        `expected "${ua}" to contain ${OWN_USER_AGENT_TOKEN}`,
+      );
       assert.doesNotMatch(ua, /aws-amplify\/6\.15\.4/);
     }
   });


### PR DESCRIPTION
## Summary

The user-agent assertions in `backend-notifications`' API handler tests pinned the package's **major** version, so they only held while the package sat at `0.x`. This makes the assertions track the package's real version instead, so they stay correct across every future version bump.

This unblocks the changesets **"Version Packages"** release PR: that PR bumps `@aws-amplify/backend-notifications` from `0.1.0` to `1.0.0` before CI runs, at which point the emitted token becomes `amplify-backend-notifications/1.0.0` and the pinned `0.x` regex no longer matches — failing `test_with_baseline_dependencies` and `test_with_coverage`. Left as-is, it would block every release going forward.

## What it changes

`packages/backend-notifications/src/lambda/api/handler.test.ts` (test-only — no runtime/public API change):

- Reads the version from the package's own `package.json` via `new URL('../../../package.json', import.meta.url)` + `readFileSync` + `JSON.parse` — the same ESM-safe, Windows-safe pattern the runtime helper `client_config.ts` and its sibling `client_config.test.ts` already use (notably *not* `new URL(import.meta.url).pathname`, which breaks on Windows).
- Replaces both `assert.match(ua, /amplify-backend-notifications\/0\.\d+\.\d+/)` occurrences with an exact containment check against `amplify-backend-notifications/${PACKAGE_VERSION}`, with a message that prints the offending user-agent on failure.

This is strictly *stronger* than the previous regex: it asserts the exact version actually emitted, rather than any `0.x` value, while no longer encoding the major. The tests' original intent is unchanged — our token is present on both the Customer Profiles and DynamoDB calls, and only our token appears when the inbound header is absent.

## Testing

- `tsc --build packages/backend-notifications` + `post:compile` — exit 0.
- Full `backend-notifications` unit suite: **269/269 passing**, 0 failures.
- **Verified the fix survives the release bump:** temporarily set `package.json` to `1.0.0` in the working tree and re-ran `handler.test` — **22/22 passing**. Confirmed the emitted token became `amplify-backend-notifications/1.0.0`, which the *old* pinned regex does **not** match (i.e. the old assertion genuinely would have failed the release PR). `package.json` was then reverted to `0.1.0`; the version bump is intentionally **not** part of this commit, as the release bot owns it.
- Swept the package for other version-pinned assertions: none remain. The `0.1.0` literals in `client_ua.test.ts` are self-authored fixtures (the test builds its own `context.userAgent` array and asserts it is preserved) and never read the real package version, so they cannot drift on a bump.
- `eslint --max-warnings 0` and `prettier --check` clean on the touched file. `API.md` unchanged.
- No changeset: `scripts/check_changeset_completeness.ts` passes (exit 0) — it only requires changesets for changed files under `packages/` that do not end in `test.ts`, and this change is test-only.