### PR TITLE
ci(health_checks): add concurrency to cancel superseded PR runs

### DIFF
--- a/.github/workflows/health_checks.yml
+++ b/.github/workflows/health_checks.yml
@@ -76,6 +76,10 @@ on:
         type: string
         default: '["22", "24", "26"]'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Health checks can run on un-released code. Often work in progress.
   # Disable data from there.


### PR DESCRIPTION
## Summary
Adds a workflow-level `concurrency` group to `health_checks.yml` so superseded pull request runs are cancelled automatically instead of stacking up.

## Details
`health_checks.yml` is triggered by both `pull_request` and `schedule`, and previously had no concurrency control. Pushing multiple commits to a PR queued up multiple multi-hour runs rather than cancelling superseded ones, which adds avoidable load to the shared runner pool.

`cancel-in-progress` is scoped to `pull_request` events only:

- Package publishes run only on push to `main`/`hotfix` and are never cancelled.
- Scheduled runs are never cancelled.
- Internal PRs targeting `main` do run e2e deploys, so cancelling a superseded run can leave e2e resources behind. These are reclaimed by the hourly `e2e_resource_cleanup` workflow, so any orphan is short-lived and self-healing. This is an acceptable tradeoff versus letting superseded multi-hour runs pile up.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
