### PR TITLE
fix(deps): bump aws-cdk-lib to ^2.267.0 to fix Windows/Node 26.8 asset fingerprint EINVAL

### DIFF
--- a/.changeset/bump-aws-cdk-lib-windows-fingerprint-einval.md
+++ b/.changeset/bump-aws-cdk-lib-windows-fingerprint-einval.md
@@ -1,0 +1,18 @@
+---
+'@aws-amplify/backend-output-storage': patch
+'@aws-amplify/backend-notifications': patch
+'@aws-amplify/backend-function': patch
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/backend-storage': patch
+'@aws-amplify/backend-data': patch
+'@aws-amplify/backend-auth': patch
+'@aws-amplify/auth-construct': patch
+'@aws-amplify/ai-constructs': patch
+'@aws-amplify/platform-core': patch
+'@aws-amplify/plugin-types': patch
+'@aws-amplify/backend-cli': patch
+'@aws-amplify/backend-ai': patch
+'@aws-amplify/backend': patch
+---
+
+Bump aws-cdk-lib to ^2.267.0 to fix Windows asset-fingerprint EINVAL under Node.js >= 26.8.0 (aws/aws-cdk#38692)

--- a/.changeset/bump-aws-cdk-lib-windows-fingerprint-einval.md
+++ b/.changeset/bump-aws-cdk-lib-windows-fingerprint-einval.md
@@ -13,6 +13,7 @@
 '@aws-amplify/backend-cli': patch
 '@aws-amplify/backend-ai': patch
 '@aws-amplify/backend': patch
+'create-amplify': patch
 ---
 
 Bump aws-cdk-lib to ^2.267.0 to fix Windows asset-fingerprint EINVAL under Node.js >= 26.8.0 (aws/aws-cdk#38692)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7632,16 +7632,14 @@
       "license": "MIT"
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.263",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
-      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
-      "license": "Apache-2.0"
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
-      "license": "Apache-2.0"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q=="
     },
     "node_modules/@aws-cdk/aws-service-spec": {
       "version": "0.1.166",
@@ -7727,42 +7725,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.7.0.tgz",
-      "integrity": "sha512-zzPA859b8+rn1yLs+vscgqU5f/7KvFKhLTVqbwkgEJz1MLvYPEHTpmGNEcE2LtxT2mabYzja+p6zQoggwDdxbw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@aws-cdk/cdk-assets-lib/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -7798,24 +7760,23 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
+      "version": "54.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.21.0.tgz",
+      "integrity": "sha512-URh+k3/xG+e48lF41qBn/J8TzxwBaHt7Wsg5ZF+W4l76yiPhFmW7atV0BMVrWy7jh4SGO+yCuuqJe+CNjSk31w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7823,7 +7784,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -8078,42 +8039,6 @@
       }
     },
     "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.7.0.tgz",
-      "integrity": "sha512-zzPA859b8+rn1yLs+vscgqU5f/7KvFKhLTVqbwkgEJz1MLvYPEHTpmGNEcE2LtxT2mabYzja+p6zQoggwDdxbw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
@@ -24126,10 +24051,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.244.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.244.0.tgz",
-      "integrity": "sha512-j5FVeZv5W+v6j6OnW8RjoN04T+8pYvDJJV7yXhhj4IiGDKPgMH3fflQLQXJousd2QQk+nSAjghDVJcrZ4GFyGA==",
+      "version": "2.267.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.267.0.tgz",
+      "integrity": "sha512-ubmc2Th+XFjQAy6cnihRmH9Xxf9X2iZ5Vuf0g/4kBiBSoLahJy5cwJB5TmicEpitZ+fHBRyfoAZ4BkLk4G0Stg==",
       "bundleDependencies": [
+        "@aws/cloudformation-validate",
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
         "case",
@@ -24139,27 +24065,25 @@
         "minimatch",
         "punycode",
         "semver",
-        "table",
         "yaml",
         "mime-types"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.263",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.1.1",
-        "@aws-cdk/cloud-assembly-schema": "^52.1.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.7.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.6",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
-        "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "semver": "^7.8.5",
+        "yaml": "1.10.3"
       },
       "engines": {
         "node": ">= 20.0.0"
@@ -24169,92 +24093,32 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.7.0-beta",
       "inBundle": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -24265,14 +24129,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.9",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -24283,49 +24147,8 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24350,21 +24173,8 @@
         "node": ">= 4"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24381,11 +24191,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
@@ -24407,11 +24212,11 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -24428,16 +24233,8 @@
         "node": ">=6"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -24445,61 +24242,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/string-width": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.9.0",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
@@ -24511,7 +24253,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -36368,7 +36110,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -36598,7 +36339,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36618,7 +36359,7 @@
         "@aws-sdk/util-arn-parser": "^3.893.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36645,7 +36386,7 @@
         "@types/lodash.snakecase": "^4.1.9"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36662,7 +36403,7 @@
         "@aws-amplify/plugin-types": "^1.12.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36684,7 +36425,7 @@
         "@types/aws-lambda": "^8.10.119"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36707,7 +36448,7 @@
         "@aws-amplify/platform-core": "^1.11.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -36725,7 +36466,7 @@
         "tsx": "4.19.4"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "typescript": "^5.0.0"
       }
     },
@@ -36762,6 +36503,7 @@
     },
     "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.5.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -36770,6 +36512,7 @@
     },
     "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.8.5",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -37034,7 +36777,7 @@
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -37072,7 +36815,7 @@
         "@types/aws-lambda": "^8.10.137"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -37097,7 +36840,7 @@
         "@aws-amplify/plugin-types": "^1.12.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1"
+        "aws-cdk-lib": "^2.267.0"
       }
     },
     "packages/backend-platform-test-stubs": {
@@ -37106,7 +36849,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.11.2",
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -37137,7 +36880,7 @@
         "@aws-amplify/platform-core": "^1.11.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -37191,7 +36934,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
-        "aws-cdk-lib": "^2.234.1"
+        "aws-cdk-lib": "^2.267.0"
       }
     },
     "packages/cli-core": {
@@ -37513,7 +37256,7 @@
         "aws-amplify": "6.14.4",
         "aws-appsync-auth-link": "^3.0.7",
         "aws-cdk": "^2.1107.0",
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0",
         "execa": "^9.5.1",
         "fs-extra": "^11.1.1",
@@ -38179,7 +37922,7 @@
         "@types/uuid": "10.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -38208,7 +37951,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.267.0",
         "constructs": "^10.0.0"
       }
     },
@@ -38245,6 +37988,7 @@
     },
     "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.5.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -38253,6 +37997,7 @@
     },
     "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.8.5",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {

--- a/packages/ai-constructs/package.json
+++ b/packages/ai-constructs/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/auth-construct/package.json
+++ b/packages/auth-construct/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/util-arn-parser": "^3.893.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-ai/package.json
+++ b/packages/backend-ai/package.json
@@ -34,7 +34,7 @@
     "@aws-amplify/plugin-types": "^1.12.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-auth/package.json
+++ b/packages/backend-auth/package.json
@@ -36,7 +36,7 @@
     "@types/aws-lambda": "^8.10.119"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -28,7 +28,7 @@
     "@aws-amplify/platform-core": "^1.11.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   },
   "dependencies": {

--- a/packages/backend-deployer/package.json
+++ b/packages/backend-deployer/package.json
@@ -32,7 +32,7 @@
     "minimatch": "10.2.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "typescript": "^5.0.0"
   },
   "overrides": {

--- a/packages/backend-function/package.json
+++ b/packages/backend-function/package.json
@@ -42,7 +42,7 @@
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-notifications/package.json
+++ b/packages/backend-notifications/package.json
@@ -45,7 +45,7 @@
     "@types/aws-lambda": "^8.10.137"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-output-storage/package.json
+++ b/packages/backend-output-storage/package.json
@@ -28,6 +28,6 @@
     "@aws-amplify/plugin-types": "^1.12.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1"
+    "aws-cdk-lib": "^2.267.0"
   }
 }

--- a/packages/backend-platform-test-stubs/package.json
+++ b/packages/backend-platform-test-stubs/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-amplify/plugin-types": "^1.11.2",
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend-storage/package.json
+++ b/packages/backend-storage/package.json
@@ -32,7 +32,7 @@
     "@aws-amplify/platform-core": "^1.11.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,7 @@
     "@aws-sdk/client-amplify": "^3.936.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/types": "^3.734.0",
-    "aws-cdk-lib": "^2.234.1"
+    "aws-cdk-lib": "^2.267.0"
   },
   "devDependencies": {
     "@types/envinfo": "^7.8.3",

--- a/packages/create-amplify/src/default_packages.json
+++ b/packages/create-amplify/src/default_packages.json
@@ -2,7 +2,7 @@
   "defaultDevPackages": [
     "@aws-amplify/backend",
     "@aws-amplify/backend-cli",
-    "aws-cdk-lib@2.244.0",
+    "aws-cdk-lib@2.267.0",
     "constructs@^10.0.0",
     "typescript@^5.0.0",
     "tsx",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -42,7 +42,7 @@
     "aws-amplify": "6.14.4",
     "aws-appsync-auth-link": "^3.0.7",
     "aws-cdk": "^2.1107.0",
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0",
     "execa": "^9.5.1",
     "fs-extra": "^11.1.1",

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -46,7 +46,7 @@
     "zod": "3.25.17"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0",
     "@aws-sdk/types": "^3.734.0"
   },

--- a/templates/construct/package.json
+++ b/templates/construct/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.267.0",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
## Problem

On Windows, CDK asset fingerprinting fails with `EINVAL` on Node.js >= 26.8.0. Any Amplify command that hashes assets (`ampx sandbox`, `ampx pipeline-deploy`, anything that synthesizes a stack containing an asset) throws before it can produce an asset hash, so the backend cannot be deployed at all from a Windows machine on a current Node runtime.

Root cause is in `aws-cdk-lib`, not in this repo. In `aws-cdk-lib` 2.244.0 (the version pinned here), `core/lib/fs/fingerprint.js` opens each file for hashing with the flag combination `O_DSYNC | O_RDONLY | O_SYNC`. Historically those sync flags were silently ignored on Windows. Node.js 26.8.0 started passing them through for real, and libuv rejects that combination on Windows with `EINVAL`.

The upstream fix shipped in `aws-cdk-lib` 2.254.0: `fingerprint.js` now opens with `O_RDONLY` only. Per the upstream maintainer on aws/aws-cdk#38692 the resolution for downstream consumers is purely a dependency bump — there is no source change to make here.

**Issue number, if available:** upstream aws/aws-cdk#38692

## Changes

Bump `aws-cdk-lib` from `^2.234.1` to `^2.267.0` (latest at time of writing; the fix landed in 2.254.0) across all 16 workspace packages that declare it, plus `templates/construct`. The caret-range convention already used in the repo is preserved.

- `package-lock.json` regenerated — `aws-cdk-lib` now resolves to **2.267.0** (was 2.244.0).
- `packages/create-amplify/src/default_packages.json` — regenerated via `npm run update:create-amplify-deps` so the pinned `aws-cdk-lib@2.267.0` that `create-amplify` scaffolds stays in sync with the library (required by the `check:create-amplify-deps` CI guard).
- Changeset added with a `patch` bump for the affected published packages.

Lockfile churn is small and confined to `aws-cdk-lib` and its bundled dependency set (`@aws-cdk/cloud-assembly-schema`, `aws-cdk-lib/node_modules/*`); it is a net reduction because 2.267.0 declares fewer bundled deps. No unrelated dependencies were touched.

**Corresponding docs PR, if applicable:** n/a

## Validation

This is a dependency-only change to fix a defect inside a third-party package, so there is no new runtime behavior in this repo to cover with tests. Validation was therefore aimed at (a) proving the upstream defect is actually gone in the resolved version and (b) proving the bump is non-breaking.

1. **Confirmed the upstream fix is present in the installed tree.** `node_modules/aws-cdk-lib/core/lib/fs/fingerprint.js`, `contentFingerprintMiss`:

   ```js
   const fd = fs().openSync(file, fs().constants.O_RDONLY);
   ```

   `O_RDONLY` only — the `O_SYNC`/`O_DSYNC` combination that libuv rejects on Windows is gone. Installed version confirmed as `2.267.0`.

2. **Full monorepo build is clean.** `npm run build` (`tsc --build packages/* scripts` + post-compile bundling) completes with zero TypeScript errors, so the bump introduces no type or peer-dependency breakage anywhere in the workspace.

3. **CI guard scripts pass:** `check:package-lock`, `check:package-versions`, `check:create-amplify-deps`, and `check:api` all exit 0. `check:api` reports no API surface change, i.e. no public type shifted between 2.244.0 and 2.267.0.

4. Prettier reports all changed files conform to the repo code style.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change. <!-- dependency-version-only change; the fix lives in aws-cdk-lib. Verified instead by asserting the resolved dependency no longer contains the defective open() flags, plus a clean full build and a clean API-extractor diff. -->
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR. <!-- no architectural change -->
- [x] If this PR requires a docs update, I have linked to that docs PR above. <!-- none required -->
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

> Note on the last item: this PR does not modify E2E tests or SDK call sites, but it does change the CDK version used for synthesis and asset hashing, so a maintainer may want to run the checks with `run-e2e` set as a precaution.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
