### PR TITLE
fix(seed): restore caret range for aws-amplify to allow dedup (#3323)

### DIFF
--- a/.changeset/fix-seed-aws-amplify-pin.md
+++ b/.changeset/fix-seed-aws-amplify-pin.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/seed': patch
+---
+
+Loosen `aws-amplify` from an exact version pin (`6.14.4`) back to a caret range (`^6.14.4`) so npm can deduplicate it against the consuming app's `aws-amplify` version. The exact pin (introduced in #3144, shipped in 1.1.3) forced a second, nested `aws-amplify` copy whenever the app used any other 6.x version, producing an unconfigured Amplify singleton and `Auth UserPool not configured` / `SeedingFailedError` during `ampx sandbox seed`.

--- a/packages/seed/package.json
+++ b/packages/seed/package.json
@@ -29,6 +29,6 @@
     "@aws-amplify/platform-core": "^1.11.1",
     "@aws-amplify/plugin-types": "^1.12.1",
     "@aws-sdk/client-cognito-identity-provider": "^3.936.0",
-    "aws-amplify": "6.14.4"
+    "aws-amplify": "^6.14.4"
   }
 }


### PR DESCRIPTION
Fixes #3323

`@aws-amplify/seed@1.1.3` pinned `aws-amplify` to an exact `6.14.4` in `dependencies` (releases 1.1.0-1.1.2 used `^6.0.16`). Because `aws-amplify` is a module-level singleton (`Amplify.configure()` mutates shared state), the exact pin defeats npm deduplication whenever the consumer uses any other 6.x version. npm then installs a nested copy under `node_modules/@aws-amplify/seed/node_modules/aws-amplify`; the app configures the hoisted copy while seed's helpers read the nested, unconfigured one, producing `AuthUserPoolException` wrapped as `SeedingFailedError`.

This restores the caret range so npm can dedup against any `^6.x` app.

Regression introduced in 88c4759 ("resolve Dependabot vulnerabilities #3144").

## Testing
- Install `@aws-amplify/seed` with the change in a project pinning `aws-amplify@^6.20.0`
- Confirm no `@aws-amplify/seed/node_modules/aws-amplify` duplicate is created
- `ampx sandbox seed` completes without `Auth UserPool not configured`
