### PR TITLE
fix(ci): pin @graphql-codegen/plugin-helpers to 7.2.0 to unblock canary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18871,26 +18871,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/core/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
-      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.0.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-codegen/core/node_modules/@graphql-tools/merge": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.7.tgz",
@@ -18945,62 +18925,42 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-codegen/core/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/core/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/core/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
-      "integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.2.0.tgz",
+      "integrity": "sha512-RRr9iEokKYf30YCBihtPJvIla818ucsCrYiqzKSuY9GicCmhJxj/b6dYtgjFdEEILfRMdsrQhb/5bw6jiKBWlQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^9.0.0",
-        "change-case-all": "1.0.15",
+        "@graphql-tools/utils": "^11.2.0",
+        "change-case-all": "^2.1.0",
         "common-tags": "1.8.2",
         "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.4.0"
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
-      "license": "0BSD"
+    "node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
     },
     "node_modules/@graphql-codegen/schema-ast": {
       "version": "6.0.0",
@@ -19010,25 +18970,6 @@
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^7.0.0",
         "@graphql-tools/utils": "^11.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
-      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.0.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -19055,36 +18996,6 @@
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/schema-ast/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "license": "MIT"
     },
     "node_modules/@graphql-codegen/typescript": {
       "version": "6.0.1",
@@ -19117,25 +19028,6 @@
       },
       "peerDependencies": {
         "graphql": "*"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
-      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^11.0.0",
-        "change-case-all": "^2.1.0",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
@@ -19224,24 +19116,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@graphql-codegen/typescript/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
-      }
-    },
     "node_modules/@graphql-codegen/typescript/node_modules/dependency-graph": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
@@ -19255,18 +19129,6 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "license": "MIT"
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
       "license": "MIT"
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
@@ -19290,42 +19152,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.18.8.tgz",
-      "integrity": "sha512-mb4I9j9lMGqvGggYuZ0CV+Hme08nar68xkpPbAVotg/ZBmlhZIok/HqW2BcMQi7Rj+Il5HQMeQ1wQ1M7sv/TlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^7.9.1",
-        "common-tags": "1.8.0",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.10.0.tgz",
-      "integrity": "sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@ardatan/aggregate-error": "0.0.6",
-        "camel-case": "4.1.2",
-        "tslib": "~2.2.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "license": "0BSD"
-    },
     "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case-all": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
@@ -19342,15 +19168,6 @@
         "title-case": "^3.0.3",
         "upper-case": "^2.0.2",
         "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/common-tags": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
@@ -25619,22 +25436,34 @@
       }
     },
     "node_modules/change-case-all": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
-      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
       "license": "MIT",
       "dependencies": {
-        "change-case": "^4.1.2",
-        "is-lower-case": "^2.0.2",
-        "is-upper-case": "^2.0.2",
-        "lower-case": "^2.0.2",
-        "lower-case-first": "^2.0.2",
-        "sponge-case": "^1.0.1",
-        "swap-case": "^2.0.2",
-        "title-case": "^3.0.3",
-        "upper-case": "^2.0.2",
-        "upper-case-first": "^2.0.2"
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
       }
+    },
+    "node_modules/change-case-all/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "license": "MIT"
+    },
+    "node_modules/change-case-all/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "license": "MIT"
+    },
+    "node_modules/change-case-all/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "license": "MIT"
     },
     "node_modules/chardet": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
     "typescript": "~5.8.2",
     "verdaccio": "^6.5.2"
   },
+  "overrides": {
+    "@graphql-codegen/plugin-helpers": "7.2.0"
+  },
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
## Problem

The `canary_checks` workflow's `local_checks_with_latest_dependencies` job has been failing at `tsc --build` since **2026-08-23**:

```
packages/form-generator/src/transform_appsync_introspection_schema.ts(48,35): error TS2345:
Argument of type '{ ...; profiler?: Profiler | undefined; ... }' is not assignable to parameter of type 'GenerateOptions'.
  Types of property 'profiler' are incompatible.
    Type 'Profiler | undefined' (node_modules/@graphql-codegen/plugin-helpers) is not assignable to
    type 'Profiler | undefined' (@graphql-codegen/core/node_modules/@graphql-codegen/plugin-helpers).
      Type 'Profiler' is missing the following properties: outputName, clear
```

This is **dependency version skew, not a repo code bug** — the head commit is unchanged across the last-green and first-red canary runs.

### Root cause

The canary does a lockfile-free install (`rm package-lock.json && npm install`), which resolves **two copies** of `@graphql-codegen/plugin-helpers`:

| Copy | Version | Pulled in by |
|---|---|---|
| `node_modules/@graphql-codegen/plugin-helpers` | **3.1.2** | `@aws-amplify/appsync-modelgen-plugin@2.15.3`, which declares `^3.1.1` |
| `node_modules/@graphql-codegen/core/node_modules/@graphql-codegen/plugin-helpers` | **7.2.1** | `@graphql-codegen/core@6.2.0`, which declares `^7.1.0` |

`plugin-helpers@7.2.1` (published `2026-08-23T14:29:40Z`) added `outputName` and `clear` as **required** members of the `Profiler` interface. I verified the shape across releases:

- `7.1.0` → `{ run, collect }`
- `7.2.0` → `{ run, collect }`
- **`7.2.1` → `{ outputName, clear, run, collect }`**

`3.1.2`'s `Profiler` is also `{ run, collect }`, so up to and including `7.2.0` the two duplicated copies were *structurally identical* and TypeScript accepted the cross-copy assignment. `7.2.1` broke that structural identity, so `TS2345` now fires. The duplication itself is long-standing (see the pre-existing cast and comment at `transform_appsync_introspection_schema.ts:58-64`, and #2901).

## Changes

Add a root `overrides` entry pinning `@graphql-codegen/plugin-helpers` to a single **`7.2.0`**:

```json
"overrides": {
  "@graphql-codegen/plugin-helpers": "7.2.0"
}
```

This collapses the tree to exactly **one** copy, so no cross-copy assignment can occur at all. `7.2.0` was chosen over `7.2.1` because its `Profiler` is the `{ run, collect }` shape that all consumers in the tree (including `appsync-modelgen-plugin`'s `3.x`-era expectations) are written against, so deduping to it is the least invasive point in the range.

The lockfile diff is confined to the `@graphql-codegen/*` subtree and its nested transitives (`change-case`, `swap-case`, `sponge-case`, `tslib`, `@graphql-tools/utils`) — all direct consequences of removing the duplicate copies. No unrelated dependencies were bumped.

> [!IMPORTANT]
> **This is an INTERIM unblock, not the durable fix.** The durable fix is for `aws-amplify/amplify-codegen` to bump `appsync-modelgen-plugin` to `@graphql-codegen/plugin-helpers@^7` and publish it. I checked the full registry packument: **all 292 published versions of `@aws-amplify/appsync-modelgen-plugin` cap `plugin-helpers` at `^3.1.1`** (max range across every version), and `amplify-codegen` `main` is still `^3.1.1` — so there is currently no published *or* unreleased version that permits `7.x`. Until then, no dependency-range change in this repo can dedupe the tree.
>
> **TODO:** once `appsync-modelgen-plugin` ships with `plugin-helpers@^7`, remove this override and bump `@aws-amplify/appsync-modelgen-plugin` in `packages/form-generator/package.json` instead. That will also allow the `appsync as any` cast at `transform_appsync_introspection_schema.ts:62-64` to be dropped.

**Issue number, if available:** refs #2901

## Validation

Reproduced the failure first, then verified the fix. All runs on a clean checkout of `main` (`014303a5bf`).

**1. Before — duplicate copies reproduce the canary failure.** After `rm package-lock.json && npm install`:

```
1.18.8  node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers
3.1.2   node_modules/@graphql-codegen/plugin-helpers
7.2.1   node_modules/@graphql-codegen/core/node_modules/@graphql-codegen/plugin-helpers
7.2.1   node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-codegen/plugin-helpers
7.2.1   node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/plugin-helpers
```

`npm run build` → fails with the exact `TS2345` above.

**2. After — lockfile-free install (what the canary does) resolves exactly one copy:**

```
$ find node_modules -type d -path "*@graphql-codegen/plugin-helpers"
7.2.0  node_modules/@graphql-codegen/plugin-helpers

$ npm ls @graphql-codegen/plugin-helpers --all
└── @graphql-codegen/plugin-helpers@7.2.0 overridden
    (all other consumers: "7.2.0 deduped")
```

`tsc --build packages/* scripts` → **exit 0**, and a forced clean full recompile (`tsc --build --force packages/* scripts`) → **exit 0**, zero errors.

**3. After — no regression with the committed lockfile.** `npm ci` → exit 0, single `7.2.0` copy; `npm run build` → **exit 0**, zero TS errors.

**4. Runtime behavior verified.** `packages/form-generator` is the package whose code path actually exercises `plugin-helpers` at runtime (`preset.buildGeneratesSection` → `codegen`), so its tests are the meaningful runtime check for this override:

```
ℹ tests 17
ℹ suites 3
ℹ pass 17
ℹ fail 0
```

**5. Contribution gates pass locally.** `changeset status --since main` → "NO packages to be bumped" (no `packages/*` source changed, so no changeset is applicable), `scripts/check_changeset_completeness.ts` → exit 0, and `prettier --check` on both changed files passes.

Note: this change only affects dependency resolution, so it has no runtime behavior of its own to add test coverage for; the canary workflow itself is the regression test, and it is not part of the PR checks. I'd suggest a manual `canary_checks` `workflow_dispatch` run on this branch to confirm the job goes green end-to-end (including its `npm run test` step, which I did not run in full locally).

## Checklist

These items are conditional and none of their conditions apply to this PR, so they are left unchecked deliberately rather than falsely attested:

- [ ] ~If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.~ **N/A** — this PR changes only dependency resolution and adds no runtime behavior. The existing `form-generator` suite (17 tests, all passing) covers the affected code path, and the `canary_checks` workflow is the regression test for the resolution itself.
- [ ] ~If this PR requires a change to the Project Architecture README, I have included that update in this PR.~ **N/A** — no architectural change.
- [ ] ~If this PR requires a docs update, I have linked to that docs PR above.~ **N/A** — no customer-facing change.
- [ ] ~If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.~ **N/A** — no E2E test, resource provisioning, or SDK call changes. **I have not run `run-e2e`**; happy to if a maintainer wants it given this touches shared dependency resolution.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
