### PR TITLE
ci: pin changeset init to @changesets/cli@^2 in scripts tests

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -200,6 +200,7 @@ jobs:
       - build
       - resolve_inputs
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # version 4.1.4
       - uses: ./.github/actions/setup_node

--- a/scripts/components/dependabot_version_update_handler.test.ts
+++ b/scripts/components/dependabot_version_update_handler.test.ts
@@ -88,7 +88,7 @@ void describe('dependabot version update handler', async () => {
     await setPackageDependencies(cantaloupePackagePath, { testDep: '^1.0.0' });
     await setPackageDependencies(platypusPackagePath, { testDep: '^1.0.0' });
 
-    await $`npx --package @changesets/cli -- changeset init`;
+    await $`npx --package @changesets/cli@^2 -- changeset init`;
     await gitClient.commitAllChanges('Initial setup');
     baseRef = await gitClient.getHashForCurrentCommit();
   });

--- a/scripts/components/release_lifecycle.test.ts
+++ b/scripts/components/release_lifecycle.test.ts
@@ -105,7 +105,7 @@ void describe('release lifecycle', async () => {
     await npmClient.install(['@changesets/cli']);
     await npmClient.install(['human-id@4.1.3']);
 
-    await $`npx --package @changesets/cli -- changeset init`;
+    await $`npx --package @changesets/cli@^2 -- changeset init`;
     await gitClient.commitAllChanges('Version Packages (baseline release)');
     await runPublishInTestDir();
 


### PR DESCRIPTION
## Problem

The `test_scripts` job has been hanging in CI until it is cancelled.

Two of the scripts tests initialize a throwaway changesets repo in a fresh temp directory:

```ts
await $`npx --package @changesets/cli -- changeset init`;
```

Because the command runs with `cwd` set to a temp directory that has its own `node_modules`, the root `devDependency` range for `@changesets/cli` is bypassed entirely and `npx` resolves the registry `latest` tag instead. `latest` is now `3.0.0`, whose `init` command was rewritten around an interactive prompt:

```
◆  Should the GitHub integration be used for changelogs?
○ Yes / ● No
```

`changeset init` on 3.0.0 accepts no arguments other than `-h, --help` — there is no `--yes`, `--ci`, or `--defaults` escape hatch, and setting `CI=true` does not skip the prompt. Since these tests run with `stdio: 'inherit'`, the command blocks on stdin forever and the job runs until it is cancelled. On `2.x`, the same invocation initializes non-interactively and exits 0.

## Changes

- Pin both `changeset init` call sites to `@changesets/cli@^2`, which initializes non-interactively.
- Add `timeout-minutes: 30` to the `test_scripts` job so a future stdin hang fails fast instead of consuming a full runner slot (healthy runtime for this job is ~90s).

## Validation

Verified on Node 22 with no TTY, in throwaway directories:

| Invocation | Exit |
| --- | --- |
| `@changesets/cli@3.0.0 init` | 124 (hang) |
| `CI=true @changesets/cli@3.0.0 init` | 124 (hang) |
| `@changesets/cli@3.0.0 init < /dev/null` | 13, no `config.json` written |
| `@changesets/cli@2.31.1 init` | **0**, writes `config.json` + `README.md` |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
