### PR TITLE
fix(e2e-cleanup): tear down all hosting resources instead of orphaning them

### DIFF
--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -67,6 +67,7 @@
   "declarator",
   "decrypt",
   "dedupe",
+  "deleter",
   "dependabot",
   "deployer",
   "deprecations",

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -48,6 +48,7 @@
   "chown",
   "claude",
   "cloudformation",
+  "cloudfront",
   "codebase",
   "codegen",
   "cognito",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@aws-amplify/eslint-plugin-amplify-backend-rules": "^0.0.2",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-cloudformation": "^3.936.0",
+        "@aws-sdk/client-cloudfront": "^3.936.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
         "@aws-sdk/client-dynamodb": "^3.936.0",
@@ -8957,6 +8958,551 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.936.0.tgz",
+      "integrity": "sha512-vmOZV65l7Spa5C5wz+trtSJ8q23l3wgAYgrw6GnRoPTFHqs74MtWIQLJ+5YJ9cwkytNeSTYC+TZR3rpVa5uX4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/credential-provider-node": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/client-sso": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.936.0.tgz",
+      "integrity": "sha512-0G73S2cDqYwJVvqL08eakj79MZG2QRaB56Ul8/Ps9oQxllr7DMI1IQ/N3j3xjxgpq/U36pkoFZ8aK1n7Sbr3IQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/core": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.936.0.tgz",
+      "integrity": "sha512-eGJ2ySUMvgtOziHhDRDLCrj473RJoL4J1vPjVM3NrKC/fF3/LoHjkut8AAnKmrW6a2uTzNKubigw8dEnpmpERw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.936.0.tgz",
+      "integrity": "sha512-dKajFuaugEA5i9gCKzOaVy9uTeZcApE+7Z5wdcZ6j40523fY1a56khDAUYkCfwqa7sHci4ccmxBkAo+fW1RChA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.936.0.tgz",
+      "integrity": "sha512-5FguODLXG1tWx/x8fBxH+GVrk7Hey2LbXV5h9SFzYCx/2h50URBm0+9hndg0Rd23+xzYe14F6SI9HA9c1sPnjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.936.0.tgz",
+      "integrity": "sha512-TbUv56ERQQujoHcLMcfL0Q6bVZfYF83gu/TjHkVkdSlHPOIKaG/mhE2XZSQzXv1cud6LlgeBbfzVAxJ+HPpffg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/credential-provider-env": "3.936.0",
+        "@aws-sdk/credential-provider-http": "3.936.0",
+        "@aws-sdk/credential-provider-login": "3.936.0",
+        "@aws-sdk/credential-provider-process": "3.936.0",
+        "@aws-sdk/credential-provider-sso": "3.936.0",
+        "@aws-sdk/credential-provider-web-identity": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.936.0.tgz",
+      "integrity": "sha512-8DVrdRqPyUU66gfV7VZNToh56ZuO5D6agWrkLQE/xbLJOm2RbeRgh6buz7CqV8ipRd6m+zCl9mM4F3osQLZn8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.936.0.tgz",
+      "integrity": "sha512-rk/2PCtxX9xDsQW8p5Yjoca3StqmQcSfkmD7nQ61AqAHL1YgpSQWqHE+HjfGGiHDYKG7PvE33Ku2GyA7lEIJAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.936.0",
+        "@aws-sdk/credential-provider-http": "3.936.0",
+        "@aws-sdk/credential-provider-ini": "3.936.0",
+        "@aws-sdk/credential-provider-process": "3.936.0",
+        "@aws-sdk/credential-provider-sso": "3.936.0",
+        "@aws-sdk/credential-provider-web-identity": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.936.0.tgz",
+      "integrity": "sha512-GpA4AcHb96KQK2PSPUyvChvrsEKiLhQ5NWjeef2IZ3Jc8JoosiedYqp6yhZR+S8cTysuvx56WyJIJc8y8OTrLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.936.0.tgz",
+      "integrity": "sha512-wHlEAJJvtnSyxTfNhN98JcU4taA1ED2JvuI2eePgawqBwS/Tzi0mhED1lvNIaWOkjfLd+nHALwszGrtJwEq4yQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.936.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/token-providers": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.936.0.tgz",
+      "integrity": "sha512-v3qHAuoODkoRXsAF4RG+ZVO6q2P9yYBT4GMpMEfU9wXVNn7AIfwZgTwzSUfnjNiGva5BKleWVpRpJ9DeuLFbUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+      "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.936.0.tgz",
+      "integrity": "sha512-YB40IPa7K3iaYX0lSnV9easDOLPLh+fJyUDF3BH8doX4i1AOSsYn86L4lVldmOaSX+DwiaqKHpvk4wPBdcIPWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.936.0.tgz",
+      "integrity": "sha512-eyj2tz1XmDSLSZQ5xnB7cLTVKkSJnYAEoNDSUNhzWPxrBDYeJzIbatecOKceKCU8NBf8gWWZCK/CSY0mDxMO0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/token-providers": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.936.0.tgz",
+      "integrity": "sha512-vvw8+VXk0I+IsoxZw0mX9TMJawUJvEsg3EF7zcCSetwhNPAU8Xmlhv7E/sN/FgSmm7b7DsqKoW6rVtQiCs1PWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/types": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.936.0.tgz",
+      "integrity": "sha512-XOEc7PF9Op00pWV2AYCGDSu5iHgYjIO53Py2VUQTIvP7SRCaCsXmA33mjBvC2Ms6FhSyWNa4aK4naUGIz0hQcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@smithy/util-base64": {
+      "version": "4.5.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.5.16.tgz",
+      "integrity": "sha512-80e25qWKD6hJh5BenAutni2Z6dj2AiZKmht21pcROmzWzQja8yl+KqsuDSia++hwk1Ne6RrDEBwP6I+A4R0XAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cloudtrail": {
@@ -20773,9 +21319,10 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -27817,6 +28364,25 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -36228,20 +36794,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.9.4",
-        "@aws-amplify/backend-data": "^1.7.0",
-        "@aws-amplify/backend-function": "^1.18.1",
+        "@aws-amplify/backend-data": "^1.8.0",
+        "@aws-amplify/backend-function": "^1.18.2",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/backend-secret": "^1.4.2",
         "@aws-amplify/backend-storage": "^1.5.0",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/data-schema": "^1.13.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-amplify": "^3.936.0"
       },
       "devDependencies": {
@@ -36294,7 +36860,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
@@ -36302,7 +36868,7 @@
         "@aws-amplify/data-construct": "^1.17.7",
         "@aws-amplify/data-schema-types": "^1.3.0",
         "@aws-amplify/graphql-generator": "^0.5.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "graphql": "^15.8.0"
       },
       "devDependencies": {
@@ -36317,11 +36883,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "2.1.7",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-cdk/toolkit-lib": "1.32.0",
         "execa": "^9.5.1",
         "minimatch": "10.2.3",
@@ -36621,12 +37187,12 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.5",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-s3": "^3.936.0",
         "execa": "^9.5.1"
       },
@@ -36656,12 +37222,12 @@
     },
     "packages/backend-notifications": {
       "name": "@aws-amplify/backend-notifications",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1"
+        "@aws-amplify/plugin-types": "^1.12.2"
       },
       "devDependencies": {
         "@aws-amplify/backend-output-storage": "^1.3.5",
@@ -36669,6 +37235,7 @@
         "@aws-sdk/client-connect": "^3.1079.0",
         "@aws-sdk/client-connectcampaignsv2": "^3.1079.0",
         "@aws-sdk/client-customer-profiles": "^3.936.0",
+        "@aws-sdk/client-dynamodb": "^3.936.0",
         "@aws-sdk/client-iam": "^3.936.0",
         "@aws-sdk/client-pinpoint": "^3.936.0",
         "@aws-sdk/client-qconnect": "^3.1079.0",
@@ -36746,20 +37313,20 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.8.3",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.7",
+        "@aws-amplify/backend-deployer": "^2.2.0",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.5",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/cli-core": "^2.2.6",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/form-generator": "^1.2.7",
-        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/model-generator": "^1.2.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
-        "@aws-amplify/sandbox": "^2.2.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
+        "@aws-amplify/sandbox": "^2.3.0",
         "@aws-amplify/schema-generator": "^1.4.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-cloudformation": "^3.1078.0",
@@ -36799,7 +37366,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.11.1",
@@ -36913,14 +37480,14 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.10.2",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
-        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/model-generator": "^1.2.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "zod": "3.25.17"
       },
       "devDependencies": {
@@ -37091,6 +37658,7 @@
         "@aws-amplify/platform-core": "^1.11.1",
         "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-amplify/seed": "^1.1.3",
+        "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/client-accessanalyzer": "^3.936.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-bedrock-runtime": "3.936.0",
@@ -37098,13 +37666,17 @@
         "@aws-sdk/client-cloudtrail": "^3.937.0",
         "@aws-sdk/client-cognito-identity": "^3.936.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
+        "@aws-sdk/client-customer-profiles": "^3.1079.0",
+        "@aws-sdk/client-dynamodb": "^3.936.0",
         "@aws-sdk/client-iam": "^3.936.0",
         "@aws-sdk/client-lambda": "^3.936.0",
         "@aws-sdk/client-s3": "^3.936.0",
         "@aws-sdk/client-sqs": "^3.936.0",
         "@aws-sdk/client-sts": "^3.936.0",
         "@aws-sdk/credential-providers": "^3.936.0",
+        "@smithy/protocol-http": "^5.3.12",
         "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/signature-v4": "^5.6.4",
         "@smithy/types": "^4.9.0",
         "@types/lodash.ismatch": "^4.4.9",
         "@zip.js/zip.js": "2.7.52",
@@ -37706,23 +38278,6 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "packages/integration-tests/node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "packages/integration-tests/node_modules/strip-ansi": {
       "version": "7.2.0",
       "dev": true,
@@ -37751,7 +38306,7 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.7.1",
@@ -37759,7 +38314,7 @@
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-appsync": "^3.936.0",
         "@aws-sdk/client-s3": "^3.937.0",
         "@aws-sdk/credential-providers": "^3.936.0",
@@ -37816,7 +38371,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/toolkit-lib": "1.32.0"
@@ -38054,16 +38609,16 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.7",
+        "@aws-amplify/backend-deployer": "^2.2.0",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.5",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/cli-core": "^2.2.6",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
         "@aws-sdk/client-lambda": "^3.936.0",
         "@aws-sdk/client-ssm": "^3.936.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@aws-amplify/eslint-plugin-amplify-backend-rules": "^0.0.2",
     "@aws-sdk/client-amplify": "^3.936.0",
     "@aws-sdk/client-cloudformation": "^3.936.0",
+    "@aws-sdk/client-cloudfront": "^3.936.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
     "@aws-sdk/client-dynamodb": "^3.936.0",

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -1,9 +1,5 @@
 import {
   CloudFormationClient,
-  DeleteStackCommand,
-  ListStacksCommand,
-  ListStacksCommandOutput,
-  StackStatus,
   StackSummary,
 } from '@aws-sdk/client-cloudformation';
 import {
@@ -72,6 +68,7 @@ import {
   ListTablesCommandOutput,
   TableDescription,
 } from '@aws-sdk/client-dynamodb';
+import { StackDeleter } from './components/e2e-cleanup/stack_deleter.js';
 
 const amplifyClient = new AmplifyClient({
   maxAttempts: 5,
@@ -145,44 +142,54 @@ const isStale = (creationDate: Date | undefined): boolean | undefined => {
   return now.getTime() - creationDate.getTime() > staleDurationInMilliseconds;
 };
 
-const listAllStaleTestStacks = async (): Promise<Array<StackSummary>> => {
-  let nextToken: string | undefined = undefined;
-  const stackSummaries: Array<StackSummary> = [];
-  do {
-    const listStacksResponse: ListStacksCommandOutput = await cfnClient.send(
-      new ListStacksCommand({
-        NextToken: nextToken,
-        StackStatusFilter: Object.keys(StackStatus).filter(
-          (status) => status != StackStatus.DELETE_COMPLETE,
-        ) as Array<StackStatus>,
-      }),
-    );
-    nextToken = listStacksResponse.NextToken;
-    listStacksResponse.StackSummaries?.filter(
-      (stackSummary) =>
-        stackSummary.StackName?.startsWith(TEST_AMPLIFY_RESOURCE_PREFIX) &&
-        isStackStale(stackSummary),
-    ).forEach((item) => {
-      stackSummaries.push(item);
-    });
-  } while (nextToken);
-  return stackSummaries;
+const stackDeleter = new StackDeleter(
+  cfnClient,
+  TEST_AMPLIFY_RESOURCE_PREFIX,
+  isStackStale,
+);
+
+/**
+ * Deleting a resource that a stack still owns poisons the delete path of that stack, which is
+ * how stacks end up stuck in DELETE_FAILED forever. Deleting the execution role of a custom
+ * resource for example leaves CloudFormation waiting for a Lambda function that can no longer be
+ * assumed. The ownership index must be captured before any deletion is requested, otherwise the
+ * resources of the stacks that are being deleted look free while CloudFormation still uses them.
+ */
+const liveStackResources = await stackDeleter.getResourcesOwnedByLiveStacks();
+if (!liveStackResources.isComplete) {
+  console.log(
+    'Could not determine which resources still belong to stacks. Only stack deletion will run',
+  );
+}
+
+const isOwnedByLiveStack = (
+  resourceType: string,
+  physicalResourceId: string | undefined,
+): boolean => {
+  if (
+    !liveStackResources.isOwnedByLiveStack(resourceType, physicalResourceId)
+  ) {
+    return false;
+  }
+  console.log(
+    `Skipping direct deletion of ${physicalResourceId} ${resourceType}. It belongs to a stack that has not finished deleting`,
+  );
+  return true;
 };
 
-const allStaleStacks = await listAllStaleTestStacks();
+const allStaleStacks = await stackDeleter.listStaleTopLevelStacks();
 
 for (const staleStack of allStaleStacks) {
-  if (staleStack.StackName) {
-    const stackName = staleStack.StackName;
-    try {
-      await cfnClient.send(new DeleteStackCommand({ StackName: stackName }));
-      console.log(`Successfully kicked off ${stackName} stack deletion`);
-    } catch (e) {
-      const errorMessage = e instanceof Error ? e.message : '';
-      console.log(
-        `Failed to kick off ${stackName} stack deletion. ${errorMessage}`,
-      );
-    }
+  try {
+    await stackDeleter.deleteStack(staleStack);
+    console.log(
+      `Successfully kicked off ${staleStack.StackName} stack deletion`,
+    );
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : '';
+    console.log(
+      `Failed to kick off ${staleStack.StackName} stack deletion. ${errorMessage}`,
+    );
   }
 }
 
@@ -262,6 +269,9 @@ const emptyAndDeleteS3Bucket = async (bucketName: string): Promise<void> => {
 for (const staleBucket of staleBuckets) {
   if (staleBucket.Name) {
     const bucketName = staleBucket.Name;
+    if (isOwnedByLiveStack('AWS::S3::Bucket', bucketName)) {
+      continue;
+    }
     try {
       await emptyAndDeleteS3Bucket(bucketName);
       console.log(`Successfully deleted ${bucketName} bucket`);
@@ -297,6 +307,9 @@ const staleUserPools = await listStaleCognitoUserPools();
 
 for (const staleUserPool of staleUserPools) {
   if (staleUserPool.Name) {
+    if (isOwnedByLiveStack('AWS::Cognito::UserPool', staleUserPool.Id)) {
+      continue;
+    }
     try {
       const describeUserPoolResponse = await cognitoClient.send(
         new DescribeUserPoolCommand({
@@ -446,6 +459,9 @@ const listAllStaleRoles = async (): Promise<Array<Role>> => {
 
 const allStaleRoles = await listAllStaleRoles();
 for (const staleRole of allStaleRoles) {
+  if (isOwnedByLiveStack('AWS::IAM::Role', staleRole.RoleName)) {
+    continue;
+  }
   try {
     // delete inline policies
     const inlinePolicies: ListRolePoliciesCommandOutput = await iamClient.send(
@@ -519,6 +535,9 @@ const listAllStaleSSMParameters = async (): Promise<
 
 const allStaleSSMParameters = await listAllStaleSSMParameters();
 for (const staleSSMParameter of allStaleSSMParameters) {
+  if (isOwnedByLiveStack('AWS::SSM::Parameter', staleSSMParameter.Name)) {
+    continue;
+  }
   try {
     await ssmClient.send(
       new DeleteParameterCommand({
@@ -568,6 +587,11 @@ const listAllStaleDynamoDBTables = async (): Promise<
 
 const allStaleDynamoDBTables = await listAllStaleDynamoDBTables();
 for (const staleDynamoDBTable of allStaleDynamoDBTables) {
+  if (
+    isOwnedByLiveStack('AWS::DynamoDB::Table', staleDynamoDBTable.TableName)
+  ) {
+    continue;
+  }
   try {
     await ddbClient.send(
       new DeleteTableCommand({
@@ -614,6 +638,9 @@ const listAllStaleTestLogGroups = async (): Promise<Array<LogGroup>> => {
 
 const allStaleLogGroups = await listAllStaleTestLogGroups();
 for (const logGroup of allStaleLogGroups) {
+  if (isOwnedByLiveStack('AWS::Logs::LogGroup', logGroup.logGroupName)) {
+    continue;
+  }
   try {
     await cloudWatchClient.send(
       new DeleteLogGroupCommand({

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -2,6 +2,7 @@ import {
   CloudFormationClient,
   StackSummary,
 } from '@aws-sdk/client-cloudformation';
+import { CloudFrontClient } from '@aws-sdk/client-cloudfront';
 import {
   CloudWatchLogsClient,
   DeleteLogGroupCommand,
@@ -58,6 +59,7 @@ import {
   ListTablesCommandOutput,
   TableDescription,
 } from '@aws-sdk/client-dynamodb';
+import { CloudFrontDistributionCleaner } from './components/e2e-cleanup/cloudfront_distribution_cleaner.js';
 import { S3BucketEmptier } from './components/e2e-cleanup/s3_bucket_emptier.js';
 import {
   GuardedResourceType,
@@ -70,6 +72,9 @@ const amplifyClient = new AmplifyClient({
 const cfnClient = new CloudFormationClient({
   maxAttempts: 5,
   retryMode: 'adaptive',
+});
+const cloudFrontClient = new CloudFrontClient({
+  maxAttempts: 5,
 });
 const cloudWatchClient = new CloudWatchLogsClient({
   maxAttempts: 5,
@@ -143,6 +148,10 @@ const stackDeleter = new StackDeleter(
   isStackStale,
 );
 const s3BucketEmptier = new S3BucketEmptier(s3Client);
+const cloudFrontDistributionCleaner = new CloudFrontDistributionCleaner(
+  cloudFrontClient,
+  TEST_AMPLIFY_RESOURCE_PREFIX,
+);
 
 /**
  * Deleting a resource that a stack still owns poisons the delete path of that stack, which is
@@ -210,6 +219,8 @@ const listStaleS3Buckets = async (): Promise<Array<Bucket>> => {
 };
 
 const staleBuckets = await listStaleS3Buckets();
+const bucketToDistributions =
+  await cloudFrontDistributionCleaner.buildBucketToDistributionsIndex();
 
 for (const staleBucket of staleBuckets) {
   if (staleBucket.Name) {
@@ -218,6 +229,23 @@ for (const staleBucket of staleBuckets) {
       continue;
     }
     try {
+      /**
+       * Deleting the origin bucket of a distribution that still exists leaves a distribution
+       * that serves a bucket name anybody can claim, so the distributions go first. Disabling a
+       * distribution takes tens of minutes to propagate, therefore the bucket is retained until
+       * a subsequent run of this script is able to delete its distributions.
+       */
+      const distributionReapResult =
+        await cloudFrontDistributionCleaner.reapDistributionsForBucket(
+          bucketName,
+          bucketToDistributions,
+        );
+      if (distributionReapResult === 'disable-requested') {
+        console.log(
+          `Retaining ${bucketName} bucket. A CloudFront distribution still uses it as an origin`,
+        );
+        continue;
+      }
       await s3BucketEmptier.emptyAndDelete(bucketName);
       console.log(`Successfully deleted ${bucketName} bucket`);
     } catch (e) {

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -68,13 +68,17 @@ import {
   ListTablesCommandOutput,
   TableDescription,
 } from '@aws-sdk/client-dynamodb';
-import { StackDeleter } from './components/e2e-cleanup/stack_deleter.js';
+import {
+  GuardedResourceType,
+  StackDeleter,
+} from './components/e2e-cleanup/stack_deleter.js';
 
 const amplifyClient = new AmplifyClient({
   maxAttempts: 5,
 });
 const cfnClient = new CloudFormationClient({
   maxAttempts: 5,
+  retryMode: 'adaptive',
 });
 const cloudWatchClient = new CloudWatchLogsClient({
   maxAttempts: 5,
@@ -157,19 +161,28 @@ const stackDeleter = new StackDeleter(
  */
 const liveStackResources = await stackDeleter.getResourcesOwnedByLiveStacks();
 if (!liveStackResources.isComplete) {
-  console.log(
-    'Could not determine which resources still belong to stacks. Only stack deletion will run',
+  console.warn(
+    'Could not determine which resources still belong to stacks. Only stack deletion and the Amplify branch sweep will run, every other stale resource is left to a later run',
   );
 }
 
+let resourcesSkippedWithIncompleteIndex = 0;
+
 const isOwnedByLiveStack = (
-  resourceType: string,
+  resourceType: GuardedResourceType,
   physicalResourceId: string | undefined,
 ): boolean => {
   if (
     !liveStackResources.isOwnedByLiveStack(resourceType, physicalResourceId)
   ) {
     return false;
+  }
+  if (!liveStackResources.isComplete) {
+    resourcesSkippedWithIncompleteIndex += 1;
+    console.warn(
+      `Skipping direct deletion of ${physicalResourceId} ${resourceType}. The stack ownership index is incomplete, so it cannot be told apart from a resource that a live stack still owns`,
+    );
+    return true;
   }
   console.log(
     `Skipping direct deletion of ${physicalResourceId} ${resourceType}. It belongs to a stack that has not finished deleting`,
@@ -654,4 +667,17 @@ for (const logGroup of allStaleLogGroups) {
       `Failed to delete ${logGroup.logGroupName} log group. ${errorMessage}`,
     );
   }
+}
+
+/**
+ * An incomplete ownership index means the sweeps above fail closed and leave stale resources
+ * behind. That is the safe outcome, but a silent one: the script would still exit 0, the workflow
+ * would not retry, and a multi region cleanup outage could last for weeks unnoticed. Failing the
+ * job surfaces it. The exit code is set instead of thrown so that everything above still runs.
+ */
+if (!liveStackResources.isComplete) {
+  console.warn(
+    `Cleanup left ${resourcesSkippedWithIncompleteIndex} stale resources behind because the stack ownership index was incomplete. Failing the job so that the run is retried and the cause is visible`,
+  );
+  process.exitCode = 1;
 }

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -9,17 +9,7 @@ import {
   DescribeLogGroupsCommandOutput,
   LogGroup,
 } from '@aws-sdk/client-cloudwatch-logs';
-import {
-  Bucket,
-  DeleteBucketCommand,
-  DeleteObjectsCommand,
-  ListBucketsCommand,
-  ListObjectVersionsCommand,
-  ListObjectsV2Command,
-  ListObjectsV2CommandOutput,
-  ObjectIdentifier,
-  S3Client,
-} from '@aws-sdk/client-s3';
+import { Bucket, ListBucketsCommand, S3Client } from '@aws-sdk/client-s3';
 import {
   CognitoIdentityProviderClient,
   DeleteUserPoolCommand,
@@ -68,6 +58,7 @@ import {
   ListTablesCommandOutput,
   TableDescription,
 } from '@aws-sdk/client-dynamodb';
+import { S3BucketEmptier } from './components/e2e-cleanup/s3_bucket_emptier.js';
 import {
   GuardedResourceType,
   StackDeleter,
@@ -151,6 +142,7 @@ const stackDeleter = new StackDeleter(
   TEST_AMPLIFY_RESOURCE_PREFIX,
   isStackStale,
 );
+const s3BucketEmptier = new S3BucketEmptier(s3Client);
 
 /**
  * Deleting a resource that a stack still owns poisons the delete path of that stack, which is
@@ -219,66 +211,6 @@ const listStaleS3Buckets = async (): Promise<Array<Bucket>> => {
 
 const staleBuckets = await listStaleS3Buckets();
 
-const emptyAndDeleteS3Bucket = async (bucketName: string): Promise<void> => {
-  let nextToken: string | undefined = undefined;
-  do {
-    const listObjectsResponse: ListObjectsV2CommandOutput = await s3Client.send(
-      new ListObjectsV2Command({
-        Bucket: bucketName,
-        ContinuationToken: nextToken,
-      }),
-    );
-    const objectsToDelete: ObjectIdentifier[] | undefined =
-      listObjectsResponse.Contents?.map(
-        (s3Object) => s3Object as ObjectIdentifier,
-      );
-    if (objectsToDelete && objectsToDelete.length > 0) {
-      await s3Client.send(
-        new DeleteObjectsCommand({
-          Bucket: bucketName,
-          Delete: {
-            Objects: objectsToDelete,
-          },
-        }),
-      );
-    }
-    nextToken = listObjectsResponse.NextContinuationToken;
-  } while (nextToken);
-
-  do {
-    const listVersionsResponse = await s3Client.send(
-      new ListObjectVersionsCommand({
-        Bucket: bucketName,
-        KeyMarker: nextToken,
-      }),
-    );
-    const objectsToDelete = ([] as ObjectIdentifier[])
-      .concat(
-        listVersionsResponse.DeleteMarkers?.map(
-          (s3Object) => s3Object as ObjectIdentifier,
-        ) ?? [],
-      )
-      .concat(
-        listVersionsResponse.Versions?.map(
-          (s3Object) => s3Object as ObjectIdentifier,
-        ) ?? [],
-      );
-    if (objectsToDelete.length > 0) {
-      await s3Client.send(
-        new DeleteObjectsCommand({
-          Bucket: bucketName,
-          Delete: {
-            Objects: objectsToDelete,
-          },
-        }),
-      );
-    }
-    nextToken = listVersionsResponse.NextKeyMarker;
-  } while (nextToken);
-
-  await s3Client.send(new DeleteBucketCommand({ Bucket: bucketName }));
-};
-
 for (const staleBucket of staleBuckets) {
   if (staleBucket.Name) {
     const bucketName = staleBucket.Name;
@@ -286,7 +218,7 @@ for (const staleBucket of staleBuckets) {
       continue;
     }
     try {
-      await emptyAndDeleteS3Bucket(bucketName);
+      await s3BucketEmptier.emptyAndDelete(bucketName);
       console.log(`Successfully deleted ${bucketName} bucket`);
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : '';

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -60,6 +60,7 @@ import {
   TableDescription,
 } from '@aws-sdk/client-dynamodb';
 import { CloudFrontDistributionCleaner } from './components/e2e-cleanup/cloudfront_distribution_cleaner.js';
+import { E2E_TEST_REGIONS } from './components/e2e-cleanup/e2e_test_regions.js';
 import { S3BucketEmptier } from './components/e2e-cleanup/s3_bucket_emptier.js';
 import {
   GuardedResourceType,
@@ -69,10 +70,11 @@ import {
 const amplifyClient = new AmplifyClient({
   maxAttempts: 5,
 });
-const cfnClient = new CloudFormationClient({
+const cfnClientConfig = {
   maxAttempts: 5,
   retryMode: 'adaptive',
-});
+};
+const cfnClient = new CloudFormationClient(cfnClientConfig);
 const cloudFrontClient = new CloudFrontClient({
   maxAttempts: 5,
 });
@@ -142,11 +144,16 @@ const isStale = (creationDate: Date | undefined): boolean | undefined => {
   return now.getTime() - creationDate.getTime() > staleDurationInMilliseconds;
 };
 
-const stackDeleter = new StackDeleter(
-  cfnClient,
-  TEST_AMPLIFY_RESOURCE_PREFIX,
-  isStackStale,
-);
+const createStackDeleter = (
+  cloudFormationClient: CloudFormationClient,
+): StackDeleter =>
+  new StackDeleter(
+    cloudFormationClient,
+    TEST_AMPLIFY_RESOURCE_PREFIX,
+    isStackStale,
+  );
+
+const stackDeleter = createStackDeleter(cfnClient);
 const s3BucketEmptier = new S3BucketEmptier(s3Client);
 const cloudFrontDistributionCleaner = new CloudFrontDistributionCleaner(
   cloudFrontClient,
@@ -160,8 +167,40 @@ const cloudFrontDistributionCleaner = new CloudFrontDistributionCleaner(
  * assumed. The ownership index must be captured before any deletion is requested, otherwise the
  * resources of the stacks that are being deleted look free while CloudFormation still uses them.
  */
-const liveStackResources = await stackDeleter.getResourcesOwnedByLiveStacks();
-if (!liveStackResources.isComplete) {
+const currentRegionLiveStackResources =
+  await stackDeleter.getResourcesOwnedByLiveStacks();
+
+/**
+ * S3 buckets and IAM roles are listed account wide, so this run sees the ones of every region that
+ * runs e2e tests, and the stacks of those regions have to be indexed as well. Without them a bucket
+ * or a role of another region looks free and gets deleted while a live stack of that region is still
+ * using it, which is exactly what poisons a stack delete path.
+ *
+ * Region scoped resource types are deliberately not checked against this index. Their names are
+ * only unique within a region, so the equally named resource of another region would keep a
+ * genuinely stale one from ever being cleaned up.
+ */
+const currentRegion = await cfnClient.config.region();
+const allRegionLiveStackResources = (
+  await Promise.all(
+    E2E_TEST_REGIONS.filter((region) => region !== currentRegion).map(
+      (region) =>
+        createStackDeleter(
+          new CloudFormationClient({ ...cfnClientConfig, region }),
+        ).getResourcesOwnedByLiveStacks(),
+    ),
+  )
+).reduce(
+  (mergedIndex, regionIndex) => mergedIndex.merge(regionIndex),
+  currentRegionLiveStackResources,
+);
+
+const ACCOUNT_WIDE_RESOURCE_TYPES: Array<GuardedResourceType> = [
+  'AWS::IAM::Role',
+  'AWS::S3::Bucket',
+];
+
+if (!allRegionLiveStackResources.isComplete) {
   console.warn(
     'Could not determine which resources still belong to stacks. Only stack deletion and the Amplify branch sweep will run, every other stale resource is left to a later run',
   );
@@ -173,6 +212,9 @@ const isOwnedByLiveStack = (
   resourceType: GuardedResourceType,
   physicalResourceId: string | undefined,
 ): boolean => {
+  const liveStackResources = ACCOUNT_WIDE_RESOURCE_TYPES.includes(resourceType)
+    ? allRegionLiveStackResources
+    : currentRegionLiveStackResources;
   if (
     !liveStackResources.isOwnedByLiveStack(resourceType, physicalResourceId)
   ) {
@@ -192,6 +234,29 @@ const isOwnedByLiveStack = (
 };
 
 const allStaleStacks = await stackDeleter.listStaleTopLevelStacks();
+
+/**
+ * A stack that is stuck in DELETE_FAILED because a bucket of one of its nested stacks is not empty
+ * fails the same way on every retry until that bucket is emptied. The bucket is emptied but not
+ * deleted, so that CloudFormation still owns the resource and its own delete of the bucket, and
+ * therefore of the whole stack, is what succeeds on the retry below.
+ */
+const bucketsBlockingStackDeletion =
+  await stackDeleter.findBucketsBlockingStackDeletion(allStaleStacks);
+
+for (const bucketName of bucketsBlockingStackDeletion) {
+  try {
+    await s3BucketEmptier.empty(bucketName);
+    console.log(
+      `Successfully emptied ${bucketName} bucket that blocked a stack deletion`,
+    );
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : '';
+    console.log(
+      `Failed to empty ${bucketName} bucket that blocked a stack deletion. ${errorMessage}`,
+    );
+  }
+}
 
 for (const staleStack of allStaleStacks) {
   try {
@@ -635,7 +700,7 @@ for (const logGroup of allStaleLogGroups) {
  * would not retry, and a multi region cleanup outage could last for weeks unnoticed. Failing the
  * job surfaces it. The exit code is set instead of thrown so that everything above still runs.
  */
-if (!liveStackResources.isComplete) {
+if (!allRegionLiveStackResources.isComplete) {
   console.warn(
     `Cleanup left ${resourcesSkippedWithIncompleteIndex} stale resources behind because the stack ownership index was incomplete. Failing the job so that the run is retried and the cause is visible`,
   );

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import {
+  CloudFrontClient,
+  DeleteDistributionCommand,
+  DistributionSummary,
+  GetDistributionConfigCommand,
+  ListDistributionsCommand,
+  ListDistributionsCommandOutput,
+  UpdateDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
+import { CloudFrontDistributionCleaner } from './cloudfront_distribution_cleaner.js';
+
+const TEST_RESOURCE_PREFIX = 'amplify-';
+
+const buildDistribution = (
+  id: string,
+  originDomainNames: Array<string>,
+  overrides: Partial<DistributionSummary> = {},
+): DistributionSummary =>
+  ({
+    Id: id,
+    Status: 'Deployed',
+    Enabled: true,
+    Origins: {
+      Quantity: originDomainNames.length,
+      Items: originDomainNames.map((domainName, index) => ({
+        Id: `origin-${index}`,
+        DomainName: domainName,
+      })),
+    },
+    ...overrides,
+  }) as DistributionSummary;
+
+const buildCloudFrontClient = (
+  handlers: {
+    listDistributions?: Array<ListDistributionsCommandOutput | Error>;
+    getDistributionConfig?: Array<object | Error>;
+    updateDistribution?: Array<object | Error>;
+    deleteDistribution?: Array<object | Error>;
+  } = {},
+) => {
+  const respond = (responses: Array<object | Error> | undefined) => {
+    const response = responses?.shift();
+    return response instanceof Error
+      ? Promise.reject(response)
+      : Promise.resolve(response ?? {});
+  };
+  const listDistributions: Array<object | Error> = [
+    ...(handlers.listDistributions ?? []),
+  ];
+  const getDistributionConfig: Array<object | Error> = [
+    ...(handlers.getDistributionConfig ?? []),
+  ];
+  const updateDistribution: Array<object | Error> = [
+    ...(handlers.updateDistribution ?? []),
+  ];
+  const deleteDistribution: Array<object | Error> = [
+    ...(handlers.deleteDistribution ?? []),
+  ];
+  const send = mock.fn((command: unknown) => {
+    if (command instanceof ListDistributionsCommand) {
+      return respond(listDistributions);
+    }
+    if (command instanceof GetDistributionConfigCommand) {
+      return respond(getDistributionConfig);
+    }
+    if (command instanceof UpdateDistributionCommand) {
+      return respond(updateDistribution);
+    }
+    if (command instanceof DeleteDistributionCommand) {
+      return respond(deleteDistribution);
+    }
+    return Promise.reject(new Error('Unexpected command'));
+  });
+  return {
+    cloudFrontClient: { send } as unknown as CloudFrontClient,
+    send,
+  };
+};
+
+const getCommandInputs = (
+  send: ReturnType<typeof buildCloudFrontClient>['send'],
+  commandType: unknown,
+): Array<Record<string, unknown>> =>
+  send.mock.calls
+    .map((call) => call.arguments[0])
+    .filter(
+      (command) =>
+        command instanceof (commandType as new (input: never) => object),
+    )
+    .map((command) => (command as { input: Record<string, unknown> }).input);
+
+void describe('CloudFrontDistributionCleaner', () => {
+  void describe('buildBucketToDistributionsIndex', () => {
+    void it('indexes test bucket origins of all supported domain formats', async () => {
+      const { cloudFrontClient } = buildCloudFrontClient({
+        listDistributions: [
+          {
+            DistributionList: {
+              Items: [
+                buildDistribution('D1', [
+                  'amplify-regional.s3.us-west-2.amazonaws.com',
+                ]),
+                buildDistribution('D2', ['amplify-global.s3.amazonaws.com']),
+                buildDistribution('D3', [
+                  'amplify-website.s3-website-us-west-2.amazonaws.com',
+                ]),
+              ],
+              IsTruncated: false,
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).buildBucketToDistributionsIndex();
+
+      assert.deepStrictEqual([...index.keys()].sort(), [
+        'amplify-global',
+        'amplify-regional',
+        'amplify-website',
+      ]);
+      assert.strictEqual(index.get('amplify-regional')?.[0].Id, 'D1');
+    });
+
+    void it('ignores origins that are not test buckets and follows pagination', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient({
+        listDistributions: [
+          {
+            DistributionList: {
+              Items: [
+                buildDistribution('D1', [
+                  'example.com',
+                  'other-bucket.s3.us-west-2.amazonaws.com',
+                  'api.execute-api.us-west-2.amazonaws.com',
+                ]),
+              ],
+              IsTruncated: true,
+              NextMarker: 'D1',
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+          {
+            DistributionList: {
+              Items: [
+                buildDistribution('D2', [
+                  'amplify-app.s3.us-west-2.amazonaws.com',
+                  'amplify-app.s3.us-west-2.amazonaws.com',
+                ]),
+              ],
+              IsTruncated: false,
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).buildBucketToDistributionsIndex();
+
+      assert.deepStrictEqual(getCommandInputs(send, ListDistributionsCommand), [
+        { Marker: undefined },
+        { Marker: 'D1' },
+      ]);
+      assert.deepStrictEqual([...index.keys()], ['amplify-app']);
+      assert.strictEqual(index.get('amplify-app')?.length, 1);
+    });
+
+    void it('returns an empty index instead of throwing when listing is not permitted', async () => {
+      const logMessages: Array<string> = [];
+      const { cloudFrontClient } = buildCloudFrontClient({
+        listDistributions: [
+          new Error(
+            'User is not authorized to perform cloudfront:ListDistributions',
+          ),
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        (message) => logMessages.push(message),
+      ).buildBucketToDistributionsIndex();
+
+      assert.strictEqual(index.size, 0);
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('Unable to list CloudFront distributions'),
+        ),
+      );
+    });
+  });
+
+  void describe('reapDistributionsForBucket', () => {
+    void it('reports none when the bucket has no distributions', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient();
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket('amplify-app', new Map());
+
+      assert.strictEqual(result, 'none');
+      assert.strictEqual(send.mock.callCount(), 0);
+    });
+
+    void it('disables an enabled distribution and keeps the bucket', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient({
+        getDistributionConfig: [
+          {
+            ETag: 'version-1',
+            DistributionConfig: { Enabled: true, Comment: 'x' },
+          },
+        ],
+      });
+      const distribution = buildDistribution('D1', [
+        'amplify-app.s3.us-west-2.amazonaws.com',
+      ]);
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'disable-requested');
+      assert.deepStrictEqual(
+        getCommandInputs(send, UpdateDistributionCommand),
+        [
+          {
+            Id: 'D1',
+            IfMatch: 'version-1',
+            DistributionConfig: { Enabled: false, Comment: 'x' },
+          },
+        ],
+      );
+      assert.strictEqual(
+        getCommandInputs(send, DeleteDistributionCommand).length,
+        0,
+      );
+    });
+
+    void it('waits for a disabled distribution that is not deployed yet', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient();
+      const distribution = buildDistribution(
+        'D1',
+        ['amplify-app.s3.us-west-2.amazonaws.com'],
+        { Enabled: false, Status: 'InProgress' },
+      );
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'disable-requested');
+      assert.strictEqual(send.mock.callCount(), 0);
+    });
+
+    void it('deletes a distribution that is disabled and deployed', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient({
+        getDistributionConfig: [
+          { ETag: 'version-2', DistributionConfig: { Enabled: false } },
+        ],
+      });
+      const distribution = buildDistribution(
+        'D1',
+        ['amplify-app.s3.us-west-2.amazonaws.com'],
+        { Enabled: false, Status: 'Deployed' },
+      );
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'deleted');
+      assert.deepStrictEqual(
+        getCommandInputs(send, DeleteDistributionCommand),
+        [{ Id: 'D1', IfMatch: 'version-2' }],
+      );
+    });
+
+    void it('keeps the bucket when a distribution cannot be reaped', async () => {
+      const logMessages: Array<string> = [];
+      const { cloudFrontClient } = buildCloudFrontClient({
+        getDistributionConfig: [new Error('PreconditionFailed')],
+      });
+      const distribution = buildDistribution(
+        'D1',
+        ['amplify-app.s3.us-west-2.amazonaws.com'],
+        { Enabled: false, Status: 'Deployed' },
+      );
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        (message) => logMessages.push(message),
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'disable-requested');
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('Retaining its origin bucket'),
+        ),
+      );
+    });
+
+    void it('keeps the bucket when only one of the distributions is gone', async () => {
+      const { cloudFrontClient } = buildCloudFrontClient({
+        getDistributionConfig: [
+          { ETag: 'version-1', DistributionConfig: { Enabled: false } },
+          { ETag: 'version-2', DistributionConfig: { Enabled: true } },
+        ],
+      });
+      const distributions = [
+        buildDistribution('D1', ['amplify-app.s3.us-west-2.amazonaws.com'], {
+          Enabled: false,
+          Status: 'Deployed',
+        }),
+        buildDistribution('D2', ['amplify-app.s3.us-west-2.amazonaws.com']),
+      ];
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', distributions]]),
+      );
+
+      assert.strictEqual(result, 'disable-requested');
+    });
+  });
+});

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
@@ -1,0 +1,197 @@
+import {
+  CloudFrontClient,
+  DeleteDistributionCommand,
+  DistributionList,
+  DistributionSummary,
+  GetDistributionConfigCommand,
+  ListDistributionsCommand,
+  ListDistributionsCommandOutput,
+  UpdateDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
+
+/**
+ * Matches the S3 origin domain name formats CloudFront reports, for example
+ * `bucket.s3.us-west-2.amazonaws.com`, `bucket.s3.amazonaws.com` and
+ * `bucket.s3-website-us-west-2.amazonaws.com`. The first group is the bucket name.
+ */
+const S3_ORIGIN_DOMAIN_PATTERN =
+  /^(.+?)\.s3(?:[.-]website)?(?:\.dualstack)?(?:[.-][a-z0-9-]+)?\.amazonaws\.com$/;
+
+const DEPLOYED_STATUS = 'Deployed';
+
+/**
+ * Outcome of an attempt to reap the distributions of a single bucket.
+ *
+ * `disable-requested` means at least one distribution still exists, therefore the origin
+ * bucket must be retained. `deleted` means every distribution of the bucket is gone.
+ */
+export type DistributionReapResult = 'none' | 'disable-requested' | 'deleted';
+
+/**
+ * Deletes CloudFront distributions that are left behind by failed e2e test stack deletions.
+ *
+ * A distribution cannot be deleted while it is enabled, and disabling it takes tens of minutes
+ * to propagate. Reaping is therefore a convergence across hourly runs of the cleanup job rather
+ * than a single blocking operation: one run requests the disable, a later run performs the delete.
+ */
+export class CloudFrontDistributionCleaner {
+  /**
+   * Creates CloudFront distribution cleaner.
+   */
+  constructor(
+    private readonly cloudFrontClient: CloudFrontClient,
+    private readonly testResourcePrefix: string,
+    private readonly log: (message: string) => void = console.log,
+  ) {}
+
+  /**
+   * Indexes all distributions that use a test bucket as an origin by that bucket name.
+   *
+   * Returns an empty index if the distributions cannot be listed, so that the rest of the
+   * cleanup keeps working in accounts where the cleanup role is not permitted to use CloudFront.
+   */
+  buildBucketToDistributionsIndex = async (): Promise<
+    Map<string, Array<DistributionSummary>>
+  > => {
+    const index = new Map<string, Array<DistributionSummary>>();
+    let marker: string | undefined = undefined;
+    try {
+      do {
+        const listDistributionsResponse: ListDistributionsCommandOutput =
+          await this.cloudFrontClient.send(
+            new ListDistributionsCommand({ Marker: marker }),
+          );
+        const distributionList: DistributionList | undefined =
+          listDistributionsResponse.DistributionList;
+        for (const distribution of distributionList?.Items ?? []) {
+          for (const bucketName of this.getTestBucketOrigins(distribution)) {
+            const distributions = index.get(bucketName) ?? [];
+            distributions.push(distribution);
+            index.set(bucketName, distributions);
+          }
+        }
+        marker =
+          distributionList?.IsTruncated === true
+            ? distributionList.NextMarker
+            : undefined;
+      } while (marker);
+    } catch (error) {
+      this.log(
+        `Unable to list CloudFront distributions, skipping distribution cleanup. ${this.getErrorMessage(error)}`,
+      );
+      return new Map();
+    }
+    return index;
+  };
+
+  /**
+   * Moves every distribution of the bucket one step closer to deletion.
+   *
+   * The caller must retain the bucket unless the result is `none` or `deleted`. Deleting the
+   * origin bucket of a distribution that still exists turns it into a dangling distribution
+   * that serves a bucket name anybody can claim.
+   */
+  reapDistributionsForBucket = async (
+    bucketName: string,
+    bucketToDistributions: Map<string, Array<DistributionSummary>>,
+  ): Promise<DistributionReapResult> => {
+    const distributions = bucketToDistributions.get(bucketName) ?? [];
+    let result: DistributionReapResult = 'none';
+    for (const distribution of distributions) {
+      const distributionResult = await this.reapDistribution(distribution);
+      if (distributionResult === 'disable-requested') {
+        result = 'disable-requested';
+      } else if (result === 'none') {
+        result = distributionResult;
+      }
+    }
+    return result;
+  };
+
+  private reapDistribution = async (
+    distribution: DistributionSummary,
+  ): Promise<DistributionReapResult> => {
+    const distributionId = distribution.Id;
+    if (!distributionId) {
+      return 'none';
+    }
+    try {
+      if (distribution.Enabled !== false) {
+        await this.disableDistribution(distributionId);
+        this.log(
+          `Requested disable of ${distributionId} CloudFront distribution. It will be deleted by a subsequent run`,
+        );
+        return 'disable-requested';
+      }
+      if (distribution.Status !== DEPLOYED_STATUS) {
+        this.log(
+          `The ${distributionId} CloudFront distribution is disabled but not deployed yet. It will be deleted by a subsequent run`,
+        );
+        return 'disable-requested';
+      }
+      const getDistributionConfigResponse = await this.cloudFrontClient.send(
+        new GetDistributionConfigCommand({ Id: distributionId }),
+      );
+      await this.cloudFrontClient.send(
+        new DeleteDistributionCommand({
+          Id: distributionId,
+          IfMatch: getDistributionConfigResponse.ETag,
+        }),
+      );
+      this.log(
+        `Successfully deleted ${distributionId} CloudFront distribution`,
+      );
+      return 'deleted';
+    } catch (error) {
+      // The distribution is still there, so its origin bucket must be retained.
+      this.log(
+        `Failed to reap ${distributionId} CloudFront distribution. Retaining its origin bucket. ${this.getErrorMessage(error)}`,
+      );
+      return 'disable-requested';
+    }
+  };
+
+  private disableDistribution = async (
+    distributionId: string,
+  ): Promise<void> => {
+    const getDistributionConfigResponse = await this.cloudFrontClient.send(
+      new GetDistributionConfigCommand({ Id: distributionId }),
+    );
+    if (
+      !getDistributionConfigResponse.DistributionConfig ||
+      !getDistributionConfigResponse.ETag
+    ) {
+      throw new Error(
+        `Unable to read the configuration of ${distributionId} CloudFront distribution`,
+      );
+    }
+    await this.cloudFrontClient.send(
+      new UpdateDistributionCommand({
+        Id: distributionId,
+        IfMatch: getDistributionConfigResponse.ETag,
+        DistributionConfig: {
+          ...getDistributionConfigResponse.DistributionConfig,
+          Enabled: false,
+        },
+      }),
+    );
+  };
+
+  private getTestBucketOrigins = (
+    distribution: DistributionSummary,
+  ): Array<string> => {
+    const bucketNames = new Set<string>();
+    for (const origin of distribution.Origins?.Items ?? []) {
+      const bucketName = origin.DomainName
+        ? S3_ORIGIN_DOMAIN_PATTERN.exec(origin.DomainName)?.[1]
+        : undefined;
+      if (bucketName?.startsWith(this.testResourcePrefix)) {
+        bucketNames.add(bucketName);
+      }
+    }
+    return [...bucketNames];
+  };
+
+  private getErrorMessage = (error: unknown): string =>
+    error instanceof Error ? error.message : '';
+}

--- a/scripts/components/e2e-cleanup/e2e_test_regions.test.ts
+++ b/scripts/components/e2e-cleanup/e2e_test_regions.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import { E2E_TEST_REGIONS } from './e2e_test_regions.js';
+
+const workflowPath = fileURLToPath(
+  new URL(
+    '../../../.github/workflows/e2e_resource_cleanup.yml',
+    import.meta.url,
+  ),
+);
+
+void describe('E2E_TEST_REGIONS', () => {
+  void it('lists the regions of the cleanup workflow matrix', () => {
+    const workflow = readFileSync(workflowPath, 'utf-8');
+    const matrixRegions = /^\s*region:\s*\[(?<regions>[^\]]+)\]\s*$/m.exec(
+      workflow,
+    )?.groups?.regions;
+    assert.ok(
+      matrixRegions,
+      'The cleanup workflow no longer declares its regions as a single line matrix entry, so this test cannot keep E2E_TEST_REGIONS in sync with it anymore',
+    );
+    assert.deepStrictEqual(
+      [...E2E_TEST_REGIONS].sort(),
+      matrixRegions
+        .split(',')
+        .map((region) => region.trim())
+        .sort(),
+      'E2E_TEST_REGIONS is out of sync with the region matrix of the e2e_resource_cleanup workflow. A region that runs e2e tests but is missing here is a region whose live stacks do not protect their account wide resources from the cleanup sweeps',
+    );
+  });
+});

--- a/scripts/components/e2e-cleanup/e2e_test_regions.ts
+++ b/scripts/components/e2e-cleanup/e2e_test_regions.ts
@@ -1,0 +1,16 @@
+/**
+ * The regions that the hourly e2e resource cleanup workflow runs in.
+ *
+ * The workflow runs one job per region, but S3 buckets and IAM roles are listed account wide, so
+ * every one of those jobs sees the buckets and roles of all of these regions. A job therefore has
+ * to know about the stacks of every region, otherwise it deletes a bucket or a role that a live
+ * stack of another region still owns.
+ *
+ * `e2e_test_regions.test.ts` keeps this list in sync with the workflow matrix.
+ */
+export const E2E_TEST_REGIONS = [
+  'us-west-2',
+  'us-east-1',
+  'ca-central-1',
+  'eu-central-1',
+];

--- a/scripts/components/e2e-cleanup/s3_bucket_emptier.test.ts
+++ b/scripts/components/e2e-cleanup/s3_bucket_emptier.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import {
+  DeleteBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectVersionsCommand,
+  ListObjectVersionsCommandOutput,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { S3BucketEmptier } from './s3_bucket_emptier.js';
+
+type S3Response = Record<string, unknown>;
+
+const buildS3Client = (
+  handlers: {
+    listObjectVersions?: Array<ListObjectVersionsCommandOutput>;
+    deleteObjects?: Array<S3Response>;
+    deleteBucket?: Array<S3Response | Error>;
+  } = {},
+) => {
+  const listObjectVersionsResponses = [...(handlers.listObjectVersions ?? [])];
+  const deleteObjectsResponses = [...(handlers.deleteObjects ?? [])];
+  const deleteBucketResponses = [...(handlers.deleteBucket ?? [])];
+  const send = mock.fn((command: unknown) => {
+    if (command instanceof ListObjectVersionsCommand) {
+      return Promise.resolve(listObjectVersionsResponses.shift() ?? {});
+    }
+    if (command instanceof DeleteObjectsCommand) {
+      return Promise.resolve(deleteObjectsResponses.shift() ?? {});
+    }
+    if (command instanceof DeleteBucketCommand) {
+      const response = deleteBucketResponses.shift();
+      return response instanceof Error
+        ? Promise.reject(response)
+        : Promise.resolve(response ?? {});
+    }
+    return Promise.reject(new Error('Unexpected command'));
+  });
+  return { s3Client: { send } as unknown as S3Client, send };
+};
+
+const getCommandInputs = (
+  send: ReturnType<typeof buildS3Client>['send'],
+  commandType: unknown,
+): Array<Record<string, unknown>> =>
+  send.mock.calls
+    .map((call) => call.arguments[0])
+    .filter(
+      (command) =>
+        command instanceof (commandType as new (input: never) => object),
+    )
+    .map((command) => (command as { input: Record<string, unknown> }).input);
+
+const getDeletedObjectCount = (input: Record<string, unknown>): number =>
+  ((input.Delete as Record<string, unknown>).Objects as Array<unknown>).length;
+
+const buildBucketNotEmptyError = (): Error => {
+  const error = new Error('The bucket you tried to delete is not empty');
+  error.name = 'BucketNotEmpty';
+  return error;
+};
+
+void describe('S3BucketEmptier', () => {
+  void it('deletes all object versions and delete markers, then the bucket', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        {
+          Versions: [{ Key: 'a', VersionId: 'v1' }],
+          DeleteMarkers: [{ Key: 'a', VersionId: 'v2' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket');
+
+    assert.deepStrictEqual(getCommandInputs(send, DeleteObjectsCommand), [
+      {
+        Bucket: 'test-bucket',
+        Delete: {
+          Objects: [
+            { Key: 'a', VersionId: 'v1' },
+            { Key: 'a', VersionId: 'v2' },
+          ],
+          Quiet: true,
+        },
+      },
+    ]);
+    assert.deepStrictEqual(getCommandInputs(send, DeleteBucketCommand), [
+      { Bucket: 'test-bucket' },
+    ]);
+  });
+
+  void it('paginates on both key marker and version id marker', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        {
+          Versions: [{ Key: 'a', VersionId: 'v1' }],
+          IsTruncated: true,
+          NextKeyMarker: 'a',
+          NextVersionIdMarker: 'v1',
+          $metadata: {},
+        },
+        {
+          Versions: [{ Key: 'a', VersionId: 'v2' }],
+          IsTruncated: true,
+          NextKeyMarker: 'b',
+          NextVersionIdMarker: undefined,
+          $metadata: {},
+        },
+        {
+          Versions: [{ Key: 'c', VersionId: 'v3' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket');
+
+    assert.deepStrictEqual(getCommandInputs(send, ListObjectVersionsCommand), [
+      {
+        Bucket: 'test-bucket',
+        KeyMarker: undefined,
+        VersionIdMarker: undefined,
+      },
+      { Bucket: 'test-bucket', KeyMarker: 'a', VersionIdMarker: 'v1' },
+      { Bucket: 'test-bucket', KeyMarker: 'b', VersionIdMarker: undefined },
+    ]);
+    assert.strictEqual(getCommandInputs(send, DeleteObjectsCommand).length, 3);
+  });
+
+  void it('deletes objects in batches of 1000', async () => {
+    const versions = Array.from({ length: 1001 }, (_, index) => ({
+      Key: `key-${index}`,
+      VersionId: 'v1',
+    }));
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        { Versions: versions, IsTruncated: false, $metadata: {} },
+      ],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket');
+
+    const deleteObjectsInputs = getCommandInputs(send, DeleteObjectsCommand);
+    assert.strictEqual(deleteObjectsInputs.length, 2);
+    assert.deepStrictEqual(
+      deleteObjectsInputs.map((input) => getDeletedObjectCount(input)),
+      [1000, 1],
+    );
+  });
+
+  void it('throws if the delete objects response reports errors', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        {
+          Versions: [{ Key: 'a', VersionId: 'v1' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+      deleteObjects: [
+        { Errors: [{ Key: 'a', Code: 'AccessDenied', Message: 'nope' }] },
+      ],
+    });
+
+    await assert.rejects(
+      () =>
+        new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket'),
+      (error: Error) => {
+        assert.ok(error.message.includes('Failed to delete 1 object(s)'));
+        assert.ok(error.message.includes('AccessDenied'));
+        return true;
+      },
+    );
+    assert.strictEqual(getCommandInputs(send, DeleteBucketCommand).length, 0);
+  });
+
+  void it('empties the bucket again and retries when the bucket is not empty', async () => {
+    const emptyPage: ListObjectVersionsCommandOutput = {
+      IsTruncated: false,
+      $metadata: {},
+    };
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        emptyPage,
+        {
+          Versions: [{ Key: 'written-during-cleanup', VersionId: 'v1' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+      deleteBucket: [buildBucketNotEmptyError(), {}],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket');
+
+    assert.strictEqual(
+      getCommandInputs(send, ListObjectVersionsCommand).length,
+      2,
+    );
+    assert.strictEqual(getCommandInputs(send, DeleteObjectsCommand).length, 1);
+    assert.strictEqual(getCommandInputs(send, DeleteBucketCommand).length, 2);
+  });
+
+  void it('does not retry the bucket deletion on other failures', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [{ IsTruncated: false, $metadata: {} }],
+      deleteBucket: [new Error('AccessDenied')],
+    });
+
+    await assert.rejects(
+      () =>
+        new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket'),
+      (error: Error) => {
+        assert.strictEqual(error.message, 'AccessDenied');
+        return true;
+      },
+    );
+    assert.strictEqual(getCommandInputs(send, DeleteBucketCommand).length, 1);
+  });
+});

--- a/scripts/components/e2e-cleanup/s3_bucket_emptier.test.ts
+++ b/scripts/components/e2e-cleanup/s3_bucket_emptier.test.ts
@@ -92,6 +92,31 @@ void describe('S3BucketEmptier', () => {
     ]);
   });
 
+  void it('leaves the bucket in place when it is only emptied', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        {
+          Versions: [{ Key: 'a', VersionId: 'v1' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).empty('test-bucket');
+
+    assert.deepStrictEqual(getCommandInputs(send, DeleteObjectsCommand), [
+      {
+        Bucket: 'test-bucket',
+        Delete: {
+          Objects: [{ Key: 'a', VersionId: 'v1' }],
+          Quiet: true,
+        },
+      },
+    ]);
+    assert.deepStrictEqual(getCommandInputs(send, DeleteBucketCommand), []);
+  });
+
   void it('paginates on both key marker and version id marker', async () => {
     const { s3Client, send } = buildS3Client({
       listObjectVersions: [

--- a/scripts/components/e2e-cleanup/s3_bucket_emptier.ts
+++ b/scripts/components/e2e-cleanup/s3_bucket_emptier.ts
@@ -48,7 +48,15 @@ export class S3BucketEmptier {
     }
   };
 
-  private empty = async (bucketName: string): Promise<void> => {
+  /**
+   * Removes all object versions and delete markers from the bucket, leaving the bucket in place.
+   *
+   * Unblocks a CloudFormation stack whose bucket delete failed with `BucketNotEmpty`. The bucket
+   * itself is left to CloudFormation, so that its record of the resource stays intact and the
+   * retried stack deletion can complete normally.
+   * @throws if any object could not be deleted.
+   */
+  empty = async (bucketName: string): Promise<void> => {
     let keyMarker: string | undefined = undefined;
     let versionIdMarker: string | undefined = undefined;
     let isTruncated = false;

--- a/scripts/components/e2e-cleanup/s3_bucket_emptier.ts
+++ b/scripts/components/e2e-cleanup/s3_bucket_emptier.ts
@@ -1,0 +1,119 @@
+import {
+  DeleteBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectVersionsCommand,
+  ListObjectVersionsCommandOutput,
+  ObjectIdentifier,
+  S3Client,
+} from '@aws-sdk/client-s3';
+
+const MAX_OBJECTS_PER_DELETE_REQUEST = 1000;
+
+/**
+ * Empties and deletes S3 buckets.
+ *
+ * Test buckets are versioned, therefore removing the current version of every object
+ * is not enough to make a bucket removable. All object versions and all delete markers
+ * must be removed, otherwise `DeleteBucket` fails with `BucketNotEmpty`.
+ */
+export class S3BucketEmptier {
+  /**
+   * Creates S3 bucket emptier.
+   */
+  constructor(
+    private readonly s3Client: S3Client,
+    private readonly log: (message: string) => void = console.log,
+  ) {}
+
+  /**
+   * Removes all object versions and delete markers from the bucket and then deletes the bucket.
+   *
+   * Bucket emptiness is eventually consistent and a concurrently running test may still be
+   * writing to the bucket, so a `BucketNotEmpty` failure is retried once after emptying again.
+   * @throws if any object or the bucket itself could not be deleted.
+   */
+  emptyAndDelete = async (bucketName: string): Promise<void> => {
+    await this.empty(bucketName);
+    try {
+      await this.s3Client.send(new DeleteBucketCommand({ Bucket: bucketName }));
+    } catch (error) {
+      if (!this.isBucketNotEmptyError(error)) {
+        throw error;
+      }
+      this.log(
+        `Bucket ${bucketName} was not empty when deleting it. Emptying it again.`,
+      );
+      await this.empty(bucketName);
+      await this.s3Client.send(new DeleteBucketCommand({ Bucket: bucketName }));
+    }
+  };
+
+  private empty = async (bucketName: string): Promise<void> => {
+    let keyMarker: string | undefined = undefined;
+    let versionIdMarker: string | undefined = undefined;
+    let isTruncated = false;
+    do {
+      const listObjectVersionsResponse: ListObjectVersionsCommandOutput =
+        await this.s3Client.send(
+          new ListObjectVersionsCommand({
+            Bucket: bucketName,
+            KeyMarker: keyMarker,
+            VersionIdMarker: versionIdMarker,
+          }),
+        );
+      const objectsToDelete: Array<ObjectIdentifier> = [
+        ...(listObjectVersionsResponse.Versions ?? []),
+        ...(listObjectVersionsResponse.DeleteMarkers ?? []),
+      ]
+        .filter((s3Object) => s3Object.Key !== undefined)
+        .map((s3Object) => ({
+          Key: s3Object.Key as string,
+          VersionId: s3Object.VersionId,
+        }));
+      await this.deleteObjects(bucketName, objectsToDelete);
+      // A single key can have more versions than fit in one page. Resuming with the key marker
+      // alone skips the remaining versions of that key, hence the version id marker is required.
+      keyMarker = listObjectVersionsResponse.NextKeyMarker;
+      versionIdMarker = listObjectVersionsResponse.NextVersionIdMarker;
+      isTruncated = listObjectVersionsResponse.IsTruncated === true;
+    } while (isTruncated);
+  };
+
+  private deleteObjects = async (
+    bucketName: string,
+    objectsToDelete: Array<ObjectIdentifier>,
+  ): Promise<void> => {
+    for (
+      let offset = 0;
+      offset < objectsToDelete.length;
+      offset += MAX_OBJECTS_PER_DELETE_REQUEST
+    ) {
+      const batch = objectsToDelete.slice(
+        offset,
+        offset + MAX_OBJECTS_PER_DELETE_REQUEST,
+      );
+      // DeleteObjects is a partial success API. Failures are reported in the response
+      // instead of throwing, and silently ignoring them keeps the bucket from being deleted.
+      const deleteObjectsResponse = await this.s3Client.send(
+        new DeleteObjectsCommand({
+          Bucket: bucketName,
+          Delete: { Objects: batch, Quiet: true },
+        }),
+      );
+      const errors = deleteObjectsResponse.Errors ?? [];
+      if (errors.length > 0) {
+        throw new Error(
+          `Failed to delete ${errors.length} object(s) from ${bucketName} bucket. ${errors
+            .slice(0, 5)
+            .map((error) => `${error.Key}: ${error.Code} ${error.Message}`)
+            .join('; ')}`,
+        );
+      }
+    }
+  };
+
+  private isBucketNotEmptyError = (error: unknown): boolean =>
+    error instanceof Error &&
+    (error.name === 'BucketNotEmpty' ||
+      error.message.includes('BucketNotEmpty'));
+}

--- a/scripts/components/e2e-cleanup/stack_deleter.test.ts
+++ b/scripts/components/e2e-cleanup/stack_deleter.test.ts
@@ -15,6 +15,13 @@ import { StackDeleter } from './stack_deleter.js';
 
 const TEST_RESOURCE_PREFIX = 'amplify-';
 
+/**
+ * The physical id of a nested stack resource is the arn of the nested stack itself, which is how
+ * the resources that block a root stack deletion are reachable from that root stack.
+ */
+const NESTED_STACK_ARN =
+  'arn:aws:cloudformation:us-west-2:123456789012:stack/amplify-hosting-nested/nested-id';
+
 const buildStack = (
   stackName: string,
   overrides: Partial<StackSummary> = {},
@@ -336,6 +343,46 @@ void describe('StackDeleter', () => {
       assert.deepStrictEqual(nextTokens, [undefined, '1']);
     });
 
+    void it('indexes every stack even when many of them are inspected at once', async () => {
+      const stacks = Array.from({ length: 25 }, (unused, index) =>
+        buildStack(`amplify-live-${index}`),
+      );
+      const { cfnClient, send } = buildCfnClient({
+        stacks,
+        resourcesByStack: Object.fromEntries(
+          stacks.map((stackSummary, index) => [
+            `amplify-live-${index}/`,
+            [
+              buildResource(
+                'Bucket',
+                'AWS::S3::Bucket',
+                `amplify-bucket-${index}`,
+              ),
+            ],
+          ]),
+        ),
+      });
+
+      const liveStackResources =
+        await buildStackDeleter(cfnClient).getResourcesOwnedByLiveStacks();
+
+      assert.strictEqual(liveStackResources.isComplete, true);
+      for (let index = 0; index < stacks.length; index++) {
+        assert.strictEqual(
+          liveStackResources.isOwnedByLiveStack(
+            'AWS::S3::Bucket',
+            `amplify-bucket-${index}`,
+          ),
+          true,
+          `The bucket of the amplify-live-${index} stack was not indexed`,
+        );
+      }
+      assert.strictEqual(
+        getNextTokens(send, ListStackResourcesCommand).length,
+        stacks.length,
+      );
+    });
+
     void it('refuses to build the index after a deletion was already requested', async () => {
       const { cfnClient } = buildCfnClient({
         stacks: [buildStack('amplify-stale')],
@@ -538,6 +585,423 @@ void describe('StackDeleter', () => {
           );
           return true;
         },
+      );
+    });
+
+    void it('does not ask for manual attention when only nested stacks block the deletion', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient, send } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'hostingNestedStackResource',
+              'AWS::CloudFormation::Stack',
+              NESTED_STACK_ARN,
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const retainedResources = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).deleteStack(
+        buildStack('amplify-stuck', { StackStatus: StackStatus.DELETE_FAILED }),
+      );
+
+      assert.deepStrictEqual(retainedResources, []);
+      assert.deepStrictEqual(getDeleteStackInputs(send), [
+        { StackName: 'amplify-stuck' },
+      ]);
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('blocking buckets were emptied by this run'),
+        ),
+      );
+      assert.ok(
+        !logMessages.some((message) =>
+          message.includes('needs manual attention'),
+        ),
+      );
+    });
+  });
+
+  void describe('findBucketsBlockingStackDeletion', () => {
+    void it('finds the bucket of a nested stack that blocks the root stack', async () => {
+      const { cfnClient } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'hostingNestedStackResource',
+              'AWS::CloudFormation::Stack',
+              NESTED_STACK_ARN,
+              ResourceStatus.DELETE_FAILED,
+            ),
+            buildResource('CDKMetadata', 'AWS::CDK::Metadata', 'metadata'),
+          ],
+          'amplify-hosting-nested': [
+            buildResource(
+              'HostingBucket',
+              'AWS::S3::Bucket',
+              'amplify-hosting-bucket',
+              ResourceStatus.DELETE_FAILED,
+            ),
+            buildResource(
+              'HostingDistribution',
+              'AWS::CloudFront::Distribution',
+              undefined,
+              ResourceStatus.DELETE_COMPLETE,
+            ),
+          ],
+        },
+      });
+
+      const blockingBuckets = await buildStackDeleter(
+        cfnClient,
+      ).findBucketsBlockingStackDeletion([
+        buildStack('amplify-stuck', {
+          StackStatus: StackStatus.DELETE_FAILED,
+        }),
+      ]);
+
+      assert.deepStrictEqual(blockingBuckets, ['amplify-hosting-bucket']);
+    });
+
+    void it('finds a bucket that blocks the stack it belongs to directly', async () => {
+      const { cfnClient } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'Bucket',
+              'AWS::S3::Bucket',
+              'amplify-blocking-bucket',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const blockingBuckets = await buildStackDeleter(
+        cfnClient,
+      ).findBucketsBlockingStackDeletion([
+        buildStack('amplify-stuck', {
+          StackStatus: StackStatus.DELETE_FAILED,
+        }),
+      ]);
+
+      assert.deepStrictEqual(blockingBuckets, ['amplify-blocking-bucket']);
+    });
+
+    void it('ignores resources that are not blocking the deletion', async () => {
+      const { cfnClient } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'Bucket',
+              'AWS::S3::Bucket',
+              'amplify-healthy-bucket',
+              ResourceStatus.DELETE_IN_PROGRESS,
+            ),
+            buildResource(
+              'Distribution',
+              'AWS::CloudFront::Distribution',
+              'E123',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const blockingBuckets = await buildStackDeleter(
+        cfnClient,
+      ).findBucketsBlockingStackDeletion([
+        buildStack('amplify-stuck', {
+          StackStatus: StackStatus.DELETE_FAILED,
+        }),
+      ]);
+
+      assert.deepStrictEqual(blockingBuckets, []);
+    });
+
+    void it('never empties a bucket that is not a test bucket', async () => {
+      const { cfnClient } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'Bucket',
+              'AWS::S3::Bucket',
+              'some-other-teams-bucket',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const blockingBuckets = await buildStackDeleter(
+        cfnClient,
+      ).findBucketsBlockingStackDeletion([
+        buildStack('amplify-stuck', {
+          StackStatus: StackStatus.DELETE_FAILED,
+        }),
+      ]);
+
+      assert.deepStrictEqual(blockingBuckets, []);
+    });
+
+    void it('only inspects stacks that are in DELETE_FAILED', async () => {
+      const { cfnClient, send } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stale': [
+            buildResource(
+              'Bucket',
+              'AWS::S3::Bucket',
+              'amplify-bucket',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const blockingBuckets = await buildStackDeleter(
+        cfnClient,
+      ).findBucketsBlockingStackDeletion([
+        buildStack('amplify-stale', {
+          StackStatus: StackStatus.DELETE_IN_PROGRESS,
+        }),
+      ]);
+
+      assert.deepStrictEqual(blockingBuckets, []);
+      assert.deepStrictEqual(
+        getNextTokens(send, ListStackResourcesCommand),
+        [],
+      );
+    });
+
+    void it('reports the buckets it could find when a stack cannot be inspected', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-unreadable': new Error(
+            'User is not authorized to perform: cloudformation:ListStackResources',
+          ),
+          'amplify-stuck': [
+            buildResource(
+              'Bucket',
+              'AWS::S3::Bucket',
+              'amplify-blocking-bucket',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const blockingBuckets = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).findBucketsBlockingStackDeletion([
+        buildStack('amplify-unreadable', {
+          StackStatus: StackStatus.DELETE_FAILED,
+        }),
+        buildStack('amplify-stuck', {
+          StackStatus: StackStatus.DELETE_FAILED,
+        }),
+      ]);
+
+      assert.deepStrictEqual(blockingBuckets, ['amplify-blocking-bucket']);
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('buckets that block its deletion stay unknown'),
+        ),
+      );
+    });
+
+    void it('stops following nested stacks that reference each other', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-cyclic': [
+            buildResource(
+              'NestedStack',
+              'AWS::CloudFormation::Stack',
+              'arn:aws:cloudformation:us-west-2:123456789012:stack/amplify-cyclic/id',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const blockingBuckets = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).findBucketsBlockingStackDeletion([
+        buildStack('amplify-cyclic', {
+          StackStatus: StackStatus.DELETE_FAILED,
+        }),
+      ]);
+
+      assert.deepStrictEqual(blockingBuckets, []);
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('at a nesting depth of'),
+        ),
+      );
+    });
+
+    void it('reports a nested stack failure that emptying buckets cannot unblock', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'hostingNestedStackResource',
+              'AWS::CloudFormation::Stack',
+              NESTED_STACK_ARN,
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+          'amplify-hosting-nested': [
+            buildResource(
+              'HostingDistribution',
+              'AWS::CloudFront::Distribution',
+              'E123',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const blockingBuckets = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).findBucketsBlockingStackDeletion([
+        buildStack('amplify-stuck', {
+          StackStatus: StackStatus.DELETE_FAILED,
+        }),
+      ]);
+
+      assert.deepStrictEqual(blockingBuckets, []);
+      assert.ok(
+        logMessages.some(
+          (message) =>
+            message.includes('E123 (AWS::CloudFront::Distribution)') &&
+            message.includes('needs manual attention'),
+        ),
+        `Expected a manual attention message, got ${JSON.stringify(logMessages)}`,
+      );
+    });
+
+    void it('refuses to look for blocking buckets after a deletion was already requested', async () => {
+      const { cfnClient } = buildCfnClient();
+      const stackDeleter = buildStackDeleter(cfnClient);
+      await stackDeleter.deleteStack(buildStack('amplify-stale'));
+
+      await assert.rejects(
+        () => stackDeleter.findBucketsBlockingStackDeletion([]),
+        (error: Error) => {
+          assert.strictEqual(
+            error.message,
+            'The buckets that block a stack deletion must be found before any stack deletion is requested',
+          );
+          return true;
+        },
+      );
+    });
+  });
+});
+
+void describe('LiveStackResourceIndex', () => {
+  void describe('merge', () => {
+    void it('protects the resources of both indexes', async () => {
+      const { cfnClient: firstRegionClient } = buildCfnClient({
+        stacks: [buildStack('amplify-first-region')],
+        resourcesByStack: {
+          'amplify-first-region': [
+            buildResource('Bucket', 'AWS::S3::Bucket', 'first-region-bucket'),
+          ],
+        },
+      });
+      const { cfnClient: secondRegionClient } = buildCfnClient({
+        stacks: [buildStack('amplify-second-region')],
+        resourcesByStack: {
+          'amplify-second-region': [
+            buildResource('Bucket', 'AWS::S3::Bucket', 'second-region-bucket'),
+            buildResource('Role', 'AWS::IAM::Role', 'second-region-role'),
+          ],
+        },
+      });
+
+      const mergedIndex = (
+        await buildStackDeleter(
+          firstRegionClient,
+        ).getResourcesOwnedByLiveStacks()
+      ).merge(
+        await buildStackDeleter(
+          secondRegionClient,
+        ).getResourcesOwnedByLiveStacks(),
+      );
+
+      assert.strictEqual(
+        mergedIndex.isOwnedByLiveStack(
+          'AWS::S3::Bucket',
+          'first-region-bucket',
+        ),
+        true,
+      );
+      assert.strictEqual(
+        mergedIndex.isOwnedByLiveStack(
+          'AWS::S3::Bucket',
+          'second-region-bucket',
+        ),
+        true,
+      );
+      assert.strictEqual(
+        mergedIndex.isOwnedByLiveStack('AWS::IAM::Role', 'second-region-role'),
+        true,
+      );
+      assert.strictEqual(
+        mergedIndex.isOwnedByLiveStack('AWS::S3::Bucket', 'unrelated-bucket'),
+        false,
+      );
+    });
+
+    void it('is incomplete when either index is incomplete', async () => {
+      const { cfnClient: completeClient } = buildCfnClient({
+        stacks: [buildStack('amplify-live')],
+        resourcesByStack: {
+          'amplify-live': [
+            buildResource('Bucket', 'AWS::S3::Bucket', 'live-bucket'),
+          ],
+        },
+      });
+      const { cfnClient: unreadableClient } = buildCfnClient({
+        listStacksError: new Error(
+          'User is not authorized to perform: cloudformation:ListStacks',
+        ),
+      });
+
+      const completeIndex =
+        await buildStackDeleter(completeClient).getResourcesOwnedByLiveStacks();
+      const incompleteIndex =
+        await buildStackDeleter(
+          unreadableClient,
+        ).getResourcesOwnedByLiveStacks();
+
+      assert.strictEqual(completeIndex.isComplete, true);
+      assert.strictEqual(incompleteIndex.isComplete, false);
+      assert.strictEqual(
+        completeIndex.merge(incompleteIndex).isComplete,
+        false,
+      );
+      assert.strictEqual(
+        incompleteIndex.merge(completeIndex).isComplete,
+        false,
+      );
+      assert.strictEqual(
+        completeIndex
+          .merge(incompleteIndex)
+          .isOwnedByLiveStack('AWS::S3::Bucket', 'unrelated-bucket'),
+        true,
       );
     });
   });

--- a/scripts/components/e2e-cleanup/stack_deleter.test.ts
+++ b/scripts/components/e2e-cleanup/stack_deleter.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import {
+  CloudFormationClient,
+  DeleteStackCommand,
+  DeleteStackCommandInput,
+  ListStackResourcesCommand,
+  ListStacksCommand,
+  ResourceStatus,
+  StackResourceSummary,
+  StackStatus,
+  StackSummary,
+} from '@aws-sdk/client-cloudformation';
+import { StackDeleter } from './stack_deleter.js';
+
+const TEST_RESOURCE_PREFIX = 'amplify-';
+
+const buildStack = (
+  stackName: string,
+  overrides: Partial<StackSummary> = {},
+): StackSummary => ({
+  StackName: stackName,
+  StackId: `arn:aws:cloudformation:us-west-2:123456789012:stack/${stackName}/id`,
+  CreationTime: new Date(),
+  StackStatus: StackStatus.CREATE_COMPLETE,
+  ...overrides,
+});
+
+const buildResource = (
+  logicalResourceId: string,
+  resourceType: string,
+  physicalResourceId: string | undefined,
+  resourceStatus: ResourceStatus = ResourceStatus.CREATE_COMPLETE,
+): StackResourceSummary => ({
+  LogicalResourceId: logicalResourceId,
+  ResourceType: resourceType,
+  PhysicalResourceId: physicalResourceId,
+  LastUpdatedTimestamp: new Date(),
+  ResourceStatus: resourceStatus,
+});
+
+const buildCfnClient = (
+  handlers: {
+    stacks?: Array<StackSummary>;
+    listStacksError?: Error;
+    resourcesByStack?: Record<string, Array<StackResourceSummary> | Error>;
+  } = {},
+) => {
+  const send = mock.fn((command: unknown) => {
+    if (command instanceof ListStacksCommand) {
+      return handlers.listStacksError
+        ? Promise.reject(handlers.listStacksError)
+        : Promise.resolve({ StackSummaries: handlers.stacks ?? [] });
+    }
+    if (command instanceof ListStackResourcesCommand) {
+      const stackNameOrId = command.input.StackName ?? '';
+      const resources = Object.entries(handlers.resourcesByStack ?? {}).find(
+        ([stackName]) => stackNameOrId.includes(stackName),
+      )?.[1];
+      return resources instanceof Error
+        ? Promise.reject(resources)
+        : Promise.resolve({ StackResourceSummaries: resources ?? [] });
+    }
+    if (command instanceof DeleteStackCommand) {
+      return Promise.resolve({});
+    }
+    return Promise.reject(new Error('Unexpected command'));
+  });
+  return { cfnClient: { send } as unknown as CloudFormationClient, send };
+};
+
+const getDeleteStackInputs = (
+  send: ReturnType<typeof buildCfnClient>['send'],
+): Array<DeleteStackCommandInput> =>
+  send.mock.calls
+    .map((call) => call.arguments[0])
+    .filter((command) => command instanceof DeleteStackCommand)
+    .map((command) => (command as DeleteStackCommand).input);
+
+const buildStackDeleter = (
+  cfnClient: CloudFormationClient,
+  logMessages: Array<string> = [],
+): StackDeleter =>
+  new StackDeleter(
+    cfnClient,
+    TEST_RESOURCE_PREFIX,
+    (stackSummary) => stackSummary.StackName !== 'amplify-fresh',
+    (message) => logMessages.push(message),
+  );
+
+void describe('StackDeleter', () => {
+  void describe('listStaleTopLevelStacks', () => {
+    void it('returns only stale top level test stacks', async () => {
+      const { cfnClient } = buildCfnClient({
+        stacks: [
+          buildStack('amplify-stale'),
+          buildStack('amplify-fresh'),
+          buildStack('amplify-nested', { RootId: 'root-id' }),
+          buildStack('some-other-stack'),
+        ],
+      });
+
+      const staleStacks =
+        await buildStackDeleter(cfnClient).listStaleTopLevelStacks();
+
+      assert.deepStrictEqual(
+        staleStacks.map((stackSummary) => stackSummary.StackName),
+        ['amplify-stale'],
+      );
+    });
+  });
+
+  void describe('getResourcesOwnedByLiveStacks', () => {
+    void it('indexes resources of stacks that have not finished deleting', async () => {
+      const { cfnClient } = buildCfnClient({
+        stacks: [buildStack('amplify-live')],
+        resourcesByStack: {
+          'amplify-live': [
+            buildResource('Bucket', 'AWS::S3::Bucket', 'amplify-live-bucket'),
+            buildResource('Role', 'AWS::IAM::Role', 'amplify-live-role'),
+            buildResource(
+              'GoneBucket',
+              'AWS::S3::Bucket',
+              'amplify-deleted-bucket',
+              ResourceStatus.DELETE_COMPLETE,
+            ),
+            buildResource('NoId', 'AWS::IAM::Role', undefined),
+          ],
+        },
+      });
+
+      const index =
+        await buildStackDeleter(cfnClient).getResourcesOwnedByLiveStacks();
+
+      assert.strictEqual(index.isComplete, true);
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::S3::Bucket', 'amplify-live-bucket'),
+        true,
+      );
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::IAM::Role', 'amplify-live-role'),
+        true,
+      );
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::S3::Bucket', 'amplify-deleted-bucket'),
+        false,
+      );
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::S3::Bucket', 'amplify-live-role'),
+        false,
+      );
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::S3::Bucket', undefined),
+        false,
+      );
+    });
+
+    void it('indexes stacks regardless of their name, so that non test stacks are protected too', async () => {
+      const { cfnClient } = buildCfnClient({
+        stacks: [buildStack('some-other-stack')],
+        resourcesByStack: {
+          'some-other-stack': [
+            buildResource('Bucket', 'AWS::S3::Bucket', 'amplify-shared-bucket'),
+          ],
+        },
+      });
+
+      const index =
+        await buildStackDeleter(cfnClient).getResourcesOwnedByLiveStacks();
+
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::S3::Bucket', 'amplify-shared-bucket'),
+        true,
+      );
+    });
+
+    void it('protects every resource when the resources of a stack cannot be listed', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient } = buildCfnClient({
+        stacks: [buildStack('amplify-live')],
+        resourcesByStack: {
+          'amplify-live': new Error('Throttling: Rate exceeded'),
+        },
+      });
+
+      const index = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).getResourcesOwnedByLiveStacks();
+
+      assert.strictEqual(index.isComplete, false);
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::IAM::Role', 'any-role'),
+        true,
+      );
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('skipping direct resource deletion'),
+        ),
+      );
+    });
+
+    void it('ignores stacks that finished deleting while they were being inspected', async () => {
+      const { cfnClient } = buildCfnClient({
+        stacks: [buildStack('amplify-live')],
+        resourcesByStack: {
+          'amplify-live': new Error(
+            'Stack with id amplify-live does not exist',
+          ),
+        },
+      });
+
+      const index =
+        await buildStackDeleter(cfnClient).getResourcesOwnedByLiveStacks();
+
+      assert.strictEqual(index.isComplete, true);
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::IAM::Role', 'any-role'),
+        false,
+      );
+    });
+
+    void it('protects every resource when stacks cannot be listed at all', async () => {
+      const { cfnClient } = buildCfnClient({
+        listStacksError: new Error('AccessDenied'),
+      });
+
+      const index =
+        await buildStackDeleter(cfnClient).getResourcesOwnedByLiveStacks();
+
+      assert.strictEqual(index.isComplete, false);
+      assert.strictEqual(
+        index.isOwnedByLiveStack('AWS::S3::Bucket', 'any-bucket'),
+        true,
+      );
+    });
+  });
+
+  void describe('deleteStack', () => {
+    void it('deletes a stack that is not in DELETE_FAILED without retaining resources', async () => {
+      const { cfnClient, send } = buildCfnClient();
+
+      const retainedResources = await buildStackDeleter(cfnClient).deleteStack(
+        buildStack('amplify-stale'),
+      );
+
+      assert.deepStrictEqual(retainedResources, []);
+      assert.deepStrictEqual(getDeleteStackInputs(send), [
+        { StackName: 'amplify-stale' },
+      ]);
+    });
+
+    void it('retains the resources that failed to delete when all of them are safe to leak', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient, send } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'AutoDeleteObjects',
+              'Custom::S3AutoDeleteObjects',
+              'auto-delete',
+              ResourceStatus.DELETE_FAILED,
+            ),
+            buildResource(
+              'BucketDeployment',
+              'Custom::CDKBucketDeployment',
+              'deployment',
+              ResourceStatus.DELETE_FAILED,
+            ),
+            buildResource(
+              'Bucket',
+              'AWS::S3::Bucket',
+              'amplify-stuck-bucket',
+              ResourceStatus.DELETE_FAILED,
+            ),
+            buildResource(
+              'Distribution',
+              'AWS::CloudFront::Distribution',
+              'D1',
+            ),
+          ],
+        },
+      });
+
+      const retainedResources = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).deleteStack(
+        buildStack('amplify-stuck', { StackStatus: StackStatus.DELETE_FAILED }),
+      );
+
+      assert.deepStrictEqual(retainedResources, [
+        'AutoDeleteObjects',
+        'BucketDeployment',
+        'Bucket',
+      ]);
+      assert.deepStrictEqual(getDeleteStackInputs(send), [
+        {
+          StackName: 'amplify-stuck',
+          RetainResources: ['AutoDeleteObjects', 'BucketDeployment', 'Bucket'],
+        },
+      ]);
+      assert.ok(
+        logMessages.some((message) => message.includes('while retaining')),
+      );
+    });
+
+    void it('never abandons a CloudFront distribution and asks for manual attention', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient, send } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'Distribution',
+              'AWS::CloudFront::Distribution',
+              'D1',
+              ResourceStatus.DELETE_FAILED,
+            ),
+            buildResource(
+              'Bucket',
+              'AWS::S3::Bucket',
+              'amplify-stuck-bucket',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const retainedResources = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).deleteStack(
+        buildStack('amplify-stuck', { StackStatus: StackStatus.DELETE_FAILED }),
+      );
+
+      assert.deepStrictEqual(retainedResources, []);
+      assert.deepStrictEqual(getDeleteStackInputs(send), [
+        { StackName: 'amplify-stuck' },
+      ]);
+      assert.ok(
+        logMessages.some(
+          (message) =>
+            message.includes('needs manual attention') &&
+            message.includes('Distribution (AWS::CloudFront::Distribution)'),
+        ),
+      );
+    });
+
+    void it('retries as is when no resource reports a delete failure', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient, send } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource('Bucket', 'AWS::S3::Bucket', 'amplify-stuck-bucket'),
+          ],
+        },
+      });
+
+      const retainedResources = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).deleteStack(
+        buildStack('amplify-stuck', { StackStatus: StackStatus.DELETE_FAILED }),
+      );
+
+      assert.deepStrictEqual(retainedResources, []);
+      assert.deepStrictEqual(getDeleteStackInputs(send), [
+        { StackName: 'amplify-stuck' },
+      ]);
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('needs manual attention'),
+        ),
+      );
+    });
+
+    void it('throws when the stack has no name', async () => {
+      const { cfnClient } = buildCfnClient();
+
+      await assert.rejects(
+        () =>
+          buildStackDeleter(cfnClient).deleteStack({
+            ...buildStack('amplify-stale'),
+            StackName: undefined,
+          }),
+        (error: Error) => {
+          assert.strictEqual(
+            error.message,
+            'Cannot delete a stack without a name',
+          );
+          return true;
+        },
+      );
+    });
+  });
+});

--- a/scripts/components/e2e-cleanup/stack_deleter.test.ts
+++ b/scripts/components/e2e-cleanup/stack_deleter.test.ts
@@ -42,18 +42,42 @@ const buildResource = (
 const buildCfnClient = (
   handlers: {
     stacks?: Array<StackSummary>;
+    stackPages?: Array<Array<StackSummary>>;
     listStacksError?: Error;
     resourcesByStack?: Record<string, Array<StackResourceSummary> | Error>;
+    resourcePagesByStack?: Record<string, Array<Array<StackResourceSummary>>>;
   } = {},
 ) => {
   const send = mock.fn((command: unknown) => {
     if (command instanceof ListStacksCommand) {
-      return handlers.listStacksError
-        ? Promise.reject(handlers.listStacksError)
-        : Promise.resolve({ StackSummaries: handlers.stacks ?? [] });
+      if (handlers.listStacksError) {
+        return Promise.reject(handlers.listStacksError);
+      }
+      if (handlers.stackPages) {
+        const pageIndex = Number(command.input.NextToken ?? '0');
+        return Promise.resolve({
+          StackSummaries: handlers.stackPages[pageIndex] ?? [],
+          NextToken:
+            pageIndex + 1 < handlers.stackPages.length
+              ? String(pageIndex + 1)
+              : undefined,
+        });
+      }
+      return Promise.resolve({ StackSummaries: handlers.stacks ?? [] });
     }
     if (command instanceof ListStackResourcesCommand) {
       const stackNameOrId = command.input.StackName ?? '';
+      const pages = Object.entries(handlers.resourcePagesByStack ?? {}).find(
+        ([stackName]) => stackNameOrId.includes(stackName),
+      )?.[1];
+      if (pages) {
+        const pageIndex = Number(command.input.NextToken ?? '0');
+        return Promise.resolve({
+          StackResourceSummaries: pages[pageIndex] ?? [],
+          NextToken:
+            pageIndex + 1 < pages.length ? String(pageIndex + 1) : undefined,
+        });
+      }
       const resources = Object.entries(handlers.resourcesByStack ?? {}).find(
         ([stackName]) => stackNameOrId.includes(stackName),
       )?.[1];
@@ -76,6 +100,19 @@ const getDeleteStackInputs = (
     .map((call) => call.arguments[0])
     .filter((command) => command instanceof DeleteStackCommand)
     .map((command) => (command as DeleteStackCommand).input);
+
+const getNextTokens = (
+  send: ReturnType<typeof buildCfnClient>['send'],
+  commandType: typeof ListStacksCommand | typeof ListStackResourcesCommand,
+): Array<string | undefined> =>
+  send.mock.calls
+    .map((call) => call.arguments[0])
+    .filter((command) => command instanceof commandType)
+    .map(
+      (command) =>
+        (command as ListStacksCommand | ListStackResourcesCommand).input
+          .NextToken,
+    );
 
 const buildStackDeleter = (
   cfnClient: CloudFormationClient,
@@ -107,6 +144,25 @@ void describe('StackDeleter', () => {
         staleStacks.map((stackSummary) => stackSummary.StackName),
         ['amplify-stale'],
       );
+    });
+
+    void it('follows the next token so that stacks on later pages are not missed', async () => {
+      const { cfnClient, send } = buildCfnClient({
+        stackPages: [
+          [buildStack('amplify-first-page')],
+          [buildStack('amplify-second-page')],
+        ],
+      });
+
+      const staleStacks =
+        await buildStackDeleter(cfnClient).listStaleTopLevelStacks();
+
+      assert.deepStrictEqual(
+        staleStacks.map((stackSummary) => stackSummary.StackName),
+        ['amplify-first-page', 'amplify-second-page'],
+      );
+      const nextTokens = getNextTokens(send, ListStacksCommand);
+      assert.deepStrictEqual(nextTokens, [undefined, '1']);
     });
   });
 
@@ -232,6 +288,70 @@ void describe('StackDeleter', () => {
       assert.strictEqual(
         index.isOwnedByLiveStack('AWS::S3::Bucket', 'any-bucket'),
         true,
+      );
+    });
+
+    void it('follows the next token so that resources on later pages are protected too', async () => {
+      const { cfnClient, send } = buildCfnClient({
+        stacks: [buildStack('amplify-live')],
+        resourcePagesByStack: {
+          'amplify-live': [
+            [
+              buildResource(
+                'FirstBucket',
+                'AWS::S3::Bucket',
+                'amplify-first-page-bucket',
+              ),
+            ],
+            [
+              buildResource(
+                'SecondBucket',
+                'AWS::S3::Bucket',
+                'amplify-second-page-bucket',
+              ),
+            ],
+          ],
+        },
+      });
+
+      const index =
+        await buildStackDeleter(cfnClient).getResourcesOwnedByLiveStacks();
+
+      assert.strictEqual(index.isComplete, true);
+      assert.strictEqual(
+        index.isOwnedByLiveStack(
+          'AWS::S3::Bucket',
+          'amplify-first-page-bucket',
+        ),
+        true,
+      );
+      assert.strictEqual(
+        index.isOwnedByLiveStack(
+          'AWS::S3::Bucket',
+          'amplify-second-page-bucket',
+        ),
+        true,
+      );
+      const nextTokens = getNextTokens(send, ListStackResourcesCommand);
+      assert.deepStrictEqual(nextTokens, [undefined, '1']);
+    });
+
+    void it('refuses to build the index after a deletion was already requested', async () => {
+      const { cfnClient } = buildCfnClient({
+        stacks: [buildStack('amplify-stale')],
+      });
+      const stackDeleter = buildStackDeleter(cfnClient);
+      await stackDeleter.deleteStack(buildStack('amplify-stale'));
+
+      await assert.rejects(
+        () => stackDeleter.getResourcesOwnedByLiveStacks(),
+        (error: Error) => {
+          assert.match(
+            error.message,
+            /must be indexed before any stack deletion is requested/,
+          );
+          return true;
+        },
       );
     });
   });
@@ -370,6 +490,34 @@ void describe('StackDeleter', () => {
       assert.ok(
         logMessages.some((message) =>
           message.includes('needs manual attention'),
+        ),
+      );
+    });
+
+    void it('still requests the deletion when the resources of a DELETE_FAILED stack cannot be listed', async () => {
+      const logMessages: Array<string> = [];
+      const { cfnClient, send } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': new Error(
+            'User is not authorized to perform: cloudformation:ListStackResources',
+          ),
+        },
+      });
+
+      const retainedResources = await buildStackDeleter(
+        cfnClient,
+        logMessages,
+      ).deleteStack(
+        buildStack('amplify-stuck', { StackStatus: StackStatus.DELETE_FAILED }),
+      );
+
+      assert.deepStrictEqual(retainedResources, []);
+      assert.deepStrictEqual(getDeleteStackInputs(send), [
+        { StackName: 'amplify-stuck' },
+      ]);
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('Unable to inspect the resources'),
         ),
       );
     });

--- a/scripts/components/e2e-cleanup/stack_deleter.ts
+++ b/scripts/components/e2e-cleanup/stack_deleter.ts
@@ -15,14 +15,60 @@ import {
  * Resource types that may be abandoned to unblock a stack that is stuck in `DELETE_FAILED`.
  *
  * The custom resources are the ones that time out on delete, and their bucket is deleted by the
- * bucket sweep of a subsequent run. Any other resource type, in particular
- * `AWS::CloudFront::Distribution`, must never be abandoned.
+ * bucket sweep of a subsequent run. Any other resource type must never be abandoned. Retaining an
+ * `AWS::CloudFront::Distribution` leaks a distribution that serves a bucket name anybody can
+ * claim, and retaining an `AWS::CloudFormation::Stack` detaches a nested stack from its root: the
+ * root reaches `DELETE_COMPLETE` while the nested stack silently keeps its resources, which turns
+ * a visible failure into an invisible orphan.
  */
 const RESOURCE_TYPES_SAFE_TO_RETAIN = [
   'Custom::S3AutoDeleteObjects',
   'Custom::CDKBucketDeployment',
   'AWS::S3::Bucket',
 ];
+
+const NESTED_STACK_RESOURCE_TYPE = 'AWS::CloudFormation::Stack';
+const BUCKET_RESOURCE_TYPE = 'AWS::S3::Bucket';
+
+/**
+ * How deep nested stacks are followed when looking for the resources that block a stack deletion.
+ *
+ * Amplify nests one level deep. The limit only exists so that an unexpected cycle cannot turn into
+ * unbounded recursion.
+ */
+const MAX_NESTED_STACK_DEPTH = 5;
+
+/**
+ * How many stacks are inspected at a time.
+ *
+ * An account accumulates hundreds of stacks, and inspecting them one after another took long
+ * enough for the cleanup job to time out before it deleted anything. The limit keeps the burst of
+ * `ListStackResources` calls small enough for the CloudFormation request quota.
+ */
+const STACK_INSPECTION_CONCURRENCY = 8;
+
+/**
+ * Runs the callback for every item, with at most `concurrency` calls in flight.
+ *
+ * The callback must handle its own errors. A rejection abandons the remaining items.
+ */
+const forEachWithBoundedConcurrency = async <T>(
+  items: Array<T>,
+  concurrency: number,
+  callback: (item: T) => Promise<void>,
+): Promise<void> => {
+  let nextIndex = 0;
+  const consumeItems = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      await callback(items[nextIndex++]);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () =>
+      consumeItems(),
+    ),
+  );
+};
 
 /**
  * Resource types that the cleanup script sweeps directly, outside of CloudFormation.
@@ -82,6 +128,37 @@ export class LiveStackResourceIndex {
         ?.has(physicalResourceId) ?? false
     );
   };
+
+  /**
+   * Combines this index with another one, for example the index of another region.
+   *
+   * The result is only complete when both indexes are, so a region that could not be inspected
+   * makes every caller fail closed instead of deleting a resource of that region.
+   */
+  merge = (other: LiveStackResourceIndex): LiveStackResourceIndex => {
+    const mergedPhysicalResourceIdsByType = new Map<string, Set<string>>();
+    for (const source of [
+      this.physicalResourceIdsByType,
+      other.physicalResourceIdsByType,
+    ]) {
+      for (const [resourceType, physicalResourceIds] of source) {
+        const mergedPhysicalResourceIds =
+          mergedPhysicalResourceIdsByType.get(resourceType) ??
+          new Set<string>();
+        for (const physicalResourceId of physicalResourceIds) {
+          mergedPhysicalResourceIds.add(physicalResourceId);
+        }
+        mergedPhysicalResourceIdsByType.set(
+          resourceType,
+          mergedPhysicalResourceIds,
+        );
+      }
+    }
+    return new LiveStackResourceIndex(
+      mergedPhysicalResourceIdsByType,
+      this.isComplete && other.isComplete,
+    );
+  };
 }
 
 /**
@@ -126,11 +203,9 @@ export class StackDeleter {
    * after a deletion was requested throws, so that the ordering cannot regress unnoticed.
    */
   getResourcesOwnedByLiveStacks = async (): Promise<LiveStackResourceIndex> => {
-    if (this.deletionRequested) {
-      throw new Error(
-        'The resources owned by live stacks must be indexed before any stack deletion is requested',
-      );
-    }
+    this.assertNoDeletionRequested(
+      'The resources owned by live stacks must be indexed before any stack deletion is requested',
+    );
     const physicalResourceIdsByType = new Map<string, Set<string>>();
     let activeStacks: Array<StackSummary>;
     try {
@@ -142,36 +217,84 @@ export class StackDeleter {
       return new LiveStackResourceIndex(physicalResourceIdsByType, false);
     }
     let isComplete = true;
-    for (const stackSummary of activeStacks) {
-      const stackNameOrId = stackSummary.StackId ?? stackSummary.StackName;
-      if (!stackNameOrId) {
-        continue;
-      }
-      try {
-        const stackResources = await this.listStackResources(stackNameOrId);
-        for (const stackResource of stackResources) {
-          this.indexStackResource(physicalResourceIdsByType, stackResource);
+    await forEachWithBoundedConcurrency(
+      activeStacks,
+      STACK_INSPECTION_CONCURRENCY,
+      async (stackSummary) => {
+        const stackNameOrId = stackSummary.StackId ?? stackSummary.StackName;
+        if (!stackNameOrId) {
+          return;
         }
-      } catch (error) {
-        if (this.isStackNotFoundError(error)) {
-          continue;
+        try {
+          const stackResources = await this.listStackResources(stackNameOrId);
+          for (const stackResource of stackResources) {
+            this.indexStackResource(physicalResourceIdsByType, stackResource);
+          }
+        } catch (error) {
+          if (this.isStackNotFoundError(error)) {
+            return;
+          }
+          isComplete = false;
+          this.log(
+            `Unable to list resources of ${stackSummary.StackName} stack, skipping direct resource deletion. ${this.getErrorMessage(error)}`,
+          );
         }
-        isComplete = false;
-        this.log(
-          `Unable to list resources of ${stackSummary.StackName} stack, skipping direct resource deletion. ${this.getErrorMessage(error)}`,
-        );
-      }
-    }
+      },
+    );
     return new LiveStackResourceIndex(physicalResourceIdsByType, isComplete);
+  };
+
+  /**
+   * Finds the buckets whose contents block the deletion of the given stacks.
+   *
+   * Every stack of the known `DELETE_FAILED` backlog blocks on a single resource, its nested
+   * hosting stack, and that nested stack in turn blocks on a versioned bucket that CloudFormation
+   * cannot delete because it is not empty. The bucket is invisible from the root stack, so nested
+   * stacks are followed to find it.
+   *
+   * Emptying those buckets and leaving the deletion of the bucket itself to CloudFormation is what
+   * makes the retried stack deletion succeed. Retaining the nested stack instead would detach it
+   * from its root, so the root would reach `DELETE_COMPLETE` while the nested stack silently kept
+   * its bucket and its distribution.
+   *
+   * Must be called before any stack deletion is requested, otherwise the buckets are emptied after
+   * CloudFormation already retried and failed the deletion they block.
+   */
+  findBucketsBlockingStackDeletion = async (
+    stackSummaries: Array<StackSummary>,
+  ): Promise<Array<string>> => {
+    this.assertNoDeletionRequested(
+      'The buckets that block a stack deletion must be found before any stack deletion is requested',
+    );
+    const bucketNames = new Set<string>();
+    await forEachWithBoundedConcurrency(
+      stackSummaries.filter(
+        (stackSummary) =>
+          stackSummary.StackStatus === StackStatus.DELETE_FAILED,
+      ),
+      STACK_INSPECTION_CONCURRENCY,
+      async (stackSummary) => {
+        const stackNameOrId = stackSummary.StackId ?? stackSummary.StackName;
+        if (stackNameOrId) {
+          await this.collectBucketsBlockingStackDeletion(
+            stackNameOrId,
+            bucketNames,
+            1,
+          );
+        }
+      },
+    );
+    return [...bucketNames];
   };
 
   /**
    * Requests deletion of the stack.
    *
-   * A stack that is already in `DELETE_FAILED` fails the same way on every retry unless the
-   * resources that failed to delete are abandoned, which is what keeps stacks stuck for months.
-   * Those resources are only abandoned when all of them are safe to leak, and the bucket sweep
-   * of a subsequent run picks them up.
+   * A stack that is already in `DELETE_FAILED` fails the same way on every retry unless whatever
+   * blocks it is dealt with, which is what keeps stacks stuck for months. Resources that are safe
+   * to leak are abandoned, and the bucket sweep of a subsequent run picks them up. Everything else
+   * is retried as is, because `findBucketsBlockingStackDeletion` emptied the buckets that block the
+   * nested stacks of this stack before this deletion was requested.
    * @returns the logical ids of the resources that CloudFormation was asked to retain.
    */
   deleteStack = async (stackSummary: StackSummary): Promise<Array<string>> => {
@@ -188,11 +311,8 @@ export class StackDeleter {
     }
     let failedResources: Array<StackResourceSummary>;
     try {
-      failedResources = (
-        await this.listStackResources(stackSummary.StackId ?? stackName)
-      ).filter(
-        (stackResource) =>
-          stackResource.ResourceStatus === ResourceStatus.DELETE_FAILED,
+      failedResources = await this.listFailedResources(
+        stackSummary.StackId ?? stackName,
       );
     } catch (error) {
       this.log(
@@ -211,7 +331,7 @@ export class StackDeleter {
     );
     if (failedResources.length === 0 || resourcesToKeepDeleting.length > 0) {
       this.log(
-        `The ${stackName} stack cannot be unblocked automatically and needs manual attention. Retrying its deletion as is. Resources that failed to delete: ${this.describeResources(resourcesToKeepDeleting)}`,
+        this.describeRetriedStackDeletion(stackName, resourcesToKeepDeleting),
       );
       await this.cfnClient.send(
         new DeleteStackCommand({ StackName: stackName }),
@@ -233,6 +353,92 @@ export class StackDeleter {
       `Retrying deletion of the ${stackName} stack while retaining ${this.describeResources(failedResources)}`,
     );
     return retainResources;
+  };
+
+  private collectBucketsBlockingStackDeletion = async (
+    stackNameOrId: string,
+    bucketNames: Set<string>,
+    depth: number,
+  ): Promise<void> => {
+    if (depth > MAX_NESTED_STACK_DEPTH) {
+      this.log(
+        `Stopped looking for the buckets that block the deletion of ${stackNameOrId} at a nesting depth of ${MAX_NESTED_STACK_DEPTH}`,
+      );
+      return;
+    }
+    let failedResources: Array<StackResourceSummary>;
+    try {
+      failedResources = await this.listFailedResources(stackNameOrId);
+    } catch (error) {
+      if (!this.isStackNotFoundError(error)) {
+        this.log(
+          `Unable to inspect the resources of ${stackNameOrId}, so the buckets that block its deletion stay unknown. ${this.getErrorMessage(error)}`,
+        );
+      }
+      return;
+    }
+    for (const failedResource of failedResources) {
+      const physicalResourceId = failedResource.PhysicalResourceId;
+      if (!physicalResourceId) {
+        continue;
+      }
+      if (failedResource.ResourceType === NESTED_STACK_RESOURCE_TYPE) {
+        // The physical id of a nested stack resource is the arn of the nested stack itself.
+        await this.collectBucketsBlockingStackDeletion(
+          physicalResourceId,
+          bucketNames,
+          depth + 1,
+        );
+      } else if (
+        failedResource.ResourceType === BUCKET_RESOURCE_TYPE &&
+        physicalResourceId.startsWith(this.testResourcePrefix)
+      ) {
+        bucketNames.add(physicalResourceId);
+      } else if (depth > 1) {
+        // A failure inside a nested stack is invisible to `deleteStack`, which only ever sees the
+        // nested stack resource itself, so this is the only place it can be reported.
+        this.log(
+          `The ${stackNameOrId} nested stack failed to delete ${physicalResourceId} (${failedResource.ResourceType}), which emptying buckets cannot unblock, so its root stack needs manual attention`,
+        );
+      }
+    }
+  };
+
+  private listFailedResources = async (
+    stackNameOrId: string,
+  ): Promise<Array<StackResourceSummary>> =>
+    (await this.listStackResources(stackNameOrId)).filter(
+      (stackResource) =>
+        stackResource.ResourceStatus === ResourceStatus.DELETE_FAILED,
+    );
+
+  /**
+   * A stack whose blockers cannot be retained is retried as is, but for two very different reasons.
+   *
+   * A stack blocked by nested stacks is expected to be retried: the buckets that block those nested
+   * stacks were emptied earlier in this run, and the retry is what applies that. Any other blocker
+   * is something this script does not know how to resolve, and saying so is the only way it reaches
+   * a human instead of quietly repeating every hour.
+   */
+  private describeRetriedStackDeletion = (
+    stackName: string,
+    resourcesToKeepDeleting: Array<StackResourceSummary>,
+  ): string => {
+    const isBlockedOnlyByNestedStacks =
+      resourcesToKeepDeleting.length > 0 &&
+      resourcesToKeepDeleting.every(
+        (stackResource) =>
+          stackResource.ResourceType === NESTED_STACK_RESOURCE_TYPE,
+      );
+    return isBlockedOnlyByNestedStacks
+      ? `Retrying deletion of the ${stackName} stack, which is blocked by nested stacks whose blocking buckets were emptied by this run: ${this.describeResources(resourcesToKeepDeleting)}`
+      : `The ${stackName} stack cannot be unblocked automatically and needs manual attention. Retrying its deletion as is. Resources that failed to delete: ${this.describeResources(resourcesToKeepDeleting)}`;
+  };
+
+  private assertNoDeletionRequested = (message: string): void => {
+    if (this.deletionRequested) {
+      throw new Error(message);
+    }
   };
 
   private listActiveStacks = async (): Promise<Array<StackSummary>> => {

--- a/scripts/components/e2e-cleanup/stack_deleter.ts
+++ b/scripts/components/e2e-cleanup/stack_deleter.ts
@@ -1,0 +1,284 @@
+import {
+  CloudFormationClient,
+  DeleteStackCommand,
+  ListStackResourcesCommand,
+  ListStackResourcesCommandOutput,
+  ListStacksCommand,
+  ListStacksCommandOutput,
+  ResourceStatus,
+  StackResourceSummary,
+  StackStatus,
+  StackSummary,
+} from '@aws-sdk/client-cloudformation';
+
+/**
+ * Resource types that may be abandoned to unblock a stack that is stuck in `DELETE_FAILED`.
+ *
+ * The custom resources are the ones that time out on delete, and their bucket is deleted by the
+ * bucket sweep of a subsequent run. Any other resource type, in particular
+ * `AWS::CloudFront::Distribution`, must never be abandoned.
+ */
+const RESOURCE_TYPES_SAFE_TO_RETAIN = [
+  'Custom::S3AutoDeleteObjects',
+  'Custom::CDKBucketDeployment',
+  'AWS::S3::Bucket',
+];
+
+/**
+ * Resources of CloudFormation stacks that have not finished deleting.
+ *
+ * Deleting a resource that a stack still owns breaks the delete path of that stack. Deleting the
+ * execution role of a custom resource for example leaves CloudFormation waiting for a Lambda
+ * function that can no longer be assumed, which fails the stack delete with a generic
+ * `did not receive a response from your Custom Resource` timeout, permanently.
+ */
+export class LiveStackResourceIndex {
+  /**
+   * Creates an index of resources owned by stacks that have not finished deleting.
+   */
+  constructor(
+    private readonly physicalResourceIdsByType: Map<string, Set<string>>,
+    /**
+     * Whether every stack could be inspected. Callers must not delete resources directly
+     * while the index is incomplete.
+     */
+    readonly isComplete: boolean,
+  ) {}
+
+  /**
+   * Whether the resource may still be owned by a stack that has not finished deleting.
+   *
+   * Returns `true` for every resource while the index is incomplete, so that callers
+   * fail closed instead of deleting a resource out from under a live stack.
+   */
+  isOwnedByLiveStack = (
+    resourceType: string,
+    physicalResourceId: string | undefined,
+  ): boolean => {
+    if (!this.isComplete) {
+      return true;
+    }
+    if (!physicalResourceId) {
+      return false;
+    }
+    return (
+      this.physicalResourceIdsByType
+        .get(resourceType)
+        ?.has(physicalResourceId) ?? false
+    );
+  };
+}
+
+/**
+ * Deletes stale e2e test CloudFormation stacks and tells which resources are still owned by stacks.
+ */
+export class StackDeleter {
+  private activeStacks: Array<StackSummary> | undefined = undefined;
+
+  /**
+   * Creates stack deleter.
+   */
+  constructor(
+    private readonly cfnClient: CloudFormationClient,
+    private readonly testResourcePrefix: string,
+    private readonly isStackStale: (
+      stackSummary: StackSummary,
+    ) => boolean | undefined,
+    private readonly log: (message: string) => void = console.log,
+  ) {}
+
+  /**
+   * Lists stale test stacks that are not nested in another stack.
+   *
+   * Nested stacks are deleted by their root stack. Deleting them directly always fails.
+   */
+  listStaleTopLevelStacks = async (): Promise<Array<StackSummary>> => {
+    const activeStacks = await this.listActiveStacks();
+    return activeStacks.filter(
+      (stackSummary) =>
+        !stackSummary.RootId &&
+        stackSummary.StackName?.startsWith(this.testResourcePrefix) &&
+        this.isStackStale(stackSummary) === true,
+    );
+  };
+
+  /**
+   * Indexes the resources of all stacks that have not finished deleting.
+   *
+   * Must be called before any stack deletion is requested, otherwise resources of the stacks
+   * that are being deleted look free while CloudFormation is still working on them.
+   */
+  getResourcesOwnedByLiveStacks = async (): Promise<LiveStackResourceIndex> => {
+    const physicalResourceIdsByType = new Map<string, Set<string>>();
+    let activeStacks: Array<StackSummary>;
+    try {
+      activeStacks = await this.listActiveStacks();
+    } catch (error) {
+      this.log(
+        `Unable to list stacks, skipping direct resource deletion. ${this.getErrorMessage(error)}`,
+      );
+      return new LiveStackResourceIndex(physicalResourceIdsByType, false);
+    }
+    let isComplete = true;
+    for (const stackSummary of activeStacks) {
+      const stackNameOrId = stackSummary.StackId ?? stackSummary.StackName;
+      if (!stackNameOrId) {
+        continue;
+      }
+      try {
+        const stackResources = await this.listStackResources(stackNameOrId);
+        for (const stackResource of stackResources) {
+          this.indexStackResource(physicalResourceIdsByType, stackResource);
+        }
+      } catch (error) {
+        if (this.isStackNotFoundError(error)) {
+          continue;
+        }
+        isComplete = false;
+        this.log(
+          `Unable to list resources of ${stackSummary.StackName} stack, skipping direct resource deletion. ${this.getErrorMessage(error)}`,
+        );
+      }
+    }
+    return new LiveStackResourceIndex(physicalResourceIdsByType, isComplete);
+  };
+
+  /**
+   * Requests deletion of the stack.
+   *
+   * A stack that is already in `DELETE_FAILED` fails the same way on every retry unless the
+   * resources that failed to delete are abandoned, which is what keeps stacks stuck for months.
+   * Those resources are only abandoned when all of them are safe to leak, and the bucket sweep
+   * of a subsequent run picks them up.
+   * @returns the logical ids of the resources that CloudFormation was asked to retain.
+   */
+  deleteStack = async (stackSummary: StackSummary): Promise<Array<string>> => {
+    const stackName = stackSummary.StackName;
+    if (!stackName) {
+      throw new Error('Cannot delete a stack without a name');
+    }
+    if (stackSummary.StackStatus !== StackStatus.DELETE_FAILED) {
+      await this.cfnClient.send(
+        new DeleteStackCommand({ StackName: stackName }),
+      );
+      return [];
+    }
+    const failedResources = (
+      await this.listStackResources(stackSummary.StackId ?? stackName)
+    ).filter(
+      (stackResource) =>
+        stackResource.ResourceStatus === ResourceStatus.DELETE_FAILED,
+    );
+    const resourcesToKeepDeleting = failedResources.filter(
+      (stackResource) =>
+        !RESOURCE_TYPES_SAFE_TO_RETAIN.includes(
+          stackResource.ResourceType ?? '',
+        ),
+    );
+    if (failedResources.length === 0 || resourcesToKeepDeleting.length > 0) {
+      this.log(
+        `The ${stackName} stack cannot be unblocked automatically and needs manual attention. Retrying its deletion as is. Resources that failed to delete: ${this.describeResources(resourcesToKeepDeleting)}`,
+      );
+      await this.cfnClient.send(
+        new DeleteStackCommand({ StackName: stackName }),
+      );
+      return [];
+    }
+    const retainResources = failedResources
+      .map((stackResource) => stackResource.LogicalResourceId)
+      .filter((logicalResourceId): logicalResourceId is string =>
+        Boolean(logicalResourceId),
+      );
+    await this.cfnClient.send(
+      new DeleteStackCommand({
+        StackName: stackName,
+        RetainResources: retainResources,
+      }),
+    );
+    this.log(
+      `Retrying deletion of the ${stackName} stack while retaining ${this.describeResources(failedResources)}`,
+    );
+    return retainResources;
+  };
+
+  private listActiveStacks = async (): Promise<Array<StackSummary>> => {
+    if (this.activeStacks) {
+      return this.activeStacks;
+    }
+    const stackSummaries: Array<StackSummary> = [];
+    let nextToken: string | undefined = undefined;
+    do {
+      const listStacksResponse: ListStacksCommandOutput =
+        await this.cfnClient.send(
+          new ListStacksCommand({
+            NextToken: nextToken,
+            StackStatusFilter: Object.keys(StackStatus).filter(
+              (status) => status != StackStatus.DELETE_COMPLETE,
+            ) as Array<StackStatus>,
+          }),
+        );
+      nextToken = listStacksResponse.NextToken;
+      stackSummaries.push(...(listStacksResponse.StackSummaries ?? []));
+    } while (nextToken);
+    this.activeStacks = stackSummaries;
+    return stackSummaries;
+  };
+
+  private listStackResources = async (
+    stackNameOrId: string,
+  ): Promise<Array<StackResourceSummary>> => {
+    const stackResources: Array<StackResourceSummary> = [];
+    let nextToken: string | undefined = undefined;
+    do {
+      const listStackResourcesResponse: ListStackResourcesCommandOutput =
+        await this.cfnClient.send(
+          new ListStackResourcesCommand({
+            StackName: stackNameOrId,
+            NextToken: nextToken,
+          }),
+        );
+      nextToken = listStackResourcesResponse.NextToken;
+      stackResources.push(
+        ...(listStackResourcesResponse.StackResourceSummaries ?? []),
+      );
+    } while (nextToken);
+    return stackResources;
+  };
+
+  private indexStackResource = (
+    physicalResourceIdsByType: Map<string, Set<string>>,
+    stackResource: StackResourceSummary,
+  ): void => {
+    if (
+      !stackResource.ResourceType ||
+      !stackResource.PhysicalResourceId ||
+      stackResource.ResourceStatus === ResourceStatus.DELETE_COMPLETE
+    ) {
+      return;
+    }
+    const physicalResourceIds =
+      physicalResourceIdsByType.get(stackResource.ResourceType) ??
+      new Set<string>();
+    physicalResourceIds.add(stackResource.PhysicalResourceId);
+    physicalResourceIdsByType.set(
+      stackResource.ResourceType,
+      physicalResourceIds,
+    );
+  };
+
+  private describeResources = (
+    stackResources: Array<StackResourceSummary>,
+  ): string =>
+    stackResources
+      .map(
+        (stackResource) =>
+          `${stackResource.LogicalResourceId} (${stackResource.ResourceType})`,
+      )
+      .join(', ');
+
+  private isStackNotFoundError = (error: unknown): boolean =>
+    error instanceof Error && error.message.includes('does not exist');
+
+  private getErrorMessage = (error: unknown): string =>
+    error instanceof Error ? error.message : '';
+}

--- a/scripts/components/e2e-cleanup/stack_deleter.ts
+++ b/scripts/components/e2e-cleanup/stack_deleter.ts
@@ -25,6 +25,21 @@ const RESOURCE_TYPES_SAFE_TO_RETAIN = [
 ];
 
 /**
+ * Resource types that the cleanup script sweeps directly, outside of CloudFormation.
+ *
+ * The guard is typed to this union so that a typo in a resource type string is a compile error.
+ * An unchecked string would silently match nothing, and the guard would let the sweep delete a
+ * resource that a live stack still owns, which is the failure this index exists to prevent.
+ */
+export type GuardedResourceType =
+  | 'AWS::Cognito::UserPool'
+  | 'AWS::DynamoDB::Table'
+  | 'AWS::IAM::Role'
+  | 'AWS::Logs::LogGroup'
+  | 'AWS::S3::Bucket'
+  | 'AWS::SSM::Parameter';
+
+/**
  * Resources of CloudFormation stacks that have not finished deleting.
  *
  * Deleting a resource that a stack still owns breaks the delete path of that stack. Deleting the
@@ -52,7 +67,7 @@ export class LiveStackResourceIndex {
    * fail closed instead of deleting a resource out from under a live stack.
    */
   isOwnedByLiveStack = (
-    resourceType: string,
+    resourceType: GuardedResourceType,
     physicalResourceId: string | undefined,
   ): boolean => {
     if (!this.isComplete) {
@@ -74,6 +89,7 @@ export class LiveStackResourceIndex {
  */
 export class StackDeleter {
   private activeStacks: Array<StackSummary> | undefined = undefined;
+  private deletionRequested = false;
 
   /**
    * Creates stack deleter.
@@ -106,9 +122,15 @@ export class StackDeleter {
    * Indexes the resources of all stacks that have not finished deleting.
    *
    * Must be called before any stack deletion is requested, otherwise resources of the stacks
-   * that are being deleted look free while CloudFormation is still working on them.
+   * that are being deleted look free while CloudFormation is still working on them. Calling it
+   * after a deletion was requested throws, so that the ordering cannot regress unnoticed.
    */
   getResourcesOwnedByLiveStacks = async (): Promise<LiveStackResourceIndex> => {
+    if (this.deletionRequested) {
+      throw new Error(
+        'The resources owned by live stacks must be indexed before any stack deletion is requested',
+      );
+    }
     const physicalResourceIdsByType = new Map<string, Set<string>>();
     let activeStacks: Array<StackSummary>;
     try {
@@ -157,18 +179,30 @@ export class StackDeleter {
     if (!stackName) {
       throw new Error('Cannot delete a stack without a name');
     }
+    this.deletionRequested = true;
     if (stackSummary.StackStatus !== StackStatus.DELETE_FAILED) {
       await this.cfnClient.send(
         new DeleteStackCommand({ StackName: stackName }),
       );
       return [];
     }
-    const failedResources = (
-      await this.listStackResources(stackSummary.StackId ?? stackName)
-    ).filter(
-      (stackResource) =>
-        stackResource.ResourceStatus === ResourceStatus.DELETE_FAILED,
-    );
+    let failedResources: Array<StackResourceSummary>;
+    try {
+      failedResources = (
+        await this.listStackResources(stackSummary.StackId ?? stackName)
+      ).filter(
+        (stackResource) =>
+          stackResource.ResourceStatus === ResourceStatus.DELETE_FAILED,
+      );
+    } catch (error) {
+      this.log(
+        `Unable to inspect the resources of the ${stackName} stack that is in DELETE_FAILED, so it cannot be unblocked automatically. Retrying its deletion as is. ${this.getErrorMessage(error)}`,
+      );
+      await this.cfnClient.send(
+        new DeleteStackCommand({ StackName: stackName }),
+      );
+      return [];
+    }
     const resourcesToKeepDeleting = failedResources.filter(
       (stackResource) =>
         !RESOURCE_TYPES_SAFE_TO_RETAIN.includes(


### PR DESCRIPTION
Consolidates the three previously-stacked PRs (#3304, #3305 closed in favour of this one).

## What

The hourly `e2e-resource-cleanup` job deletes resources directly while the stacks that own them are still deleting. That poisons those stacks' delete path — a deleted custom-resource execution role leaves CloudFormation waiting on a Lambda it can no longer assume — so stacks land in `DELETE_FAILED` and every later run fails identically. **The job creates the backlog it is meant to drain.** It also deleted S3 origin buckets out from under CloudFront distributions (orphaned distributions, subdomain-takeover risk), and never fully emptied versioned buckets.

## Fix

Under `scripts/components/e2e-cleanup/`, wired into `cleanup_e2e_resources.ts`:

- **`StackDeleter`** — indexes the resources of every not-yet-deleted stack **before** any delete is issued; all six direct sweeps skip anything a live stack still owns. Fails closed (skips everything) and loud (`process.exitCode = 1`) when the index can't be built. Stacks are inspected with bounded concurrency so an account with hundreds of stacks is indexed well within the job timeout.
- **`S3BucketEmptier`** — paginates `ListObjectVersions` on both `KeyMarker` and `VersionIdMarker`, batches `DeleteObjects` at 1000, throws on `Errors[]`, re-empties once on `BucketNotEmpty`.
- **`CloudFrontDistributionCleaner`** — maps buckets to distributions via their S3 origin domains and converges across hourly runs (enabled → disable → wait for `Deployed` → delete). A bucket is only deleted once its distributions are gone, so the origin never outlives the distribution.

### Draining the existing backlog

Verified read-only against a test account: **every** stuck root stack blocks on exactly one resource, its nested hosting stack, and that nested stack in turn blocks only on `AWS::S3::Bucket` — a versioned bucket CloudFormation can't delete because it isn't empty (`409 ... You must delete all versions in the bucket`). The bucket is invisible from the root, which is why the drain never saw it.

`findBucketsBlockingStackDeletion` therefore walks nested stacks to find the blocking buckets and empties them **before** the stack delete is retried. The bucket itself is left to CloudFormation, so its record of the resource stays intact and its own delete succeeds on the retry.

Retaining the nested stack instead — the one-line allowlist change — would *detach* it from its root: the root would reach `DELETE_COMPLETE` while the nested stack silently kept its bucket and its distribution. That converts a visible failure into an invisible orphan, so `AWS::CloudFormation::Stack` is deliberately **not** in the retain allowlist. A nested-stack failure that emptying can't fix (e.g. a distribution) is logged for a human, since `deleteStack` only ever sees the nested stack resource itself.

### Region scoping

S3 buckets and IAM roles are listed **account wide**, so each per-region job sees the buckets and roles of all four regions while the ownership index only covered one — a role owned by a live stack in another region looked free. The index is now built across every region in the workflow matrix before any sweep. Region-scoped types (Cognito, DynamoDB, SSM, log groups) stay scoped to the current region, because their names are only unique within a region and the equally-named resource of another region would otherwise keep a genuinely stale one from ever being cleaned up. `e2e_test_regions.test.ts` parses the workflow and fails if the region list drifts from the matrix.

## Tests

94/94 (`npm run test:scripts`), 45 new. `tsc`, `eslint --max-warnings 0`, `prettier --check` clean.

## Notes

- **IAM prerequisite (out of repo):** the cleanup role needs `cloudfront:ListDistributions/GetDistribution/GetDistributionConfig/UpdateDistribution/DeleteDistribution/TagResource` and `cloudformation:DescribeStacks/DescribeStackResources/ListStackResources`. Both degrade gracefully — CloudFront reaping is inert and the sweeps fail closed until it lands — so merge order doesn't matter.
- **`check_pr_size` is red and advisory** — not a required check on `main` (precedent: #3265 merged at +15,994). ~660 of the added lines are `package-lock.json` and roughly two thirds of the rest are tests. Happy to re-split if you'd rather review it in pieces.
- `e2e_notices macos-14` and `e2e_iam_access_drift` are pre-existing flakes that also fail on `main`.
- No `packages/*` changes, so no changeset.
