### PR TITLE
fix(backend-deployer): map toolkit-lib countAssemblyResults crash to a fault

### DIFF
--- a/.changeset/toolkit-lib-metadata-null-guard.md
+++ b/.changeset/toolkit-lib-metadata-null-guard.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-deployer': patch
+---
+
+Map the `@aws-cdk/toolkit-lib` `countAssemblyResults` crash (`TypeError: Cannot convert undefined or null to object` when a synthesized stack has no metadata) to a fault instead of a misleading backend `SyntaxError`.

--- a/packages/backend-deployer/src/cdk_error_mapper.test.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.test.ts
@@ -545,3 +545,49 @@ void describe('Node version error per deployment type', () => {
     );
   });
 });
+
+void describe('toolkit-lib countAssemblyResults metadata crash', () => {
+  const cdkErrorMapper = new CdkErrorMapper(formatterStub);
+
+  // The TypeError @aws-cdk/toolkit-lib throws when a stack has no metadata.
+  // Refs aws-amplify/amplify-backend#3316.
+  const buildCountAssemblyResultsError = () => {
+    const error = new TypeError('Cannot convert undefined or null to object');
+    error.stack = [
+      'TypeError: Cannot convert undefined or null to object',
+      '    at Object.values (<anonymous>)',
+      '    at node_modules/@aws-cdk/toolkit-lib/lib/toolkit/private/count-assembly-results.js:12:30',
+      '    at Array.flatMap (<anonymous>)',
+      '    at countAssemblyResults (node_modules/@aws-cdk/toolkit-lib/lib/toolkit/private/count-assembly-results.js:12:10)',
+      '    at synthAndMeasure (node_modules/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.js:1709:59)',
+    ].join('\n');
+    return error;
+  };
+
+  void it('classifies the crash as a fault, not a user error', () => {
+    const error = cdkErrorMapper.getAmplifyError(
+      buildCountAssemblyResultsError(),
+    );
+    assert.equal(error.name, 'CDKSynthAssemblyMetadataFault');
+    // Must be classified as a FAULT (internal/library bug), not a user ERROR
+    // that would tell the customer to fix their own backend code.
+    assert.equal(error.classification, 'FAULT');
+    assert.match(error.message, /@aws-cdk\/toolkit-lib/);
+  });
+
+  void it('preserves the original TypeError as the cause', () => {
+    const original = buildCountAssemblyResultsError();
+    const error = cdkErrorMapper.getAmplifyError(original);
+    assert.equal(error.cause, original);
+  });
+
+  void it('does not intercept unrelated TypeErrors (still a backend SyntaxError)', () => {
+    const unrelated = new TypeError('foo is not a function');
+    unrelated.stack =
+      'TypeError: foo is not a function\n    at amplify/backend.ts:3:1';
+    assert.throws(
+      () => cdkErrorMapper.getAmplifyError(unrelated),
+      (thrown: Error) => thrown.name === 'SyntaxError',
+    );
+  });
+});

--- a/packages/backend-deployer/src/cdk_error_mapper.ts
+++ b/packages/backend-deployer/src/cdk_error_mapper.ts
@@ -168,6 +168,34 @@ export class CdkErrorMapper {
         error,
       );
     } else if (
+      error.name === 'TypeError' &&
+      /Cannot convert undefined or null to object/.test(error.message) &&
+      /countAssemblyResults/.test(error.stack ?? '')
+    ) {
+      // @aws-cdk/toolkit-lib bug: countAssemblyResults calls
+      // Object.values(stack.metadata) with no null guard and throws when a
+      // synthesized stack has no metadata. This is a library fault, not a
+      // customer backend error, so it must not fall through to the generic
+      // TypeError branch below. Refs aws-amplify/amplify-backend#3316.
+      // This match relies on the TypeError reaching the mapper without being
+      // wrapped by an intermediate layer: the countAssemblyResults stack frame
+      // is the stable anchor, while the error.name check would silently miss
+      // if a layer wraps the error into a new type before it gets here.
+      // TODO(aws-amplify/amplify-backend#3316): the upstream null guard is
+      // merged (aws/aws-cdk-cli#1952). Once a @aws-cdk/toolkit-lib release ships
+      // it and this package bumps its pin, countAssemblyResults no longer throws
+      // and this branch becomes dead code — remove it as part of that bump.
+      return new AmplifyFault(
+        'CDKSynthAssemblyMetadataFault',
+        {
+          message:
+            'Unable to synthesize the Amplify backend due to a bug in the CDK toolkit library (@aws-cdk/toolkit-lib) that fails when a synthesized stack has no metadata.',
+          resolution:
+            'This is a known upstream bug in @aws-cdk/toolkit-lib, not an issue in your backend code; retrying is unlikely to help. Track aws-amplify/amplify-backend#3316 for a fix.',
+        },
+        error,
+      );
+    } else if (
       ['TypeError', 'TransformError', 'ReferenceError', 'SyntaxError'].some(
         (errorName) => errorName === error.name,
       )
@@ -628,6 +656,7 @@ export type CDKDeploymentError =
   | 'CDKAssetBundleError'
   | 'CDKNotFoundError'
   | 'CDKResolveAWSAccountError'
+  | 'CDKSynthAssemblyMetadataFault'
   | 'CDKVersionMismatchError'
   | 'CFNUpdateNotSupportedError'
   | 'CloudformationResourceCircularDependencyError'


### PR DESCRIPTION
## Problem

`npx ampx sandbox` and `ampx pipeline-deploy` crash during synth with a generic, misleading error that blames the customer's backend code:

```
[SyntaxError] Unable to build the Amplify backend definition.
 ∟ Caused by: [TypeError] Cannot convert undefined or null to object
Resolution: Check the Caused by error and fix any issues in your backend code
```

Running with `--debug` shows the crash is not in the customer's `amplify/backend.ts` at all — it originates inside `@aws-cdk/toolkit-lib`:

```
TypeError: Cannot convert undefined or null to object
    at Object.values (<anonymous>)
    at .../@aws-cdk/toolkit-lib/lib/toolkit/private/count-assembly-results.js
    at countAssemblyResults (.../count-assembly-results.js)
    at synthAndMeasure (.../toolkit.js)
    at async Toolkit.synth (.../toolkit.js)
```

`countAssemblyResults` calls `Object.values(stack.metadata)` with no null guard, and at least one nested stack that a Gen 2 backend (auth + multi-model data + storage) generates has `metadata` undefined — so `Object.values(undefined)` throws. This is a library bug, not a customer error, but `backend-deployer` re-wraps the `TypeError` via the generic `TypeError → SyntaxError` mapping and tells the customer to fix their own backend.

**Issue number, if available:** #3316

## Changes

- `cdk_error_mapper.ts`: add a specific branch — placed **before** the generic `TypeError` branch — that detects this crash signature (`TypeError` + `Cannot convert undefined or null to object` + `countAssemblyResults` in the stack) and maps it to a **fault** (`CDKSynthAssemblyMetadataFault`) with an accurate, non-blaming message and a `resolution` that points at the upstream bug, instead of a customer-facing `SyntaxError`. The original error is preserved as the cause.
- `cdk_error_mapper.ts`: add `CDKSynthAssemblyMetadataFault` to the `CDKDeploymentError` union so the named fault is consistent with every other error there (review nit).
- `cdk_error_mapper.ts`: add a `TODO` above the fault branch linking aws/aws-cdk-cli#1952 — once a `@aws-cdk/toolkit-lib` release ships the merged null guard and this package bumps its pin, `countAssemblyResults` no longer throws and this branch becomes dead code to remove (review nit).

**Note on scope:** this PR only reclassifies the error so customers are no longer told to debug backend code that is not at fault. It does **not** fix the crash itself — the missing null guard lives in `@aws-cdk/toolkit-lib` and the actual fix belongs upstream in `aws/aws-cdk-cli` (`Object.values(s.metadata ?? {})`, merged in aws/aws-cdk-cli#1952). A `@aws-cdk/toolkit-lib` version bump was considered but dropped: no published release contains the guard yet, so bumping would not fix the crash, and `main` deliberately pins `1.32.0`.

**Supersedes #3329**, which became un-reopenable after its head branch lost common history with `main` during a rebase. This PR is the same branch (`fix/toolkit-lib-metadata-null-guard-3316`) rebuilt cleanly on current `main`, carrying the original fix plus the two review nits above.

**Corresponding docs PR, if applicable:** N/A

## Validation

- Added 3 unit tests in `cdk_error_mapper.test.ts`:
  - the crash signature maps to `CDKSynthAssemblyMetadataFault` and is classified as a `FAULT` (not a customer `ERROR`);
  - the original `TypeError` is preserved as the `cause`;
  - an unrelated `TypeError` still maps to the existing backend `SyntaxError` (no regression / over-broad match).
- `backend-deployer` error-mapper suite: **65/65 pass**. `tsc --build` on `backend-deployer` clean, prettier + eslint clean.
- Manual verification: N/A — the change is error classification only; unit coverage over `getAmplifyError` exercises the exact mapping path.

## Checklist

- [x] If this PR includes a functional change to the runtime behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a change to the Project Architecture README, I have included that update in this PR.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.
- [ ] If this PR modifies E2E tests, makes changes to resource provisioning, or makes SDK calls, I have run the PR checks with the `run-e2e` label set.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

no linked-issue close: partially addresses #3316 (improves the error message); the underlying crash fix is upstream in aws/aws-cdk-cli, so this PR intentionally does not close the issue.
