### PR TITLE
fix(hosting): upgrade @aws-blocks/hosting to ^0.1.10

### DIFF
--- a/.changeset/upgrade-aws-blocks-hosting-0-1-10.md
+++ b/.changeset/upgrade-aws-blocks-hosting-0-1-10.md
@@ -1,0 +1,9 @@
+---
+'@aws-amplify/hosting': patch
+---
+
+fix(hosting): upgrade `@aws-blocks/hosting` to `^0.1.10`
+
+Bumps the vendored `@aws-blocks/hosting` construct from `0.1.5` to `0.1.10` to
+pick up the latest construct fixes and improvements. `@aws-blocks/pipeline`
+remains at `^0.1.1`, which is the latest published version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7635,33 +7635,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@aws-blocks/hosting": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@aws-blocks/hosting/-/hosting-0.1.5.tgz",
-      "integrity": "sha512-dET+NiQdbCPQezAKddQzD/2jEtXpwRJoQgPZtS/KgooVLPa0lK4G/dLjDu40HBE4+JluuCoTqeuDKZjidQ99IA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1075.0",
-        "@aws-sdk/signature-v4a": "^3.1069.0",
-        "cross-spawn": "^7.0.6",
-        "fast-glob": "^3.3.2",
-        "jiti": "^2.4.0",
-        "local-pkg": "^0.5.0",
-        "parse-cache-control": "^1.0.1",
-        "semver": "^7.6.0",
-        "zod": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opennextjs/aws": ">=3.10.0",
-        "aws-cdk-lib": "^2.257.0",
-        "constructs": "^10.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@opennextjs/aws": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@aws-blocks/pipeline": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@aws-blocks/pipeline/-/pipeline-0.1.1.tgz",
@@ -37404,8 +37377,35 @@
         "@aws-amplify/backend-output-storage": "^1.3.4",
         "@aws-amplify/platform-core": "^1.11.0",
         "@aws-amplify/plugin-types": "^1.12.0",
-        "@aws-blocks/hosting": "^0.1.5",
+        "@aws-blocks/hosting": "^0.1.10",
         "@aws-blocks/pipeline": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@opennextjs/aws": ">=3.10.0",
+        "aws-cdk-lib": "^2.257.0",
+        "constructs": "^10.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@opennextjs/aws": {
+          "optional": true
+        }
+      }
+    },
+    "packages/hosting/node_modules/@aws-blocks/hosting": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@aws-blocks/hosting/-/hosting-0.1.10.tgz",
+      "integrity": "sha512-vTb6uQGWeY6A8vj4r6O74FFjrM+ew0Vv6HMnqXYEDLTD00lqvmQWhvk3YAK49bKIB9SPO6J7+IWA41IntAZXtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1075.0",
+        "@aws-sdk/signature-v4a": "^3.1069.0",
+        "cross-spawn": "^7.0.6",
+        "fast-glob": "^3.3.2",
+        "jiti": "^2.4.0",
+        "local-pkg": "^0.5.0",
+        "parse-cache-control": "^1.0.1",
+        "semver": "^7.6.0",
+        "zod": "^3.25.0"
       },
       "peerDependencies": {
         "@opennextjs/aws": ">=3.10.0",

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -43,7 +43,7 @@
     "@aws-amplify/backend-output-storage": "^1.3.4",
     "@aws-amplify/platform-core": "^1.11.0",
     "@aws-amplify/plugin-types": "^1.12.0",
-    "@aws-blocks/hosting": "^0.1.5",
+    "@aws-blocks/hosting": "^0.1.10",
     "@aws-blocks/pipeline": "^0.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
Bumps the vendored `@aws-blocks/hosting` construct dependency in `@aws-amplify/hosting` from `^0.1.5` to `^0.1.10` (latest on public npm).

`@aws-blocks/pipeline` is left at `^0.1.1` — that is already the latest published version on public npm.

## Changes
- `packages/hosting/package.json`: `@aws-blocks/hosting` `^0.1.5` → `^0.1.10`
- `package-lock.json`: regenerated; `@aws-blocks/hosting` resolves to `0.1.10` from `registry.npmjs.org`
- Added a patch changeset for `@aws-amplify/hosting`

## Notes
- Targets `snapshot/iac-hosting` (not `main`).
- Lockfile was regenerated forcing the `@aws-blocks` scope to public npm so the resolved URL/version match what CI installs.