### PR TITLE
fix(scripts): allow @aws-amplify/backend-notifications 2.x in check_package_versions

### DIFF
--- a/.changeset/check-package-versions-backend-notifications-2x.md
+++ b/.changeset/check-package-versions-backend-notifications-2x.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: allow `@aws-amplify/backend-notifications` 2.x in the check_package_versions guard (build script only, no published package change)

--- a/scripts/check_package_versions.ts
+++ b/scripts/check_package_versions.ts
@@ -13,6 +13,7 @@ const getExpectedMajorVersion = (packageName: string) => {
     case 'ampx':
       return '0.';
     case '@aws-amplify/backend-deployer':
+    case '@aws-amplify/backend-notifications':
     case '@aws-amplify/cli-core':
     case '@aws-amplify/sandbox':
       return '2.';


### PR DESCRIPTION
## Problem

Every pull request against `main` fails the `check_package_versions` (health_checks) CI job:

```
Error: Expected package @aws-amplify/backend-notifications version to start with "1." but found version 2.0.0.
```

`@aws-amplify/backend-notifications` is already at `2.0.0` on `main`, but the `scripts/check_package_versions.ts` guard still expects it to start with `1.` — it isn't listed in `getExpectedMajorVersion`, so it falls into the `default` case (`'1.'`). The `check_package_versions` job runs `changeset version` and then this guard, so the guard rejects the `2.` major on every PR, regardless of what the PR changes.

**Issue number, if available:** N/A (CI/tooling fix; surfaced while working on #3316)

## Changes

- `scripts/check_package_versions.ts`: add `@aws-amplify/backend-notifications` to the group whose expected major version is `2.` (alongside `@aws-amplify/backend-deployer`, `@aws-amplify/cli-core`, and `@aws-amplify/sandbox`).
- Adds an empty changeset — the change is to a repo build script, not a published package, so no version bump is intended.

**Corresponding docs PR, if applicable:** N/A

## Validation

- Ran `npx tsx scripts/check_package_versions.ts` locally: **exits 1 without the fix** (with the exact CI error above) and **exits 0 with the fix**, confirming this change is what unblocks the check.
- Verified the changeset gates pass: `changeset status --since origin/main` exits 0 and `scripts/check_changeset_completeness.ts` exits 0 with the empty changeset.
- prettier + eslint clean on the changed file.
- No runtime/behavioral change — this only widens an allowlist in a build-time guard.

## Checklist

- [ ] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the Project Architecture README, I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

no linked-issue close: CI-guard/tooling fix, not tied to a tracked issue.
