### PR TITLE
fix(create-amplify): exit cleanly when project path prompt is canceled

### DIFF
--- a/.changeset/create-amplify-prompt-cancel.md
+++ b/.changeset/create-amplify-prompt-cancel.md
@@ -1,0 +1,5 @@
+---
+'create-amplify': patch
+---
+
+Exit cleanly when the project path prompt is canceled with Ctrl+C instead of printing an Inquirer stack trace.

--- a/packages/create-amplify/src/create_amplify.ts
+++ b/packages/create-amplify/src/create_amplify.ts
@@ -7,38 +7,6 @@
   If customers have a cached version of the create-amplify package, they might execute that cached version even after we publish features and fixes to the package on npm.
  */
 
-import {
-  LogLevel,
-  PackageManagerControllerFactory,
-  format,
-  printer,
-} from '@aws-amplify/cli-core';
-import { ProjectRootValidator } from './project_root_validator.js';
-import { AmplifyProjectCreator } from './amplify_project_creator.js';
-import { getProjectRoot } from './get_project_root.js';
-import { GitIgnoreInitializer } from './gitignore_initializer.js';
-import { InitialProjectFileGenerator } from './initial_project_file_generator.js';
+import { runCreateAmplify } from './create_amplify_runner.js';
 
-const projectRoot = await getProjectRoot();
-
-const packageManagerControllerFactory = new PackageManagerControllerFactory(
-  projectRoot,
-);
-
-const packageManagerController =
-  packageManagerControllerFactory.getPackageManagerController();
-
-const amplifyProjectCreator = new AmplifyProjectCreator(
-  projectRoot,
-  packageManagerController,
-  new ProjectRootValidator(projectRoot),
-  new GitIgnoreInitializer(projectRoot),
-  new InitialProjectFileGenerator(projectRoot, packageManagerController),
-);
-
-try {
-  await amplifyProjectCreator.create();
-} catch (err) {
-  printer.log(format.error(err), LogLevel.ERROR);
-  process.exitCode = 1;
-}
+await runCreateAmplify();

--- a/packages/create-amplify/src/create_amplify_runner.test.ts
+++ b/packages/create-amplify/src/create_amplify_runner.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+import { LogLevel, format, printer } from '@aws-amplify/cli-core';
+import { runCreateAmplify } from './create_amplify_runner.js';
+
+void describe('runCreateAmplify', () => {
+  const originalExitCode = process.exitCode;
+  const printerLogMock = mock.method(printer, 'log');
+
+  beforeEach(() => {
+    printerLogMock.mock.resetCalls();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+  });
+
+  void it('exits cleanly when the project root prompt is force closed', async () => {
+    const createProject = mock.fn(
+      async (projectRoot: string): Promise<void> => {
+        assert.fail(`Unexpected project creation at ${projectRoot}`);
+      },
+    );
+
+    await runCreateAmplify({
+      getProjectRoot: () =>
+        Promise.reject(new Error('User force closed the prompt with 0 null')),
+      createProject,
+    });
+
+    assert.equal(createProject.mock.callCount(), 0);
+    assert.equal(printerLogMock.mock.callCount(), 0);
+    assert.equal(process.exitCode, undefined);
+  });
+
+  void it('logs unexpected errors and sets a failing exit code', async () => {
+    const error = new Error('Unexpected failure');
+
+    await runCreateAmplify({
+      getProjectRoot: () => Promise.reject(error),
+    });
+
+    assert.deepEqual(printerLogMock.mock.calls[0].arguments, [
+      format.error(error),
+      LogLevel.ERROR,
+    ]);
+    assert.equal(process.exitCode, 1);
+  });
+
+  void it('creates the project at the resolved root', async () => {
+    const createProject = mock.fn(
+      async (projectRoot: string): Promise<void> => {
+        assert.equal(projectRoot, '/project/root');
+      },
+    );
+
+    await runCreateAmplify({
+      getProjectRoot: () => Promise.resolve('/project/root'),
+      createProject,
+    });
+
+    assert.equal(createProject.mock.callCount(), 1);
+    assert.equal(createProject.mock.calls[0].arguments[0], '/project/root');
+    assert.equal(printerLogMock.mock.callCount(), 0);
+    assert.equal(process.exitCode, undefined);
+  });
+});

--- a/packages/create-amplify/src/create_amplify_runner.ts
+++ b/packages/create-amplify/src/create_amplify_runner.ts
@@ -1,0 +1,55 @@
+import {
+  LogLevel,
+  PackageManagerControllerFactory,
+  format,
+  printer,
+} from '@aws-amplify/cli-core';
+import { AmplifyProjectCreator } from './amplify_project_creator.js';
+import { getProjectRoot } from './get_project_root.js';
+import { GitIgnoreInitializer } from './gitignore_initializer.js';
+import { InitialProjectFileGenerator } from './initial_project_file_generator.js';
+import { ProjectRootValidator } from './project_root_validator.js';
+
+export type CreateAmplifyRunnerOptions = {
+  getProjectRoot?: () => Promise<string>;
+  createProject?: (projectRoot: string) => Promise<void>;
+};
+
+const createProject = async (projectRoot: string): Promise<void> => {
+  const packageManagerControllerFactory = new PackageManagerControllerFactory(
+    projectRoot,
+  );
+  const packageManagerController =
+    packageManagerControllerFactory.getPackageManagerController();
+  const amplifyProjectCreator = new AmplifyProjectCreator(
+    projectRoot,
+    packageManagerController,
+    new ProjectRootValidator(projectRoot),
+    new GitIgnoreInitializer(projectRoot),
+    new InitialProjectFileGenerator(projectRoot, packageManagerController),
+  );
+
+  await amplifyProjectCreator.create();
+};
+
+const isUserForceClosePromptError = (error: unknown): boolean =>
+  error instanceof Error &&
+  error.message.includes('User force closed the prompt');
+
+/** Runs the create-amplify workflow and converts prompt cancellation into a clean exit. */
+export const runCreateAmplify = async ({
+  getProjectRoot: resolveProjectRoot = getProjectRoot,
+  createProject: createAmplifyProject = createProject,
+}: CreateAmplifyRunnerOptions = {}): Promise<void> => {
+  try {
+    const projectRoot = await resolveProjectRoot();
+    await createAmplifyProject(projectRoot);
+  } catch (error) {
+    if (isUserForceClosePromptError(error)) {
+      return;
+    }
+
+    printer.log(format.error(error), LogLevel.ERROR);
+    process.exitCode = 1;
+  }
+};


### PR DESCRIPTION
## Problem

Fixes #825.

`create-amplify.ts` awaited `getProjectRoot()` before entering its existing `try` block. Pressing Ctrl+C at the first project-path prompt causes Inquirer to reject with `User force closed the prompt`, so the rejection bypassed the error boundary and Node printed the full stack trace.

**Issue number, if available:** #825

## Changes

- Keep the executable entry point limited to invoking a new `runCreateAmplify` workflow function.
- Move project-root resolution, package-manager setup, and project creation behind one error boundary.
- Treat only Inquirer prompt-force-close errors as intentional cancellation:
  - no error output;
  - no project creation;
  - exit code remains 0.
- Preserve the existing behavior for every other failure:
  - formatted error is logged;
  - process exit code is set to 1.
- Inject project-root resolution and project creation into the runner for focused tests without invoking the real package manager.
- Add a patch changeset for `create-amplify`.

**Corresponding docs PR, if applicable:** Not applicable. This corrects CLI cancellation behavior without changing documented commands or options.

## Validation

### Automated

- `npm run build`
  - Passed for the full monorepo.
- `npm run test:dir packages/create-amplify`
  - 22 tests passed across 6 suites.
  - New coverage verifies prompt cancellation, ordinary error handling, and successful project creation.
- ESLint with zero warnings for all changed TypeScript files
  - Passed.
- Prettier check for all changed files and the changeset
  - Passed.
- `tsx scripts/check_package_json.ts`
  - Passed.
- Pre-push repository hooks
  - changeset status passed and selected `create-amplify` for a patch bump;
  - package-lock validation passed;
  - API extraction/check passed.
- `git diff --check`
  - Passed.

### Manual terminal reproduction

Ran the built `create-amplify` executable in a PTY and sent Ctrl+C at:

`? Where should we create your project? (.)`

Result:

- exit code: 0;
- no error or stack trace printed;
- no project creation started.

## Risk

Low. The successful workflow is unchanged and now executes from the runner. The error-path distinction uses the same Inquirer message already recognized by the main Amplify CLI error handler. Unknown errors continue to log and fail exactly as before.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the Project Architecture README, I have included that update in this PR. Not required; no architecture boundary changed.
- [x] If this PR requires a docs update, I have linked to that docs PR above. Not required; no documented interface changed.
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set. Not applicable; this PR changes none of those areas.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.