### PR TITLE
fix(backend-deployer): bump @aws-cdk/toolkit-lib to 1.40.0 to restore STANDARD mode on hotswap fallback

### DIFF
--- a/.changeset/bump-cdk-toolkit-lib-1-40-express-fallback.md
+++ b/.changeset/bump-cdk-toolkit-lib-1-40-express-fallback.md
@@ -1,0 +1,18 @@
+---
+'@aws-amplify/backend-deployer': patch
+'@aws-amplify/plugin-types': patch
+---
+
+fix: bump `@aws-cdk/toolkit-lib` to 1.40.0 so hotswap fallback deployments stay in STANDARD mode
+
+`@aws-cdk/toolkit-lib` 1.32.0 forced `express: true` whenever a `hotswap`
+deployment fell back to a full deployment, so every `ampx sandbox` deploy that
+could not be hotswapped was sent to CloudFormation with
+`DeploymentConfig.Mode=EXPRESS` even though `--express` was not passed. Express
+mode is opt-in, and the override also relaxed the rollback and replacement
+checks of the fallback deployment.
+
+The override was reverted upstream in `@aws-cdk/toolkit-lib` 1.38.1
+(aws/aws-cdk-cli#1801). Bumping to 1.40.0 restores the intended behavior:
+`--express` is honored when passed, and a hotswap fallback deploys in STANDARD
+mode otherwise.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7761,6 +7761,35 @@
         "node": ">= 18.0.0"
       }
     },
+    "node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.4.0.tgz",
+      "integrity": "sha512-ooStESI1uXNcFAx1IgG6XcN7SsMuenoaxSb1FHqcLqwy7Lq5HUMWM52mtIzrS/uJmoFNvoxQ7fGbk8MfCGIjlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-source-map": "^0.6.1",
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=54.21.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
       "version": "54.21.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.21.0.tgz",
@@ -9438,7 +9467,6 @@
       "version": "3.1017.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.1017.0.tgz",
       "integrity": "sha512-8hLCehexCIkOjMXDdN9laWH/cEv+Qb7PGDNqRbJSQB517b7uY4JIJa5Lskm/B1O8LaJiGmUvBtwMr2MnC9T94g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -9489,7 +9517,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
       "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -30103,6 +30130,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
+      "license": "MIT"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -36451,7 +36484,7 @@
       "dependencies": {
         "@aws-amplify/platform-core": "^1.11.1",
         "@aws-amplify/plugin-types": "^1.12.2",
-        "@aws-cdk/toolkit-lib": "1.32.0",
+        "@aws-cdk/toolkit-lib": "1.40.0",
         "execa": "^9.5.1",
         "minimatch": "10.2.3",
         "strip-ansi": "^7.1.0",
@@ -36462,70 +36495,22 @@
         "typescript": "^5.0.0"
       }
     },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.6.tgz",
-      "integrity": "sha512-lw+Z5JT4e5rAMMR8tvj2yKSIQTvlxpBeYMUjfSgpJ4RN9d94vF6CpnvPqq6LsfO37n6jw0ufQrDNrR8ZHWKkuw==",
-      "dependencies": {
-        "jsonschema": "^1.5.0",
-        "semver": "^7.8.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.10.0.tgz",
-      "integrity": "sha512-G0uTune/+jvpCf3CkPUbFBMGgRJYh4NPJuvzzBHS7kLgT7EaKX5bOYBR0+VrVr4hEoCs3YlSK8uEr6AZYSIq/Q==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "dependencies": {
-        "jsonschema": "^1.5.0",
-        "semver": "^7.8.5"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.5.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/backend-deployer/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.5",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/backend-deployer/node_modules/@aws-cdk/toolkit-lib": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.32.0.tgz",
-      "integrity": "sha512-gZ/gWngRa3ZKwPOcw4zw2+NkJe73mG5XK1/FOEiz6yERJqI+s0QpXCnnOnsDr6l9o6w3Uexpfhd7wueho33hww==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.40.0.tgz",
+      "integrity": "sha512-HN+rIdHoa9Zb/N53L3l1E2ldcW8wdB1HcnUMFp2SglDrCQpDZ62f5oiZ2wY2whQYTez1hGMNr65H94jk6hFhrA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/cdk-assets-lib": "^1",
-        "@aws-cdk/cloud-assembly-api": "2.2.6",
-        "@aws-cdk/cloud-assembly-schema": ">=54.7.0",
+        "@aws-cdk/cloud-assembly-api": "2.4.0",
+        "@aws-cdk/cloud-assembly-schema": ">=54.21.0",
         "@aws-cdk/cloudformation-diff": "^2",
         "@aws-cdk/cx-api": "^2",
         "@aws-sdk/client-appsync": "^3",
         "@aws-sdk/client-bedrock-agentcore-control": "^3",
         "@aws-sdk/client-cloudcontrol": "^3",
         "@aws-sdk/client-cloudformation": "^3",
+        "@aws-sdk/client-cloudtrail": "^3",
         "@aws-sdk/client-cloudwatch-logs": "^3",
         "@aws-sdk/client-codebuild": "^3",
         "@aws-sdk/client-ec2": "^3",
@@ -36549,16 +36534,16 @@
         "@smithy/shared-ini-file-loader": "^4",
         "@smithy/util-retry": "^4",
         "@smithy/util-waiter": "^4",
-        "cdk-from-cfn": "^0.304.0",
+        "cdk-from-cfn": "^0.325.0",
         "chalk": "^4",
         "chokidar": "^4",
+        "cross-spawn": "^7.0.6",
         "fast-deep-equal": "^3.1.3",
         "fast-glob": "^3.3.3",
         "fs-extra": "^11",
         "p-limit": "^3",
         "picomatch": "^4",
-        "semver": "^7.8.4",
-        "split2": "^4.2.0",
+        "semver": "^7.8.5",
         "wrap-ansi": "^7",
         "yaml": "^1",
         "yazl": "^3.3.1"
@@ -36581,9 +36566,10 @@
       }
     },
     "packages/backend-deployer/node_modules/cdk-from-cfn": {
-      "version": "0.304.0",
-      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.304.0.tgz",
-      "integrity": "sha512-OLw/T42SqnlU3DERX0R1e9R/VaLVDuMwKAFONm9nzIineHANqnXRg9u83FAyEzaf9sOvN4qCCDlsjAp29WnTHw=="
+      "version": "0.325.0",
+      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.325.0.tgz",
+      "integrity": "sha512-V7DvZ5QQHB8aEciiy6MVMMVSCrbrpbEj+KKO6y14Haesjm3E0l8z2sNCKCXpbBaTjM7JDctPaEy0pMc/736LMg==",
+      "license": "MIT OR Apache-2.0"
     },
     "packages/backend-deployer/node_modules/chalk": {
       "version": "4.1.2",
@@ -36642,6 +36628,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -37950,7 +37937,7 @@
       "version": "1.12.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/toolkit-lib": "1.32.0"
+        "@aws-cdk/toolkit-lib": "1.40.0"
       },
       "peerDependencies": {
         "@aws-sdk/types": "^3.734.0",
@@ -37958,70 +37945,22 @@
         "constructs": "^10.0.0"
       }
     },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.6.tgz",
-      "integrity": "sha512-lw+Z5JT4e5rAMMR8tvj2yKSIQTvlxpBeYMUjfSgpJ4RN9d94vF6CpnvPqq6LsfO37n6jw0ufQrDNrR8ZHWKkuw==",
-      "dependencies": {
-        "jsonschema": "^1.5.0",
-        "semver": "^7.8.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.10.0.tgz",
-      "integrity": "sha512-G0uTune/+jvpCf3CkPUbFBMGgRJYh4NPJuvzzBHS7kLgT7EaKX5bOYBR0+VrVr4hEoCs3YlSK8uEr6AZYSIq/Q==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "dependencies": {
-        "jsonschema": "^1.5.0",
-        "semver": "^7.8.5"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.5.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/plugin-types/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.5",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/plugin-types/node_modules/@aws-cdk/toolkit-lib": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.32.0.tgz",
-      "integrity": "sha512-gZ/gWngRa3ZKwPOcw4zw2+NkJe73mG5XK1/FOEiz6yERJqI+s0QpXCnnOnsDr6l9o6w3Uexpfhd7wueho33hww==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.40.0.tgz",
+      "integrity": "sha512-HN+rIdHoa9Zb/N53L3l1E2ldcW8wdB1HcnUMFp2SglDrCQpDZ62f5oiZ2wY2whQYTez1hGMNr65H94jk6hFhrA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/cdk-assets-lib": "^1",
-        "@aws-cdk/cloud-assembly-api": "2.2.6",
-        "@aws-cdk/cloud-assembly-schema": ">=54.7.0",
+        "@aws-cdk/cloud-assembly-api": "2.4.0",
+        "@aws-cdk/cloud-assembly-schema": ">=54.21.0",
         "@aws-cdk/cloudformation-diff": "^2",
         "@aws-cdk/cx-api": "^2",
         "@aws-sdk/client-appsync": "^3",
         "@aws-sdk/client-bedrock-agentcore-control": "^3",
         "@aws-sdk/client-cloudcontrol": "^3",
         "@aws-sdk/client-cloudformation": "^3",
+        "@aws-sdk/client-cloudtrail": "^3",
         "@aws-sdk/client-cloudwatch-logs": "^3",
         "@aws-sdk/client-codebuild": "^3",
         "@aws-sdk/client-ec2": "^3",
@@ -38045,16 +37984,16 @@
         "@smithy/shared-ini-file-loader": "^4",
         "@smithy/util-retry": "^4",
         "@smithy/util-waiter": "^4",
-        "cdk-from-cfn": "^0.304.0",
+        "cdk-from-cfn": "^0.325.0",
         "chalk": "^4",
         "chokidar": "^4",
+        "cross-spawn": "^7.0.6",
         "fast-deep-equal": "^3.1.3",
         "fast-glob": "^3.3.3",
         "fs-extra": "^11",
         "p-limit": "^3",
         "picomatch": "^4",
-        "semver": "^7.8.4",
-        "split2": "^4.2.0",
+        "semver": "^7.8.5",
         "wrap-ansi": "^7",
         "yaml": "^1",
         "yazl": "^3.3.1"
@@ -38067,9 +38006,10 @@
       }
     },
     "packages/plugin-types/node_modules/cdk-from-cfn": {
-      "version": "0.304.0",
-      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.304.0.tgz",
-      "integrity": "sha512-OLw/T42SqnlU3DERX0R1e9R/VaLVDuMwKAFONm9nzIineHANqnXRg9u83FAyEzaf9sOvN4qCCDlsjAp29WnTHw=="
+      "version": "0.325.0",
+      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.325.0.tgz",
+      "integrity": "sha512-V7DvZ5QQHB8aEciiy6MVMMVSCrbrpbEj+KKO6y14Haesjm3E0l8z2sNCKCXpbBaTjM7JDctPaEy0pMc/736LMg==",
+      "license": "MIT OR Apache-2.0"
     },
     "packages/plugin-types/node_modules/chalk": {
       "version": "4.1.2",
@@ -38128,6 +38068,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/packages/backend-deployer/package.json
+++ b/packages/backend-deployer/package.json
@@ -28,7 +28,7 @@
     "execa": "^9.5.1",
     "tsx": "4.19.4",
     "strip-ansi": "^7.1.0",
-    "@aws-cdk/toolkit-lib": "1.32.0",
+    "@aws-cdk/toolkit-lib": "1.40.0",
     "minimatch": "10.2.3"
   },
   "peerDependencies": {

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/types": "^3.734.0"
   },
   "dependencies": {
-    "@aws-cdk/toolkit-lib": "1.32.0"
+    "@aws-cdk/toolkit-lib": "1.40.0"
   },
   "imports": {
     "#package.json": "./package.json"


### PR DESCRIPTION
## Problem

`ampx sandbox` deployments were being sent to CloudFormation in **Express mode
without anyone passing `--express`**. This surfaced as sustained
`DeploymentConfig.Mode=EXPRESS` traffic from the Amplify e2e/canary fleet
(~5.7k events/day/account across 8 accounts, Aug 16-29), even though
`--express` is documented and implemented as opt-in and appears nowhere in our
e2e harness.

Express mode lets stack operations complete before resources finish
stabilizing. Applying it implicitly changes deployment semantics that callers
did not ask for, and it also relaxed the rollback/replacement safety checks of
the affected deployment.

## Root cause

`@aws-cdk/toolkit-lib` 1.32.0, `lib/api/deployments/deploy-stack.js:119`:

```js
if (deploymentMethod.fallback) {
    await ioHelper.defaults.info('Falling back to doing a full deployment');
    options.sdk.appendCustomUserAgent('cdk-hotswap/fallback');
    deploymentMethod = deploymentMethod.fallback;
    options = { ...options, express: true };   // <-- unconditional
}
```

Spread-then-override, with no guard: the caller's `express` value is discarded.
`express: undefined` **and an explicit `express: false`** both become `true`.
That mutated object is passed to `FullCloudFormationDeployment` (`:133`) whose
`deployConfig()` (`:245`) emits `Mode: this.options.express ? 'EXPRESS' : 'STANDARD'`.

Every sandbox deploy takes that branch, because
`packages/backend-deployer/src/cdk_deployer.ts:152-154` requests:

```ts
deploymentMethod: isSandbox
  ? { method: 'hotswap', fallback: { method: 'direct' } }
  : { method: 'direct' },
```

So any sandbox deploy that cannot be hotswapped (the first deploy, and every
structural change) fell through to the fallback and deployed as EXPRESS. Branch
deployments use `{ method: 'direct' }` with no fallback and were never affected.

Because the override clobbers an explicit `false`, **no Amplify-side workaround
was possible** — the fix had to come from the toolkit.

## Upstream fix

Reverted in `@aws-cdk/toolkit-lib` **1.38.1** via **aws/aws-cdk-cli#1801**. The
fallback block no longer touches `express`.

## What this PR does

- Bumps `@aws-cdk/toolkit-lib` `1.32.0` → **`1.40.0`** (latest stable, ≥1.38.1) in:
  - `packages/backend-deployer/package.json`
  - `packages/plugin-types/package.json`
- Refreshes `package-lock.json`.
- Adds a patch changeset for `@aws-amplify/backend-deployer` and
  `@aws-amplify/plugin-types`.

No source changes: our opt-in wiring
(`cdk_deployer.ts:156` — `...(isSandbox && deployProps?.express ? { express: true } : {})`)
was already correct.

## Verification

Confirmed in the installed 1.40.0 that the regression is gone:

```js
116:        if (deploymentMethod.fallback) {
117:            await ioHelper.defaults.info('Falling back to doing a full deployment');
118:            options.sdk.appendCustomUserAgent('cdk-hotswap/fallback');
119:            deploymentMethod = deploymentMethod.fallback;
120:        }
```

Also confirmed the exact revert version by unpacking the published tarballs —
occurrences of `express: true` in `deploy-stack.js`: 1.37.0 → 1, 1.38.0 → 1,
**1.38.1 → 0**.

- `npm run build` → exit 0
- `packages/backend-deployer` unit tests → **79/79 pass**, including
  `enables Express mode for sandbox deployments when requested` and
  `does not enable Express mode for branch deployments` — **unmodified**
- `packages/sandbox` unit tests → **58/58 pass**

Net user-visible effect: `ampx sandbox --express` still works; `ampx sandbox`
without the flag deploys in STANDARD mode again, including on the
hotswap → full-deploy fallback path.

## Follow-up (not in this PR)

Worth an e2e/canary confirmation on one affected account that
`CreateStack`/`UpdateStack` calls carrying the `cdk-hotswap/fallback` user agent
now report `Mode=STANDARD`.
