### PR TITLE
fix(e2e-cleanup): delete every object version when emptying a test bucket

### DIFF
--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -9,17 +9,7 @@ import {
   DescribeLogGroupsCommandOutput,
   LogGroup,
 } from '@aws-sdk/client-cloudwatch-logs';
-import {
-  Bucket,
-  DeleteBucketCommand,
-  DeleteObjectsCommand,
-  ListBucketsCommand,
-  ListObjectVersionsCommand,
-  ListObjectsV2Command,
-  ListObjectsV2CommandOutput,
-  ObjectIdentifier,
-  S3Client,
-} from '@aws-sdk/client-s3';
+import { Bucket, ListBucketsCommand, S3Client } from '@aws-sdk/client-s3';
 import {
   CognitoIdentityProviderClient,
   DeleteUserPoolCommand,
@@ -68,6 +58,7 @@ import {
   ListTablesCommandOutput,
   TableDescription,
 } from '@aws-sdk/client-dynamodb';
+import { S3BucketEmptier } from './components/e2e-cleanup/s3_bucket_emptier.js';
 import {
   GuardedResourceType,
   StackDeleter,
@@ -151,6 +142,7 @@ const stackDeleter = new StackDeleter(
   TEST_AMPLIFY_RESOURCE_PREFIX,
   isStackStale,
 );
+const s3BucketEmptier = new S3BucketEmptier(s3Client);
 
 /**
  * Deleting a resource that a stack still owns poisons the delete path of that stack, which is
@@ -219,66 +211,6 @@ const listStaleS3Buckets = async (): Promise<Array<Bucket>> => {
 
 const staleBuckets = await listStaleS3Buckets();
 
-const emptyAndDeleteS3Bucket = async (bucketName: string): Promise<void> => {
-  let nextToken: string | undefined = undefined;
-  do {
-    const listObjectsResponse: ListObjectsV2CommandOutput = await s3Client.send(
-      new ListObjectsV2Command({
-        Bucket: bucketName,
-        ContinuationToken: nextToken,
-      }),
-    );
-    const objectsToDelete: ObjectIdentifier[] | undefined =
-      listObjectsResponse.Contents?.map(
-        (s3Object) => s3Object as ObjectIdentifier,
-      );
-    if (objectsToDelete && objectsToDelete.length > 0) {
-      await s3Client.send(
-        new DeleteObjectsCommand({
-          Bucket: bucketName,
-          Delete: {
-            Objects: objectsToDelete,
-          },
-        }),
-      );
-    }
-    nextToken = listObjectsResponse.NextContinuationToken;
-  } while (nextToken);
-
-  do {
-    const listVersionsResponse = await s3Client.send(
-      new ListObjectVersionsCommand({
-        Bucket: bucketName,
-        KeyMarker: nextToken,
-      }),
-    );
-    const objectsToDelete = ([] as ObjectIdentifier[])
-      .concat(
-        listVersionsResponse.DeleteMarkers?.map(
-          (s3Object) => s3Object as ObjectIdentifier,
-        ) ?? [],
-      )
-      .concat(
-        listVersionsResponse.Versions?.map(
-          (s3Object) => s3Object as ObjectIdentifier,
-        ) ?? [],
-      );
-    if (objectsToDelete.length > 0) {
-      await s3Client.send(
-        new DeleteObjectsCommand({
-          Bucket: bucketName,
-          Delete: {
-            Objects: objectsToDelete,
-          },
-        }),
-      );
-    }
-    nextToken = listVersionsResponse.NextKeyMarker;
-  } while (nextToken);
-
-  await s3Client.send(new DeleteBucketCommand({ Bucket: bucketName }));
-};
-
 for (const staleBucket of staleBuckets) {
   if (staleBucket.Name) {
     const bucketName = staleBucket.Name;
@@ -286,7 +218,7 @@ for (const staleBucket of staleBuckets) {
       continue;
     }
     try {
-      await emptyAndDeleteS3Bucket(bucketName);
+      await s3BucketEmptier.emptyAndDelete(bucketName);
       console.log(`Successfully deleted ${bucketName} bucket`);
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : '';

--- a/scripts/components/e2e-cleanup/s3_bucket_emptier.test.ts
+++ b/scripts/components/e2e-cleanup/s3_bucket_emptier.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import {
+  DeleteBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectVersionsCommand,
+  ListObjectVersionsCommandOutput,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { S3BucketEmptier } from './s3_bucket_emptier.js';
+
+type S3Response = Record<string, unknown>;
+
+const buildS3Client = (
+  handlers: {
+    listObjectVersions?: Array<ListObjectVersionsCommandOutput>;
+    deleteObjects?: Array<S3Response>;
+    deleteBucket?: Array<S3Response | Error>;
+  } = {},
+) => {
+  const listObjectVersionsResponses = [...(handlers.listObjectVersions ?? [])];
+  const deleteObjectsResponses = [...(handlers.deleteObjects ?? [])];
+  const deleteBucketResponses = [...(handlers.deleteBucket ?? [])];
+  const send = mock.fn((command: unknown) => {
+    if (command instanceof ListObjectVersionsCommand) {
+      return Promise.resolve(listObjectVersionsResponses.shift() ?? {});
+    }
+    if (command instanceof DeleteObjectsCommand) {
+      return Promise.resolve(deleteObjectsResponses.shift() ?? {});
+    }
+    if (command instanceof DeleteBucketCommand) {
+      const response = deleteBucketResponses.shift();
+      return response instanceof Error
+        ? Promise.reject(response)
+        : Promise.resolve(response ?? {});
+    }
+    return Promise.reject(new Error('Unexpected command'));
+  });
+  return { s3Client: { send } as unknown as S3Client, send };
+};
+
+const getCommandInputs = (
+  send: ReturnType<typeof buildS3Client>['send'],
+  commandType: unknown,
+): Array<Record<string, unknown>> =>
+  send.mock.calls
+    .map((call) => call.arguments[0])
+    .filter(
+      (command) =>
+        command instanceof (commandType as new (input: never) => object),
+    )
+    .map((command) => (command as { input: Record<string, unknown> }).input);
+
+const getDeletedObjectCount = (input: Record<string, unknown>): number =>
+  ((input.Delete as Record<string, unknown>).Objects as Array<unknown>).length;
+
+const buildBucketNotEmptyError = (): Error => {
+  const error = new Error('The bucket you tried to delete is not empty');
+  error.name = 'BucketNotEmpty';
+  return error;
+};
+
+void describe('S3BucketEmptier', () => {
+  void it('deletes all object versions and delete markers, then the bucket', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        {
+          Versions: [{ Key: 'a', VersionId: 'v1' }],
+          DeleteMarkers: [{ Key: 'a', VersionId: 'v2' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket');
+
+    assert.deepStrictEqual(getCommandInputs(send, DeleteObjectsCommand), [
+      {
+        Bucket: 'test-bucket',
+        Delete: {
+          Objects: [
+            { Key: 'a', VersionId: 'v1' },
+            { Key: 'a', VersionId: 'v2' },
+          ],
+          Quiet: true,
+        },
+      },
+    ]);
+    assert.deepStrictEqual(getCommandInputs(send, DeleteBucketCommand), [
+      { Bucket: 'test-bucket' },
+    ]);
+  });
+
+  void it('paginates on both key marker and version id marker', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        {
+          Versions: [{ Key: 'a', VersionId: 'v1' }],
+          IsTruncated: true,
+          NextKeyMarker: 'a',
+          NextVersionIdMarker: 'v1',
+          $metadata: {},
+        },
+        {
+          Versions: [{ Key: 'a', VersionId: 'v2' }],
+          IsTruncated: true,
+          NextKeyMarker: 'b',
+          NextVersionIdMarker: undefined,
+          $metadata: {},
+        },
+        {
+          Versions: [{ Key: 'c', VersionId: 'v3' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket');
+
+    assert.deepStrictEqual(getCommandInputs(send, ListObjectVersionsCommand), [
+      {
+        Bucket: 'test-bucket',
+        KeyMarker: undefined,
+        VersionIdMarker: undefined,
+      },
+      { Bucket: 'test-bucket', KeyMarker: 'a', VersionIdMarker: 'v1' },
+      { Bucket: 'test-bucket', KeyMarker: 'b', VersionIdMarker: undefined },
+    ]);
+    assert.strictEqual(getCommandInputs(send, DeleteObjectsCommand).length, 3);
+  });
+
+  void it('deletes objects in batches of 1000', async () => {
+    const versions = Array.from({ length: 1001 }, (_, index) => ({
+      Key: `key-${index}`,
+      VersionId: 'v1',
+    }));
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        { Versions: versions, IsTruncated: false, $metadata: {} },
+      ],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket');
+
+    const deleteObjectsInputs = getCommandInputs(send, DeleteObjectsCommand);
+    assert.strictEqual(deleteObjectsInputs.length, 2);
+    assert.deepStrictEqual(
+      deleteObjectsInputs.map((input) => getDeletedObjectCount(input)),
+      [1000, 1],
+    );
+  });
+
+  void it('throws if the delete objects response reports errors', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        {
+          Versions: [{ Key: 'a', VersionId: 'v1' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+      deleteObjects: [
+        { Errors: [{ Key: 'a', Code: 'AccessDenied', Message: 'nope' }] },
+      ],
+    });
+
+    await assert.rejects(
+      () =>
+        new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket'),
+      (error: Error) => {
+        assert.ok(error.message.includes('Failed to delete 1 object(s)'));
+        assert.ok(error.message.includes('AccessDenied'));
+        return true;
+      },
+    );
+    assert.strictEqual(getCommandInputs(send, DeleteBucketCommand).length, 0);
+  });
+
+  void it('empties the bucket again and retries when the bucket is not empty', async () => {
+    const emptyPage: ListObjectVersionsCommandOutput = {
+      IsTruncated: false,
+      $metadata: {},
+    };
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [
+        emptyPage,
+        {
+          Versions: [{ Key: 'written-during-cleanup', VersionId: 'v1' }],
+          IsTruncated: false,
+          $metadata: {},
+        },
+      ],
+      deleteBucket: [buildBucketNotEmptyError(), {}],
+    });
+
+    await new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket');
+
+    assert.strictEqual(
+      getCommandInputs(send, ListObjectVersionsCommand).length,
+      2,
+    );
+    assert.strictEqual(getCommandInputs(send, DeleteObjectsCommand).length, 1);
+    assert.strictEqual(getCommandInputs(send, DeleteBucketCommand).length, 2);
+  });
+
+  void it('does not retry the bucket deletion on other failures', async () => {
+    const { s3Client, send } = buildS3Client({
+      listObjectVersions: [{ IsTruncated: false, $metadata: {} }],
+      deleteBucket: [new Error('AccessDenied')],
+    });
+
+    await assert.rejects(
+      () =>
+        new S3BucketEmptier(s3Client, () => {}).emptyAndDelete('test-bucket'),
+      (error: Error) => {
+        assert.strictEqual(error.message, 'AccessDenied');
+        return true;
+      },
+    );
+    assert.strictEqual(getCommandInputs(send, DeleteBucketCommand).length, 1);
+  });
+});

--- a/scripts/components/e2e-cleanup/s3_bucket_emptier.ts
+++ b/scripts/components/e2e-cleanup/s3_bucket_emptier.ts
@@ -1,0 +1,119 @@
+import {
+  DeleteBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectVersionsCommand,
+  ListObjectVersionsCommandOutput,
+  ObjectIdentifier,
+  S3Client,
+} from '@aws-sdk/client-s3';
+
+const MAX_OBJECTS_PER_DELETE_REQUEST = 1000;
+
+/**
+ * Empties and deletes S3 buckets.
+ *
+ * Test buckets are versioned, therefore removing the current version of every object
+ * is not enough to make a bucket removable. All object versions and all delete markers
+ * must be removed, otherwise `DeleteBucket` fails with `BucketNotEmpty`.
+ */
+export class S3BucketEmptier {
+  /**
+   * Creates S3 bucket emptier.
+   */
+  constructor(
+    private readonly s3Client: S3Client,
+    private readonly log: (message: string) => void = console.log,
+  ) {}
+
+  /**
+   * Removes all object versions and delete markers from the bucket and then deletes the bucket.
+   *
+   * Bucket emptiness is eventually consistent and a concurrently running test may still be
+   * writing to the bucket, so a `BucketNotEmpty` failure is retried once after emptying again.
+   * @throws if any object or the bucket itself could not be deleted.
+   */
+  emptyAndDelete = async (bucketName: string): Promise<void> => {
+    await this.empty(bucketName);
+    try {
+      await this.s3Client.send(new DeleteBucketCommand({ Bucket: bucketName }));
+    } catch (error) {
+      if (!this.isBucketNotEmptyError(error)) {
+        throw error;
+      }
+      this.log(
+        `Bucket ${bucketName} was not empty when deleting it. Emptying it again.`,
+      );
+      await this.empty(bucketName);
+      await this.s3Client.send(new DeleteBucketCommand({ Bucket: bucketName }));
+    }
+  };
+
+  private empty = async (bucketName: string): Promise<void> => {
+    let keyMarker: string | undefined = undefined;
+    let versionIdMarker: string | undefined = undefined;
+    let isTruncated = false;
+    do {
+      const listObjectVersionsResponse: ListObjectVersionsCommandOutput =
+        await this.s3Client.send(
+          new ListObjectVersionsCommand({
+            Bucket: bucketName,
+            KeyMarker: keyMarker,
+            VersionIdMarker: versionIdMarker,
+          }),
+        );
+      const objectsToDelete: Array<ObjectIdentifier> = [
+        ...(listObjectVersionsResponse.Versions ?? []),
+        ...(listObjectVersionsResponse.DeleteMarkers ?? []),
+      ]
+        .filter((s3Object) => s3Object.Key !== undefined)
+        .map((s3Object) => ({
+          Key: s3Object.Key as string,
+          VersionId: s3Object.VersionId,
+        }));
+      await this.deleteObjects(bucketName, objectsToDelete);
+      // A single key can have more versions than fit in one page. Resuming with the key marker
+      // alone skips the remaining versions of that key, hence the version id marker is required.
+      keyMarker = listObjectVersionsResponse.NextKeyMarker;
+      versionIdMarker = listObjectVersionsResponse.NextVersionIdMarker;
+      isTruncated = listObjectVersionsResponse.IsTruncated === true;
+    } while (isTruncated);
+  };
+
+  private deleteObjects = async (
+    bucketName: string,
+    objectsToDelete: Array<ObjectIdentifier>,
+  ): Promise<void> => {
+    for (
+      let offset = 0;
+      offset < objectsToDelete.length;
+      offset += MAX_OBJECTS_PER_DELETE_REQUEST
+    ) {
+      const batch = objectsToDelete.slice(
+        offset,
+        offset + MAX_OBJECTS_PER_DELETE_REQUEST,
+      );
+      // DeleteObjects is a partial success API. Failures are reported in the response
+      // instead of throwing, and silently ignoring them keeps the bucket from being deleted.
+      const deleteObjectsResponse = await this.s3Client.send(
+        new DeleteObjectsCommand({
+          Bucket: bucketName,
+          Delete: { Objects: batch, Quiet: true },
+        }),
+      );
+      const errors = deleteObjectsResponse.Errors ?? [];
+      if (errors.length > 0) {
+        throw new Error(
+          `Failed to delete ${errors.length} object(s) from ${bucketName} bucket. ${errors
+            .slice(0, 5)
+            .map((error) => `${error.Key}: ${error.Code} ${error.Message}`)
+            .join('; ')}`,
+        );
+      }
+    }
+  };
+
+  private isBucketNotEmptyError = (error: unknown): boolean =>
+    error instanceof Error &&
+    (error.name === 'BucketNotEmpty' ||
+      error.message.includes('BucketNotEmpty'));
+}


### PR DESCRIPTION
> Stacked on #3303 — review that first. This PR targets `fix/e2e-cleanup-live-stack-ownership`, so its diff only shows the S3 changes.

## Problem

Test buckets are versioned, and the previous emptying logic could not reliably empty one. `DeleteBucket` then failed with `BucketNotEmpty` and the bucket leaked. Three separate defects:

**1. Version pagination was broken.**

A single `nextToken` variable was shared across two sequential `do/while` loops:

```ts
let nextToken: string | undefined = undefined;
do { /* ListObjectsV2 ... */ nextToken = listObjectsResponse.NextContinuationToken; } while (nextToken);

do {
  const listVersionsResponse = await s3Client.send(
    new ListObjectVersionsCommand({ Bucket: bucketName, KeyMarker: nextToken }),
  );
  ...
  nextToken = listVersionsResponse.NextKeyMarker;
} while (nextToken);
```

The versions loop started from the leftover value of the objects loop (always `undefined` at that point — the first loop only exits when it is falsy), and it only ever advanced `NextKeyMarker`. `ListObjectVersions` pages on **both** `KeyMarker` and `VersionIdMarker`, so a key with more versions than fit in one page had the rest of its versions silently skipped.

Pagination was also driven by "is there a marker" rather than by `IsTruncated`, which is the documented termination signal.

**2. `DeleteObjects` failures were discarded.**

`DeleteObjects` is a partial-success API — it reports per-object failures in `Errors[]` in a `200` response instead of throwing. The response was never inspected, so a bucket that could not be emptied looked like a clean success and the real reason for the subsequent `BucketNotEmpty` was lost.

**3. Requests were not batched.**

`DeleteObjects` accepts at most 1000 keys. A `ListObjectVersions` page holding more than that (versions + delete markers combined) was rejected outright.

## Fix

`S3BucketEmptier` (new, `scripts/components/e2e-cleanup/s3_bucket_emptier.ts`):

- Paginates on **both** `NextKeyMarker` and `NextVersionIdMarker`, terminating on `IsTruncated`.
- Deletes versions **and** delete markers, batched at 1000.
- Throws when the response reports `Errors[]`, including the first few object keys and codes so the log says *why*.
- Retries `DeleteBucket` once after emptying again on `BucketNotEmpty`, because bucket emptiness is eventually consistent and a concurrent test may still be writing. Any other failure propagates unchanged.

The separate `ListObjectsV2` pass is gone: `ListObjectVersions` already returns the current version of every object, so it was duplicated work and doubled the request count on every bucket.

## Tests

6 new unit tests in `s3_bucket_emptier.test.ts`: full version + delete-marker removal, pagination across both markers, 1000-item batching, throwing on reported `Errors[]`, the `BucketNotEmpty` re-empty-and-retry path, and that other failures are *not* retried.

```
ℹ tests 75
ℹ pass 75
ℹ fail 0
```

`tsc --noEmit -p scripts/tsconfig.json`, `eslint --max-warnings 0`, and `prettier --check` are all clean.

## Notes for the reviewer

- No new IAM permissions. The same `s3:ListBucketVersions` / `s3:DeleteObject` / `s3:DeleteBucket` actions are used; only the call pattern changed.
- No `packages/*` code is touched, so there is no changeset.

## Validation

- [x] Unit tests pass
- [x] `tsc`, `eslint`, `prettier` clean
- [x] PR size check passes


---

### Review stack

This fix is split into three stacked PRs to stay under the repo's 1000-line PR size limit. Each is independently correct and reviewable:

1. **#3303 — stop deleting resources that live stacks still own** (base, targets `main`) — the primary bug, plus draining the existing `DELETE_FAILED` backlog.
2. **#3304 — delete every object version when emptying a test bucket** (targets #3303's branch).
3. **#3305 — delete the CloudFront distributions of test buckets** (targets #3304's branch) — the subdomain-takeover risk.

Merge in order 3303 → 3304 → 3305.


> **Why "no checks reported" on this PR:** `health_checks.yml` only triggers on PRs targeting `main`, `hotfix`, or `feature/**`. This PR targets its parent's `fix/...` branch, so CI is idle by design. GitHub auto-retargets this PR to `main` when its parent merges, and the full suite runs at that point. #3303 (the base of the stack, targeting `main`) is fully green.
>
> Verified locally on this exact branch in the meantime:
> ```
> tsc --noEmit -p scripts/tsconfig.json   clean
> eslint --max-warnings 0                 clean
> prettier --check                        clean
> npm run test:scripts                    75 pass / 0 fail
> npm run diff:check <parent>             within size limits
> ```
