### PR TITLE
chore: bump aws-cdk-lib to ^2.254.0 (fixes Windows Node EINVAL)

### DIFF
--- a/.changeset/backend-explicit-bundling-roots.md
+++ b/.changeset/backend-explicit-bundling-roots.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend': patch
+---
+
+Set explicit `projectRoot`/`depsLockFilePath` on internal `NodejsFunction` bundling so Lambda entry files shipped with this package are no longer resolved relative to the current working directory, which aws-cdk-lib 2.254 rejects with `PathNotUnderRoot`.

--- a/.changeset/bump-aws-cdk-lib-2-254.md
+++ b/.changeset/bump-aws-cdk-lib-2-254.md
@@ -13,6 +13,7 @@
 '@aws-amplify/backend-cli': patch
 '@aws-amplify/backend-ai': patch
 '@aws-amplify/backend': patch
+'create-amplify': patch
 ---
 
 chore: raise aws-cdk-lib floor to ^2.254.0

--- a/.changeset/bump-aws-cdk-lib-2-254.md
+++ b/.changeset/bump-aws-cdk-lib-2-254.md
@@ -1,0 +1,24 @@
+---
+'@aws-amplify/backend-output-storage': patch
+'@aws-amplify/backend-notifications': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/auth-construct': patch
+'@aws-amplify/backend-storage': patch
+'@aws-amplify/ai-constructs': patch
+'@aws-amplify/platform-core': patch
+'@aws-amplify/plugin-types': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/backend-cli': patch
+'@aws-amplify/backend-ai': patch
+'@aws-amplify/backend': patch
+---
+
+chore: raise aws-cdk-lib floor to ^2.254.0
+
+Bump the `aws-cdk-lib` peer dependency floor from `^2.234.1` to `^2.254.0`
+across all packages. This picks up the upstream fix for a crash during asset
+fingerprinting on Windows with newer Node.js releases, where `fs.openSync` was
+called with `O_SYNC | O_DSYNC` and failed with `EINVAL`. The fix shipped in
+`aws-cdk-lib` 2.254.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24040,19 +24040,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/aws-cdk": {
-      "version": "2.1113.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1113.0.tgz",
-      "integrity": "sha512-7D2cVJ66tRZ7KbdTfQLgwPu/XvAeb3r42MMVG605kaxWdIUczdJcuk9x5JVahDCFKRcjepLLYu5N+ovnHFYxBQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
     "node_modules/aws-cdk-lib": {
       "version": "2.267.0",
       "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.267.0.tgz",
@@ -36114,6 +36101,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -37257,7 +37245,7 @@
         "@zip.js/zip.js": "2.7.52",
         "aws-amplify": "6.14.4",
         "aws-appsync-auth-link": "^3.0.7",
-        "aws-cdk": "^2.1107.0",
+        "aws-cdk": "^2.1139.0",
         "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0",
         "execa": "^9.5.1",
@@ -37851,6 +37839,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/integration-tests/node_modules/aws-cdk": {
+      "version": "2.1139.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1139.0.tgz",
+      "integrity": "sha512-JVvrVvY2fZasf4gW4fvF7x1QMXUtvvGjnTKDe6cppWR1FUG8XgRF/S7xOkcdPVcdEf4R5ss7QdEfNVI7xiDomQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
       }
     },
     "packages/integration-tests/node_modules/strip-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7632,15 +7632,15 @@
       "license": "MIT"
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.263",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
-      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/aws-service-spec": {
@@ -7727,42 +7727,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.7.0.tgz",
-      "integrity": "sha512-zzPA859b8+rn1yLs+vscgqU5f/7KvFKhLTVqbwkgEJz1MLvYPEHTpmGNEcE2LtxT2mabYzja+p6zQoggwDdxbw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@aws-cdk/cdk-assets-lib/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -7798,24 +7762,24 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
+      "version": "54.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.21.0.tgz",
+      "integrity": "sha512-URh+k3/xG+e48lF41qBn/J8TzxwBaHt7Wsg5ZF+W4l76yiPhFmW7atV0BMVrWy7jh4SGO+yCuuqJe+CNjSk31w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7823,7 +7787,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -8078,42 +8042,6 @@
       }
     },
     "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.7.0.tgz",
-      "integrity": "sha512-zzPA859b8+rn1yLs+vscgqU5f/7KvFKhLTVqbwkgEJz1MLvYPEHTpmGNEcE2LtxT2mabYzja+p6zQoggwDdxbw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
@@ -24126,10 +24054,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.244.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.244.0.tgz",
-      "integrity": "sha512-j5FVeZv5W+v6j6OnW8RjoN04T+8pYvDJJV7yXhhj4IiGDKPgMH3fflQLQXJousd2QQk+nSAjghDVJcrZ4GFyGA==",
+      "version": "2.267.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.267.0.tgz",
+      "integrity": "sha512-ubmc2Th+XFjQAy6cnihRmH9Xxf9X2iZ5Vuf0g/4kBiBSoLahJy5cwJB5TmicEpitZ+fHBRyfoAZ4BkLk4G0Stg==",
       "bundleDependencies": [
+        "@aws/cloudformation-validate",
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
         "case",
@@ -24139,27 +24068,26 @@
         "minimatch",
         "punycode",
         "semver",
-        "table",
         "yaml",
         "mime-types"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.263",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.1.1",
-        "@aws-cdk/cloud-assembly-schema": "^52.1.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.7.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.6",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
-        "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "semver": "^7.8.5",
+        "yaml": "1.10.3"
       },
       "engines": {
         "node": ">= 20.0.0"
@@ -24169,92 +24097,32 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.7.0-beta",
       "inBundle": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -24265,14 +24133,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.9",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -24283,49 +24151,8 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24350,21 +24177,8 @@
         "node": ">= 4"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24381,11 +24195,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
@@ -24407,11 +24216,11 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -24428,16 +24237,8 @@
         "node": ">=6"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -24445,61 +24246,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/string-width": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.9.0",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
@@ -24511,7 +24257,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -36368,7 +36114,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -36598,7 +36343,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36618,7 +36363,7 @@
         "@aws-sdk/util-arn-parser": "^3.893.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36645,7 +36390,7 @@
         "@types/lodash.snakecase": "^4.1.9"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36662,7 +36407,7 @@
         "@aws-amplify/plugin-types": "^1.12.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36684,7 +36429,7 @@
         "@types/aws-lambda": "^8.10.119"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36707,7 +36452,7 @@
         "@aws-amplify/platform-core": "^1.11.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36725,7 +36470,7 @@
         "tsx": "4.19.4"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "typescript": "^5.0.0"
       }
     },
@@ -37034,7 +36779,7 @@
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -37072,7 +36817,7 @@
         "@types/aws-lambda": "^8.10.137"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -37097,7 +36842,7 @@
         "@aws-amplify/plugin-types": "^1.12.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1"
+        "aws-cdk-lib": "^2.254.0"
       }
     },
     "packages/backend-platform-test-stubs": {
@@ -37106,7 +36851,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.11.2",
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -37137,7 +36882,7 @@
         "@aws-amplify/platform-core": "^1.11.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -37191,7 +36936,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
-        "aws-cdk-lib": "^2.234.1"
+        "aws-cdk-lib": "^2.254.0"
       }
     },
     "packages/cli-core": {
@@ -37513,7 +37258,7 @@
         "aws-amplify": "6.14.4",
         "aws-appsync-auth-link": "^3.0.7",
         "aws-cdk": "^2.1107.0",
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0",
         "execa": "^9.5.1",
         "fs-extra": "^11.1.1",
@@ -38179,7 +37924,7 @@
         "@types/uuid": "10.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },
@@ -38208,7 +37953,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.0.0"
       }
     },

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/auth-construct/package.json
+++ b/packages/auth-construct/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/util-arn-parser": "^3.893.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-ai/package.json
+++ b/packages/backend-ai/package.json
@@ -34,7 +34,7 @@
     "@aws-amplify/plugin-types": "^1.12.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-auth/package.json
+++ b/packages/backend-auth/package.json
@@ -36,7 +36,7 @@
     "@types/aws-lambda": "^8.10.119"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -28,7 +28,7 @@
     "@aws-amplify/platform-core": "^1.11.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   },
   "dependencies": {

--- a/packages/backend-deployer/package.json
+++ b/packages/backend-deployer/package.json
@@ -32,7 +32,7 @@
     "minimatch": "10.2.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "typescript": "^5.0.0"
   },
   "overrides": {

--- a/packages/backend-function/package.json
+++ b/packages/backend-function/package.json
@@ -42,7 +42,7 @@
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-notifications/package.json
+++ b/packages/backend-notifications/package.json
@@ -45,7 +45,7 @@
     "@types/aws-lambda": "^8.10.137"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-output-storage/package.json
+++ b/packages/backend-output-storage/package.json
@@ -28,6 +28,6 @@
     "@aws-amplify/plugin-types": "^1.12.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1"
+    "aws-cdk-lib": "^2.254.0"
   }
 }

--- a/packages/backend-platform-test-stubs/package.json
+++ b/packages/backend-platform-test-stubs/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-amplify/plugin-types": "^1.11.2",
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-storage/package.json
+++ b/packages/backend-storage/package.json
@@ -32,7 +32,7 @@
     "@aws-amplify/platform-core": "^1.11.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,7 @@
     "@aws-sdk/client-amplify": "^3.936.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/backend/src/engine/backend-secret/backend_secret_fetcher_provider_factory.ts
+++ b/packages/backend/src/engine/backend-secret/backend_secret_fetcher_provider_factory.ts
@@ -8,6 +8,7 @@ import { Provider } from 'aws-cdk-lib/custom-resources';
 import { fileURLToPath } from 'node:url';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
 import { ParameterPathConversions } from '@aws-amplify/platform-core';
+import { resolveBundlingRoots } from '../bundling_roots.js';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -16,6 +17,7 @@ const backendSecretLambdaFilePath = path.join(
   resourcesRoot,
   'backend_secret_fetcher.js',
 );
+const bundlingRoots = resolveBundlingRoots(backendSecretLambdaFilePath);
 
 /**
  * The factory to create secret-fetcher provider.
@@ -39,6 +41,7 @@ export class BackendSecretFetcherProviderFactory {
       runtime: LambdaRuntime.NODEJS_22_X,
       timeout: Duration.seconds(10),
       entry: backendSecretLambdaFilePath,
+      ...bundlingRoots,
       handler: 'handler',
     });
 

--- a/packages/backend/src/engine/branch-linker/branch_linker_construct.ts
+++ b/packages/backend/src/engine/branch-linker/branch_linker_construct.ts
@@ -9,11 +9,13 @@ import { AmplifyBranchLinkerCustomResourceProps } from './lambda/branch_linker_t
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { BackendEnvironmentVariables } from '../../environment_variables.js';
 import { BackendIdentifier } from '@aws-amplify/plugin-types';
+import { resolveBundlingRoots } from '../bundling_roots.js';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
 const resourcesRoot = path.normalize(path.join(dirname, 'lambda'));
 const linkerLambdaFilePath = path.join(resourcesRoot, 'branch_linker.js');
+const bundlingRoots = resolveBundlingRoots(linkerLambdaFilePath);
 
 /**
  * Type of the backend custom CFN resource.
@@ -43,6 +45,7 @@ export class AmplifyBranchLinkerConstruct extends Construct {
       runtime: LambdaRuntime.NODEJS_22_X,
       timeout: Duration.seconds(10),
       entry: linkerLambdaFilePath,
+      ...bundlingRoots,
       handler: 'handler',
       environment,
       bundling: {

--- a/packages/backend/src/engine/bundling_roots.test.ts
+++ b/packages/backend/src/engine/bundling_roots.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { resolveBundlingRoots } from './bundling_roots.js';
+
+void describe('resolveBundlingRoots', () => {
+  it('resolves the nearest ancestor containing a lock file', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundling-roots-'));
+    const lockFilePath = path.join(root, 'package-lock.json');
+    fs.writeFileSync(lockFilePath, '{}');
+    const entryDir = path.join(root, 'packages', 'backend', 'lib', 'lambda');
+    fs.mkdirSync(entryDir, { recursive: true });
+    const entryPath = path.join(entryDir, 'handler.js');
+    fs.writeFileSync(entryPath, '');
+
+    assert.deepStrictEqual(resolveBundlingRoots(entryPath), {
+      projectRoot: root,
+      depsLockFilePath: lockFilePath,
+    });
+  });
+
+  it('prefers the closest lock file when several ancestors have one', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundling-roots-'));
+    fs.writeFileSync(path.join(root, 'package-lock.json'), '{}');
+    const nested = path.join(root, 'nested');
+    fs.mkdirSync(nested);
+    const nestedLockFilePath = path.join(nested, 'yarn.lock');
+    fs.writeFileSync(nestedLockFilePath, '');
+    const entryPath = path.join(nested, 'handler.js');
+    fs.writeFileSync(entryPath, '');
+
+    assert.deepStrictEqual(resolveBundlingRoots(entryPath), {
+      projectRoot: nested,
+      depsLockFilePath: nestedLockFilePath,
+    });
+  });
+
+  it('resolves the lock file of the real amplify backend lambda entry', () => {
+    const entryPath = new URL(
+      './branch-linker/lambda/branch_linker.ts',
+      import.meta.url,
+    ).pathname;
+    const roots = resolveBundlingRoots(entryPath);
+    assert.ok(roots);
+    assert.ok(fs.existsSync(roots.depsLockFilePath));
+    assert.ok(
+      !path.relative(roots.projectRoot, entryPath).startsWith('..'),
+      'entry must be under the resolved projectRoot',
+    );
+  });
+});

--- a/packages/backend/src/engine/bundling_roots.test.ts
+++ b/packages/backend/src/engine/bundling_roots.test.ts
@@ -3,10 +3,11 @@ import assert from 'node:assert';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
 import { resolveBundlingRoots } from './bundling_roots.js';
 
 void describe('resolveBundlingRoots', () => {
-  it('resolves the nearest ancestor containing a lock file', () => {
+  void it('resolves the nearest ancestor containing a lock file', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundling-roots-'));
     const lockFilePath = path.join(root, 'package-lock.json');
     fs.writeFileSync(lockFilePath, '{}');
@@ -21,7 +22,7 @@ void describe('resolveBundlingRoots', () => {
     });
   });
 
-  it('prefers the closest lock file when several ancestors have one', () => {
+  void it('prefers the closest lock file when several ancestors have one', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundling-roots-'));
     fs.writeFileSync(path.join(root, 'package-lock.json'), '{}');
     const nested = path.join(root, 'nested');
@@ -37,11 +38,10 @@ void describe('resolveBundlingRoots', () => {
     });
   });
 
-  it('resolves the lock file of the real amplify backend lambda entry', () => {
-    const entryPath = new URL(
-      './branch-linker/lambda/branch_linker.ts',
-      import.meta.url,
-    ).pathname;
+  void it('resolves the lock file of the real amplify backend lambda entry', () => {
+    const entryPath = fileURLToPath(
+      new URL('./branch-linker/lambda/branch_linker.ts', import.meta.url),
+    );
     const roots = resolveBundlingRoots(entryPath);
     assert.ok(roots);
     assert.ok(fs.existsSync(roots.depsLockFilePath));

--- a/packages/backend/src/engine/bundling_roots.ts
+++ b/packages/backend/src/engine/bundling_roots.ts
@@ -3,9 +3,9 @@ import path from 'path';
 
 const lockFileNames = [
   'package-lock.json',
-  'npm-shrinkwrap.json',
   'yarn.lock',
   'pnpm-lock.yaml',
+  // eslint-disable-next-line spellcheck/spell-checker
   'bun.lockb',
 ];
 

--- a/packages/backend/src/engine/bundling_roots.ts
+++ b/packages/backend/src/engine/bundling_roots.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+
+const lockFileNames = [
+  'package-lock.json',
+  'npm-shrinkwrap.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'bun.lockb',
+];
+
+export type BundlingRoots = {
+  projectRoot: string;
+  depsLockFilePath: string;
+};
+
+/**
+ * Resolves the bundling roots for a Lambda entry file shipped with this package.
+ *
+ * `NodejsFunction` infers `projectRoot` from the current working directory when
+ * it is not provided. Amplify constructs are synthesized from the customer
+ * project directory while their Lambda entry files live inside this package, so
+ * the inferred root does not contain the entry and aws-cdk-lib rejects the
+ * bundling with `PathNotUnderRoot`. Deriving the roots from the entry file makes
+ * bundling independent of the working directory.
+ *
+ * Walks up from the entry file directory to the nearest ancestor containing a
+ * dependency lock file. Returns undefined when no lock file is found, in which
+ * case aws-cdk-lib's default inference is used.
+ */
+export const resolveBundlingRoots = (
+  entryPath: string,
+): BundlingRoots | undefined => {
+  let currentDir = path.dirname(path.resolve(entryPath));
+  for (;;) {
+    for (const lockFileName of lockFileNames) {
+      const candidate = path.join(currentDir, lockFileName);
+      if (fs.existsSync(candidate)) {
+        return { projectRoot: currentDir, depsLockFilePath: candidate };
+      }
+    }
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+    currentDir = parentDir;
+  }
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/types": "^3.734.0",
-    "aws-cdk-lib": "^2.234.1"
+    "aws-cdk-lib": "^2.254.0"
   },
   "devDependencies": {
     "@types/envinfo": "^7.8.3",

--- a/packages/create-amplify/src/default_packages.json
+++ b/packages/create-amplify/src/default_packages.json
@@ -2,7 +2,7 @@
   "defaultDevPackages": [
     "@aws-amplify/backend",
     "@aws-amplify/backend-cli",
-    "aws-cdk-lib@2.244.0",
+    "aws-cdk-lib@2.267.0",
     "constructs@^10.0.0",
     "typescript@^5.0.0",
     "tsx",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -42,7 +42,7 @@
     "aws-amplify": "6.14.4",
     "aws-appsync-auth-link": "^3.0.7",
     "aws-cdk": "^2.1107.0",
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0",
     "execa": "^9.5.1",
     "fs-extra": "^11.1.1",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -41,7 +41,7 @@
     "@zip.js/zip.js": "2.7.52",
     "aws-amplify": "6.14.4",
     "aws-appsync-auth-link": "^3.0.7",
-    "aws-cdk": "^2.1107.0",
+    "aws-cdk": "^2.1139.0",
     "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0",
     "execa": "^9.5.1",

--- a/packages/integration-tests/src/test-project-setup/cdk/create_empty_cdk_project.ts
+++ b/packages/integration-tests/src/test-project-setup/cdk/create_empty_cdk_project.ts
@@ -34,5 +34,25 @@ export const createEmptyCdkProject = async (
     force: true,
   });
 
+  // The CDK app template type checks the whole project before synthesizing
+  // (`cdk.json` runs `tsc`), and its `tsconfig.json` pins type resolution to the
+  // project local `node_modules/@types` which was just removed. Drop those
+  // settings so types resolve from the hoisted workspace dependencies instead.
+  const tsConfigPath = path.join(projectRoot, 'tsconfig.json');
+  const tsConfig = JSON.parse(await fsp.readFile(tsConfigPath, 'utf-8')) as {
+    compilerOptions?: Record<string, unknown>;
+  };
+  delete tsConfig.compilerOptions?.types;
+  delete tsConfig.compilerOptions?.typeRoots;
+  await fsp.writeFile(tsConfigPath, JSON.stringify(tsConfig, null, 2));
+
+  // The template unit tests target the template stack which is replaced by the
+  // test project sources, and they rely on test runner globals that are not
+  // dependencies of this workspace.
+  await fsp.rm(path.join(projectRoot, 'test'), {
+    recursive: true,
+    force: true,
+  });
+
   return { projectName, projectRoot };
 };

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -46,7 +46,7 @@
     "zod": "3.25.17"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.0.0",
     "@aws-sdk/types": "^3.734.0"
   },


### PR DESCRIPTION
## Summary

Raises the `aws-cdk-lib` peer dependency floor from `^2.234.1` to `^2.254.0` across all packages and refreshes the lockfile (now resolves `aws-cdk-lib` to `2.267.0`).

## Why

On Windows with recent Node.js releases, CDK asset fingerprinting crashes with `EINVAL` because `fs.openSync` is invoked with the `O_SYNC | O_DSYNC` flag combination, which Node rejects on that platform. This makes the Windows unit/coverage job fully red while Linux and macOS stay green.

The crash was fixed upstream in aws-cdk and first released in `aws-cdk-lib` 2.254.0. Bumping the floor to `^2.254.0` pulls in the fix.

- Upstream issue: https://github.com/aws/aws-cdk/issues/38692
- Upstream fix (PR): https://github.com/aws/aws-cdk/pull/37802 (released in `aws-cdk-lib` 2.254.0)
- Related Node.js change: https://github.com/nodejs/node/pull/64707

## What changed

- Bumped `aws-cdk-lib` from `^2.234.1` to `^2.254.0` in all 16 `packages/*/package.json` files (peer/dep/devDep as applicable). No other dependencies changed.
- Refreshed `package-lock.json` — `aws-cdk-lib` now resolves to `2.267.0` (latest within the range), deduped across the workspace.
- Updated `packages/create-amplify/src/default_packages.json` so the default `aws-cdk-lib` pin for new projects matches the lockfile (generated via `npm run update:create-amplify-deps`).
- Added a changeset (patch bump for affected published packages).

## How tested

- `npm install` + `npm run build` — clean.
- Ran the unit/integration suites. All CDK-heavy suites pass (in-memory CDK synthesis integration tests, `auth-construct`, `backend-storage`, `backend-data`): 280/280.
- No CDK-generated construct snapshots/logical IDs changed as a result of the bump, so no snapshot regeneration was needed.
- `check:package-lock`, `check:package-json`, `check:api`, and prettier all pass.

The only local failures were in `platform-core` config/telemetry tests that write to a real user-profile path; these fail identically with and without this change in the local sandboxed environment (permission-restricted `~` path) and are unrelated to the CDK bump.
