### PR TITLE
fix(e2e-cleanup): fail-closed CloudFront origin guard + broaden S3 origin matching to prevent dangling distributions

### DIFF
--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -136,6 +136,7 @@
   "dotfiles",
   "downlevel",
   "dpl",
+  "dualstack",
   "durations",
   "dynamodb",
   "ecma",

--- a/.eslint_dictionary.json
+++ b/.eslint_dictionary.json
@@ -466,6 +466,7 @@
   "unlink",
   "unminified",
   "unparseable",
+  "unreapable",
   "unschedulable",
   "unshallow",
   "unterminated",

--- a/scripts/cleanup_e2e_resources.ts
+++ b/scripts/cleanup_e2e_resources.ts
@@ -64,6 +64,7 @@ import { CloudFrontDistributionCleaner } from './components/e2e-cleanup/cloudfro
 import { CustomerProfilesDomainCleaner } from './components/e2e-cleanup/customer_profiles_domain_cleaner.js';
 import { E2E_TEST_REGIONS } from './components/e2e-cleanup/e2e_test_regions.js';
 import { S3BucketEmptier } from './components/e2e-cleanup/s3_bucket_emptier.js';
+import { StaleBucketSweeper } from './components/e2e-cleanup/stale_bucket_sweeper.js';
 import {
   GuardedResourceType,
   StackDeleter,
@@ -249,6 +250,12 @@ const isOwnedByLiveStack = (
   return true;
 };
 
+const staleBucketSweeper = new StaleBucketSweeper(
+  s3BucketEmptier,
+  cloudFrontDistributionCleaner,
+  (bucketName) => isOwnedByLiveStack('AWS::S3::Bucket', bucketName),
+);
+
 const allStaleStacks = await stackDeleter.listStaleTopLevelStacks();
 
 /**
@@ -303,38 +310,12 @@ const staleBuckets = await listStaleS3Buckets();
 const bucketToDistributions =
   await cloudFrontDistributionCleaner.buildBucketToDistributionsIndex();
 
-for (const staleBucket of staleBuckets) {
-  if (staleBucket.Name) {
-    const bucketName = staleBucket.Name;
-    if (isOwnedByLiveStack('AWS::S3::Bucket', bucketName)) {
-      continue;
-    }
-    try {
-      /**
-       * Deleting the origin bucket of a distribution that still exists leaves a distribution
-       * that serves a bucket name anybody can claim, so the distributions go first. Disabling a
-       * distribution takes tens of minutes to propagate, therefore the bucket is retained until
-       * a subsequent run of this script is able to delete its distributions.
-       */
-      const distributionReapResult =
-        await cloudFrontDistributionCleaner.reapDistributionsForBucket(
-          bucketName,
-          bucketToDistributions,
-        );
-      if (distributionReapResult === 'disable-requested') {
-        console.log(
-          `Retaining ${bucketName} bucket. A CloudFront distribution still uses it as an origin`,
-        );
-        continue;
-      }
-      await s3BucketEmptier.emptyAndDelete(bucketName);
-      console.log(`Successfully deleted ${bucketName} bucket`);
-    } catch (e) {
-      const errorMessage = e instanceof Error ? e.message : '';
-      console.log(`Failed to delete ${bucketName} bucket. ${errorMessage}`);
-    }
-  }
-}
+await staleBucketSweeper.sweep(
+  staleBuckets
+    .map((staleBucket) => staleBucket.Name)
+    .filter((bucketName): bucketName is string => bucketName !== undefined),
+  bucketToDistributions,
+);
 
 const listStaleCognitoUserPools = async () => {
   let nextToken: string | undefined = undefined;

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
@@ -7,9 +7,13 @@ import {
   GetDistributionConfigCommand,
   ListDistributionsCommand,
   ListDistributionsCommandOutput,
+  Origin,
   UpdateDistributionCommand,
 } from '@aws-sdk/client-cloudfront';
-import { CloudFrontDistributionCleaner } from './cloudfront_distribution_cleaner.js';
+import {
+  BucketToDistributionsIndex,
+  CloudFrontDistributionCleaner,
+} from './cloudfront_distribution_cleaner.js';
 
 const TEST_RESOURCE_PREFIX = 'amplify-';
 
@@ -18,19 +22,36 @@ const buildDistribution = (
   originDomainNames: Array<string>,
   overrides: Partial<DistributionSummary> = {},
 ): DistributionSummary =>
+  buildDistributionWithOrigins(
+    id,
+    originDomainNames.map((domainName, index) => ({
+      Id: `origin-${index}`,
+      DomainName: domainName,
+    })),
+    overrides,
+  );
+
+const buildDistributionWithOrigins = (
+  id: string,
+  origins: Array<Partial<Origin>>,
+  overrides: Partial<DistributionSummary> = {},
+): DistributionSummary =>
   ({
     Id: id,
     Status: 'Deployed',
     Enabled: true,
     Origins: {
-      Quantity: originDomainNames.length,
-      Items: originDomainNames.map((domainName, index) => ({
-        Id: `origin-${index}`,
-        DomainName: domainName,
-      })),
+      Quantity: origins.length,
+      Items: origins,
     },
     ...overrides,
   }) as DistributionSummary;
+
+const buildIndex = (
+  entries: Array<[string, Array<DistributionSummary>]> = [],
+  isComplete = true,
+): BucketToDistributionsIndex =>
+  new BucketToDistributionsIndex(new Map(entries), isComplete);
 
 const buildCloudFrontClient = (
   handlers: {
@@ -91,41 +112,86 @@ const getCommandInputs = (
     )
     .map((command) => (command as { input: Record<string, unknown> }).input);
 
+const buildIndexOf = async (
+  distributions: Array<DistributionSummary>,
+): Promise<BucketToDistributionsIndex> => {
+  const { cloudFrontClient } = buildCloudFrontClient({
+    listDistributions: [
+      {
+        DistributionList: { Items: distributions, IsTruncated: false },
+        $metadata: {},
+      } as ListDistributionsCommandOutput,
+    ],
+  });
+  return new CloudFrontDistributionCleaner(
+    cloudFrontClient,
+    TEST_RESOURCE_PREFIX,
+    () => {},
+  ).buildBucketToDistributionsIndex();
+};
+
 void describe('CloudFrontDistributionCleaner', () => {
   void describe('buildBucketToDistributionsIndex', () => {
     void it('indexes test bucket origins of all supported domain formats', async () => {
-      const { cloudFrontClient } = buildCloudFrontClient({
-        listDistributions: [
+      const index = await buildIndexOf([
+        buildDistribution('D1', [
+          'amplify-regional.s3.us-west-2.amazonaws.com',
+        ]),
+        buildDistribution('D2', ['amplify-global.s3.amazonaws.com']),
+        buildDistribution('D3', [
+          'amplify-website.s3-website-us-west-2.amazonaws.com',
+        ]),
+        buildDistribution('D4', [
+          'amplify-dualstack.s3.dualstack.us-west-2.amazonaws.com',
+        ]),
+        buildDistribution('D5', [
+          'amplify-china.s3.cn-north-1.amazonaws.com.cn',
+        ]),
+        buildDistributionWithOrigins('D6', [
           {
-            DistributionList: {
-              Items: [
-                buildDistribution('D1', [
-                  'amplify-regional.s3.us-west-2.amazonaws.com',
-                ]),
-                buildDistribution('D2', ['amplify-global.s3.amazonaws.com']),
-                buildDistribution('D3', [
-                  'amplify-website.s3-website-us-west-2.amazonaws.com',
-                ]),
-              ],
-              IsTruncated: false,
-            },
-            $metadata: {},
-          } as ListDistributionsCommandOutput,
-        ],
-      });
+            Id: 'origin-0',
+            DomainName: 's3.us-west-2.amazonaws.com',
+            OriginPath: '/amplify-path-style',
+          },
+        ]),
+        buildDistributionWithOrigins('D7', [
+          {
+            Id: 'origin-0',
+            DomainName: 's3.amazonaws.com/amplify-legacy-path-style/site',
+          },
+        ]),
+        buildDistributionWithOrigins('D8', [
+          {
+            Id: 'origin-0',
+            DomainName: 'amplify-odd-suffix.s3.some-new-endpoint.example',
+            S3OriginConfig: { OriginAccessIdentity: '' },
+          },
+        ]),
+      ]);
 
-      const index = await new CloudFrontDistributionCleaner(
-        cloudFrontClient,
-        TEST_RESOURCE_PREFIX,
-        () => {},
-      ).buildBucketToDistributionsIndex();
-
-      assert.deepStrictEqual([...index.keys()].sort(), [
+      assert.deepStrictEqual(index.getBucketNames().sort(), [
+        'amplify-china',
+        'amplify-dualstack',
         'amplify-global',
+        'amplify-legacy-path-style',
+        'amplify-odd-suffix',
+        'amplify-path-style',
         'amplify-regional',
         'amplify-website',
       ]);
-      assert.strictEqual(index.get('amplify-regional')?.[0].Id, 'D1');
+      assert.strictEqual(index.isComplete, true);
+      assert.strictEqual(
+        index.getDistributions('amplify-regional')[0].Id,
+        'D1',
+      );
+      assert.strictEqual(
+        index.getDistributions('amplify-legacy-path-style')[0].Id,
+        'D7',
+      );
+      assert.strictEqual(
+        index.getDistributions('amplify-odd-suffix')[0].Id,
+        'D8',
+      );
     });
 
     void it('ignores origins that are not test buckets and follows pagination', async () => {
@@ -170,11 +236,36 @@ void describe('CloudFrontDistributionCleaner', () => {
         { Marker: undefined },
         { Marker: 'D1' },
       ]);
-      assert.deepStrictEqual([...index.keys()], ['amplify-app']);
-      assert.strictEqual(index.get('amplify-app')?.length, 1);
+      assert.deepStrictEqual(index.getBucketNames(), ['amplify-app']);
+      assert.strictEqual(index.getDistributions('amplify-app').length, 1);
     });
 
-    void it('returns an empty index instead of throwing when listing is not permitted', async () => {
+    void it('ignores origins that are not S3 buckets at all', async () => {
+      const index = await buildIndexOf([
+        buildDistributionWithOrigins('D1', [
+          { Id: 'origin-0', DomainName: 'amplify-app.example.com' },
+          {
+            Id: 'origin-1',
+            DomainName: 'amplify-api.execute-api.us-west-2.amazonaws.com',
+          },
+          {
+            Id: 'origin-2',
+            DomainName: 'amplify-lb.elb.us-west-2.amazonaws.com',
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: 'https-only',
+            },
+          },
+          { Id: 'origin-3', DomainName: 's3.us-west-2.amazonaws.com' },
+        ]),
+      ]);
+
+      assert.deepStrictEqual(index.getBucketNames(), []);
+      assert.strictEqual(index.isComplete, true);
+    });
+
+    void it('reports an incomplete index instead of throwing when listing is not permitted', async () => {
       const logMessages: Array<string> = [];
       const { cloudFrontClient } = buildCloudFrontClient({
         listDistributions: [
@@ -190,12 +281,41 @@ void describe('CloudFrontDistributionCleaner', () => {
         (message) => logMessages.push(message),
       ).buildBucketToDistributionsIndex();
 
-      assert.strictEqual(index.size, 0);
+      assert.strictEqual(index.isComplete, false);
+      assert.deepStrictEqual(index.getBucketNames(), []);
       assert.ok(
         logMessages.some((message) =>
           message.includes('Unable to list CloudFront distributions'),
         ),
       );
+    });
+
+    void it('reports an incomplete index when a later page of distributions cannot be listed', async () => {
+      const { cloudFrontClient } = buildCloudFrontClient({
+        listDistributions: [
+          {
+            DistributionList: {
+              Items: [
+                buildDistribution('D1', [
+                  'amplify-app.s3.us-west-2.amazonaws.com',
+                ]),
+              ],
+              IsTruncated: true,
+              NextMarker: 'D1',
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+          new Error('Rate exceeded'),
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).buildBucketToDistributionsIndex();
+
+      assert.strictEqual(index.isComplete, false);
     });
   });
 
@@ -207,9 +327,22 @@ void describe('CloudFrontDistributionCleaner', () => {
         cloudFrontClient,
         TEST_RESOURCE_PREFIX,
         () => {},
-      ).reapDistributionsForBucket('amplify-app', new Map());
+      ).reapDistributionsForBucket('amplify-app', buildIndex());
 
       assert.strictEqual(result, 'none');
+      assert.strictEqual(send.mock.callCount(), 0);
+    });
+
+    void it('reports index-incomplete without calling CloudFront when the index is incomplete', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient();
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket('amplify-app', buildIndex([], false));
+
+      assert.strictEqual(result, 'index-incomplete');
       assert.strictEqual(send.mock.callCount(), 0);
     });
 
@@ -232,7 +365,7 @@ void describe('CloudFrontDistributionCleaner', () => {
         () => {},
       ).reapDistributionsForBucket(
         'amplify-app',
-        new Map([['amplify-app', [distribution]]]),
+        buildIndex([['amplify-app', [distribution]]]),
       );
 
       assert.strictEqual(result, 'disable-requested');
@@ -266,7 +399,7 @@ void describe('CloudFrontDistributionCleaner', () => {
         () => {},
       ).reapDistributionsForBucket(
         'amplify-app',
-        new Map([['amplify-app', [distribution]]]),
+        buildIndex([['amplify-app', [distribution]]]),
       );
 
       assert.strictEqual(result, 'disable-requested');
@@ -291,7 +424,7 @@ void describe('CloudFrontDistributionCleaner', () => {
         () => {},
       ).reapDistributionsForBucket(
         'amplify-app',
-        new Map([['amplify-app', [distribution]]]),
+        buildIndex([['amplify-app', [distribution]]]),
       );
 
       assert.strictEqual(result, 'deleted');
@@ -318,7 +451,7 @@ void describe('CloudFrontDistributionCleaner', () => {
         (message) => logMessages.push(message),
       ).reapDistributionsForBucket(
         'amplify-app',
-        new Map([['amplify-app', [distribution]]]),
+        buildIndex([['amplify-app', [distribution]]]),
       );
 
       assert.strictEqual(result, 'disable-requested');
@@ -350,7 +483,7 @@ void describe('CloudFrontDistributionCleaner', () => {
         () => {},
       ).reapDistributionsForBucket(
         'amplify-app',
-        new Map([['amplify-app', distributions]]),
+        buildIndex([['amplify-app', distributions]]),
       );
 
       assert.strictEqual(result, 'disable-requested');

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
@@ -207,6 +207,10 @@ void describe('CloudFrontDistributionCleaner', () => {
 
       assert.deepStrictEqual(index.getBucketNames(), []);
       assert.strictEqual(index.isComplete, false);
+      assert.strictEqual(
+        index.incompleteReason,
+        'unrecognized-s3-origin: distribution D1',
+      );
     });
 
     void it('ignores origins that are not test buckets and follows pagination', async () => {
@@ -366,6 +370,10 @@ void describe('CloudFrontDistributionCleaner', () => {
       ).buildBucketToDistributionsIndex();
 
       assert.strictEqual(index.isComplete, false);
+      assert.strictEqual(
+        index.incompleteReason,
+        'list-distributions-error: User is not authorized to perform cloudfront:ListDistributions',
+      );
       assert.deepStrictEqual(index.getBucketNames(), []);
       assert.ok(
         logMessages.some((message) =>

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
@@ -163,7 +163,7 @@ void describe('CloudFrontDistributionCleaner', () => {
         buildDistributionWithOrigins('D8', [
           {
             Id: 'origin-0',
-            DomainName: 'amplify-odd-suffix.s3.some-new-endpoint.example',
+            DomainName: 'amplify-dotted.bucket.s3.us-west-2.amazonaws.com',
             S3OriginConfig: { OriginAccessIdentity: '' },
           },
         ]),
@@ -171,10 +171,10 @@ void describe('CloudFrontDistributionCleaner', () => {
 
       assert.deepStrictEqual(index.getBucketNames().sort(), [
         'amplify-china',
+        'amplify-dotted.bucket',
         'amplify-dualstack',
         'amplify-global',
         'amplify-legacy-path-style',
-        'amplify-odd-suffix',
         'amplify-path-style',
         'amplify-regional',
         'amplify-website',
@@ -189,9 +189,24 @@ void describe('CloudFrontDistributionCleaner', () => {
         'D7',
       );
       assert.strictEqual(
-        index.getDistributions('amplify-odd-suffix')[0].Id,
+        index.getDistributions('amplify-dotted.bucket')[0].Id,
         'D8',
       );
+    });
+
+    void it('marks the index incomplete for an unrecognized S3 origin', async () => {
+      const index = await buildIndexOf([
+        buildDistributionWithOrigins('D1', [
+          {
+            Id: 'origin-0',
+            DomainName: 'amplify-app.s3.some-new-endpoint.example',
+            S3OriginConfig: { OriginAccessIdentity: '' },
+          },
+        ]),
+      ]);
+
+      assert.deepStrictEqual(index.getBucketNames(), []);
+      assert.strictEqual(index.isComplete, false);
     });
 
     void it('ignores origins that are not test buckets and follows pagination', async () => {
@@ -238,6 +253,75 @@ void describe('CloudFrontDistributionCleaner', () => {
       ]);
       assert.deepStrictEqual(index.getBucketNames(), ['amplify-app']);
       assert.strictEqual(index.getDistributions('amplify-app').length, 1);
+    });
+
+    void it('marks the index incomplete when a truncated page has no next marker', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient({
+        listDistributions: [
+          {
+            DistributionList: {
+              Marker: '',
+              MaxItems: 100,
+              Quantity: 0,
+              Items: [],
+              IsTruncated: true,
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).buildBucketToDistributionsIndex();
+
+      assert.strictEqual(index.isComplete, false);
+      assert.deepStrictEqual(getCommandInputs(send, ListDistributionsCommand), [
+        { Marker: undefined },
+      ]);
+    });
+
+    void it('marks the index incomplete when a pagination marker repeats', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient({
+        listDistributions: [
+          {
+            DistributionList: {
+              Marker: '',
+              MaxItems: 100,
+              Quantity: 0,
+              Items: [],
+              IsTruncated: true,
+              NextMarker: 'D1',
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+          {
+            DistributionList: {
+              Marker: 'D1',
+              MaxItems: 100,
+              Quantity: 0,
+              Items: [],
+              IsTruncated: true,
+              NextMarker: 'D1',
+            },
+            $metadata: {},
+          } as ListDistributionsCommandOutput,
+        ],
+      });
+
+      const index = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).buildBucketToDistributionsIndex();
+
+      assert.strictEqual(index.isComplete, false);
+      assert.deepStrictEqual(getCommandInputs(send, ListDistributionsCommand), [
+        { Marker: undefined },
+        { Marker: 'D1' },
+      ]);
     });
 
     void it('ignores origins that are not S3 buckets at all', async () => {

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts
@@ -438,6 +438,26 @@ void describe('CloudFrontDistributionCleaner', () => {
       assert.strictEqual(send.mock.callCount(), 0);
     });
 
+    void it('reports unreapable when an indexed distribution is missing an id', async () => {
+      const { cloudFrontClient, send } = buildCloudFrontClient();
+      const distribution = {
+        Enabled: false,
+        Status: 'Deployed',
+      } as DistributionSummary;
+
+      const result = await new CloudFrontDistributionCleaner(
+        cloudFrontClient,
+        TEST_RESOURCE_PREFIX,
+        () => {},
+      ).reapDistributionsForBucket(
+        'amplify-app',
+        buildIndex([['amplify-app', [distribution]]]),
+      );
+
+      assert.strictEqual(result, 'unreapable');
+      assert.strictEqual(send.mock.callCount(), 0);
+    });
+
     void it('disables an enabled distribution and keeps the bucket', async () => {
       const { cloudFrontClient, send } = buildCloudFrontClient({
         getDistributionConfig: [

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
@@ -6,16 +6,28 @@ import {
   GetDistributionConfigCommand,
   ListDistributionsCommand,
   ListDistributionsCommandOutput,
+  Origin,
   UpdateDistributionCommand,
 } from '@aws-sdk/client-cloudfront';
 
 /**
- * Matches the S3 origin domain name formats CloudFront reports, for example
- * `bucket.s3.us-west-2.amazonaws.com`, `bucket.s3.amazonaws.com` and
- * `bucket.s3-website-us-west-2.amazonaws.com`. The first group is the bucket name.
+ * Matches the virtual hosted style S3 origin domain names CloudFront reports, for example
+ * `bucket.s3.us-west-2.amazonaws.com`, `bucket.s3.amazonaws.com`,
+ * `bucket.s3-website-us-west-2.amazonaws.com`, `bucket.s3.dualstack.us-west-2.amazonaws.com`
+ * and the China partition form `bucket.s3.cn-north-1.amazonaws.com.cn`. The first group is the
+ * bucket name.
  */
-const S3_ORIGIN_DOMAIN_PATTERN =
-  /^(.+?)\.s3(?:[.-]website)?(?:\.dualstack)?(?:[.-][a-z0-9-]+)?\.amazonaws\.com$/;
+const S3_VIRTUAL_HOSTED_ORIGIN_DOMAIN_PATTERN =
+  /^(.+?)\.s3(?:[.-]website)?(?:[.-]fips)?(?:\.dualstack)?(?:[.-][a-z0-9-]+)?\.amazonaws\.com(?:\.[a-z]{2})?$/;
+
+/**
+ * Matches the legacy path style S3 origin hosts, where the host carries no bucket name at all and
+ * the bucket is the leading segment of the path, for example `s3.amazonaws.com` or
+ * `s3.us-west-2.amazonaws.com` with a `/bucket` path. The path is taken from the domain name when
+ * it carries one and from the origin path otherwise.
+ */
+const S3_PATH_STYLE_ORIGIN_HOST_PATTERN =
+  /^s3(?:[.-]website)?(?:[.-]fips)?(?:\.dualstack)?(?:[.-][a-z0-9-]+)?\.amazonaws\.com(?:\.[a-z]{2})?$/;
 
 const DEPLOYED_STATUS = 'Deployed';
 
@@ -23,9 +35,49 @@ const DEPLOYED_STATUS = 'Deployed';
  * Outcome of an attempt to reap the distributions of a single bucket.
  *
  * `disable-requested` means at least one distribution still exists, therefore the origin
- * bucket must be retained. `deleted` means every distribution of the bucket is gone.
+ * bucket must be retained. `index-incomplete` means the distributions of the bucket are unknown,
+ * therefore the origin bucket must be retained as well. `deleted` means every distribution of the
+ * bucket is gone.
  */
-export type DistributionReapResult = 'none' | 'disable-requested' | 'deleted';
+export type DistributionReapResult =
+  | 'none'
+  | 'index-incomplete'
+  | 'disable-requested'
+  | 'deleted';
+
+/**
+ * Index of the CloudFront distributions that use each test bucket as an origin.
+ *
+ * `isComplete` is false when the distributions could not be listed. A caller must not delete any
+ * bucket while the index is incomplete: an incomplete index makes every bucket look origin free,
+ * so deleting buckets would leave dangling distributions behind that serve a bucket name anybody
+ * can claim. Retaining the buckets instead is always safe because a later healthy run deletes them.
+ */
+export class BucketToDistributionsIndex {
+  /**
+   * Creates an index of distributions by the name of the test bucket they use as an origin.
+   */
+  constructor(
+    private readonly distributionsByBucketName: Map<
+      string,
+      Array<DistributionSummary>
+    >,
+    readonly isComplete: boolean,
+  ) {}
+
+  /**
+   * Returns the distributions that use the bucket as an origin, or an empty list if none do.
+   */
+  getDistributions = (bucketName: string): Array<DistributionSummary> =>
+    this.distributionsByBucketName.get(bucketName) ?? [];
+
+  /**
+   * Returns the names of the test buckets that are used as a distribution origin.
+   */
+  getBucketNames = (): Array<string> => [
+    ...this.distributionsByBucketName.keys(),
+  ];
+}
 
 /**
  * Deletes CloudFront distributions that are left behind by failed e2e test stack deletions.
@@ -47,42 +99,47 @@ export class CloudFrontDistributionCleaner {
   /**
    * Indexes all distributions that use a test bucket as an origin by that bucket name.
    *
-   * Returns an empty index if the distributions cannot be listed, so that the rest of the
-   * cleanup keeps working in accounts where the cleanup role is not permitted to use CloudFront.
+   * Returns an index marked as incomplete if the distributions cannot be listed, for example in
+   * accounts where the cleanup role is not permitted to use CloudFront or when the CloudFront API
+   * throttles. The caller must then retain every bucket instead of deleting origin buckets on the
+   * strength of an index that knows about no distribution at all.
    */
-  buildBucketToDistributionsIndex = async (): Promise<
-    Map<string, Array<DistributionSummary>>
-  > => {
-    const index = new Map<string, Array<DistributionSummary>>();
-    let marker: string | undefined = undefined;
-    try {
-      do {
-        const listDistributionsResponse: ListDistributionsCommandOutput =
-          await this.cloudFrontClient.send(
-            new ListDistributionsCommand({ Marker: marker }),
-          );
-        const distributionList: DistributionList | undefined =
-          listDistributionsResponse.DistributionList;
-        for (const distribution of distributionList?.Items ?? []) {
-          for (const bucketName of this.getTestBucketOrigins(distribution)) {
-            const distributions = index.get(bucketName) ?? [];
-            distributions.push(distribution);
-            index.set(bucketName, distributions);
+  buildBucketToDistributionsIndex =
+    async (): Promise<BucketToDistributionsIndex> => {
+      const distributionsByBucketName = new Map<
+        string,
+        Array<DistributionSummary>
+      >();
+      let marker: string | undefined = undefined;
+      try {
+        do {
+          const listDistributionsResponse: ListDistributionsCommandOutput =
+            await this.cloudFrontClient.send(
+              new ListDistributionsCommand({ Marker: marker }),
+            );
+          const distributionList: DistributionList | undefined =
+            listDistributionsResponse.DistributionList;
+          for (const distribution of distributionList?.Items ?? []) {
+            for (const bucketName of this.getTestBucketOrigins(distribution)) {
+              const distributions =
+                distributionsByBucketName.get(bucketName) ?? [];
+              distributions.push(distribution);
+              distributionsByBucketName.set(bucketName, distributions);
+            }
           }
-        }
-        marker =
-          distributionList?.IsTruncated === true
-            ? distributionList.NextMarker
-            : undefined;
-      } while (marker);
-    } catch (error) {
-      this.log(
-        `Unable to list CloudFront distributions, skipping distribution cleanup. ${this.getErrorMessage(error)}`,
-      );
-      return new Map();
-    }
-    return index;
-  };
+          marker =
+            distributionList?.IsTruncated === true
+              ? distributionList.NextMarker
+              : undefined;
+        } while (marker);
+      } catch (error) {
+        this.log(
+          `Unable to list CloudFront distributions. Stale buckets must be retained by this run because their origin usage is unknown. ${this.getErrorMessage(error)}`,
+        );
+        return new BucketToDistributionsIndex(distributionsByBucketName, false);
+      }
+      return new BucketToDistributionsIndex(distributionsByBucketName, true);
+    };
 
   /**
    * Moves every distribution of the bucket one step closer to deletion.
@@ -93,9 +150,13 @@ export class CloudFrontDistributionCleaner {
    */
   reapDistributionsForBucket = async (
     bucketName: string,
-    bucketToDistributions: Map<string, Array<DistributionSummary>>,
+    bucketToDistributions: BucketToDistributionsIndex,
   ): Promise<DistributionReapResult> => {
-    const distributions = bucketToDistributions.get(bucketName) ?? [];
+    if (!bucketToDistributions.isComplete) {
+      // The distributions of the bucket are unknown, so the bucket cannot be proven origin free.
+      return 'index-incomplete';
+    }
+    const distributions = bucketToDistributions.getDistributions(bucketName);
     let result: DistributionReapResult = 'none';
     for (const distribution of distributions) {
       const distributionResult = await this.reapDistribution(distribution);
@@ -182,14 +243,58 @@ export class CloudFrontDistributionCleaner {
   ): Array<string> => {
     const bucketNames = new Set<string>();
     for (const origin of distribution.Origins?.Items ?? []) {
-      const bucketName = origin.DomainName
-        ? S3_ORIGIN_DOMAIN_PATTERN.exec(origin.DomainName)?.[1]
-        : undefined;
+      const bucketName = this.getOriginBucketName(origin);
       if (bucketName?.startsWith(this.testResourcePrefix)) {
         bucketNames.add(bucketName);
       }
     }
     return [...bucketNames];
+  };
+
+  /**
+   * Extracts the origin bucket name from an origin, covering every S3 origin form we may find in
+   * the test accounts. An origin form that is not recognized here makes its bucket look origin
+   * free, therefore each form must be handled explicitly rather than falling through.
+   */
+  private getOriginBucketName = (origin: Origin): string | undefined => {
+    const domainName = origin.DomainName;
+    if (!domainName) {
+      return undefined;
+    }
+    // A domain name is normally a bare host, but tolerate one that carries a path style path.
+    const [host, ...domainNamePathSegments] = domainName.split('/');
+    const virtualHostedBucketName =
+      S3_VIRTUAL_HOSTED_ORIGIN_DOMAIN_PATTERN.exec(host)?.[1];
+    if (virtualHostedBucketName) {
+      return virtualHostedBucketName;
+    }
+    if (S3_PATH_STYLE_ORIGIN_HOST_PATTERN.test(host)) {
+      // Legacy path style: the host names no bucket, the leading path segment does.
+      return (
+        this.getLeadingPathSegment(domainNamePathSegments.join('/')) ??
+        this.getLeadingPathSegment(origin.OriginPath)
+      );
+    }
+    if (origin.S3OriginConfig) {
+      // The origin is an S3 origin even though its suffix is not one we know, for example in a
+      // partition or an endpoint form this script has never seen. The bucket name is still the
+      // leading label of the host.
+      return this.getLeadingHostLabel(host);
+    }
+    return undefined;
+  };
+
+  private getLeadingPathSegment = (
+    path: string | undefined,
+  ): string | undefined =>
+    path?.split('/').find((segment) => segment.length > 0);
+
+  private getLeadingHostLabel = (host: string): string | undefined => {
+    const [leadingLabel, ...remainingLabels] = host.split('.');
+    // A single label host cannot carry both a bucket name and an S3 endpoint.
+    return remainingLabels.length > 0 && leadingLabel.length > 0
+      ? leadingLabel
+      : undefined;
   };
 
   private getErrorMessage = (error: unknown): string =>

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
@@ -39,14 +39,15 @@ type OriginBucketNameResult =
 /**
  * Outcome of an attempt to reap the distributions of a single bucket.
  *
- * `disable-requested` means at least one distribution still exists, therefore the origin
- * bucket must be retained. `index-incomplete` means the distributions of the bucket are unknown,
- * therefore the origin bucket must be retained as well. `deleted` means every distribution of the
- * bucket is gone.
+ * `disable-requested` means at least one distribution still exists, therefore the origin bucket
+ * must be retained. `unreapable` means a distribution cannot be managed safely and the run must
+ * fail. `index-incomplete` means the distributions of the bucket are unknown, therefore the origin
+ * bucket must be retained as well. `deleted` means every distribution of the bucket is gone.
  */
 export type DistributionReapResult =
   | 'none'
   | 'index-incomplete'
+  | 'unreapable'
   | 'disable-requested'
   | 'deleted';
 
@@ -197,9 +198,15 @@ export class CloudFrontDistributionCleaner {
     let result: DistributionReapResult = 'none';
     for (const distribution of distributions) {
       const distributionResult = await this.reapDistribution(distribution);
-      if (distributionResult === 'index-incomplete') {
+      if (distributionResult === 'unreapable') {
+        result = 'unreapable';
+      } else if (
+        result !== 'unreapable' &&
+        distributionResult === 'index-incomplete'
+      ) {
         result = 'index-incomplete';
       } else if (
+        result !== 'unreapable' &&
         result !== 'index-incomplete' &&
         distributionResult === 'disable-requested'
       ) {
@@ -219,7 +226,7 @@ export class CloudFrontDistributionCleaner {
       this.log(
         'CloudFront distribution summary is missing an id. Retaining its origin bucket because the distribution cannot be reaped safely',
       );
-      return 'index-incomplete';
+      return 'unreapable';
     }
     try {
       if (distribution.Enabled !== false) {

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
@@ -68,6 +68,7 @@ export class BucketToDistributionsIndex {
       Array<DistributionSummary>
     >,
     readonly isComplete: boolean,
+    readonly incompleteReason?: string,
   ) {}
 
   /**
@@ -135,6 +136,7 @@ export class CloudFrontDistributionCleaner {
               return new BucketToDistributionsIndex(
                 distributionsByBucketName,
                 false,
+                `unrecognized-s3-origin: distribution ${distribution.Id ?? '<unknown>'}`,
               );
             }
             for (const bucketName of bucketNames) {
@@ -153,6 +155,7 @@ export class CloudFrontDistributionCleaner {
               return new BucketToDistributionsIndex(
                 distributionsByBucketName,
                 false,
+                `invalid-pagination: marker ${marker ?? '<initial>'}`,
               );
             }
             seenMarkers.add(nextMarker);
@@ -162,10 +165,15 @@ export class CloudFrontDistributionCleaner {
           }
         } while (marker);
       } catch (error) {
+        const errorMessage = this.getErrorMessage(error);
         this.log(
-          `Unable to list CloudFront distributions. Stale buckets must be retained by this run because their origin usage is unknown. ${this.getErrorMessage(error)}`,
+          `Unable to list CloudFront distributions. Stale buckets must be retained by this run because their origin usage is unknown. ${errorMessage}`,
         );
-        return new BucketToDistributionsIndex(distributionsByBucketName, false);
+        return new BucketToDistributionsIndex(
+          distributionsByBucketName,
+          false,
+          `list-distributions-error: ${errorMessage || 'unknown error'}`,
+        );
       }
       return new BucketToDistributionsIndex(distributionsByBucketName, true);
     };

--- a/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
+++ b/scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts
@@ -31,6 +31,11 @@ const S3_PATH_STYLE_ORIGIN_HOST_PATTERN =
 
 const DEPLOYED_STATUS = 'Deployed';
 
+type OriginBucketNameResult =
+  | { kind: 'matched'; bucket: string }
+  | { kind: 'not-s3' }
+  | { kind: 'unrecognized-s3' };
+
 /**
  * Outcome of an attempt to reap the distributions of a single bucket.
  *
@@ -111,6 +116,7 @@ export class CloudFrontDistributionCleaner {
         Array<DistributionSummary>
       >();
       let marker: string | undefined = undefined;
+      const seenMarkers = new Set<string>();
       try {
         do {
           const listDistributionsResponse: ListDistributionsCommandOutput =
@@ -120,17 +126,40 @@ export class CloudFrontDistributionCleaner {
           const distributionList: DistributionList | undefined =
             listDistributionsResponse.DistributionList;
           for (const distribution of distributionList?.Items ?? []) {
-            for (const bucketName of this.getTestBucketOrigins(distribution)) {
+            const { bucketNames, hasUnrecognizedS3Origin } =
+              this.getTestBucketOrigins(distribution);
+            if (hasUnrecognizedS3Origin) {
+              this.log(
+                `CloudFront distribution ${distribution.Id ?? '<unknown>'} has an unrecognized S3 origin. Stale buckets must be retained because the origin bucket cannot be identified`,
+              );
+              return new BucketToDistributionsIndex(
+                distributionsByBucketName,
+                false,
+              );
+            }
+            for (const bucketName of bucketNames) {
               const distributions =
                 distributionsByBucketName.get(bucketName) ?? [];
               distributions.push(distribution);
               distributionsByBucketName.set(bucketName, distributions);
             }
           }
-          marker =
-            distributionList?.IsTruncated === true
-              ? distributionList.NextMarker
-              : undefined;
+          if (distributionList?.IsTruncated === true) {
+            const nextMarker = distributionList.NextMarker;
+            if (!nextMarker || seenMarkers.has(nextMarker)) {
+              this.log(
+                `CloudFront distribution pagination did not provide a new marker. Stale buckets must be retained because the distribution index is incomplete`,
+              );
+              return new BucketToDistributionsIndex(
+                distributionsByBucketName,
+                false,
+              );
+            }
+            seenMarkers.add(nextMarker);
+            marker = nextMarker;
+          } else {
+            marker = undefined;
+          }
         } while (marker);
       } catch (error) {
         this.log(
@@ -160,7 +189,12 @@ export class CloudFrontDistributionCleaner {
     let result: DistributionReapResult = 'none';
     for (const distribution of distributions) {
       const distributionResult = await this.reapDistribution(distribution);
-      if (distributionResult === 'disable-requested') {
+      if (distributionResult === 'index-incomplete') {
+        result = 'index-incomplete';
+      } else if (
+        result !== 'index-incomplete' &&
+        distributionResult === 'disable-requested'
+      ) {
         result = 'disable-requested';
       } else if (result === 'none') {
         result = distributionResult;
@@ -174,7 +208,10 @@ export class CloudFrontDistributionCleaner {
   ): Promise<DistributionReapResult> => {
     const distributionId = distribution.Id;
     if (!distributionId) {
-      return 'none';
+      this.log(
+        'CloudFront distribution summary is missing an id. Retaining its origin bucket because the distribution cannot be reaped safely',
+      );
+      return 'index-incomplete';
     }
     try {
       if (distribution.Enabled !== false) {
@@ -240,15 +277,24 @@ export class CloudFrontDistributionCleaner {
 
   private getTestBucketOrigins = (
     distribution: DistributionSummary,
-  ): Array<string> => {
+  ): {
+    bucketNames: Array<string>;
+    hasUnrecognizedS3Origin: boolean;
+  } => {
     const bucketNames = new Set<string>();
+    let hasUnrecognizedS3Origin = false;
     for (const origin of distribution.Origins?.Items ?? []) {
-      const bucketName = this.getOriginBucketName(origin);
-      if (bucketName?.startsWith(this.testResourcePrefix)) {
-        bucketNames.add(bucketName);
+      const originBucketName = this.getOriginBucketName(origin);
+      if (originBucketName.kind === 'unrecognized-s3') {
+        hasUnrecognizedS3Origin = true;
+      } else if (
+        originBucketName.kind === 'matched' &&
+        originBucketName.bucket.startsWith(this.testResourcePrefix)
+      ) {
+        bucketNames.add(originBucketName.bucket);
       }
     }
-    return [...bucketNames];
+    return { bucketNames: [...bucketNames], hasUnrecognizedS3Origin };
   };
 
   /**
@@ -256,46 +302,41 @@ export class CloudFrontDistributionCleaner {
    * the test accounts. An origin form that is not recognized here makes its bucket look origin
    * free, therefore each form must be handled explicitly rather than falling through.
    */
-  private getOriginBucketName = (origin: Origin): string | undefined => {
+  private getOriginBucketName = (origin: Origin): OriginBucketNameResult => {
     const domainName = origin.DomainName;
     if (!domainName) {
-      return undefined;
+      return origin.S3OriginConfig
+        ? { kind: 'unrecognized-s3' }
+        : { kind: 'not-s3' };
     }
     // A domain name is normally a bare host, but tolerate one that carries a path style path.
     const [host, ...domainNamePathSegments] = domainName.split('/');
     const virtualHostedBucketName =
       S3_VIRTUAL_HOSTED_ORIGIN_DOMAIN_PATTERN.exec(host)?.[1];
     if (virtualHostedBucketName) {
-      return virtualHostedBucketName;
+      return { kind: 'matched', bucket: virtualHostedBucketName };
     }
     if (S3_PATH_STYLE_ORIGIN_HOST_PATTERN.test(host)) {
       // Legacy path style: the host names no bucket, the leading path segment does.
-      return (
+      const pathStyleBucketName =
         this.getLeadingPathSegment(domainNamePathSegments.join('/')) ??
-        this.getLeadingPathSegment(origin.OriginPath)
-      );
+        this.getLeadingPathSegment(origin.OriginPath);
+      if (pathStyleBucketName) {
+        return { kind: 'matched', bucket: pathStyleBucketName };
+      }
+      return origin.S3OriginConfig
+        ? { kind: 'unrecognized-s3' }
+        : { kind: 'not-s3' };
     }
-    if (origin.S3OriginConfig) {
-      // The origin is an S3 origin even though its suffix is not one we know, for example in a
-      // partition or an endpoint form this script has never seen. The bucket name is still the
-      // leading label of the host.
-      return this.getLeadingHostLabel(host);
-    }
-    return undefined;
+    return origin.S3OriginConfig
+      ? { kind: 'unrecognized-s3' }
+      : { kind: 'not-s3' };
   };
 
   private getLeadingPathSegment = (
     path: string | undefined,
   ): string | undefined =>
     path?.split('/').find((segment) => segment.length > 0);
-
-  private getLeadingHostLabel = (host: string): string | undefined => {
-    const [leadingLabel, ...remainingLabels] = host.split('.');
-    // A single label host cannot carry both a bucket name and an S3 endpoint.
-    return remainingLabels.length > 0 && leadingLabel.length > 0
-      ? leadingLabel
-      : undefined;
-  };
 
   private getErrorMessage = (error: unknown): string =>
     error instanceof Error ? error.message : '';

--- a/scripts/components/e2e-cleanup/stack_deleter.test.ts
+++ b/scripts/components/e2e-cleanup/stack_deleter.test.ts
@@ -472,6 +472,33 @@ void describe('StackDeleter', () => {
       );
     });
 
+    void it('retains a LogRetention resource that is the only failed resource', async () => {
+      const { cfnClient, send } = buildCfnClient({
+        resourcesByStack: {
+          'amplify-stuck': [
+            buildResource(
+              'LogRetention',
+              'Custom::LogRetention',
+              'log-retention',
+              ResourceStatus.DELETE_FAILED,
+            ),
+          ],
+        },
+      });
+
+      const retainedResources = await buildStackDeleter(cfnClient).deleteStack(
+        buildStack('amplify-stuck', { StackStatus: StackStatus.DELETE_FAILED }),
+      );
+
+      assert.deepStrictEqual(retainedResources, ['LogRetention']);
+      assert.deepStrictEqual(getDeleteStackInputs(send), [
+        {
+          StackName: 'amplify-stuck',
+          RetainResources: ['LogRetention'],
+        },
+      ]);
+    });
+
     void it('never abandons a CloudFront distribution and asks for manual attention', async () => {
       const logMessages: Array<string> = [];
       const { cfnClient, send } = buildCfnClient({

--- a/scripts/components/e2e-cleanup/stack_deleter.ts
+++ b/scripts/components/e2e-cleanup/stack_deleter.ts
@@ -24,6 +24,7 @@ import {
 const RESOURCE_TYPES_SAFE_TO_RETAIN = [
   'Custom::S3AutoDeleteObjects',
   'Custom::CDKBucketDeployment',
+  'Custom::LogRetention',
   'AWS::S3::Bucket',
 ];
 

--- a/scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts
+++ b/scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import {
+  DeleteBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectVersionsCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import {
+  CloudFrontClient,
+  DeleteDistributionCommand,
+  DistributionSummary,
+  GetDistributionConfigCommand,
+  ListDistributionsCommand,
+  UpdateDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
+import { S3BucketEmptier } from './s3_bucket_emptier.js';
+import {
+  BucketToDistributionsIndex,
+  CloudFrontDistributionCleaner,
+} from './cloudfront_distribution_cleaner.js';
+import { StaleBucketSweeper } from './stale_bucket_sweeper.js';
+
+const TEST_RESOURCE_PREFIX = 'amplify-';
+
+const buildS3Client = (deleteBucketError?: Error) => {
+  const send = mock.fn((command: unknown) => {
+    if (command instanceof ListObjectVersionsCommand) {
+      return Promise.resolve({ IsTruncated: false });
+    }
+    if (command instanceof DeleteObjectsCommand) {
+      return Promise.resolve({});
+    }
+    if (command instanceof DeleteBucketCommand) {
+      return deleteBucketError
+        ? Promise.reject(deleteBucketError)
+        : Promise.resolve({});
+    }
+    return Promise.reject(new Error('Unexpected command'));
+  });
+  return { s3Client: { send } as unknown as S3Client, send };
+};
+
+const buildCloudFrontClient = () => {
+  const send = mock.fn((command: unknown) => {
+    if (
+      command instanceof GetDistributionConfigCommand ||
+      command instanceof UpdateDistributionCommand ||
+      command instanceof DeleteDistributionCommand ||
+      command instanceof ListDistributionsCommand
+    ) {
+      return Promise.resolve({
+        ETag: 'version-1',
+        DistributionConfig: { Enabled: true },
+      });
+    }
+    return Promise.reject(new Error('Unexpected command'));
+  });
+  return { cloudFrontClient: { send } as unknown as CloudFrontClient, send };
+};
+
+const getDeletedBucketNames = (
+  send: ReturnType<typeof buildS3Client>['send'],
+): Array<unknown> =>
+  send.mock.calls
+    .map((call) => call.arguments[0])
+    .filter((command) => command instanceof DeleteBucketCommand)
+    .map((command) => (command as DeleteBucketCommand).input.Bucket as unknown);
+
+const buildEnabledDistribution = (id: string): DistributionSummary =>
+  ({ Id: id, Enabled: true, Status: 'Deployed' }) as DistributionSummary;
+
+const buildSweeper = (
+  options: {
+    ownedBucketNames?: Array<string>;
+    deleteBucketError?: Error;
+    signalIncompleteRun?: () => void;
+  } = {},
+) => {
+  const logMessages: Array<string> = [];
+  const { s3Client, send: s3Send } = buildS3Client(options.deleteBucketError);
+  const { cloudFrontClient, send: cloudFrontSend } = buildCloudFrontClient();
+  const sweeper = new StaleBucketSweeper(
+    new S3BucketEmptier(s3Client, () => {}),
+    new CloudFrontDistributionCleaner(
+      cloudFrontClient,
+      TEST_RESOURCE_PREFIX,
+      () => {},
+    ),
+    (bucketName) => (options.ownedBucketNames ?? []).includes(bucketName),
+    (message) => logMessages.push(message),
+    options.signalIncompleteRun ?? (() => {}),
+  );
+  return { sweeper, s3Send, cloudFrontSend, logMessages };
+};
+
+void describe('StaleBucketSweeper', () => {
+  void it('retains every bucket and fails the run when the distribution index is incomplete', async () => {
+    let incompleteRunSignalCount = 0;
+    const { sweeper, s3Send, cloudFrontSend, logMessages } = buildSweeper({
+      signalIncompleteRun: () => {
+        incompleteRunSignalCount += 1;
+      },
+    });
+
+    const result = await sweeper.sweep(
+      ['amplify-app-1', 'amplify-app-2'],
+      new BucketToDistributionsIndex(new Map(), false),
+    );
+
+    assert.deepStrictEqual(result, {
+      deletedBucketNames: [],
+      retainedBucketNames: ['amplify-app-1', 'amplify-app-2'],
+    });
+    assert.strictEqual(s3Send.mock.callCount(), 0);
+    assert.strictEqual(cloudFrontSend.mock.callCount(), 0);
+    assert.strictEqual(incompleteRunSignalCount, 1);
+    assert.ok(
+      logMessages.some(
+        (message) =>
+          message.includes('Retaining all 2 stale buckets') &&
+          message.includes('CloudFront distribution index is incomplete'),
+      ),
+    );
+  });
+
+  void it('fails the process by default when the distribution index is incomplete', async () => {
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+      const { s3Client } = buildS3Client();
+      const { cloudFrontClient } = buildCloudFrontClient();
+      const sweeper = new StaleBucketSweeper(
+        new S3BucketEmptier(s3Client, () => {}),
+        new CloudFrontDistributionCleaner(
+          cloudFrontClient,
+          TEST_RESOURCE_PREFIX,
+          () => {},
+        ),
+        () => false,
+        () => {},
+      );
+
+      await sweeper.sweep(
+        ['amplify-app-1'],
+        new BucketToDistributionsIndex(new Map(), false),
+      );
+
+      assert.strictEqual(process.exitCode, 1);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  void it('deletes a bucket that no live stack and no distribution uses', async () => {
+    const index = new BucketToDistributionsIndex(new Map(), true);
+    const { sweeper, s3Send, logMessages } = buildSweeper();
+
+    const result = await sweeper.sweep(['amplify-app-1'], index);
+
+    assert.deepStrictEqual(result, {
+      deletedBucketNames: ['amplify-app-1'],
+      retainedBucketNames: [],
+    });
+    assert.deepStrictEqual(getDeletedBucketNames(s3Send), ['amplify-app-1']);
+    assert.ok(
+      logMessages.includes('Successfully deleted amplify-app-1 bucket'),
+    );
+  });
+
+  void it('retains a bucket that a distribution still uses as an origin', async () => {
+    const index = new BucketToDistributionsIndex(
+      new Map([['amplify-app-1', [buildEnabledDistribution('D1')]]]),
+      true,
+    );
+    const { sweeper, s3Send, cloudFrontSend, logMessages } = buildSweeper();
+
+    const result = await sweeper.sweep(
+      ['amplify-app-1', 'amplify-app-2'],
+      index,
+    );
+
+    assert.deepStrictEqual(result, {
+      deletedBucketNames: ['amplify-app-2'],
+      retainedBucketNames: ['amplify-app-1'],
+    });
+    assert.deepStrictEqual(getDeletedBucketNames(s3Send), ['amplify-app-2']);
+    assert.ok(cloudFrontSend.mock.callCount() > 0);
+    assert.ok(
+      logMessages.includes(
+        'Retaining amplify-app-1 bucket. A CloudFront distribution still uses it as an origin',
+      ),
+    );
+  });
+
+  void it('skips a bucket that a live stack still owns without touching CloudFront', async () => {
+    const index = new BucketToDistributionsIndex(new Map(), true);
+    const { sweeper, s3Send, cloudFrontSend } = buildSweeper({
+      ownedBucketNames: ['amplify-app-1'],
+    });
+
+    const result = await sweeper.sweep(['amplify-app-1'], index);
+
+    assert.deepStrictEqual(result, {
+      deletedBucketNames: [],
+      retainedBucketNames: ['amplify-app-1'],
+    });
+    assert.strictEqual(s3Send.mock.callCount(), 0);
+    assert.strictEqual(cloudFrontSend.mock.callCount(), 0);
+  });
+
+  void it('keeps sweeping the remaining buckets when one delete fails', async () => {
+    const index = new BucketToDistributionsIndex(new Map(), true);
+    const { sweeper, logMessages } = buildSweeper({
+      deleteBucketError: new Error('AccessDenied'),
+    });
+
+    const result = await sweeper.sweep(
+      ['amplify-app-1', 'amplify-app-2'],
+      index,
+    );
+
+    assert.deepStrictEqual(result, {
+      deletedBucketNames: [],
+      retainedBucketNames: ['amplify-app-1', 'amplify-app-2'],
+    });
+    assert.ok(
+      logMessages.includes(
+        'Failed to delete amplify-app-1 bucket. AccessDenied',
+      ),
+    );
+    assert.ok(
+      logMessages.includes(
+        'Failed to delete amplify-app-2 bucket. AccessDenied',
+      ),
+    );
+  });
+});

--- a/scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts
+++ b/scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts
@@ -207,7 +207,12 @@ void describe('StaleBucketSweeper', () => {
       new Map([['amplify-app-1', [distribution]]]),
       true,
     );
-    const { sweeper, s3Send, cloudFrontSend } = buildSweeper();
+    let incompleteRunSignalCount = 0;
+    const { sweeper, s3Send, cloudFrontSend, logMessages } = buildSweeper({
+      signalIncompleteRun: () => {
+        incompleteRunSignalCount += 1;
+      },
+    });
 
     const result = await sweeper.sweep(['amplify-app-1'], index);
 
@@ -217,6 +222,14 @@ void describe('StaleBucketSweeper', () => {
     });
     assert.deepStrictEqual(getDeletedBucketNames(s3Send), []);
     assert.strictEqual(cloudFrontSend.mock.callCount(), 0);
+    assert.strictEqual(incompleteRunSignalCount, 1);
+    assert.ok(
+      logMessages.some(
+        (message) =>
+          message.includes('CloudFrontDistributionUnreapable') &&
+          message.includes('amplify-app-1'),
+      ),
+    );
   });
 
   void it('skips a bucket that a live stack still owns without touching CloudFront', async () => {

--- a/scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts
+++ b/scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts
@@ -193,6 +193,27 @@ void describe('StaleBucketSweeper', () => {
     );
   });
 
+  void it('retains a bucket when its indexed distribution is missing an id', async () => {
+    const distribution = {
+      Enabled: false,
+      Status: 'Deployed',
+    } as DistributionSummary;
+    const index = new BucketToDistributionsIndex(
+      new Map([['amplify-app-1', [distribution]]]),
+      true,
+    );
+    const { sweeper, s3Send, cloudFrontSend } = buildSweeper();
+
+    const result = await sweeper.sweep(['amplify-app-1'], index);
+
+    assert.deepStrictEqual(result, {
+      deletedBucketNames: [],
+      retainedBucketNames: ['amplify-app-1'],
+    });
+    assert.deepStrictEqual(getDeletedBucketNames(s3Send), []);
+    assert.strictEqual(cloudFrontSend.mock.callCount(), 0);
+  });
+
   void it('skips a bucket that a live stack still owns without touching CloudFront', async () => {
     const index = new BucketToDistributionsIndex(new Map(), true);
     const { sweeper, s3Send, cloudFrontSend } = buildSweeper({

--- a/scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts
+++ b/scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts
@@ -105,7 +105,11 @@ void describe('StaleBucketSweeper', () => {
 
     const result = await sweeper.sweep(
       ['amplify-app-1', 'amplify-app-2'],
-      new BucketToDistributionsIndex(new Map(), false),
+      new BucketToDistributionsIndex(
+        new Map(),
+        false,
+        'unrecognized-s3-origin: distribution D1',
+      ),
     );
 
     assert.deepStrictEqual(result, {
@@ -119,7 +123,8 @@ void describe('StaleBucketSweeper', () => {
       logMessages.some(
         (message) =>
           message.includes('Retaining all 2 stale buckets') &&
-          message.includes('CloudFront distribution index is incomplete'),
+          message.includes('CloudFrontDistributionIndexIncomplete') &&
+          message.includes('unrecognized-s3-origin: distribution D1'),
       ),
     );
   });

--- a/scripts/components/e2e-cleanup/stale_bucket_sweeper.ts
+++ b/scripts/components/e2e-cleanup/stale_bucket_sweeper.ts
@@ -1,0 +1,100 @@
+import { S3BucketEmptier } from './s3_bucket_emptier.js';
+import {
+  BucketToDistributionsIndex,
+  CloudFrontDistributionCleaner,
+} from './cloudfront_distribution_cleaner.js';
+
+/**
+ * The buckets a sweep deleted and the buckets it deliberately retained.
+ */
+export type StaleBucketSweepResult = {
+  deletedBucketNames: Array<string>;
+  retainedBucketNames: Array<string>;
+};
+
+/**
+ * Deletes the stale e2e test buckets that no live stack and no CloudFront distribution still uses.
+ *
+ * The sweep is fail closed: a bucket is only deleted once it is proven to be free of both a live
+ * stack owner and a distribution origin usage. Retaining a bucket costs a little storage until a
+ * later run deletes it, whereas deleting the origin bucket of a distribution that still exists
+ * leaves a dangling distribution that serves a bucket name anybody can claim.
+ */
+export class StaleBucketSweeper {
+  /**
+   * Creates stale bucket sweeper.
+   */
+  constructor(
+    private readonly s3BucketEmptier: S3BucketEmptier,
+    private readonly cloudFrontDistributionCleaner: CloudFrontDistributionCleaner,
+    private readonly isOwnedByLiveStack: (bucketName: string) => boolean,
+    private readonly log: (message: string) => void = console.log,
+    private readonly signalIncompleteRun: () => void = () => {
+      process.exitCode = 1;
+    },
+  ) {}
+
+  /**
+   * Deletes the buckets of `bucketNames` that are provably unused.
+   *
+   * Every bucket is retained when the distribution index is incomplete, because an incomplete
+   * index makes every bucket look origin free. The run is then marked as failed so that it is
+   * retried and the cause of the incomplete index is visible.
+   */
+  sweep = async (
+    bucketNames: Array<string>,
+    bucketToDistributions: BucketToDistributionsIndex,
+  ): Promise<StaleBucketSweepResult> => {
+    if (!bucketToDistributions.isComplete) {
+      this.log(
+        `Retaining all ${bucketNames.length} stale buckets of this run. The CloudFront distribution index is incomplete, so no bucket can be told apart from the origin bucket of a distribution that still exists. Failing the job so that the run is retried and the cause is visible`,
+      );
+      this.signalIncompleteRun();
+      return {
+        deletedBucketNames: [],
+        retainedBucketNames: [...bucketNames],
+      };
+    }
+    const result: StaleBucketSweepResult = {
+      deletedBucketNames: [],
+      retainedBucketNames: [],
+    };
+    for (const bucketName of bucketNames) {
+      if (this.isOwnedByLiveStack(bucketName)) {
+        result.retainedBucketNames.push(bucketName);
+        continue;
+      }
+      try {
+        /**
+         * Deleting the origin bucket of a distribution that still exists leaves a distribution
+         * that serves a bucket name anybody can claim, so the distributions go first. Disabling a
+         * distribution takes tens of minutes to propagate, therefore the bucket is retained until
+         * a subsequent run of this script is able to delete its distributions.
+         */
+        const distributionReapResult =
+          await this.cloudFrontDistributionCleaner.reapDistributionsForBucket(
+            bucketName,
+            bucketToDistributions,
+          );
+        if (
+          distributionReapResult === 'disable-requested' ||
+          distributionReapResult === 'index-incomplete'
+        ) {
+          this.log(
+            `Retaining ${bucketName} bucket. A CloudFront distribution still uses it as an origin`,
+          );
+          result.retainedBucketNames.push(bucketName);
+          continue;
+        }
+        await this.s3BucketEmptier.emptyAndDelete(bucketName);
+        this.log(`Successfully deleted ${bucketName} bucket`);
+        result.deletedBucketNames.push(bucketName);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : '';
+        this.log(`Failed to delete ${bucketName} bucket. ${errorMessage}`);
+        result.retainedBucketNames.push(bucketName);
+      }
+    }
+    return result;
+  };
+}

--- a/scripts/components/e2e-cleanup/stale_bucket_sweeper.ts
+++ b/scripts/components/e2e-cleanup/stale_bucket_sweeper.ts
@@ -47,7 +47,7 @@ export class StaleBucketSweeper {
   ): Promise<StaleBucketSweepResult> => {
     if (!bucketToDistributions.isComplete) {
       this.log(
-        `Retaining all ${bucketNames.length} stale buckets of this run. The CloudFront distribution index is incomplete, so no bucket can be told apart from the origin bucket of a distribution that still exists. Failing the job so that the run is retried and the cause is visible`,
+        `CloudFrontDistributionIndexIncomplete: Retaining all ${bucketNames.length} stale buckets of this run. No bucket can be told apart from the origin bucket of a distribution that still exists. Failing the job so that the run is retried. Reason: ${bucketToDistributions.incompleteReason ?? 'unknown'}`,
       );
       this.signalIncompleteRun();
       return {

--- a/scripts/components/e2e-cleanup/stale_bucket_sweeper.ts
+++ b/scripts/components/e2e-cleanup/stale_bucket_sweeper.ts
@@ -76,6 +76,14 @@ export class StaleBucketSweeper {
             bucketName,
             bucketToDistributions,
           );
+        if (distributionReapResult === 'unreapable') {
+          this.log(
+            `CloudFrontDistributionUnreapable: Retaining ${bucketName} bucket and failing the job because an indexed CloudFront distribution cannot be reaped safely`,
+          );
+          this.signalIncompleteRun();
+          result.retainedBucketNames.push(bucketName);
+          continue;
+        }
         if (
           distributionReapResult === 'disable-requested' ||
           distributionReapResult === 'index-incomplete'


### PR DESCRIPTION
## Problem

The e2e resource janitor (`scripts/cleanup_e2e_resources.ts`) can delete the **origin S3 bucket** of a CloudFront distribution that still exists. The result is a *dangling distribution*: a live distribution whose origin bucket name is now unclaimed, so anyone who creates a bucket with that name controls what the distribution serves.

This is the mechanism behind AWS AppSec finding `palisade.udd.cloudfront.distribution.dangling` (SIM **V2338459152**) observed in the e2e test accounts.

`CloudFrontDistributionCleaner` (added in #3303) already lists distributions first, guards origin buckets, and does a two-phase `disable → wait → delete`. That closed the common case, but two residual gaps still let the janitor delete an origin bucket:

### Gap 1 — the origin guard failed OPEN on a `ListDistributions` error

`buildBucketToDistributionsIndex` (`cloudfront_distribution_cleaner.ts` L53-85 before this change) caught any failure of `ListDistributions` and returned an **empty `Map`** (L78-84). An empty index is indistinguishable from "no bucket is used as an origin", so the bucket delete pass (`cleanup_e2e_resources.ts` L302-336 before this change) ran completely **unguarded**: every stale bucket looked origin free and was deleted, turning every distribution in the account into a dangling distribution.

Any transient CloudFront hiccup was enough to trigger it — throttling (`Rate exceeded`), a permission gap on `cloudfront:ListDistributions`, or a failure while paginating after the first page had already succeeded.

### Gap 2 — S3 origin matching missed several origin forms

`S3_ORIGIN_DOMAIN_PATTERN` (L17-18) and `getTestBucketOrigins` (L180-193) only matched virtual-hosted `*.amazonaws.com` REST / website / dualstack forms. Any other S3 origin form silently fell through, the bucket then looked origin free, and it was deleted — the same dangling outcome, just via a different path. Missed forms: legacy path-style origins (bucket in the *path*, not the host), non-standard partitions (`amazonaws.com.cn`), and any endpoint form the regex had never seen.

**Issue number, if available:** n/a (internal AWS AppSec finding `palisade.udd.cloudfront.distribution.dangling`, SIM V2338459152)

## Changes

### Gap 1: fail CLOSED on an incomplete distribution index

Mirrors the existing fail-closed pattern of `LiveStackResourceIndex` in `stack_deleter.ts` (L96-130), which already protects *every* resource when the stack-ownership index could not be fully built.

- **`scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.ts`**
  - New exported `BucketToDistributionsIndex` class carrying an `isComplete` flag plus `getDistributions(bucketName)` / `getBucketNames()`. `buildBucketToDistributionsIndex` now returns this instead of a bare `Map`.
  - A `ListDistributions` failure — on the first page or on any later page — yields `isComplete === false` instead of an empty `Map`, and logs that stale buckets must be retained because their origin usage is unknown.
  - `DistributionReapResult` gains `'index-incomplete'`. `reapDistributionsForBucket` returns it immediately, without making a single CloudFront call, when the index is incomplete. This is defense in depth: no caller can delete an origin bucket on the strength of an index that knows nothing.

- **`scripts/components/e2e-cleanup/stale_bucket_sweeper.ts`** (new) — the bucket delete loop, extracted from `cleanup_e2e_resources.ts` so it is unit testable (the surrounding script is a top-level-await entry point and cannot be imported). When the index is **not** complete it skips bucket deletion **entirely** for the run, retains every stale bucket, logs the reason, and sets `process.exitCode = 1` — the same "fail the job so the run is retried and the cause is visible" signal the incomplete stack-ownership index already uses (`cleanup_e2e_resources.ts` L721-732). Retaining buckets is safe and self-healing: a later healthy run deletes them.

- **`scripts/cleanup_e2e_resources.ts`** — constructs `StaleBucketSweeper` (with the existing `isOwnedByLiveStack` guard bound to `AWS::S3::Bucket`) and replaces the inline delete loop with a single `sweep(...)` call. Behavior and log strings for the healthy path are unchanged; the existing stack-index `process.exitCode` block is untouched.

### Gap 2: broaden S3 origin matching

In `cloudfront_distribution_cleaner.ts`, `getOriginBucketName` now recognizes, in order:

1. **Virtual-hosted** (regression-preserved): `bucket.s3.us-west-2.amazonaws.com`, `bucket.s3.amazonaws.com`, `bucket.s3-website-us-west-2.amazonaws.com`, `bucket.s3.dualstack.us-west-2.amazonaws.com` — plus optional `fips` and a **non-standard partition suffix** such as `bucket.s3.cn-north-1.amazonaws.com.cn`.
2. **Legacy path-style**, where the host names no bucket at all (`s3.amazonaws.com`, `s3.<region>.amazonaws.com`) and the bucket is the leading path segment. Taken from the domain name when it carries a path, otherwise from the origin's `OriginPath`.
3. **`S3OriginConfig` present** → the origin *is* an S3 origin even if its suffix is one this script has never seen, so the bucket name is read from the leading label of the host.

Genuinely non-S3 origins (`example.com`, `*.execute-api.*`, `*.elb.*`, and a bare `s3.<region>.amazonaws.com` with no bucket anywhere) still yield no bucket, so nothing new is treated as an origin bucket.

**No changeset**: this PR only touches `scripts/` and `.eslint_dictionary.json`, no released package. Verified with `changeset status --since origin/main` ("NO packages to be bumped") and `scripts/check_changeset_completeness.ts` (both exit 0).

**Corresponding docs PR, if applicable:** n/a

## Validation

All commands run from the repo root on this branch.

| Command | Result |
| --- | --- |
| `npx tsc --build scripts` | exit 0, no diagnostics |
| `npm run test:dir scripts/components/e2e-cleanup/cloudfront_distribution_cleaner.test.ts` | **12/12 pass**, 0 fail |
| `npm run test:dir scripts/components/e2e-cleanup/stale_bucket_sweeper.test.ts` | **6/6 pass**, 0 fail |
| `npm run test:scripts` (full script suite) | **109 pass, 0 fail** (24 suites) |
| `npx eslint --max-warnings 0 scripts/` | exit 0 |
| `npx tsx scripts/check_package_json.ts` | exit 0 |
| `npx prettier --check .` | "All matched files use Prettier code style!" |

`npm run lint` over the whole repo also reports one pre-existing error in `packages/backend-auth/src/reference_construct.test.ts:115` (`@typescript-eslint/restrict-template-expressions`), which reproduces on unmodified `main` and is unrelated to this PR.

New/updated unit tests (`node:test`, SDK clients mocked exactly as the existing tests do):

**Gap 1**
- `ListDistributions` throws → `index.isComplete === false`, no bucket names, reason logged.
- A failure on a *later* page (first page already succeeded) → `isComplete === false`.
- `reapDistributionsForBucket` on an incomplete index → `'index-incomplete'` with **zero** CloudFront calls.
- `StaleBucketSweeper.sweep` with an incomplete index → **retains all** buckets, `deletedBucketNames: []`, **zero** S3 and zero CloudFront calls, and the failure signal fires.
- The default signal sets `process.exitCode = 1` (asserted with save/restore).
- Healthy-path regressions: an unused bucket is emptied and deleted; a bucket with a live distribution is retained (no `DeleteBucket`); a bucket a live stack still owns is skipped without touching CloudFront; a delete failure is logged and the sweep continues to the remaining buckets.

**Gap 2**
- Bucket extracted for: REST regional, REST global, website, dualstack (regressions) + `amazonaws.com.cn`, path-style via `OriginPath`, path-style via a domain name carrying the path, and `S3OriginConfig` with an unknown suffix.
- No bucket returned for genuinely non-S3 origins (`example.com`, `execute-api`, `elb` with `CustomOriginConfig`, and a bucket-less `s3.<region>.amazonaws.com`).

`StaleBucketSweeper` tests exercise the **real** `S3BucketEmptier` and the **real** `CloudFrontDistributionCleaner`; only the AWS SDK clients are mocked.

## Follow-up / NOT addressed in this PR

These are architectural and belong to the Amplify CLI team; they are out of scope here. This PR stops the janitor from *creating* dangling distributions, but it does not reap the ones already wedged behind a stuck stack.

**GAP 3 — the janitor cannot un-wedge a `DELETE_FAILED` hosting-standalone stack, and never independently reaps its distribution**

1. **`deleteStack` retries uselessly forever.** `stack_deleter.ts` (L24-28, L300-356) can only make progress on a `DELETE_FAILED` stack by retaining resources whose type is in `RESOURCE_TYPES_SAFE_TO_RETAIN`. When the blocker is the stack's **custom-resource Lambda function**, that type is not in the list, so no `RetainResources` set can unblock the delete: every hourly run re-issues the same `DeleteStack` and fails the same way, indefinitely.
2. **The distribution is never reaped independently.** `CloudFrontDistributionCleaner` only acts on distributions matched to a stale bucket that is already **ownership-free**. While the parent stack is not `DELETE_COMPLETE` (i.e. `DELETE_FAILED`), its bucket is still owned by a live stack and is correctly skipped — so the distribution is never even considered, no matter how long the stack stays wedged. There is no independent sweep for "distribution parented to a stack that will never finish deleting".

**Root cause of the wedge** (confirmed in the affected account): the custom-resource Lambdas' **IAM execution roles were deleted** — `aws iam get-role` on the role returns `NoSuchEntity`. Without an assumable execution role the Lambda can never run, so it never sends a response to CloudFormation, and the stack delete eventually fails with *"did not receive a response from your Custom Resource"*. The e2e janitor's own IAM-role sweep is the likely deleter of those roles, which is exactly why the stack-ownership index in `stack_deleter.ts` exists and must stay fail-closed.

A durable fix needs some combination of: an independent distribution sweep keyed on the distribution's own staleness/tags rather than on an ownership-free bucket; and a way to un-wedge a custom-resource-blocked stack (e.g. recreating the execution role, or responding to the pending CloudFormation callback directly).

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [x] If this PR requires a change to the [Project Architecture README](../PROJECT_ARCHITECTURE.md), I have included that update in this PR. — not required, no architectural change
- [x] If this PR requires a docs update, I have linked to that docs PR above. — not required
- [x] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set. — this changes the e2e *cleanup* script (not the e2e tests themselves); it is covered by unit tests and I cannot apply labels on this repo, so please add `run-e2e` if you would like a full run.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
