### PR TITLE
fix(ai-constructs): strip extra Bedrock tool use fields before sending to AppSync

### DIFF
--- a/.changeset/tooluse-type-field-appsync.md
+++ b/.changeset/tooluse-type-field-appsync.md
@@ -1,0 +1,13 @@
+---
+'@aws-amplify/ai-constructs': patch
+---
+
+fix(ai-constructs): strip extra Bedrock tool use fields before sending to AppSync
+
+`ConversationTurnResponseSender.serializeContent` spread the entire Bedrock
+`ToolUseBlock` into the AppSync mutation. Newer `@aws-sdk/client-bedrock-runtime`
+versions add fields (e.g. `type`) that are not part of the generated
+`AmplifyAIToolUseBlockInput`, causing the conversation handler to fail with
+"Field 'type' is not defined by type 'AmplifyAIToolUseBlockInput'" whenever a
+tool (such as a `responseComponents` tool) is invoked. Only `toolUseId`, `name`,
+and the stringified `input` are now forwarded.

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.test.ts
@@ -300,6 +300,118 @@ void describe('Conversation turn response sender', () => {
     });
   });
 
+  void it('does not forward extra tool use fields not accepted by AppSync', async () => {
+    const userAgentProvider = new UserAgentProvider(
+      {} as unknown as ConversationTurnEvent,
+    );
+    mock.method(userAgentProvider, 'getUserAgent', () => '');
+    const graphqlRequestExecutor = new GraphqlRequestExecutor(
+      '',
+      '',
+      userAgentProvider,
+    );
+    const executeGraphqlMock = mock.method(
+      graphqlRequestExecutor,
+      'executeGraphql',
+      () =>
+        // Mock successful Appsync response
+        Promise.resolve(),
+    );
+    const sender = new ConversationTurnResponseSender(
+      event,
+      userAgentProvider,
+      graphqlRequestExecutor,
+    );
+    // Newer `@aws-sdk/client-bedrock-runtime` versions add extra fields (e.g. `type`)
+    // to the tool use block. These are not part of the AppSync-generated
+    // `AmplifyAIToolUseBlockInput` and must not be forwarded, otherwise the mutation
+    // is rejected with "Field 'type' is not defined by type 'AmplifyAIToolUseBlockInput'".
+    const toolUseBlock = {
+      toolUse: {
+        name: 'testTool',
+        toolUseId: 'testToolUseId',
+        input: {
+          testPropertyKey: 'testPropertyValue',
+        },
+        type: 'tool_use',
+      },
+    } as unknown as ContentBlock.ToolUseMember;
+    const response: Array<ContentBlock> = [toolUseBlock];
+    await sender.sendResponse(response);
+
+    assert.strictEqual(executeGraphqlMock.mock.calls.length, 1);
+    const request = executeGraphqlMock.mock.calls[0]
+      .arguments[0] as GraphqlRequest<MutationResponseInput>;
+    assert.deepStrictEqual(request.variables.input.content, [
+      {
+        toolUse: {
+          input: JSON.stringify(toolUseBlock.toolUse.input),
+          name: toolUseBlock.toolUse.name,
+          toolUseId: toolUseBlock.toolUse.toolUseId,
+        },
+      },
+    ]);
+  });
+
+  void it('does not forward extra tool use fields not accepted by AppSync when streaming', async () => {
+    const userAgentProvider = new UserAgentProvider(
+      {} as unknown as ConversationTurnEvent,
+    );
+    mock.method(userAgentProvider, 'getUserAgent', () => '');
+    const graphqlRequestExecutor = new GraphqlRequestExecutor(
+      '',
+      '',
+      userAgentProvider,
+    );
+    const executeGraphqlMock = mock.method(
+      graphqlRequestExecutor,
+      'executeGraphql',
+      () =>
+        // Mock successful Appsync response
+        Promise.resolve(),
+    );
+    const sender = new ConversationTurnResponseSender(
+      event,
+      userAgentProvider,
+      graphqlRequestExecutor,
+    );
+    // See the non-streaming test above: the streaming path accumulates tool use
+    // blocks that may carry extra SDK fields (e.g. `type`), which must be stripped
+    // before the accumulated content is sent to AppSync.
+    const toolUseBlock = {
+      toolUse: {
+        name: 'testTool',
+        toolUseId: 'testToolUseId',
+        input: {
+          testPropertyKey: 'testPropertyValue',
+        },
+        type: 'tool_use',
+      },
+    } as unknown as ContentBlock.ToolUseMember;
+    const chunk: StreamingResponseChunk = {
+      accumulatedTurnContent: [toolUseBlock],
+      associatedUserMessageId: 'testAssociatedUserMessageId',
+      contentBlockIndex: 1,
+      contentBlockDeltaIndex: 2,
+      conversationId: 'testConversationId',
+      contentBlockText: 'testBlockText',
+    };
+    await sender.sendResponseChunk(chunk);
+
+    assert.strictEqual(executeGraphqlMock.mock.calls.length, 1);
+    const request = executeGraphqlMock.mock.calls[0]
+      .arguments[0] as GraphqlRequest<MutationStreamingResponseInput>;
+    assert.deepStrictEqual(request.variables.input.accumulatedTurnContent, [
+      {
+        toolUse: {
+          input: JSON.stringify(toolUseBlock.toolUse.input),
+          name: toolUseBlock.toolUse.name,
+          toolUseId: toolUseBlock.toolUse.toolUseId,
+        },
+      },
+    ]);
+  });
+
   void it('sends errors response back to appsync', async () => {
     const userAgentProvider = new UserAgentProvider(
       {} as unknown as ConversationTurnEvent,

--- a/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
+++ b/packages/ai-constructs/src/conversation/runtime/conversation_turn_response_sender.ts
@@ -152,7 +152,13 @@ export class ConversationTurnResponseSender {
         // arbitrary JSON values.
         // We need to stringify it before sending it to AppSync to prevent type errors.
         const input = JSON.stringify(block.toolUse.input);
-        return { toolUse: { ...block.toolUse, input } };
+        // Only forward the fields that the AppSync-generated `AmplifyAIToolUseBlockInput`
+        // accepts. We intentionally avoid spreading the whole Bedrock SDK `ToolUseBlock`,
+        // because newer `@aws-sdk/client-bedrock-runtime` versions add extra fields (e.g.
+        // `type`) that are not part of the AppSync input type and cause the mutation to be
+        // rejected with "Field '...' is not defined by type 'AmplifyAIToolUseBlockInput'".
+        const { toolUseId, name } = block.toolUse;
+        return { toolUse: { toolUseId, name, input } };
       }
       return block;
     });


### PR DESCRIPTION
## Problem

Fixes #3302.

When using `responseComponents` on `AIConversation`, any LLM tool call makes the conversation handler Lambda fail with an AppSync validation error and the streaming turn silently errors out with no response delivered to the client:

```
Variable '$input' got invalid value ... at 'input.accumulatedTurnContent[0].toolUse';
Field 'type' is not defined by type 'AmplifyAIToolUseBlockInput'
```

## Root cause

`ConversationTurnResponseSender.serializeContent` spread the entire Bedrock SDK `ToolUseBlock` into the AppSync mutation:

```ts
const input = JSON.stringify(block.toolUse.input);
return { toolUse: { ...block.toolUse, input } };
```

Newer `@aws-sdk/client-bedrock-runtime` versions add extra fields to the tool use block (e.g. `type`), which flow through the streaming accumulator in `bedrock_converse_adapter.ts` and this spread into the mutation. The AppSync-generated `AmplifyAIToolUseBlockInput` only accepts `{ toolUseId, name, input }`, so AppSync rejects the mutation. `serializeContent` is the single choke point for both the streaming and non-streaming response paths.

## Fix

Explicitly pick only the fields `AmplifyAIToolUseBlockInput` accepts instead of spreading the whole SDK object. This is also defensive against future SDK field additions.

```ts
const input = JSON.stringify(block.toolUse.input);
const { toolUseId, name } = block.toolUse;
return { toolUse: { toolUseId, name, input } };
```

## Tests

Added two regression tests (non-streaming + streaming) in `conversation_turn_response_sender.test.ts` that attach an extra `type` field to the tool use block and assert it is stripped from the mutation. Verified they **fail** against the old spread implementation and **pass** with the fix. All 7 tests in the file pass; `tsc --build` and `prettier` are clean.

## Checklist

- [x] Changeset added (`@aws-amplify/ai-constructs`, patch)
- [x] Unit tests added and passing
