### PR TITLE
fix(e2e-cleanup): delete the CloudFront distributions of test buckets

### DIFF
--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -48,6 +48,7 @@
   "chown",
   "claude",
   "cloudformation",
+  "cloudfront",
   "codebase",
   "codegen",
   "cognito",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@aws-amplify/eslint-plugin-amplify-backend-rules": "^0.0.2",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-cloudformation": "^3.936.0",
+        "@aws-sdk/client-cloudfront": "^3.936.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
         "@aws-sdk/client-dynamodb": "^3.936.0",
@@ -8957,6 +8958,551 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.936.0.tgz",
+      "integrity": "sha512-vmOZV65l7Spa5C5wz+trtSJ8q23l3wgAYgrw6GnRoPTFHqs74MtWIQLJ+5YJ9cwkytNeSTYC+TZR3rpVa5uX4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/credential-provider-node": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/client-sso": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.936.0.tgz",
+      "integrity": "sha512-0G73S2cDqYwJVvqL08eakj79MZG2QRaB56Ul8/Ps9oQxllr7DMI1IQ/N3j3xjxgpq/U36pkoFZ8aK1n7Sbr3IQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/core": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.936.0.tgz",
+      "integrity": "sha512-eGJ2ySUMvgtOziHhDRDLCrj473RJoL4J1vPjVM3NrKC/fF3/LoHjkut8AAnKmrW6a2uTzNKubigw8dEnpmpERw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.936.0.tgz",
+      "integrity": "sha512-dKajFuaugEA5i9gCKzOaVy9uTeZcApE+7Z5wdcZ6j40523fY1a56khDAUYkCfwqa7sHci4ccmxBkAo+fW1RChA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.936.0.tgz",
+      "integrity": "sha512-5FguODLXG1tWx/x8fBxH+GVrk7Hey2LbXV5h9SFzYCx/2h50URBm0+9hndg0Rd23+xzYe14F6SI9HA9c1sPnjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.936.0.tgz",
+      "integrity": "sha512-TbUv56ERQQujoHcLMcfL0Q6bVZfYF83gu/TjHkVkdSlHPOIKaG/mhE2XZSQzXv1cud6LlgeBbfzVAxJ+HPpffg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/credential-provider-env": "3.936.0",
+        "@aws-sdk/credential-provider-http": "3.936.0",
+        "@aws-sdk/credential-provider-login": "3.936.0",
+        "@aws-sdk/credential-provider-process": "3.936.0",
+        "@aws-sdk/credential-provider-sso": "3.936.0",
+        "@aws-sdk/credential-provider-web-identity": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.936.0.tgz",
+      "integrity": "sha512-8DVrdRqPyUU66gfV7VZNToh56ZuO5D6agWrkLQE/xbLJOm2RbeRgh6buz7CqV8ipRd6m+zCl9mM4F3osQLZn8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.936.0.tgz",
+      "integrity": "sha512-rk/2PCtxX9xDsQW8p5Yjoca3StqmQcSfkmD7nQ61AqAHL1YgpSQWqHE+HjfGGiHDYKG7PvE33Ku2GyA7lEIJAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.936.0",
+        "@aws-sdk/credential-provider-http": "3.936.0",
+        "@aws-sdk/credential-provider-ini": "3.936.0",
+        "@aws-sdk/credential-provider-process": "3.936.0",
+        "@aws-sdk/credential-provider-sso": "3.936.0",
+        "@aws-sdk/credential-provider-web-identity": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.936.0.tgz",
+      "integrity": "sha512-GpA4AcHb96KQK2PSPUyvChvrsEKiLhQ5NWjeef2IZ3Jc8JoosiedYqp6yhZR+S8cTysuvx56WyJIJc8y8OTrLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.936.0.tgz",
+      "integrity": "sha512-wHlEAJJvtnSyxTfNhN98JcU4taA1ED2JvuI2eePgawqBwS/Tzi0mhED1lvNIaWOkjfLd+nHALwszGrtJwEq4yQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.936.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/token-providers": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.936.0.tgz",
+      "integrity": "sha512-v3qHAuoODkoRXsAF4RG+ZVO6q2P9yYBT4GMpMEfU9wXVNn7AIfwZgTwzSUfnjNiGva5BKleWVpRpJ9DeuLFbUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+      "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.936.0.tgz",
+      "integrity": "sha512-YB40IPa7K3iaYX0lSnV9easDOLPLh+fJyUDF3BH8doX4i1AOSsYn86L4lVldmOaSX+DwiaqKHpvk4wPBdcIPWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.936.0.tgz",
+      "integrity": "sha512-eyj2tz1XmDSLSZQ5xnB7cLTVKkSJnYAEoNDSUNhzWPxrBDYeJzIbatecOKceKCU8NBf8gWWZCK/CSY0mDxMO0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/token-providers": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.936.0.tgz",
+      "integrity": "sha512-vvw8+VXk0I+IsoxZw0mX9TMJawUJvEsg3EF7zcCSetwhNPAU8Xmlhv7E/sN/FgSmm7b7DsqKoW6rVtQiCs1PWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/types": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.936.0.tgz",
+      "integrity": "sha512-XOEc7PF9Op00pWV2AYCGDSu5iHgYjIO53Py2VUQTIvP7SRCaCsXmA33mjBvC2Ms6FhSyWNa4aK4naUGIz0hQcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@smithy/util-base64": {
+      "version": "4.5.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.5.16.tgz",
+      "integrity": "sha512-80e25qWKD6hJh5BenAutni2Z6dj2AiZKmht21pcROmzWzQja8yl+KqsuDSia++hwk1Ne6RrDEBwP6I+A4R0XAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cloudtrail": {
@@ -20773,9 +21319,10 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -27817,6 +28364,25 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -36228,20 +36794,20 @@
     },
     "packages/backend": {
       "name": "@aws-amplify/backend",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-auth": "^1.9.4",
-        "@aws-amplify/backend-data": "^1.7.0",
-        "@aws-amplify/backend-function": "^1.18.1",
+        "@aws-amplify/backend-data": "^1.8.0",
+        "@aws-amplify/backend-function": "^1.18.2",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.5",
         "@aws-amplify/backend-secret": "^1.4.2",
         "@aws-amplify/backend-storage": "^1.5.0",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/data-schema": "^1.13.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-amplify": "^3.936.0"
       },
       "devDependencies": {
@@ -36294,7 +36860,7 @@
     },
     "packages/backend-data": {
       "name": "@aws-amplify/backend-data",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
@@ -36302,7 +36868,7 @@
         "@aws-amplify/data-construct": "^1.17.7",
         "@aws-amplify/data-schema-types": "^1.3.0",
         "@aws-amplify/graphql-generator": "^0.5.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "graphql": "^15.8.0"
       },
       "devDependencies": {
@@ -36317,11 +36883,11 @@
     },
     "packages/backend-deployer": {
       "name": "@aws-amplify/backend-deployer",
-      "version": "2.1.7",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-cdk/toolkit-lib": "1.32.0",
         "execa": "^9.5.1",
         "minimatch": "10.2.3",
@@ -36621,12 +37187,12 @@
     },
     "packages/backend-function": {
       "name": "@aws-amplify/backend-function",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-output-storage": "^1.3.5",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-s3": "^3.936.0",
         "execa": "^9.5.1"
       },
@@ -36656,12 +37222,12 @@
     },
     "packages/backend-notifications": {
       "name": "@aws-amplify/backend-notifications",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1"
+        "@aws-amplify/plugin-types": "^1.12.2"
       },
       "devDependencies": {
         "@aws-amplify/backend-output-storage": "^1.3.5",
@@ -36669,6 +37235,7 @@
         "@aws-sdk/client-connect": "^3.1079.0",
         "@aws-sdk/client-connectcampaignsv2": "^3.1079.0",
         "@aws-sdk/client-customer-profiles": "^3.936.0",
+        "@aws-sdk/client-dynamodb": "^3.936.0",
         "@aws-sdk/client-iam": "^3.936.0",
         "@aws-sdk/client-pinpoint": "^3.936.0",
         "@aws-sdk/client-qconnect": "^3.1079.0",
@@ -36746,20 +37313,20 @@
     },
     "packages/cli": {
       "name": "@aws-amplify/backend-cli",
-      "version": "1.8.3",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.7",
+        "@aws-amplify/backend-deployer": "^2.2.0",
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.5",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/cli-core": "^2.2.6",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/form-generator": "^1.2.7",
-        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/model-generator": "^1.2.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
-        "@aws-amplify/sandbox": "^2.2.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
+        "@aws-amplify/sandbox": "^2.3.0",
         "@aws-amplify/schema-generator": "^1.4.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-cloudformation": "^3.1078.0",
@@ -36799,7 +37366,7 @@
     },
     "packages/cli-core": {
       "name": "@aws-amplify/cli-core",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/platform-core": "^1.11.1",
@@ -36913,14 +37480,14 @@
     },
     "packages/client-config": {
       "name": "@aws-amplify/client-config",
-      "version": "1.10.2",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.8.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
-        "@aws-amplify/model-generator": "^1.2.3",
+        "@aws-amplify/model-generator": "^1.2.4",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "zod": "3.25.17"
       },
       "devDependencies": {
@@ -37091,6 +37658,7 @@
         "@aws-amplify/platform-core": "^1.11.1",
         "@aws-amplify/plugin-types": "^1.12.1",
         "@aws-amplify/seed": "^1.1.3",
+        "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/client-accessanalyzer": "^3.936.0",
         "@aws-sdk/client-amplify": "^3.936.0",
         "@aws-sdk/client-bedrock-runtime": "3.936.0",
@@ -37098,13 +37666,17 @@
         "@aws-sdk/client-cloudtrail": "^3.937.0",
         "@aws-sdk/client-cognito-identity": "^3.936.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
+        "@aws-sdk/client-customer-profiles": "^3.1079.0",
+        "@aws-sdk/client-dynamodb": "^3.936.0",
         "@aws-sdk/client-iam": "^3.936.0",
         "@aws-sdk/client-lambda": "^3.936.0",
         "@aws-sdk/client-s3": "^3.936.0",
         "@aws-sdk/client-sqs": "^3.936.0",
         "@aws-sdk/client-sts": "^3.936.0",
         "@aws-sdk/credential-providers": "^3.936.0",
+        "@smithy/protocol-http": "^5.3.12",
         "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/signature-v4": "^5.6.4",
         "@smithy/types": "^4.9.0",
         "@types/lodash.ismatch": "^4.4.9",
         "@zip.js/zip.js": "2.7.52",
@@ -37706,23 +38278,6 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "packages/integration-tests/node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "packages/integration-tests/node_modules/strip-ansi": {
       "version": "7.2.0",
       "dev": true,
@@ -37751,7 +38306,7 @@
     },
     "packages/model-generator": {
       "name": "@aws-amplify/model-generator",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.7.1",
@@ -37759,7 +38314,7 @@
         "@aws-amplify/graphql-generator": "^0.5.1",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-appsync": "^3.936.0",
         "@aws-sdk/client-s3": "^3.937.0",
         "@aws-sdk/credential-providers": "^3.936.0",
@@ -37816,7 +38371,7 @@
     },
     "packages/plugin-types": {
       "name": "@aws-amplify/plugin-types",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/toolkit-lib": "1.32.0"
@@ -38054,16 +38609,16 @@
     },
     "packages/sandbox": {
       "name": "@aws-amplify/sandbox",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^2.1.7",
+        "@aws-amplify/backend-deployer": "^2.2.0",
         "@aws-amplify/backend-secret": "^1.4.2",
-        "@aws-amplify/cli-core": "^2.2.5",
-        "@aws-amplify/client-config": "^1.10.2",
+        "@aws-amplify/cli-core": "^2.2.6",
+        "@aws-amplify/client-config": "^1.11.0",
         "@aws-amplify/deployed-backend-client": "^1.8.2",
         "@aws-amplify/platform-core": "^1.11.1",
-        "@aws-amplify/plugin-types": "^1.12.1",
+        "@aws-amplify/plugin-types": "^1.12.2",
         "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
         "@aws-sdk/client-lambda": "^3.936.0",
         "@aws-sdk/client-ssm": "^3.936.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@aws-amplify/eslint-plugin-amplify-backend-rules": "^0.0.2",
     "@aws-sdk/client-amplify": "^3.936.0",
     "@aws-sdk/client-cloudformation": "^3.936.0",
+    "@aws-sdk/client-cloudfront": "^3.936.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.936.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
     "@aws-sdk/client-dynamodb": "^3.936.0",

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -2,6 +2,7 @@ import {
   CloudFormationClient,
   StackSummary,
 } from '@aws-sdk/client-cloudformation';
+import { CloudFrontClient } from '@aws-sdk/client-cloudfront';
 import {
   CloudWatchLogsClient,
   DeleteLogGroupCommand,
@@ -58,6 +59,7 @@ import {
   ListTablesCommandOutput,
   TableDescription,
 } from '@aws-sdk/client-dynamodb';
+import { CloudFrontDistributionCleaner } from './components/e2e-cleanup/cloudfront_distribution_cleaner.js';
 import { S3BucketEmptier } from './components/e2e-cleanup/s3_bucket_emptier.js';
 import {
   GuardedResourceType,
@@ -70,6 +72,9 @@ const amplifyClient = new AmplifyClient({
 const cfnClient = new CloudFormationClient({
   maxAttempts: 5,
   retryMode: 'adaptive',
+});
+const cloudFrontClient = new CloudFrontClient({
+  maxAttempts: 5,
 });
 const cloudWatchClient = new CloudWatchLogsClient({
   maxAttempts: 5,
@@ -143,6 +148,10 @@ const stackDeleter = new StackDeleter(
   isStackStale,
 );
 const s3BucketEmptier = new S3BucketEmptier(s3Client);
+const cloudFrontDistributionCleaner = new CloudFrontDistributionCleaner(
+  cloudFrontClient,
+  TEST_AMPLIFY_RESOURCE_PREFIX,
+);
 
 /**
  * Deleting a resource that a stack still owns poisons the delete path of that stack, which is
@@ -210,6 +219,8 @@ const listStaleS3Buckets = async (): Promise<Array<Bucket>> => {
 };
 
 const staleBuckets = await listStaleS3Buckets();
+const bucketToDistributions =
+  await cloudFrontDistributionCleaner.buildBucketToDistributionsIndex();
 
 for (const staleBucket of staleBuckets) {
   if (staleBucket.Name) {
@@ -218,6 +229,23 @@ for (const staleBucket of staleBuckets) {
       continue;
     }
     try {
+      /**
+       * Deleting the origin bucket of a distribution that still exists leaves a distribution
+       * that serves a bucket name anybody can claim, so the distributions go first. Disabling a
+       * distribution takes tens of minutes to propagate, therefore the bucket is retained until
+       * a subsequent run of this script is able to delete its distributions.
+       */
+      const distributionReapResult =
+        await cloudFrontDistributionCleaner.reapDistributionsForBucket(
+          bucketName,
+          bucketToDistributions,
+        );
+      if (distributionReapResult === 'disable-requested') {
+        console.log(
+          `Retaining ${bucketName} bucket. A CloudFront distribution still uses it as an origin`,
+        );
+        continue;
+      }
       await s3BucketEmptier.emptyAndDelete(bucketName);
       console.log(`Successfully deleted ${bucketName} bucket`);
     } catch (e) {

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import {
+  CloudFrontClient,
+  DeleteDistributionCommand,
+  DistributionSummary,
+  GetDistributionConfigCommand,
+  ListDistributionsCommand,
+  ListDistributionsCommandOutput,
+  UpdateDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
+import { CloudFrontDistributionCleaner } from './cloudfront_distribution_cleaner.js';
+
+const TEST_RESOURCE_PREFIX = 'amplify-';
+
+const buildDistribution = (
+  id: string,
+  originDomainNames: Array<string>,
+  overrides: Partial<DistributionSummary> = {},
+): DistributionSummary =>
+  ({
+    Id: id,
+    Status: 'Deployed',
+    Enabled: true,
+    Origins: {
+      Quantity: originDomainNames.length,
+      Items: originDomainNames.map((domainName, index) => ({
+        Id: `origin-${index}`,
+        DomainName: domainName,
+      })),
+    },
+    ...overrides,
+  }) as DistributionSummary;
+
+const buildCloudFrontClient = (
+  handlers: {
+    listDistributions?: Array<ListDistributionsCommandOutput | Error>;
+    getDistributionConfig?: Array<object | Error>;
+    updateDistribution?: Array<object | Error>;
+    deleteDistribution?: Array<object | Error>;
+  } = {},
+) => {
+  const respond = (responses: Array<object | Error> | undefined) => {
+    const response = responses?.shift();
+    return response instanceof Error
+      ? Promise.reject(response)
+      : Promise.resolve(response ?? {});
+  };
+  const listDistributions: Array<object | Error> = [
+    ...(handlers.listDistributions ?? []),
+  ];
+  const getDistributionConfig: Array<object | Error> = [
+    ...(handlers.getDistributionConfig ?? []),
+  ];
+  const updateDistribution: Array<object | Error> = [
+    ...(handlers.updateDistribution ?? []),
+  ];
+  const deleteDistribution: Array<object | Error> = [
+    ...(handlers.deleteDistribution ?? []),
+  ];
+  const send = mock.fn((command: unknown) => {
+    if (command instanceof ListDistributionsCommand) {
+      return respond(listDistributions);
+    }
+    if (command instanceof GetDistributionConfigCommand) {
+      return respond(getDistributionConfig);
+    }
+    if (command instanceof UpdateDistributionCommand) {
+      return respond(updateDistribution);
+    }
+    if (command instanceof DeleteDistributionCommand) {
+      return respond(deleteDistribution);
+    }
+    return Promise.reject(new Error('Unexpected command'));
+  });
+  return {
+    cloudFrontClient: { send } as unknown as CloudFrontClient,
+    send,
+  };
+};
+
+const getCommandInputs = (
+  send: ReturnType<typeof buildCloudFrontClient>['send'],
+  commandType: unknown,
+): Array<Record<string, unknown>> =>
+  send.mock.calls
+    .map((call) => call.arguments[0])
+    .filter(
+      (command) =>
+        command instanceof (commandType as new (input: never) => object),
+    )
+    .map((command) => (command as { input: Record<string, unknown> }).input);
+
+void describe('CloudFrontDistributionCleaner', () => {
+  void describe('buildBucketToDistributionsIndex', () => {
+    void it('indexes test bucket origins of all supported domain formats', async () => {
+      const { cloudFrontClient } = buildCloudFrontClient({
+        listDistributions: [
+          {
+            DistributionList: {
+              Items: [
+                buildDistribution('D1', [
+                  'amplify-regional.s3.us-west-2.amazonaws.com',
+                ]),
+                buildDistribution('D2', ['amplify-global.s3.amazonaws.com']),
+                buildDistribution('D3', [
+                  'amplify-website.s3-website-us-west-2.amazonaws.com',
+                ]),
+              ],
+              IsTruncated: false,
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).buildBucketToDistributionsIndex();
+
+      assert.deepStrictEqual([...index.keys()].sort(), [
+        'amplify-global',
+        'amplify-regional',
+        'amplify-website',
+      ]);
+      assert.strictEqual(index.get('amplify-regional')?.[0].Id, 'D1');
+    });
+
+    void it('ignores origins that are not test buckets and follows pagination', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient({
+        listDistributions: [
+          {
+            DistributionList: {
+              Items: [
+                buildDistribution('D1', [
+                  'example.com',
+                  'other-bucket.s3.us-west-2.amazonaws.com',
+                  'api.execute-api.us-west-2.amazonaws.com',
+                ]),
+              ],
+              IsTruncated: true,
+              NextMarker: 'D1',
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+          {
+            DistributionList: {
+              Items: [
+                buildDistribution('D2', [
+                  'amplify-app.s3.us-west-2.amazonaws.com',
+                  'amplify-app.s3.us-west-2.amazonaws.com',
+                ]),
+              ],
+              IsTruncated: false,
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).buildBucketToDistributionsIndex();
+
+      assert.deepStrictEqual(getCommandInputs(send, ListDistributionsCommand), [
+        { Marker: undefined },
+        { Marker: 'D1' },
+      ]);
+      assert.deepStrictEqual([...index.keys()], ['amplify-app']);
+      assert.strictEqual(index.get('amplify-app')?.length, 1);
+    });
+
+    void it('returns an empty index instead of throwing when listing is not permitted', async () => {
+      const logMessages: Array<string> = [];
+      const { cloudFrontClient } = buildCloudFrontClient({
+        listDistributions: [
+          new Error(
+            'User is not authorized to perform cloudfront:ListDistributions',
+          ),
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        (message) => logMessages.push(message),
+      ).buildBucketToDistributionsIndex();
+
+      assert.strictEqual(index.size, 0);
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('Unable to list CloudFront distributions'),
+        ),
+      );
+    });
+  });
+
+  void describe('reapDistributionsForBucket', () => {
+    void it('reports none when the bucket has no distributions', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient();
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket('amplify-app', new Map());
+
+      assert.strictEqual(result, 'none');
+      assert.strictEqual(send.mock.callCount(), 0);
+    });
+
+    void it('disables an enabled distribution and keeps the bucket', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient({
+        getDistributionConfig: [
+          {
+            ETag: 'version-1',
+            DistributionConfig: { Enabled: true, Comment: 'x' },
+          },
+        ],
+      });
+      const distribution = buildDistribution('D1', [
+        'amplify-app.s3.us-west-2.amazonaws.com',
+      ]);
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'disable-requested');
+      assert.deepStrictEqual(
+        getCommandInputs(send, UpdateDistributionCommand),
+        [
+          {
+            Id: 'D1',
+            IfMatch: 'version-1',
+            DistributionConfig: { Enabled: false, Comment: 'x' },
+          },
+        ],
+      );
+      assert.strictEqual(
+        getCommandInputs(send, DeleteDistributionCommand).length,
+        0,
+      );
+    });
+
+    void it('waits for a disabled distribution that is not deployed yet', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient();
+      const distribution = buildDistribution(
+        'D1',
+        ['amplify-app.s3.us-west-2.amazonaws.com'],
+        { Enabled: false, Status: 'InProgress' },
+      );
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'disable-requested');
+      assert.strictEqual(send.mock.callCount(), 0);
+    });
+
+    void it('deletes a distribution that is disabled and deployed', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient({
+        getDistributionConfig: [
+          { ETag: 'version-2', DistributionConfig: { Enabled: false } },
+        ],
+      });
+      const distribution = buildDistribution(
+        'D1',
+        ['amplify-app.s3.us-west-2.amazonaws.com'],
+        { Enabled: false, Status: 'Deployed' },
+      );
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'deleted');
+      assert.deepStrictEqual(
+        getCommandInputs(send, DeleteDistributionCommand),
+        [{ Id: 'D1', IfMatch: 'version-2' }],
+      );
+    });
+
+    void it('keeps the bucket when a distribution cannot be reaped', async () => {
+      const logMessages: Array<string> = [];
+      const { cloudFrontClient } = buildCloudFrontClient({
+        getDistributionConfig: [new Error('PreconditionFailed')],
+      });
+      const distribution = buildDistribution(
+        'D1',
+        ['amplify-app.s3.us-west-2.amazonaws.com'],
+        { Enabled: false, Status: 'Deployed' },
+      );
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        (message) => logMessages.push(message),
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'disable-requested');
+      assert.ok(
+        logMessages.some((message) =>
+          message.includes('Retaining its origin bucket'),
+        ),
+      );
+    });
+
+    void it('keeps the bucket when only one of the distributions is gone', async () => {
+      const { cloudFrontClient } = buildCloudFrontClient({
+        getDistributionConfig: [
+          { ETag: 'version-1', DistributionConfig: { Enabled: false } },
+          { ETag: 'version-2', DistributionConfig: { Enabled: true } },
+        ],
+      });
+      const distributions = [
+        buildDistribution('D1', ['amplify-app.s3.us-west-2.amazonaws.com'], {
+          Enabled: false,
+          Status: 'Deployed',
+        }),
+        buildDistribution('D2', ['amplify-app.s3.us-west-2.amazonaws.com']),
+      ];
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        new Map([['amplify-app', distributions]]),
+      );
+
+      assert.strictEqual(result, 'disable-requested');
+    });
+  });
+});

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
@@ -1,0 +1,197 @@
+import {
+  CloudFrontClient,
+  DeleteDistributionCommand,
+  DistributionList,
+  DistributionSummary,
+  GetDistributionConfigCommand,
+  ListDistributionsCommand,
+  ListDistributionsCommandOutput,
+  UpdateDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
+
+/**
+ * Matches the S3 origin domain name formats CloudFront reports, for example
+ * `bucket.s3.us-west-2.amazonaws.com`, `bucket.s3.amazonaws.com` and
+ * `bucket.s3-website-us-west-2.amazonaws.com`. The first group is the bucket name.
+ */
+const S3_ORIGIN_DOMAIN_PATTERN =
+  /^(.+?)\.s3(?:[.-]website)?(?:\.dualstack)?(?:[.-][a-z0-9-]+)?\.amazonaws\.com$/;
+
+const DEPLOYED_STATUS = 'Deployed';
+
+/**
+ * Outcome of an attempt to reap the distributions of a single bucket.
+ *
+ * `disable-requested` means at least one distribution still exists, therefore the origin
+ * bucket must be retained. `deleted` means every distribution of the bucket is gone.
+ */
+export type DistributionReapResult = 'none' | 'disable-requested' | 'deleted';
+
+/**
+ * Deletes CloudFront distributions that are left behind by failed e2e test stack deletions.
+ *
+ * A distribution cannot be deleted while it is enabled, and disabling it takes tens of minutes
+ * to propagate. Reaping is therefore a convergence across hourly runs of the cleanup job rather
+ * than a single blocking operation: one run requests the disable, a later run performs the delete.
+ */
+export class CloudFrontDistributionCleaner {
+  /**
+   * Creates CloudFront distribution cleaner.
+   */
+  constructor(
+    private readonly cloudFrontClient: CloudFrontClient,
+    private readonly testResourcePrefix: string,
+    private readonly log: (message: string) => void = console.log,
+  ) {}
+
+  /**
+   * Indexes all distributions that use a test bucket as an origin by that bucket name.
+   *
+   * Returns an empty index if the distributions cannot be listed, so that the rest of the
+   * cleanup keeps working in accounts where the cleanup role is not permitted to use CloudFront.
+   */
+  buildBucketToDistributionsIndex = async (): Promise<
+    Map<string, Array<DistributionSummary>>
+  > => {
+    const index = new Map<string, Array<DistributionSummary>>();
+    let marker: string | undefined = undefined;
+    try {
+      do {
+        const listDistributionsResponse: ListDistributionsCommandOutput =
+          await this.cloudFrontClient.send(
+            new ListDistributionsCommand({ Marker: marker }),
+          );
+        const distributionList: DistributionList | undefined =
+          listDistributionsResponse.DistributionList;
+        for (const distribution of distributionList?.Items ?? []) {
+          for (const bucketName of this.getTestBucketOrigins(distribution)) {
+            const distributions = index.get(bucketName) ?? [];
+            distributions.push(distribution);
+            index.set(bucketName, distributions);
+          }
+        }
+        marker =
+          distributionList?.IsTruncated === true
+            ? distributionList.NextMarker
+            : undefined;
+      } while (marker);
+    } catch (error) {
+      this.log(
+        `Unable to list CloudFront distributions, skipping distribution cleanup. ${this.getErrorMessage(error)}`,
+      );
+      return new Map();
+    }
+    return index;
+  };
+
+  /**
+   * Moves every distribution of the bucket one step closer to deletion.
+   *
+   * The caller must retain the bucket unless the result is `none` or `deleted`. Deleting the
+   * origin bucket of a distribution that still exists turns it into a dangling distribution
+   * that serves a bucket name anybody can claim.
+   */
+  reapDistributionsForBucket = async (
+    bucketName: string,
+    bucketToDistributions: Map<string, Array<DistributionSummary>>,
+  ): Promise<DistributionReapResult> => {
+    const distributions = bucketToDistributions.get(bucketName) ?? [];
+    let result: DistributionReapResult = 'none';
+    for (const distribution of distributions) {
+      const distributionResult = await this.reapDistribution(distribution);
+      if (distributionResult === 'disable-requested') {
+        result = 'disable-requested';
+      } else if (result === 'none') {
+        result = distributionResult;
+      }
+    }
+    return result;
+  };
+
+  private reapDistribution = async (
+    distribution: DistributionSummary,
+  ): Promise<DistributionReapResult> => {
+    const distributionId = distribution.Id;
+    if (!distributionId) {
+      return 'none';
+    }
+    try {
+      if (distribution.Enabled !== false) {
+        await this.disableDistribution(distributionId);
+        this.log(
+          `Requested disable of ${distributionId} CloudFront distribution. It will be deleted by a subsequent run`,
+        );
+        return 'disable-requested';
+      }
+      if (distribution.Status !== DEPLOYED_STATUS) {
+        this.log(
+          `The ${distributionId} CloudFront distribution is disabled but not deployed yet. It will be deleted by a subsequent run`,
+        );
+        return 'disable-requested';
+      }
+      const getDistributionConfigResponse = await this.cloudFrontClient.send(
+        new GetDistributionConfigCommand({ Id: distributionId }),
+      );
+      await this.cloudFrontClient.send(
+        new DeleteDistributionCommand({
+          Id: distributionId,
+          IfMatch: getDistributionConfigResponse.ETag,
+        }),
+      );
+      this.log(
+        `Successfully deleted ${distributionId} CloudFront distribution`,
+      );
+      return 'deleted';
+    } catch (error) {
+      // The distribution is still there, so its origin bucket must be retained.
+      this.log(
+        `Failed to reap ${distributionId} CloudFront distribution. Retaining its origin bucket. ${this.getErrorMessage(error)}`,
+      );
+      return 'disable-requested';
+    }
+  };
+
+  private disableDistribution = async (
+    distributionId: string,
+  ): Promise<void> => {
+    const getDistributionConfigResponse = await this.cloudFrontClient.send(
+      new GetDistributionConfigCommand({ Id: distributionId }),
+    );
+    if (
+      !getDistributionConfigResponse.DistributionConfig ||
+      !getDistributionConfigResponse.ETag
+    ) {
+      throw new Error(
+        `Unable to read the configuration of ${distributionId} CloudFront distribution`,
+      );
+    }
+    await this.cloudFrontClient.send(
+      new UpdateDistributionCommand({
+        Id: distributionId,
+        IfMatch: getDistributionConfigResponse.ETag,
+        DistributionConfig: {
+          ...getDistributionConfigResponse.DistributionConfig,
+          Enabled: false,
+        },
+      }),
+    );
+  };
+
+  private getTestBucketOrigins = (
+    distribution: DistributionSummary,
+  ): Array<string> => {
+    const bucketNames = new Set<string>();
+    for (const origin of distribution.Origins?.Items ?? []) {
+      const bucketName = origin.DomainName
+        ? S3_ORIGIN_DOMAIN_PATTERN.exec(origin.DomainName)?.[1]
+        : undefined;
+      if (bucketName?.startsWith(this.testResourcePrefix)) {
+        bucketNames.add(bucketName);
+      }
+    }
+    return [...bucketNames];
+  };
+
+  private getErrorMessage = (error: unknown): string =>
+    error instanceof Error ? error.message : '';
+}


### PR DESCRIPTION
> Stacked on #3304 (which is stacked on #3303) — review those first. This PR targets `fix/e2e-cleanup-s3-object-versions`, so its diff only shows the CloudFront changes.

## Problem

**Nothing in the cleanup job ever deleted CloudFront distributions.**

Hosting e2e tests create them. When a stack fails to delete, the distribution is left behind. The bucket sweep then deletes the origin bucket **out from under it**.

That leaves a running distribution whose S3 origin points at a bucket name that no longer exists. S3 bucket names are globally claimable, so **anyone can create that bucket and serve their own content from the distribution's `*.cloudfront.net` domain** — a subdomain-takeover primitive on an AWS-owned domain. The distributions also keep costing money indefinitely and are never reclaimed.

The ordering is exactly backwards: today the bucket goes first and the distribution is orphaned.

## Fix

`CloudFrontDistributionCleaner` (new, `scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts`):

**1. Index distributions by their origin bucket**

`buildBucketToDistributionsIndex()` pages `ListDistributions` once per run and maps `bucketName -> DistributionSummary[]`, parsing the three S3 origin domain formats CloudFront reports:

```
bucket.s3.<region>.amazonaws.com
bucket.s3.amazonaws.com
bucket.s3-website-<region>.amazonaws.com
```

Only buckets matching the `amplify-` test prefix are indexed, so a non-test distribution is never touched.

**2. Converge across runs, not within one**

A distribution cannot be deleted while it is enabled, and disabling one takes tens of minutes to propagate. Blocking the hourly job on that is not viable, so reaping is idempotent and spread across runs:

| Distribution state | Action | Result |
|---|---|---|
| `Enabled` | `UpdateDistribution` with `Enabled: false` | `disable-requested` |
| disabled, `Status != Deployed` | wait | `disable-requested` |
| disabled, `Status == Deployed` | `DeleteDistribution` | `deleted` |
| no distributions for bucket | — | `none` |

**3. Reverse the ordering — bucket last**

The bucket sweep now reaps distributions *first* and **retains the bucket** unless every distribution using it is gone. This closes the takeover window: the origin bucket outlives the distribution, not the other way round.

## Graceful degradation (important)

CloudFront reaping is **inert until the IAM role is updated**, and is designed so that landing this ahead of the role change is safe:

- `ListDistributions` failure (e.g. `AccessDenied`) is logged and returns an **empty index** rather than throwing. Every bucket then reaps `none` and the rest of the cleanup behaves exactly as before.
- A per-distribution failure is treated as **still present** (`disable-requested`), so the caller retains the bucket rather than orphaning the distribution. Failing to reap never escalates into the very problem this fixes.

### IAM prerequisite (out of repo)

The `e2e-resource-cleanup` role needs:

```
cloudfront:ListDistributions
cloudfront:GetDistribution
cloudfront:GetDistributionConfig
cloudfront:UpdateDistribution
cloudfront:DeleteDistribution
cloudfront:TagResource
```

(plus, from #3303: `cloudformation:DescribeStacks`, `cloudformation:DescribeStackResources`, `cloudformation:ListStackResources`)

Until that lands this PR is a no-op beyond one extra logged `ListDistributions` attempt per run.

## Tests

9 new unit tests in `cloudfront_distribution_cleaner.test.ts`: all three origin domain formats, non-test origins ignored, `ListDistributions` pagination, the `AccessDenied` empty-index path, and each of the four reap outcomes including "one of two distributions still present ⇒ retain bucket" and "reap failed ⇒ retain bucket".

```
ℹ tests 75
ℹ pass 75
ℹ fail 0
```

`tsc --noEmit -p scripts/tsconfig.json`, `eslint --max-warnings 0`, and `prettier --check` are all clean.

## Notes for the reviewer

- Adds `@aws-sdk/client-cloudfront` to root `devDependencies`, pinned to `^3.936.0` to match every sibling `@aws-sdk/client-*` declaration.
- No `packages/*` code is touched, so there is no changeset.
- Draining the existing `DELETE_FAILED` backlog happens in #3303; this PR stops new orphans from being created.

## Validation

- [x] Unit tests pass
- [x] `tsc`, `eslint`, `prettier` clean
- [x] PR size check passes


---

### Review stack

This fix is split into three stacked PRs to stay under the repo's 1000-line PR size limit. Each is independently correct and reviewable:

1. **#3303 — stop deleting resources that live stacks still own** (base, targets `main`) — the primary bug, plus draining the existing `DELETE_FAILED` backlog.
2. **#3304 — delete every object version when emptying a test bucket** (targets #3303's branch).
3. **#3305 — delete the CloudFront distributions of test buckets** (targets #3304's branch) — the subdomain-takeover risk.

Merge in order 3303 → 3304 → 3305.


> **Why "no checks reported" on this PR:** `health_checks.yml` only triggers on PRs targeting `main`, `hotfix`, or `feature/**`. This PR targets its parent's `fix/...` branch, so CI is idle by design. GitHub auto-retargets this PR to `main` when its parent merges, and the full suite runs at that point. #3303 (the base of the stack, targeting `main`) is fully green.
>
> Verified locally on this exact branch in the meantime:
> ```
> tsc --noEmit -p scripts/tsconfig.json   clean
> eslint --max-warnings 0                 clean
> prettier --check                        clean
> npm run test:scripts                    75 pass / 0 fail
> npm run diff:check <parent>             within size limits
> ```
